### PR TITLE
Fix Int literals silently truncating to 32 bits in SQL encoding

### DIFF
--- a/Sources/SwiftQL/SQLEncoder.swift
+++ b/Sources/SwiftQL/SQLEncoder.swift
@@ -232,7 +232,7 @@ public struct XLiteFormatter: XLFormatter {
     }
     
     public func integer(_ value: Int) -> String {
-        String(format: "%d", value)
+        String(value)
     }
     
     public func real(_ value: Double) -> String {
@@ -264,7 +264,7 @@ public struct XLiteFormatter: XLFormatter {
     }
     
     public func indexedBinding(_ index: Int) -> String {
-        String(format: "?%d", index + 1)
+        "?\(index + 1)"
     }
 }
 

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -73,8 +73,46 @@ final class XLExecutionTests: XCTestCase {
         XCTAssertEqual(results.count, 1)
         XCTAssertEqual(results[0], TestTable(id: "bar", value: 42))
     }
-    
-    
+
+
+    func testSelectWhereLargeIntegerLiteral() throws {
+        try createTestTable()
+        try insertTest(TestTable(id: "max", value: Int(Int64.max)))
+        try insertTest(TestTable(id: "min", value: Int(Int64.min)))
+        try insertTest(TestTable(id: "timestamp", value: 1_752_000_000_000))
+
+        let statement = sql { s in
+            let t = s.table(TestTable.self)
+            Select(t)
+            From(t)
+            Where(t.value == 1_752_000_000_000)
+        }
+        let results = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0], TestTable(id: "timestamp", value: 1_752_000_000_000))
+
+        let maxStatement = sql { s in
+            let t = s.table(TestTable.self)
+            Select(t)
+            From(t)
+            Where(t.value == Int(Int64.max))
+        }
+        let maxResults = try database.makeRequest(with: maxStatement).fetchAll()
+        XCTAssertEqual(maxResults.count, 1)
+        XCTAssertEqual(maxResults[0], TestTable(id: "max", value: Int(Int64.max)))
+
+        let minStatement = sql { s in
+            let t = s.table(TestTable.self)
+            Select(t)
+            From(t)
+            Where(t.value == Int(Int64.min))
+        }
+        let minResults = try database.makeRequest(with: minStatement).fetchAll()
+        XCTAssertEqual(minResults.count, 1)
+        XCTAssertEqual(minResults[0], TestTable(id: "min", value: Int(Int64.min)))
+    }
+
+
     func testSelectWhereLike() throws {
         try createTestTable()
         try insertTest(TestTable(id: "foo", value: 9000))

--- a/Tests/SQLTests/SQLSyntaxTests.swift
+++ b/Tests/SQLTests/SQLSyntaxTests.swift
@@ -45,7 +45,25 @@ final class XLSyntaxTests: XCTestCase {
         let expression: Int = 12
         XCTAssertEqual(encoder.makeSQL(expression).sql, "12")
     }
-    
+
+
+    func test_IntegerLiteral_Int64Max() {
+        let expression: Int = Int(Int64.max)
+        XCTAssertEqual(encoder.makeSQL(expression).sql, "9223372036854775807")
+    }
+
+
+    func test_IntegerLiteral_Int64Min() {
+        let expression: Int = Int(Int64.min)
+        XCTAssertEqual(encoder.makeSQL(expression).sql, "-9223372036854775808")
+    }
+
+
+    func test_IntegerLiteral_MillisecondEpochTimestamp() {
+        let expression: Int = 1_752_000_000_000
+        XCTAssertEqual(encoder.makeSQL(expression).sql, "1752000000000")
+    }
+
     
     func test_RealLiteral() {
         let expression: Double = 17.4


### PR DESCRIPTION
Fixes #100

## Problem

`XLiteFormatter.integer(_:)` in `Sources/SwiftQL/SQLEncoder.swift` formatted `Int` values with `String(format: "%d", value)`. On Darwin, `%d` reads only 32 bits from the varargs slot, so any `Int` outside ±2³¹ was silently emitted as a different number in generated SQL (e.g. `5_000_000_000` became `705032704`). This corrupted millisecond epoch timestamps, snowflake-style IDs, and any other large integer literal — data-corrupting writes and silently wrong query filters, with no error.

## Fix

- `XLiteFormatter.integer(_:)`: replaced `String(format: "%d", value)` with `String(value)`, consistent with `real(_:)` on the adjacent line.
- `XLiteFormatter.indexedBinding(_:)`: same `%d` pattern, replaced with string interpolation for consistency (binding indexes can't realistically exceed 2³¹, but the fix is free).

## Other `String(format:)` sites audited

- `FoundationExtensions.swift:18` — `%02x` over `UInt8` bytes; values always fit in 32 bits, safe.
- `SQLMeta.swift:401` — `%d` over the per-statement alias counter (`cte%d` / `t%d` / `p%d`); the counter starts at 0 and increments per alias within a single statement, so it cannot approach 2³¹. Left unchanged since `nameFormat` is a public format-string API.

## Regression tests

- `XLSyntaxTests`: generated SQL text for `Int(Int64.max)`, `Int(Int64.min)`, and a millisecond epoch timestamp (`1_752_000_000_000`).
- `XLExecutionTests.testSelectWhereLargeIntegerLiteral`: execution round-trip through SQLite — inserts rows with `Int64.max`, `Int64.min`, and a millisecond timestamp, then reads each back via a `Where` filter using the large integer literal (which exercises the fixed literal-encoding path).

Full suite passes: 222 tests, 0 failures (`swift test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)