### PR TITLE
Add a downstream Swift 5 language-mode compatibility fixture

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,7 +1,0 @@
-{
-  "issue": 153,
-  "title": "Add a downstream Swift 5 language-mode compatibility fixture",
-  "url": "https://github.com/lukevanin/swiftql/issues/153",
-  "branch": "codex/153-downstream-swift5-fixture",
-  "session_id": "019f6ab7-ff93-71b2-977a-aa0d3f5c581b"
-}

--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,0 +1,7 @@
+{
+  "issue": 153,
+  "title": "Add a downstream Swift 5 language-mode compatibility fixture",
+  "url": "https://github.com/lukevanin/swiftql/issues/153",
+  "branch": "codex/153-downstream-swift5-fixture",
+  "session_id": "019f6ab7-ff93-71b2-977a-aa0d3f5c581b"
+}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -81,7 +81,9 @@ jobs:
             mkdir -p "$source_directory"
             git archive --format=tar HEAD | tar -xf - -C "$source_directory"
             rm "$source_directory/Package.resolved"
+            rm "$source_directory/IntegrationTests/Swift5Client/Package.resolved"
             test ! -e "$source_directory/Package.resolved"
+            test ! -e "$source_directory/IntegrationTests/Swift5Client/Package.resolved"
           fi
           printf 'SWIFTQL_SOURCE=%s\n' "$source_directory" >> "$GITHUB_ENV"
 
@@ -160,6 +162,18 @@ jobs:
           cd "$SWIFTQL_SOURCE"
           scripts/ci/check-strict-concurrency.sh \
             "$RUNNER_TEMP/swift-strict-concurrency.log"
+
+      - name: Run downstream Swift 5 language-mode client
+        if: ${{ matrix.swift_series == '6.0' }}
+        env:
+          RESOLUTION_MODE: ${{ matrix.resolution }}
+          SWIFTQL_DOWNSTREAM_SCRATCH_PATH: ${{ runner.temp }}/swift5-client-build
+        run: |
+          set -euo pipefail
+          cd "$SWIFTQL_SOURCE"
+          scripts/ci/check-downstream-swift5-client.sh \
+            "$RESOLUTION_MODE" \
+            "$RUNNER_TEMP/swift5-client.log"
 
       - name: Verify checkout remains clean
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Added an external Swift package fixture that uses SwiftQL's public macros,
+  typed queries, binding, and SQLite execution from Swift 5 language mode under
+  the supported Swift 6 compiler. CI runs it with pinned and clean resolution.
 - Added a reproducible `swiftql-benchmark` executable that reports raw samples,
   median, and p95 for SwiftQL construction/rendering, uncached SQLite
   preparation, statement-cache hits, reset/binding, execution, and production

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -77,6 +77,47 @@ xcrun swift test --skip-build -v
 
 The workflow is the canonical executable specification for both procedures.
 
+## Downstream Swift 5 language-mode client
+
+The supported Swift 6 compiler also builds and runs
+[`IntegrationTests/Swift5Client`](IntegrationTests/Swift5Client) as an external
+package. The fixture depends on the repository root through SwiftPM, imports
+only the public `SwiftQL` product, expands representative `@SQLTable` and
+`@SQLResult` macros, constructs a typed query, binds a named value, and executes
+the query against a temporary SQLite database.
+
+The fixture's manifest explicitly selects Swift 5 language mode. Compile-time
+guards fail if it is built by a pre-Swift-6 compiler or if a Swift 6 compiler
+silently enables Swift 6 language mode. Run its committed-resolution path with:
+
+```sh
+export DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer
+SWIFTQL_DOWNSTREAM_SCRATCH_PATH="$(mktemp -d)" \
+  scripts/ci/check-downstream-swift5-client.sh committed
+```
+
+The committed fixture lockfile must remain byte-identical to the repository
+lockfile. The clean-resolution CI source export removes both lockfiles before
+resolution, then runs the same checker in `clean` mode. To reproduce that path
+without modifying the checkout:
+
+```sh
+clean_source="$(mktemp -d)"
+git archive --format=tar HEAD | tar -xf - -C "$clean_source"
+rm "$clean_source/Package.resolved"
+rm "$clean_source/IntegrationTests/Swift5Client/Package.resolved"
+cd "$clean_source"
+
+xcrun swift package resolve
+SWIFTQL_DOWNSTREAM_SCRATCH_PATH="$(mktemp -d)" \
+  scripts/ci/check-downstream-swift5-client.sh clean
+```
+
+The checker performs a clean fixture build, requires exactly one runtime success
+marker, and keeps build products outside the source tree. The compatibility
+matrix runs both fixture resolution paths only in its pinned Swift 6.0 cells;
+the ordinary package matrix continues to prove Swift 5.9 compiler support.
+
 ## Complete strict concurrency
 
 SwiftQL's supported Swift 6 compiler also checks every first-party product and

--- a/IntegrationTests/Swift5Client/.gitignore
+++ b/IntegrationTests/Swift5Client/.gitignore
@@ -1,0 +1,2 @@
+/.build
+/.swiftpm

