### PR TITLE
Fix test target compilation (rename XLQueryBuilder/XLInsertBuilder refs)

### DIFF
--- a/Tests/SQLTests/SQLInsertBuilderTests.swift
+++ b/Tests/SQLTests/SQLInsertBuilderTests.swift
@@ -11,7 +11,7 @@ import SwiftQL
 
 
 
-final class XLInsertBuilderTests: XCTestCase {
+final class InsertBuilderTests: XCTestCase {
     
     var encoder: XLiteEncoder!
     
@@ -30,7 +30,7 @@ final class XLInsertBuilderTests: XCTestCase {
         let schema = XLSchema()
         let table = schema.table(TestTable.self)
         let values = TestTable(id: "foo", value: 42)
-        let subject = XLInsertBuilder(insert: table).values(values)
+        let subject = InsertBuilder(insert: table).values(values)
         let result = try subject.build()
         XCTAssertEqual(encoder.makeSQL(result).sql, "INSERT INTO `Test` AS `t0` (`id`,`value`) VALUES ('foo',42)")
     }
@@ -38,7 +38,7 @@ final class XLInsertBuilderTests: XCTestCase {
     func testInsertWithoutValuesShouldFail() throws {
         let schema = XLSchema()
         let table = schema.table(TestTable.self)
-        let subject = XLInsertBuilder(insert: table)
+        let subject = InsertBuilder(insert: table)
         XCTAssertThrowsError(try subject.build())
     }
 }

--- a/Tests/SQLTests/Tests/XLQueryBuilderTests.swift
+++ b/Tests/SQLTests/Tests/XLQueryBuilderTests.swift
@@ -10,7 +10,7 @@ import GRDB
 import SwiftQL
 
     
-final class XLQueryBuilderTests: XCTestCase {
+final class QueryBuilderTests: XCTestCase {
     
     var encoder: XLiteEncoder!
     
@@ -32,7 +32,7 @@ final class XLQueryBuilderTests: XCTestCase {
         
         let company = schema.table(CompanyTable.self)
         
-        var query = XLQueryBuilder(select: company)
+        var query = QueryBuilder(select: company)
         query = query.from(company)
         
         let finalResult = try encoder.makeSQL(query.build()).sql
@@ -47,7 +47,7 @@ final class XLQueryBuilderTests: XCTestCase {
         
         let company = schema.table(CompanyTable.self)
         
-        var query = XLQueryBuilder(select: company)
+        var query = QueryBuilder(select: company)
         query = query.from(company)
         query = query.and(company.name == "Apple")
         
@@ -63,7 +63,7 @@ final class XLQueryBuilderTests: XCTestCase {
         
         let company = schema.table(CompanyTable.self)
         
-        var query = XLQueryBuilder(select: company)
+        var query = QueryBuilder(select: company)
         query = query.from(company)
         query = query.orderBy(company.name.ascending())
         
@@ -80,7 +80,7 @@ final class XLQueryBuilderTests: XCTestCase {
         let company = schema.table(CompanyTable.self)
         let employee = schema.nullableTable(EmployeeTable.self)
         
-        var query = XLQueryBuilder(select: company)
+        var query = QueryBuilder(select: company)
         query = query.from(company)
         query = query.leftJoin(employee, on: employee.companyId == company.id)
         
@@ -97,7 +97,7 @@ final class XLQueryBuilderTests: XCTestCase {
         let company = schema.table(CompanyTable.self)
         let employee = schema.nullableTable(EmployeeTable.self)
         
-        var query = XLQueryBuilder(select: company)
+        var query = QueryBuilder(select: company)
         query = query.from(company)
         query = query.leftJoin(employee, on: employee.companyId == company.id)
         query = query.and(employee.name == "Tim")
@@ -115,7 +115,7 @@ final class XLQueryBuilderTests: XCTestCase {
         let company = schema.table(CompanyTable.self)
         let employee = schema.nullableTable(EmployeeTable.self)
         
-        var query = XLQueryBuilder(select: company)
+        var query = QueryBuilder(select: company)
         query = query.from(company)
         query = query.leftJoin(employee, on: employee.companyId == company.id)
         query = query.and(employee.name == "Tim")


### PR DESCRIPTION
## Summary

The test target has not compiled since commit `922b8f62` renamed `XLQueryBuilder` → `QueryBuilder` and `XLInsertBuilder` → `InsertBuilder` in `Sources/` without updating the tests. As a result `swift test` (and the `Swift` GitHub Actions workflow) has been failing since October 2025 — zero tests have run in that window.

This PR updates the two stale test files to the current type names.

## Changes

- `Tests/SQLTests/Tests/XLQueryBuilderTests.swift`: `XLQueryBuilder` → `QueryBuilder` (6 constructor calls + the test class name)
- `Tests/SQLTests/SQLInsertBuilderTests.swift`: `XLInsertBuilder` → `InsertBuilder` (2 constructor calls + the test class name)

Pure identifier renames — no behavioural change.

## Verification

```
swift test
Executed 218 tests, with 0 failures (0 unexpected) in 0.53 seconds
```

First green build of the suite in ~9 months. This is the gating item for all other test/CI work.

## Notes

- The `QueryBuilder.build()` LIMIT/OFFSET bug (#107) did **not** surface here — the existing `QueryBuilder` tests don't exercise limit/offset, so that bug is real but simply uncovered. Pinning it with a new test is part of #118.

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)