### PR TITLE
Throw structured errors for column read failures

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,0 +1,11 @@
+{
+  "task_name": "XLColumnReader: Throw an error when reading fails.",
+  "issue_number": 38,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/38",
+  "workspace_repo": "lukevanin/swiftql",
+  "codex_session_title": "lukevanin/swiftql#38 - Throw on column read failure",
+  "codex_session_id": "019f6ab7-ff93-71b2-977a-aa0d3f5c581b",
+  "codex_session_url": null,
+  "task_branch": "codex/38-xlcolumnreader-throw-on-read-failure",
+  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/38-xlcolumnreader-throw-on-read-failure"
+}

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -15,24 +15,46 @@ struct GRDBRowAdapter: XLColumnReader {
     
     let row: GRDB.Row
     
-    func isNull(at index: Int) -> Bool {
-        row.hasNull(atIndex: index)
+    func isNull(at index: Int) throws -> Bool {
+        try databaseValue(at: index, expectedType: nil).isNull
     }
     
-    func readInteger(at index: Int) -> Int {
-        row[index]
+    func readInteger(at index: Int) throws -> Int {
+        try read(Int.self, at: index)
     }
     
-    func readReal(at index: Int) -> Double {
-        row[index]
+    func readReal(at index: Int) throws -> Double {
+        try read(Double.self, at: index)
     }
     
-    func readText(at index: Int) -> String {
-        row[index]
+    func readText(at index: Int) throws -> String {
+        try read(String.self, at: index)
     }
     
-    func readBlob(at index: Int) -> Data {
-        row[index]
+    func readBlob(at index: Int) throws -> Data {
+        try read(Data.self, at: index)
+    }
+
+    private func read<Value>(_ type: Value.Type, at index: Int) throws -> Value where Value: DatabaseValueConvertible {
+        let expectedType = String(describing: type)
+        return try decode(
+            databaseValue: databaseValue(at: index, expectedType: expectedType),
+            as: type,
+            at: index
+        )
+    }
+
+    private func databaseValue(at index: Int, expectedType: String?) throws -> DatabaseValue {
+        guard index >= 0 && index < row.count else {
+            throw XLColumnReadError(
+                index: index,
+                expectedType: expectedType,
+                failure: .indexOutOfBounds(valueCount: row.count)
+            )
+        }
+        let values = row.databaseValues
+        let valueIndex = values.index(values.startIndex, offsetBy: index)
+        return values[valueIndex]
     }
 }
 
@@ -41,24 +63,82 @@ struct GRDBValuesAdapter: XLColumnReader {
     
     let values: [GRDB.DatabaseValue]
     
-    func isNull(at index: Int) -> Bool {
-        values[index].isNull
+    func isNull(at index: Int) throws -> Bool {
+        try databaseValue(at: index, expectedType: nil).isNull
     }
     
-    func readInteger(at index: Int) -> Int {
-        Int.fromDatabaseValue(values[index])!
+    func readInteger(at index: Int) throws -> Int {
+        try read(Int.self, at: index)
     }
     
-    func readReal(at index: Int) -> Double {
-        Double.fromDatabaseValue(values[index])!
+    func readReal(at index: Int) throws -> Double {
+        try read(Double.self, at: index)
     }
     
-    func readText(at index: Int) -> String {
-        String.fromDatabaseValue(values[index])!
+    func readText(at index: Int) throws -> String {
+        try read(String.self, at: index)
     }
     
-    func readBlob(at index: Int) -> Data {
-        Data.fromDatabaseValue(values[index])!
+    func readBlob(at index: Int) throws -> Data {
+        try read(Data.self, at: index)
+    }
+
+    private func read<Value>(_ type: Value.Type, at index: Int) throws -> Value where Value: DatabaseValueConvertible {
+        let expectedType = String(describing: type)
+        return try decode(
+            databaseValue: databaseValue(at: index, expectedType: expectedType),
+            as: type,
+            at: index
+        )
+    }
+
+    private func databaseValue(at index: Int, expectedType: String?) throws -> DatabaseValue {
+        guard values.indices.contains(index) else {
+            throw XLColumnReadError(
+                index: index,
+                expectedType: expectedType,
+                failure: .indexOutOfBounds(valueCount: values.count)
+            )
+        }
+        return values[index]
+    }
+}
+
+
+private func decode<Value>(databaseValue: DatabaseValue, as type: Value.Type, at index: Int) throws -> Value where Value: DatabaseValueConvertible {
+    let expectedType = String(describing: type)
+    guard !databaseValue.isNull else {
+        throw XLColumnReadError(
+            index: index,
+            expectedType: expectedType,
+            failure: .nullValue
+        )
+    }
+    guard let value = Value.fromDatabaseValue(databaseValue) else {
+        throw XLColumnReadError(
+            index: index,
+            expectedType: expectedType,
+            failure: .typeMismatch(actualType: databaseValue.storageClassName)
+        )
+    }
+    return value
+}
+
+
+private extension DatabaseValue {
+    var storageClassName: String {
+        switch storage {
+        case .null:
+            return "NULL"
+        case .int64:
+            return "INTEGER"
+        case .double:
+            return "REAL"
+        case .string:
+            return "TEXT"
+        case .blob:
+            return "BLOB"
+        }
     }
 }
 

--- a/Sources/SwiftQL/SQLExpression.swift
+++ b/Sources/SwiftQL/SQLExpression.swift
@@ -257,7 +257,14 @@ extension XLEnum {
         
     public init(reader: XLColumnReader, at index: Int) throws {
         let rawValue = try RawValue(reader: reader, at: index)
-        self = Self(rawValue: rawValue) ?? Self.sqlDefault()
+        guard let value = Self(rawValue: rawValue) else {
+            throw XLColumnReadError(
+                index: index,
+                expectedType: String(describing: Self.self),
+                failure: .invalidValue(actualValue: String(reflecting: rawValue))
+            )
+        }
+        self = value
     }
     
     public func bind(context: inout XLBindingContext) {
@@ -332,7 +339,7 @@ extension Optional: XLLiteral where Wrapped: XLLiteral {
     }
 
     public init(reader: XLColumnReader, at index: Int) throws {
-        if reader.isNull(at: index) {
+        if try reader.isNull(at: index) {
             self = nil
         }
         else {

--- a/Sources/SwiftQL/SQLMeta.swift
+++ b/Sources/SwiftQL/SQLMeta.swift
@@ -31,13 +31,83 @@ public class XLDatabaseMetadataObject: XLDatabaseMetadata {
 }
 
 
-// MARK: - Table
+// MARK: - Column reading
+
+
+///
+/// An error encountered while reading a typed value from a database result or
+/// custom-function argument.
+///
+public struct XLColumnReadError: Error, Equatable, LocalizedError, CustomStringConvertible, Sendable {
+
+    ///
+    /// The reason a value could not be read.
+    ///
+    public enum Failure: Equatable, Sendable {
+        /// The requested index was outside the available values.
+        case indexOutOfBounds(valueCount: Int)
+
+        /// A non-optional read encountered SQL `NULL`.
+        case nullValue
+
+        /// The SQLite storage class could not be converted to the requested type.
+        case typeMismatch(actualType: String)
+
+        /// The stored value could not be represented by the requested logical type.
+        case invalidValue(actualValue: String)
+    }
+
+    /// The zero-based column or argument index.
+    public let index: Int
+
+    /// The requested Swift type, when the read requested a typed value.
+    public let expectedType: String?
+
+    /// The reason the read failed.
+    public let failure: Failure
+
+    /// Creates a structured column-read error.
+    ///
+    /// - Parameters:
+    ///   - index: The zero-based column or argument index.
+    ///   - expectedType: The requested Swift type, if any.
+    ///   - failure: The reason the read failed.
+    public init(index: Int, expectedType: String?, failure: Failure) {
+        self.index = index
+        self.expectedType = expectedType
+        self.failure = failure
+    }
+
+    public var errorDescription: String? {
+        let location = "value at index \(index)"
+        switch failure {
+        case .indexOutOfBounds(let valueCount):
+            return "Cannot read \(location): index is outside a result containing \(valueCount) values."
+        case .nullValue:
+            return "Cannot read NULL \(location) as \(expectedType ?? "a non-optional value")."
+        case .typeMismatch(let actualType):
+            return "Cannot read \(actualType) \(location) as \(expectedType ?? "the requested type")."
+        case .invalidValue(let actualValue):
+            return "Cannot decode \(actualValue) \(location) as \(expectedType ?? "the requested type")."
+        }
+    }
+
+    public var description: String {
+        errorDescription ?? "Unable to read database value at index \(index)."
+    }
+}
 
 
 ///
 /// Reads the value for a column for a row returned from a select query.
 ///
 /// Used when reading results of a query returned by SQLite.
+///
+/// Readers use SQLite storage classes consistently for query results and
+/// custom-function arguments. Integer reads accept INTEGER and representable
+/// REAL values; real reads accept INTEGER and REAL; text reads accept TEXT and
+/// UTF-8 BLOB; and BLOB reads accept BLOB and the UTF-8 bytes of TEXT. Other
+/// storage-class conversions throw ``XLColumnReadError``.
 ///
 public protocol XLColumnReader {
     
@@ -47,8 +117,9 @@ public protocol XLColumnReader {
     /// - Parameter index: Index of the column to examine.
     ///
     /// - Returns: `true` if the column value is NULL.
+    /// - Throws: ``XLColumnReadError`` if `index` is outside the available values.
     ///
-    func isNull(at index: Int) -> Bool
+    func isNull(at index: Int) throws -> Bool
     
     ///
     /// Reads an integer value for a column at a given index.
@@ -56,8 +127,9 @@ public protocol XLColumnReader {
     /// - Parameter index: Index of the column to read.
     ///
     /// - Returns: Integer value for the column.
+    /// - Throws: ``XLColumnReadError`` if the value cannot be read as an integer.
     ///
-    func readInteger(at index: Int) -> Int
+    func readInteger(at index: Int) throws -> Int
     
     ///
     /// Reads a real number for a column at a given index.
@@ -65,8 +137,9 @@ public protocol XLColumnReader {
     /// - Parameter index: Index of the column to read.
     ///
     /// - Returns: Floating point value for the column.
+    /// - Throws: ``XLColumnReadError`` if the value cannot be read as a real number.
     ///
-    func readReal(at index: Int) -> Double
+    func readReal(at index: Int) throws -> Double
     
     ///
     /// Reads a text value for the column at a given index
@@ -74,8 +147,9 @@ public protocol XLColumnReader {
     /// - Parameter index: Index of the column to read.
     ///
     /// - Returns: String value for the column.
+    /// - Throws: ``XLColumnReadError`` if the value cannot be read as text.
     ///
-    func readText(at index: Int) -> String
+    func readText(at index: Int) throws -> String
     
     ///
     /// Reads a BLOB value for the column at a given index.
@@ -83,8 +157,9 @@ public protocol XLColumnReader {
     /// - Parameter index: Index of the column to read.
     ///
     /// - Returns: Data value for the column.
+    /// - Throws: ``XLColumnReadError`` if the value cannot be read as a BLOB.
     ///
-    func readBlob(at index: Int) -> Data
+    func readBlob(at index: Int) throws -> Data
 }
 
 
@@ -189,6 +264,9 @@ public protocol XLRowWritable<Row>: XLEncodable {
 }
 
 
+// MARK: - Result
+
+
 ///
 /// Metadata associated with a struct annotated with `@SQLResult`.
 ///
@@ -277,6 +355,9 @@ public protocol XLResult {
     ///
     static func makeSQLAnonymousNullableNamedResult(namespace: XLNamespace, dependency: XLNamedTableDeclaration) -> MetaNullableNamedResult
 }
+
+
+// MARK: - Table
 
 
 ///

--- a/Sources/SwiftQL/SwiftQL.docc/CustomFunctions.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomFunctions.md
@@ -64,10 +64,10 @@ public struct HaversineDistance: SQLCustomFunction {
     // Define the implementation details for how the function works. This is 
     // called at runtime from SQL, and the results are returned to SQL.
     public static func execute(reader: SQLColumnReader) throws -> Double {
-        let latA = radians(degrees: reader.readReal(at: 0))
-        let lonA = radians(degrees: reader.readReal(at: 1))
-        let latB = radians(degrees: reader.readReal(at: 2))
-        let lonB = radians(degrees: reader.readReal(at: 3))
+        let latA = try radians(degrees: reader.readReal(at: 0))
+        let lonA = try radians(degrees: reader.readReal(at: 1))
+        let latB = try radians(degrees: reader.readReal(at: 2))
+        let lonB = try radians(degrees: reader.readReal(at: 3))
         return acos(sin(latA) * sin(latB) + cos(latA) * cos(latB) * cos(lonB - lonA)) * 6371
     }
     

--- a/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
@@ -53,7 +53,7 @@ extension UUID: XLCustomType, XLEquatable, XLComparable {
     
     // 3. Initialize the custom type from a database field.
     public init(reader: XLColumnReader, at index: Int) throws {
-        let rawValue = reader.readText(at: index)
+        let rawValue = try reader.readText(at: index)
         guard let uuid =  UUID(uuidString: rawValue) else {
             throw InternalError.uuidInvalid(rawValue)
         }
@@ -168,8 +168,8 @@ extension Date: SQLCustomType, SQLEquatable, SQLComparable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) {
-        let rawValue = reader.readText(at: index)
+    public init(reader: XLColumnReader, at index: Int) throws {
+        let rawValue = try reader.readText(at: index)
         guard let date = self.dateFormatter.date(from: rawValue) else {
             throw InternalError.dateInvalid(rawValue)
         }
@@ -248,6 +248,10 @@ define a custom `MyUUID` standalone type which wraps a `UUID`:
 
 ```swift
 struct MyUUID: SQLCustomType, Equatable {
+
+    private enum ReadError: Error {
+        case invalidUUID(String)
+    }
     
     public typealias T = Self
     
@@ -257,8 +261,12 @@ struct MyUUID: SQLCustomType, Equatable {
         self.wrappedValue = wrappedValue
     }
     
-    public init(reader: XLColumnReader, at index: Int) {
-        wrappedValue = UUID(uuidString: reader.readText(at: index))!
+    public init(reader: XLColumnReader, at index: Int) throws {
+        let rawValue = try reader.readText(at: index)
+        guard let wrappedValue = UUID(uuidString: rawValue) else {
+            throw ReadError.invalidUUID(rawValue)
+        }
+        self.wrappedValue = wrappedValue
     }
     
     public func bind(context: inout XLBindingContext) {

--- a/Sources/SwiftQL/Types/Intrinsic.swift
+++ b/Sources/SwiftQL/Types/Intrinsic.swift
@@ -18,8 +18,8 @@ extension Bool: XLExpression, XLLiteral, XLEquatable, XLComparable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) {
-        self = reader.readInteger(at: index) != 0
+    public init(reader: XLColumnReader, at index: Int) throws {
+        self = try reader.readInteger(at: index) != 0
     }
     
     public func bind(context: inout XLBindingContext) {
@@ -43,8 +43,8 @@ extension Int: XLExpression, XLLiteral, XLEquatable, XLComparable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) {
-        self = reader.readInteger(at: index)
+    public init(reader: XLColumnReader, at index: Int) throws {
+        self = try reader.readInteger(at: index)
     }
     
     public func bind(context: inout XLBindingContext) {
@@ -68,8 +68,8 @@ extension Double: XLExpression, XLLiteral, XLEquatable, XLComparable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) {
-        self = reader.readReal(at: index)
+    public init(reader: XLColumnReader, at index: Int) throws {
+        self = try reader.readReal(at: index)
     }
     
     public func bind(context: inout XLBindingContext) {
@@ -97,8 +97,8 @@ extension String: XLExpression, XLLiteral, XLEquatable, XLComparable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) {
-        self = reader.readText(at: index)
+    public init(reader: XLColumnReader, at index: Int) throws {
+        self = try reader.readText(at: index)
     }
     
     public func bind(context: inout XLBindingContext) {
@@ -122,8 +122,8 @@ extension Data: XLExpression, XLLiteral, XLEquatable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) {
-        self = reader.readBlob(at: index)
+    public init(reader: XLColumnReader, at index: Int) throws {
+        self = try reader.readBlob(at: index)
     }
     
     public func bind(context: inout XLBindingContext) {

--- a/Tests/SQLTests/SQLColumnReadErrorTests.swift
+++ b/Tests/SQLTests/SQLColumnReadErrorTests.swift
@@ -1,0 +1,271 @@
+import Foundation
+import GRDB
+import XCTest
+@testable import SwiftQL
+
+
+enum ColumnReadTestStatus: Int, XLEnum {
+    typealias T = Self
+
+    case ready = 1
+
+    static func sqlDefault() -> ColumnReadTestStatus {
+        .ready
+    }
+}
+
+
+@SQLTable(name: "ColumnReadStatus")
+struct ColumnReadStatusRow: Equatable {
+    let status: ColumnReadTestStatus
+}
+
+
+struct ColumnReadIntegerFunction: XLCustomFunction {
+    typealias T = Int
+
+    static let definition = XLCustomFunctionDefinition(
+        name: "columnReadInteger",
+        numberOfArguments: 1
+    )
+
+    private let value: any XLExpression<Int?>
+
+    init(_ value: any XLExpression<Int?>) {
+        self.value = value
+    }
+
+    func makeSQL(context: inout XLBuilder) {
+        context.simpleFunction(name: Self.definition.name) { context in
+            context.listItem(expression: value.makeSQL)
+        }
+    }
+
+    static func execute(reader: XLColumnReader) throws -> Int {
+        try reader.readInteger(at: 0)
+    }
+}
+
+
+final class XLColumnReadErrorTests: XCTestCase {
+    private var database: GRDBDatabase!
+    private var databasePool: DatabasePool!
+    private var databaseDirectoryURL: URL!
+
+    override func setUpWithError() throws {
+        databaseDirectoryURL = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(
+            at: databaseDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        let fileURL = databaseDirectoryURL.appending(path: "database.sqlite", directoryHint: .notDirectory)
+        var builder = try GRDBDatabaseBuilder(
+            url: fileURL,
+            configuration: Configuration(),
+            logger: nil
+        )
+        builder.addFunction(ColumnReadIntegerFunction.self)
+        database = try builder.build()
+        databasePool = database.databasePool
+    }
+
+    override func tearDown() {
+        databasePool = nil
+        database = nil
+        try? FileManager.default.removeItem(at: databaseDirectoryURL)
+        databaseDirectoryURL = nil
+    }
+
+    func testGRDBRowAdapterReadsIntrinsicValuesAndOptionalNull() throws {
+        let row = try fetchRow(sql: "SELECT 42, 1.5, 'text', X'00FF', NULL")
+        let reader = GRDBRowAdapter(row: row)
+
+        XCTAssertEqual(try reader.readInteger(at: 0), 42)
+        XCTAssertEqual(try reader.readReal(at: 1), 1.5)
+        XCTAssertEqual(try reader.readText(at: 2), "text")
+        XCTAssertEqual(try reader.readBlob(at: 3), Data([0x00, 0xff]))
+        XCTAssertTrue(try reader.isNull(at: 4))
+        XCTAssertNil(try Int?(reader: reader, at: 4))
+    }
+
+    func testAdaptersUseStorageClassConversionsConsistently() throws {
+        let rowReader = GRDBRowAdapter(
+            row: try fetchRow(sql: "SELECT 42, 42.75, X'74657874', 'blob'")
+        )
+        let valuesReader = GRDBValuesAdapter(values: [
+            42.databaseValue,
+            42.75.databaseValue,
+            Data("text".utf8).databaseValue,
+            "blob".databaseValue,
+        ])
+
+        for reader in [rowReader as any XLColumnReader, valuesReader as any XLColumnReader] {
+            XCTAssertEqual(try reader.readReal(at: 0), 42)
+            XCTAssertEqual(try reader.readInteger(at: 1), 42)
+            XCTAssertEqual(try reader.readText(at: 2), "text")
+            XCTAssertEqual(try reader.readBlob(at: 3), Data("blob".utf8))
+            assertColumnReadError(
+                try reader.readText(at: 0),
+                equals: XLColumnReadError(
+                    index: 0,
+                    expectedType: "String",
+                    failure: .typeMismatch(actualType: "INTEGER")
+                )
+            )
+        }
+    }
+
+    func testGRDBRowAdapterThrowsStructuredErrors() throws {
+        let reader = GRDBRowAdapter(row: try fetchRow(sql: "SELECT NULL, 'text'"))
+
+        assertColumnReadError(
+            try reader.readInteger(at: 0),
+            equals: XLColumnReadError(
+                index: 0,
+                expectedType: "Int",
+                failure: .nullValue
+            )
+        )
+        assertColumnReadError(
+            try reader.readInteger(at: 1),
+            equals: XLColumnReadError(
+                index: 1,
+                expectedType: "Int",
+                failure: .typeMismatch(actualType: "TEXT")
+            )
+        )
+        assertColumnReadError(
+            try reader.readInteger(at: 2),
+            equals: XLColumnReadError(
+                index: 2,
+                expectedType: "Int",
+                failure: .indexOutOfBounds(valueCount: 2)
+            )
+        )
+        assertColumnReadError(
+            try reader.isNull(at: -1),
+            equals: XLColumnReadError(
+                index: -1,
+                expectedType: nil,
+                failure: .indexOutOfBounds(valueCount: 2)
+            )
+        )
+    }
+
+    func testGRDBValuesAdapterThrowsStructuredErrors() {
+        let reader = GRDBValuesAdapter(values: [DatabaseValue.null, "text".databaseValue])
+
+        assertColumnReadError(
+            try reader.readInteger(at: 0),
+            equals: XLColumnReadError(
+                index: 0,
+                expectedType: "Int",
+                failure: .nullValue
+            )
+        )
+        assertColumnReadError(
+            try reader.readInteger(at: 1),
+            equals: XLColumnReadError(
+                index: 1,
+                expectedType: "Int",
+                failure: .typeMismatch(actualType: "TEXT")
+            )
+        )
+        assertColumnReadError(
+            try reader.readInteger(at: 2),
+            equals: XLColumnReadError(
+                index: 2,
+                expectedType: "Int",
+                failure: .indexOutOfBounds(valueCount: 2)
+            )
+        )
+    }
+
+    func testFetchOnePropagatesNullReadError() throws {
+        try databasePool.write { database in
+            try database.execute(sql: "CREATE TABLE Test (id TEXT NOT NULL, value INTEGER)")
+            try database.execute(sql: "INSERT INTO Test (id, value) VALUES ('row', NULL)")
+        }
+        let statement = sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+        }
+
+        assertColumnReadError(
+            try database.makeRequest(with: statement).fetchOne(),
+            equals: XLColumnReadError(
+                index: 1,
+                expectedType: "Int",
+                failure: .nullValue
+            )
+        )
+    }
+
+    func testEnumReaderRejectsUnknownRawValue() throws {
+        try databasePool.write { database in
+            try database.execute(sql: "CREATE TABLE ColumnReadStatus (status INTEGER NOT NULL)")
+            try database.execute(sql: "INSERT INTO ColumnReadStatus (status) VALUES (99)")
+        }
+        let statement = sql { schema in
+            let table = schema.table(ColumnReadStatusRow.self)
+            Select(table)
+            From(table)
+        }
+
+        assertColumnReadError(
+            try database.makeRequest(with: statement).fetchOne(),
+            equals: XLColumnReadError(
+                index: 0,
+                expectedType: "ColumnReadTestStatus",
+                failure: .invalidValue(actualValue: "99")
+            )
+        )
+    }
+
+    func testEnumReaderAcceptsKnownRawValue() throws {
+        try databasePool.write { database in
+            try database.execute(sql: "CREATE TABLE ColumnReadStatus (status INTEGER NOT NULL)")
+            try database.execute(sql: "INSERT INTO ColumnReadStatus (status) VALUES (1)")
+        }
+        let statement = sql { schema in
+            let table = schema.table(ColumnReadStatusRow.self)
+            Select(table)
+            From(table)
+        }
+
+        XCTAssertEqual(
+            try database.makeRequest(with: statement).fetchOne(),
+            ColumnReadStatusRow(status: .ready)
+        )
+    }
+
+    func testCustomFunctionTurnsNullReadIntoSQLiteError() throws {
+        XCTAssertThrowsError(
+            try databasePool.read { database in
+                try Int.fetchOne(database, sql: "SELECT columnReadInteger(NULL)")
+            }
+        ) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("Cannot read NULL value at index 0 as Int."), message)
+        }
+    }
+
+    private func fetchRow(sql: String) throws -> Row {
+        try databasePool.read { database in
+            try XCTUnwrap(Row.fetchOne(database, sql: sql))
+        }
+    }
+
+    private func assertColumnReadError<T>(
+        _ expression: @autoclosure () throws -> T,
+        equals expectedError: XLColumnReadError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try expression(), file: file, line: line) { error in
+            XCTAssertEqual(error as? XLColumnReadError, expectedError, file: file, line: line)
+        }
+    }
+}

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -144,8 +144,8 @@ extension Date: XLCustomType, XLEquatable, XLComparable {
     public typealias T = Self
     
     // Decode the date from an XL result.
-    public init(reader: XLColumnReader, at index: Int) {
-        let rawValue = reader.readReal(at: index)
+    public init(reader: XLColumnReader, at index: Int) throws {
+        let rawValue = try reader.readReal(at: index)
         self = Date(julianDay: rawValue)!
     }
     
@@ -231,10 +231,10 @@ public struct HaversineDistance: XLCustomFunction {
     // Define the implementation details for how the function works. This is called at runtime from XL, and the results
     // are returned to XL.
     public static func execute(reader: XLColumnReader) throws -> Double {
-        let latA = radians(degrees: reader.readReal(at: 0))
-        let lonA = radians(degrees: reader.readReal(at: 1))
-        let latB = radians(degrees: reader.readReal(at: 2))
-        let lonB = radians(degrees: reader.readReal(at: 3))
+        let latA = try radians(degrees: reader.readReal(at: 0))
+        let lonA = try radians(degrees: reader.readReal(at: 1))
+        let latB = try radians(degrees: reader.readReal(at: 2))
+        let lonB = try radians(degrees: reader.readReal(at: 3))
         return acos(sin(latA) * sin(latB) + cos(latA) * cos(latB) * cos(lonB - lonA)) * 6371
     }
     

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -665,6 +665,10 @@ final class XLExecutionTests: XCTestCase {
     func testCreateGenericTableWithObjectValue() throws {
         
         struct Wrapper: XLCustomType, Equatable {
+
+            private enum ReadError: Error {
+                case invalidUUID(String)
+            }
             
             public typealias T = Self
             
@@ -674,8 +678,12 @@ final class XLExecutionTests: XCTestCase {
                 self.wrappedValue = wrappedValue
             }
             
-            public init(reader: XLColumnReader, at index: Int) {
-                wrappedValue = UUID(uuidString: reader.readText(at: index))!
+            public init(reader: XLColumnReader, at index: Int) throws {
+                let rawValue = try reader.readText(at: index)
+                guard let wrappedValue = UUID(uuidString: rawValue) else {
+                    throw ReadError.invalidUUID(rawValue)
+                }
+                self.wrappedValue = wrappedValue
             }
             
             public func bind(context: inout XLBindingContext) {


### PR DESCRIPTION
## Summary

- make every `XLColumnReader` operation throwing
- add public, structured `XLColumnReadError` values for bounds, NULL, storage-class mismatch, and invalid logical values
- use one safe decoding contract for query rows and custom-function arguments
- reject unknown `XLEnum` raw values instead of substituting `sqlDefault()`
- update custom-type/function examples and remove their remaining invalid-UUID read trap

## Requirement evidence

- [x] NULL, wrong storage class, and invalid indexes throw instead of trapping
- [x] `GRDBRowAdapter` no longer uses GRDB's `try!` typed subscript
- [x] `GRDBValuesAdapter` no longer force-unwraps conversions
- [x] row and function-argument adapters share documented storage-class conversion behavior
- [x] optional NULL values still decode as `nil`
- [x] invalid enum raw values throw; valid raw values still decode
- [x] `fetchOne()` propagates the structured error
- [x] custom-function read failures become catchable SQLite errors

## Validation

- `swift test --filter XLColumnReadErrorTests` — 8 tests passed
- `swift test` — 280 tests passed
- `git diff --check` — clean

## Task identity

- Repository: `lukevanin/swiftql`
- Issue: #38
- Branch: `codex/38-xlcolumnreader-throw-on-read-failure`
- Worktree: `/Users/lukevanin/Developer/Luke/swiftql-worktrees/38-xlcolumnreader-throw-on-read-failure`
- Session: `019f6ab7-ff93-71b2-977a-aa0d3f5c581b`

## Scope note

`fetchAll()` still suppresses row-decoding errors; that separate propagation defect remains tracked by #109 and should land next.

Closes #38