--- a/IntegrationTests/Swift5Client/Package.resolved
+++ b/IntegrationTests/Swift5Client/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin.git",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/IntegrationTests/Swift5Client/Package.swift
+++ b/IntegrationTests/Swift5Client/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftQLSwift5Client",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(name: "SwiftQL", path: "../.."),
+    ],
+    targets: [
+        .executableTarget(
+            name: "SwiftQLSwift5Client",
+            dependencies: [
+                .product(name: "SwiftQL", package: "SwiftQL"),
+            ]
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -26,51 +26,49 @@ enum FixtureError: Error {
     case unexpectedResult(PersonSummary?)
 }
 
-@main
-struct SwiftQLSwift5Client {
-    static func main() throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("swiftql-swift5-client-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(
-            at: directory,
-            withIntermediateDirectories: false
-        )
-        defer { try? FileManager.default.removeItem(at: directory) }
+private func executeFixture(databaseURL: URL) throws -> PersonSummary? {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+    try database.makeRequest(with: sqlCreate(Person.self)).execute()
+    try database.makeRequest(
+        with: sqlInsert(Person(id: "ada", name: "Ada Lovelace", age: 36))
+    ).execute()
+    try database.makeRequest(
+        with: sqlInsert(Person(id: "grace", name: "Grace Hopper", age: 85))
+    ).execute()
 
-        let result = try executeFixture(
-            databaseURL: directory.appendingPathComponent("fixture.sqlite")
-        )
-        guard result == PersonSummary(name: "Grace Hopper", age: 85) else {
-            throw FixtureError.unexpectedResult(result)
-        }
-
-        print("SWIFTQL_DOWNSTREAM_SWIFT5_CLIENT ok")
-    }
-
-    private static func executeFixture(databaseURL: URL) throws -> PersonSummary? {
-        let database = try GRDBDatabase(url: databaseURL, logger: nil)
-        try database.makeRequest(with: sqlCreate(Person.self)).execute()
-        try database.makeRequest(
-            with: sqlInsert(Person(id: "ada", name: "Ada Lovelace", age: 36))
-        ).execute()
-        try database.makeRequest(
-            with: sqlInsert(Person(id: "grace", name: "Grace Hopper", age: 85))
-        ).execute()
-
-        let id = XLNamedBindingReference<String>(name: "id")
-        let statement = sql { schema in
-            let person = schema.table(Person.self)
-            Select(
-                PersonSummary.columns(
-                    name: person.name,
-                    age: person.age
-                )
+    let id = XLNamedBindingReference<String>(name: "id")
+    let statement = sql { schema in
+        let person = schema.table(Person.self)
+        Select(
+            PersonSummary.columns(
+                name: person.name,
+                age: person.age
             )
-            From(person)
-            Where(person.id == id)
-        }
-        var request = database.makeRequest(with: statement)
-        request.set(id, "grace")
-        return try request.fetchOne()
+        )
+        From(person)
+        Where(person.id == id)
+    }
+    var request = database.makeRequest(with: statement)
+    request.set(id, "grace")
+    return try request.fetchOne()
+}
+
+private func runFixture() throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("swiftql-swift5-client-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+        at: directory,
+        withIntermediateDirectories: false
+    )
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let result = try executeFixture(
+        databaseURL: directory.appendingPathComponent("fixture.sqlite")
+    )
+    guard result == PersonSummary(name: "Grace Hopper", age: 85) else {
+        throw FixtureError.unexpectedResult(result)
     }
 }
+
+try runFixture()
+print("SWIFTQL_DOWNSTREAM_SWIFT5_CLIENT ok")

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -1,0 +1,76 @@
+import Foundation
+import SwiftQL
+
+#if compiler(<6.0)
+#error("The downstream compatibility fixture must use the supported Swift 6 compiler.")
+#endif
+
+#if swift(>=6.0)
+#error("The downstream compatibility fixture must remain in Swift 5 language mode.")
+#endif
+
+@SQLTable(name: "DownstreamPerson")
+struct Person: Equatable {
+    let id: String
+    let name: String
+    let age: Int
+}
+
+@SQLResult
+struct PersonSummary: Equatable {
+    let name: String
+    let age: Int
+}
+
+enum FixtureError: Error {
+    case unexpectedResult(PersonSummary?)
+}
+
+@main
+struct SwiftQLSwift5Client {
+    static func main() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftql-swift5-client-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let result = try executeFixture(
+            databaseURL: directory.appendingPathComponent("fixture.sqlite")
+        )
+        guard result == PersonSummary(name: "Grace Hopper", age: 85) else {
+            throw FixtureError.unexpectedResult(result)
+        }
+
+        print("SWIFTQL_DOWNSTREAM_SWIFT5_CLIENT ok")
+    }
+
+    private static func executeFixture(databaseURL: URL) throws -> PersonSummary? {
+        let database = try GRDBDatabase(url: databaseURL, logger: nil)
+        try database.makeRequest(with: sqlCreate(Person.self)).execute()
+        try database.makeRequest(
+            with: sqlInsert(Person(id: "ada", name: "Ada Lovelace", age: 36))
+        ).execute()
+        try database.makeRequest(
+            with: sqlInsert(Person(id: "grace", name: "Grace Hopper", age: 85))
+        ).execute()
+
+        let id = XLNamedBindingReference<String>(name: "id")
+        let statement = sql { schema in
+            let person = schema.table(Person.self)
+            Select(
+                PersonSummary.columns(
+                    name: person.name,
+                    age: person.age
+                )
+            )
+            From(person)
+            Where(person.id == id)
+        }
+        var request = database.makeRequest(with: statement)
+        request.set(id, "grace")
+        return try request.fetchOne()
+    }
+}

--- a/scripts/ci/check-downstream-swift5-client.sh
+++ b/scripts/ci/check-downstream-swift5-client.sh
@@ -36,6 +36,11 @@ main() {
         cmp "$source_root/Package.resolved" "$fixture_root/Package.resolved"
     else
         test ! -e "$fixture_root/Package.resolved"
+        xcrun swift package \
+            --package-path "$fixture_root" \
+            --scratch-path "$scratch_path" \
+            resolve
+        test -f "$fixture_root/Package.resolved"
     fi
 
     xcrun swift package \

--- a/scripts/ci/check-downstream-swift5-client.sh
+++ b/scripts/ci/check-downstream-swift5-client.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+main() {
+    local resolution_mode
+    local source_root
+    local fixture_root
+    local scratch_path
+    local output_log
+    local marker_count
+
+    if [[ "$#" -gt 2 ]]; then
+        printf 'usage: %s [committed|clean] [OUTPUT_LOG]\n' "$0" >&2
+        return 64
+    fi
+
+    resolution_mode="${1:-committed}"
+    case "$resolution_mode" in
+        committed|clean)
+            ;;
+        *)
+            printf 'error: unsupported resolution mode: %s\n' "$resolution_mode" >&2
+            return 64
+            ;;
+    esac
+
+    source_root="$(cd "$(dirname "$0")/../.." && pwd -P)"
+    fixture_root="$source_root/IntegrationTests/Swift5Client"
+    scratch_path="${SWIFTQL_DOWNSTREAM_SCRATCH_PATH:-${TMPDIR:-/tmp}/swiftql-swift5-client-build}"
+    output_log="${2:-${TMPDIR:-/tmp}/swiftql-swift5-client.log}"
+
+    if [[ "$resolution_mode" == "committed" ]]; then
+        test -f "$source_root/Package.resolved"
+        test -f "$fixture_root/Package.resolved"
+        cmp "$source_root/Package.resolved" "$fixture_root/Package.resolved"
+    else
+        test ! -e "$fixture_root/Package.resolved"
+    fi
+
+    xcrun swift package \
+        --package-path "$fixture_root" \
+        --scratch-path "$scratch_path" \
+        clean
+    xcrun swift run \
+        --package-path "$fixture_root" \
+        --scratch-path "$scratch_path" \
+        --force-resolved-versions \
+        -v 2>&1 | tee "$output_log"
+
+    marker_count="$(grep -c '^SWIFTQL_DOWNSTREAM_SWIFT5_CLIENT ok$' "$output_log" || true)"
+    if [[ "$marker_count" -ne 1 ]]; then
+        printf 'error: expected one downstream client success marker; found %s\n' \
+            "$marker_count" >&2
+        return 1
+    fi
+
+    test -f "$fixture_root/Package.resolved"
+    if [[ "$resolution_mode" == "committed" ]]; then
+        cmp "$source_root/Package.resolved" "$fixture_root/Package.resolved"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Closes #153

## Summary

- add a standalone SwiftPM executable that depends on the repository as a real package and imports only the public `SwiftQL` product
- prove Swift 6 compiler / Swift 5 language-mode consumption with compile guards while exercising `@SQLTable`, `@SQLResult`, typed projection, named binding, and temporary SQLite execution
- add a fail-closed runner for committed and clean dependency resolution, with an external scratch path and exact runtime marker
- run the fixture in both Swift 6.0 compatibility lanes and document local reproduction

## Validation

- committed-resolution downstream fixture — passed on local Swift 6.3.2 in Swift 5 language mode
- clean exported-source downstream fixture — passed on local Swift 6.3.2 in Swift 5 language mode
- full `swift test --scratch-path /Users/lukevanin/Developer/Luke/swiftql/.build` — 340 tests passed
- fixture manifest dump confirms tools 5.9 and `swiftLanguageVersions: [.v5]`
- workflow YAML parse, Bash 3.2 syntax, invalid-mode negative check, lockfile tracking/comparison, `git diff --check`, and checkout cleanliness passed
- three independent reviews completed; clean-lock sequencing and portable entry-point findings were fixed and re-reviewed

Pinned Xcode 16.2 / Swift 6.0 CI in both committed and clean resolution modes remains the required merge gate.