### PR TITLE
Cast toData() to BLOB instead of NONE

### DIFF
--- a/Sources/SwiftQL/Functions/TypeCastFunctions.swift
+++ b/Sources/SwiftQL/Functions/TypeCastFunctions.swift
@@ -101,7 +101,7 @@ extension XLExpression {
     }
     
     public func toData() -> some XLExpression<Data> where T == String {
-        XLTypeCastExpression(type: "NONE", expression: self)
+        XLTypeCastExpression(type: "BLOB", expression: self)
     }
 }
 
@@ -120,7 +120,7 @@ extension XLExpression {
     }
     
     public func toData() -> some XLExpression<Optional<Data>> where T == Optional<String> {
-        XLTypeCastExpression(type: "NONE", expression: self)
+        XLTypeCastExpression(type: "BLOB", expression: self)
     }
 }
 

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -24,6 +24,7 @@ final class XLExecutionTests: XCTestCase {
         let filename = UUID().uuidString
         let fileURL = directory.appending(path: filename, directoryHint: .notDirectory).appendingPathExtension("sqlite")
         print("Connecting to database \(fileURL.path)")
+        encoder = XLiteEncoder(formatter: formatter)
         databasePool = try! DatabasePool(path: fileURL.path)
         database = try! GRDBDatabase(databasePool: databasePool, formatter: formatter, logger: nil)
     }
@@ -347,8 +348,35 @@ final class XLExecutionTests: XCTestCase {
         XCTAssertEqual(results[1], 42)
         XCTAssertEqual(results[2], 100)
     }
-    
-    
+
+
+    // MARK: - Type cast
+
+    func testStringToDataTypeofIsBlob() throws {
+        let castSQL = encoder.makeSQL("abc".toData()).sql
+        let typeName = try databasePool.read { db in
+            try String.fetchOne(db, sql: "SELECT typeof(\(castSQL))")
+        }
+        XCTAssertEqual(typeName, "blob")
+    }
+
+
+    func testStringToDataRoundTrip() throws {
+        try createTestTable()
+        try insertTest(TestTable(id: "foo", value: 1))
+
+        typealias Scalar = SQLScalarResult<Data>
+        let statement = sql { schema in
+            let t = schema.table(TestTable.self)
+            Select(result { Scalar.SQLReader(scalarValue: t.id.toData()) })
+            From(t)
+        }
+        let results = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].scalarValue, Data("foo".utf8))
+    }
+
+
     // MARK: - Recursive Common Table Expression
     
     func testScalarRecursiveCommonTableExpression() throws {

--- a/Tests/SQLTests/SQLSyntaxTests.swift
+++ b/Tests/SQLTests/SQLSyntaxTests.swift
@@ -102,9 +102,25 @@ final class XLSyntaxTests: XCTestCase {
         let expression: Data = Data([0x01])
         XCTAssertEqual(encoder.makeSQL(expression).sql, "x'01'")
     }
-    
-    
-    
+
+
+    // MARK: - Type cast
+
+
+    func test_Text_ToData_CastsToBlob() {
+        let expression = "abc".toData()
+        XCTAssertEqual(encoder.makeSQL(expression).sql, "CAST('abc' AS BLOB)")
+    }
+
+
+    func test_OptionalTextReference_ToData_CastsToBlob() {
+        let x = XLNamedBindingReference<Optional<String>>(name: "x")
+        let expression = x.toData()
+        XCTAssertEqual(encoder.makeSQL(expression).sql, "CAST(:x AS BLOB)")
+    }
+
+
+
     // MARK: - Column reference
     
     


### PR DESCRIPTION
Fixes #103

## Problem

`toData()` emitted `CAST(x AS NONE)`. Under SQLite's type-affinity rules the type name `NONE` matches no rule and falls through to NUMERIC affinity — not BLOB. So `CAST('abc' AS NONE)` yields `0` with `typeof(...) = 'integer'`, and `someString.toData()` returned a mangled number instead of the string's bytes.

## Fix

Both `toData()` overloads in `Sources/SwiftQL/Functions/TypeCastFunctions.swift` (`String` and `Optional<String>`) now emit `CAST(x AS BLOB)`. These were the only two places in the package that used `NONE` as a SQL type name.

## Tests

- `test_Text_ToData_CastsToBlob` / `test_OptionalTextReference_ToData_CastsToBlob` — SQL-text assertions that `toData()` emits `CAST(... AS BLOB)`
- `testStringToDataTypeofIsBlob` — execution test asserting `typeof()` of the `toData()` result is `'blob'`
- `testStringToDataRoundTrip` — execution test casting a string to data and comparing the fetched bytes with the expected UTF-8 bytes

Full test suite passes (`swift test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)