### PR TITLE
Date the v1.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.1.0] - Unreleased
+## [1.1.0] - 2026-07-17
 
 ### Added
 


### PR DESCRIPTION
## Summary

- finalize the v1.1.0 changelog heading with the 2026-07-17 release date
- satisfy the production-only changelog gate before the immutable `v1.1.0` tag is created

Refs #119

## Validation

- `scripts/ci/check-release-changelog.sh v1.1.0 v1.1.0`
- `git diff --check`
- `swift test --filter SQLDocumentationCatalogTests.testREADMERepositoryLinksResolveWithExactCase`

This PR intentionally does not close #119; the production safeguards, release publication, artifact verification, and closeout remain outstanding.