### PR TITLE
Fix Pages workflow context validation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
       artifact_id: ${{ steps.pages-artifact.outputs.artifact_id }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
-      DOCS_OUTPUT: ${{ runner.temp }}/swiftql-docs
+      DOCS_OUTPUT: ${{ github.workspace }}/../swiftql-docs
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Fixes the zero-job GitHub Actions schema failure discovered while verifying #151.

The job-level environment now derives the DocC output directory from the `github.workspace` context, which is valid at workflow evaluation time, instead of the step-only `runner` context.

Validation:
- GitHub workflow schema validation and pull-request artifact build (this PR)
- `git diff --check`
- YAML parse with Ruby/Psych

Refs #151