### PR TITLE
Remove invalid Join.Outer / OUTER JOIN emission

### DIFF
--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -479,6 +479,15 @@ public struct Join: XLTableStatement {
     public static func Left<T, U>(_ table: T, on constraint: any XLExpression<U>) -> Join where T: XLMetaNullableNamedResult, U: XLBoolean {
         Join(kind: .leftJoin, table: table, constraint: constraint)
     }
+
+    ///
+    /// `Join.Outer` emitted a bare `OUTER JOIN`, which SQLite rejects ("unknown join type: OUTER"),
+    /// so no query using it could ever execute. Use ``Left(_:on:)`` with a nullable table instead.
+    ///
+    @available(*, unavailable, message: "Join.Outer emitted a bare 'OUTER JOIN', which SQLite rejects, so it could never execute. Use Join.Left with a nullable table instead.")
+    public static func Outer<T, U>(_ table: T, on constraint: any XLExpression<U>) -> Join where T: XLMetaNamedResult, U: XLBoolean {
+        fatalError("Join.Outer is unavailable")
+    }
 }
 
 

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -420,10 +420,9 @@ public struct From: XLTableStatement {
 ///
 public struct Join: XLTableStatement {
     
-    public enum Kind: String {
+    public enum Kind: String, CaseIterable {
         case innerJoin = "INNER JOIN"
         case leftJoin = "LEFT JOIN"
-        case outerJoin = "OUTER JOIN"
         case crossJoin = "CROSS JOIN"
     }
     
@@ -479,13 +478,6 @@ public struct Join: XLTableStatement {
     ///
     public static func Left<T, U>(_ table: T, on constraint: any XLExpression<U>) -> Join where T: XLMetaNullableNamedResult, U: XLBoolean {
         Join(kind: .leftJoin, table: table, constraint: constraint)
-    }
-
-    ///
-    /// Creates an outer join with a column constraint.
-    ///
-    public static func Outer<T, U>(_ table: T, on constraint: any XLExpression<U>) -> Join where T: XLMetaNamedResult, U: XLBoolean {
-        Join(kind: .outerJoin, table: table, constraint: constraint)
     }
 }
 

--- a/Sources/SwiftQL/SwiftQL.docc/Queries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/Queries.md
@@ -52,9 +52,9 @@ Refer to the <doc:Expressions> guide for more details about expressions.
 ## Join
 
 The ability to join tables in a query is where relational databases really start 
-to shine. SwiftQL supports cross join, inner join, and outer join. 
+to shine. SwiftQL supports cross join, inner join, and left (outer) join. 
 
-> Note: SwiftQL does not currently support right joins.
+> Note: SwiftQL does not currently support right joins or full outer joins.
 
 First let's define an `Occupation` table that we can join to our `Person` table:
 

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -41,8 +41,16 @@ import SwiftQL
 @SQLTable struct PersonOccupation: Equatable {
 
     let person: String
-    
+
     let occupation: String
+}
+
+
+@SQLTable struct PersonOptionalOccupation: Equatable {
+
+    let person: String
+
+    let occupation: String?
 }
 
 
@@ -470,6 +478,52 @@ final class XLDocumentationTests: XCTestCase {
         ])
     }
     
+    func testExample_LeftJoin_Statement_NullRows() throws {
+        let statement = sql { schema in
+            let person = schema.table(Person.self)
+            let occupation = schema.nullableTable(Occupation.self)
+            let row = result {
+                PersonOptionalOccupation.SQLReader(
+                    person: person.name,
+                    occupation: occupation.name
+                )
+            }
+            Select(row)
+            From(person)
+            Join.Left(occupation, on: occupation.id == person.occupationId)
+        }
+        let sql = encoder.makeSQL(statement).sql
+        XCTAssertEqual(sql, "SELECT t0.name AS person, t1.name AS occupation FROM Person AS t0 LEFT JOIN Occupation AS t1 ON (t1.id IS t0.occupationId)")
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(rows, [
+            PersonOptionalOccupation(person: "John Doe", occupation: "Engineer"),
+            PersonOptionalOccupation(person: "Jane Doe", occupation: "Scientist"),
+            PersonOptionalOccupation(person: "Yogi Bear", occupation: nil),
+        ])
+    }
+
+    func testExample_LeftJoin_Functional_NullRows() throws {
+        let statement = sqlQuery { schema in
+            let person = schema.table(Person.self)
+            let occupation = schema.nullableTable(Occupation.self)
+            let result = result {
+                PersonOptionalOccupation.SQLReader(
+                    person: person.name,
+                    occupation: occupation.name
+                )
+            }
+            return select(result).from(person).leftJoin(occupation, on: occupation.id == person.occupationId)
+        }
+        let sql = encoder.makeSQL(statement).sql
+        XCTAssertEqual(sql, "SELECT t0.name AS person, t1.name AS occupation FROM Person AS t0 LEFT JOIN Occupation AS t1 ON (t1.id IS t0.occupationId)")
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(rows, [
+            PersonOptionalOccupation(person: "John Doe", occupation: "Engineer"),
+            PersonOptionalOccupation(person: "Jane Doe", occupation: "Scientist"),
+            PersonOptionalOccupation(person: "Yogi Bear", occupation: nil),
+        ])
+    }
+
     func testExample_Iif() throws {
         let statement = sqlQuery { schema in
             let person = schema.table(Person.self)

--- a/Tests/SQLTests/SQLQueryTests.swift
+++ b/Tests/SQLTests/SQLQueryTests.swift
@@ -154,7 +154,7 @@ final class XLQueryTests: XCTestCase {
             let sql = kind.rawValue
             if sql.contains("OUTER") {
                 XCTAssertTrue(
-                    sql.hasPrefix("LEFT ") || sql.hasPrefix("FULL "),
+                    sql.hasPrefix("LEFT ") || sql.hasPrefix("RIGHT ") || sql.hasPrefix("FULL "),
                     "'\(sql)' is not a valid SQLite join type"
                 )
             }

--- a/Tests/SQLTests/SQLQueryTests.swift
+++ b/Tests/SQLTests/SQLQueryTests.swift
@@ -146,6 +146,21 @@ final class XLQueryTests: XCTestCase {
         XCTAssertEqual(encoder.makeSQL(expression).sql, "WITH `cte0` AS (SELECT `t0`.`id` AS `id`, `t0`.`value` AS `value` FROM `Test` AS `t0`) SELECT `t1`.`id` AS `id`, `t1`.`value` AS `value` FROM `Test` AS `t0` LEFT JOIN `cte0` AS `t1` ON (`t1`.`id` IS `t0`.`id`)")
     }
 
+    // A bare "OUTER JOIN" is not a valid SQLite join type. SQLite only accepts
+    // OUTER as part of LEFT OUTER JOIN, RIGHT OUTER JOIN, or FULL OUTER JOIN.
+    func testJoinKind_cannotEmitBareOuterJoin() {
+        XCTAssertNil(Join.Kind(rawValue: "OUTER JOIN"))
+        for kind in Join.Kind.allCases {
+            let sql = kind.rawValue
+            if sql.contains("OUTER") {
+                XCTAssertTrue(
+                    sql.hasPrefix("LEFT ") || sql.hasPrefix("FULL "),
+                    "'\(sql)' is not a valid SQLite join type"
+                )
+            }
+        }
+    }
+
     
 //    func testSelectFromCommonTable() {
 //        let ct0 = with(as: "ct0") { query in


### PR DESCRIPTION
Fixes #102

## Problem

`Join.Outer` had two defects that made it unusable:

1. `Join.Kind.outerJoin` emitted a bare `OUTER JOIN`, which SQLite rejects with `Error: unknown join type: OUTER`. SQLite only accepts `OUTER` as part of `LEFT OUTER JOIN`, `RIGHT OUTER JOIN`, or `FULL OUTER JOIN`.
2. Unlike `Join.Left` (which correctly requires `XLMetaNullableNamedResult`), `Join.Outer` accepted a non-nullable `XLMetaNamedResult` — so even with a valid keyword, NULL rows from the outer side would have decoded into non-optional columns and failed.

## Resolution: retire the API

The broken behavior is removed rather than fixed in place. Every query using `Join.Outer` failed at execution time, so the API cannot have working callers — a search of the package, tests, and docs found zero usages. `Join.Left` remains the supported outer-join form. Proper `FULL OUTER JOIN` support (SQLite ≥ 3.39), along with CROSS join improvements, is tracked separately in #95.

For downstream source compatibility, the `Join.Outer` symbol is kept with its original signature as an `@available(*, unavailable)` stub, so any caller gets a guided compiler error pointing at `Join.Left` instead of a missing-symbol error. `Join.Kind.outerJoin` is removed outright (`Kind(rawValue: "OUTER JOIN")` now returns `nil`).

## Changes

- Remove `Join.Kind.outerJoin`; replace the `Join.Outer` factory with an `@available(*, unavailable)` stub directing callers to `Join.Left`.
- Make `Join.Kind` `CaseIterable` and add `testJoinKind_cannotEmitBareOuterJoin`, asserting no join kind can emit a bare `OUTER JOIN` (LEFT/RIGHT/FULL-prefixed forms remain permitted for the future).
- Add round-trip tests (`testExample_LeftJoin_Statement_NullRows`, `testExample_LeftJoin_Functional_NullRows`) proving both the declarative `Join.Left` and functional `leftJoin` forms generate valid SQL and decode NULL rows from the outer side into optional columns through a real SQLite database.
- Correct `Queries.md`, which claimed support for "outer join" — it now says left (outer) join and notes that right and full outer joins are unsupported.

## Testing

Full suite passes via `swift test` (all suites green), including the three new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)