### PR TITLE
Fix VariableCaseWhenThen result type and constrain free when(_:then:)

### DIFF
--- a/Sources/SwiftQL/SQLCaseWhenThen.swift
+++ b/Sources/SwiftQL/SQLCaseWhenThen.swift
@@ -177,8 +177,8 @@ private struct VariableCaseComponents {
 
 
 public struct VariableCaseWhenThen<Result>: XLExpression {
-    
-    public typealias T = Optional<String>
+
+    public typealias T = Optional<Result>
 
     private let components: VariableCaseComponents
     
@@ -225,7 +225,7 @@ public struct VariableCaseElse<Result>: XLExpression {
 }
 
 
-public func when<Condition, Result>(_ condition: any XLExpression<Condition>, then result: any XLExpression<Result>) -> VariableCaseWhenThen<Result> {
+public func when<Condition, Result>(_ condition: any XLExpression<Condition>, then result: any XLExpression<Result>) -> VariableCaseWhenThen<Result> where Condition: XLBoolean {
     VariableCaseWhenThen(
         components: VariableCaseComponents(),
         condition: condition,

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -69,6 +69,14 @@ import SwiftQL
     let color: String?
 }
 
+@SQLTable struct PersonOptionalScore: Equatable {
+
+    let person: String
+
+    let score: Int?
+}
+
+
 @SQLTable struct Invoice: Equatable {
     
     let id: String
@@ -657,6 +665,49 @@ final class XLDocumentationTests: XCTestCase {
         ])
     }
     
+    func testExample_IfCaseWhenThen_IntegerResult() throws {
+        let statement = sqlQuery { schema in
+            let person = schema.table(Person.self)
+            let result = result {
+                PersonOptionalScore.SQLReader(
+                    person: person.name,
+                    score: when(person.name == "Yogi Bear", then: 100)
+                )
+            }
+            return select(result).from(person)
+        }
+        let sql = encoder.makeSQL(statement).sql
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(sql, "SELECT t0.name AS person, (CASE WHEN (t0.name == 'Yogi Bear') THEN 100 END) AS score FROM Person AS t0")
+        XCTAssertEqual(rows, [
+            PersonOptionalScore(person: "John Doe", score: nil),
+            PersonOptionalScore(person: "Jane Doe", score: nil),
+            PersonOptionalScore(person: "Yogi Bear", score: 100),
+        ])
+    }
+
+    func testExample_IfCaseWhenThen_IntegerResult_MultipleConditions() throws {
+        let statement = sqlQuery { schema in
+            let person = schema.table(Person.self)
+            let result = result {
+                PersonOptionalScore.SQLReader(
+                    person: person.name,
+                    score: when(person.name == "Yogi Bear", then: 100)
+                        .when(person.name == "John Doe", then: 50)
+                )
+            }
+            return select(result).from(person)
+        }
+        let sql = encoder.makeSQL(statement).sql
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(sql, "SELECT t0.name AS person, (CASE WHEN (t0.name == 'Yogi Bear') THEN 100 WHEN (t0.name == 'John Doe') THEN 50 END) AS score FROM Person AS t0")
+        XCTAssertEqual(rows, [
+            PersonOptionalScore(person: "John Doe", score: 50),
+            PersonOptionalScore(person: "Jane Doe", score: nil),
+            PersonOptionalScore(person: "Yogi Bear", score: 100),
+        ])
+    }
+
     func testExample_Date() throws {
         let statement = sqlQuery { schema in
             let invoice = schema.table(Invoice.self)

--- a/Tests/SQLTests/SQLSyntaxTests.swift
+++ b/Tests/SQLTests/SQLSyntaxTests.swift
@@ -443,7 +443,26 @@ final class XLSyntaxTests: XCTestCase {
     //        }
     //        XCTAssertEqual(encoder.makeSQL(expression), "CASE WHEN (:x == 12) THEN 'blue' ELSE 'red' END")
     //    }
-    
+
+
+    func test_SearchedCaseWhenThen_IntegerResult() {
+        let x = XLNamedBindingReference<Int>(name: "x")
+        let expression = when(x == 12, then: 42)
+        // A searched CASE without an ELSE evaluates to NULL when no condition
+        // matches, so the expression type is the optional of the result type.
+        let _: any XLExpression<Int?> = expression
+        XCTAssertTrue(VariableCaseWhenThen<Int>.T.self == Int?.self)
+        XCTAssertEqual(encoder.makeSQL(expression).sql, "(CASE WHEN (:x == 12) THEN 42 END)")
+    }
+
+
+    func test_SearchedCaseWhenThenElse_IntegerResult() {
+        let x = XLNamedBindingReference<Int>(name: "x")
+        let expression = when(x == 12, then: 42).else(7)
+        let _: any XLExpression<Int> = expression
+        XCTAssertEqual(encoder.makeSQL(expression).sql, "(CASE WHEN (:x == 12) THEN 42 ELSE 7 END)")
+    }
+
     
     // MARK: - IN
     


### PR DESCRIPTION
Fixes #104

## Problem

`VariableCaseWhenThen` (the builder for searched `CASE WHEN ... THEN ... END` expressions) declared:

```swift
public typealias T = Optional<String>
```

instead of `Optional<Result>` — a copy-paste artifact from an earlier String-specific version. A searched CASE built with `when(cond, then: someIntExpr)` (without an `else`) therefore statically claimed to be an `XLExpression` over `String?` regardless of its actual result type, so it type-checked against the wrong operator overloads and could not be used where a non-String optional result was expected. The constant-case counterpart `ConstantCaseWhenThen` already used `Optional<Result>` correctly.

Additionally, the free `when(_:then:)` function left its `Condition` generic parameter unconstrained (so `when(42, then: ...)` compiled), while the equivalent instance method correctly required `Condition: XLBoolean`.

## Changes

- `VariableCaseWhenThen.T` is now `Optional<Result>`, matching `ConstantCaseWhenThen`.
- The free `when(_:then:)` now requires `Condition: XLBoolean`, matching the instance method.

## Tests

- Syntax tests (`XLSyntaxTests`): a searched CASE with an `Int` result and no ELSE now statically conforms to `XLExpression<Int?>` (with a direct assertion that `VariableCaseWhenThen<Int>.T == Int?`), plus SQL generation for the with-ELSE variant.
- Execution tests (`XLDocumentationTests`): searched CASE with an `Int` result and no ELSE decodes matched rows as `Int?` and round-trips NULL for non-matching rows, for both single and chained `when` clauses.
- Full test suite passes (268 tests, 0 failures) — no existing code relied on the incorrect `Optional<String>` typealias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)