### PR TITLE
Capture reproducible first-party Swift source coverage

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,0 +1,11 @@
+{
+  "task_name": "Capture reproducible first-party Swift source coverage",
+  "issue_number": 189,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/189",
+  "workspace_repo": "lukevanin/swiftql",
+  "codex_session_title": "lukevanin/swiftql#189 - Capture reproducible first-party Swift source coverage",
+  "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
+  "codex_session_url": null,
+  "task_branch": "codex/189-capture-reproducible-first-party-swift-source-coverage",
+  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/189-capture-reproducible-first-party-swift-source-coverage"
+}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,12 +31,122 @@ jobs:
           set -euo pipefail
           bash -n scripts/ci/*.sh
           python3 -c \
-            'import ast, pathlib; ast.parse(pathlib.Path("scripts/ci/release-archive.py").read_text())'
+            'import ast, pathlib; [ast.parse(path.read_text()) for path in pathlib.Path("scripts/ci").glob("*.py")]'
           ruby -e \
             'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |path| YAML.parse_file(path) }'
 
       - name: Run release workflow fixtures
         run: scripts/ci/test-release-workflow.sh
+
+      - name: Run source coverage reporting fixtures
+        run: python3 scripts/ci/test-source-coverage-report.py
+
+      - name: Verify checkout remains clean
+        run: |
+          git diff --exit-code
+          test -z "$(git status --porcelain)"
+
+  coverage:
+    name: Swift 6.0 / first-party source coverage
+    runs-on: macos-15
+    timeout-minutes: 60
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+
+    steps:
+      - name: Check out exact source commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact source commit
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+
+      - name: Validate pinned Swift 6 coverage environment
+        env:
+          EXPECTED_XCODE_VERSION: "16.2"
+          EXPECTED_XCODE_BUILD: 16C5032a
+          EXPECTED_SWIFT_SERIES: "6.0"
+          EXPECTED_SDK_VERSION: "15.2"
+          EXPECTED_DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+        run: scripts/ci/check-compatibility-environment.sh
+
+      - name: Run source coverage reporting fixtures
+        run: python3 scripts/ci/test-source-coverage-report.py
+
+      - name: Capture first clean coverage run
+        id: coverage-run-1
+        env:
+          SWIFTQL_COVERAGE_SCRATCH_PATH: ${{ runner.temp }}/swiftql-coverage-build-1
+        run: |
+          scripts/ci/run-source-coverage.sh \
+            "$RUNNER_TEMP/swiftql-coverage-run-1"
+
+      - name: Capture second clean coverage run
+        id: coverage-run-2
+        env:
+          SWIFTQL_COVERAGE_SCRATCH_PATH: ${{ runner.temp }}/swiftql-coverage-build-2
+        run: |
+          scripts/ci/run-source-coverage.sh \
+            "$RUNNER_TEMP/swiftql-coverage-run-2"
+
+      - name: Verify reproducible first-party source selection
+        id: coverage-reproducibility
+        run: |
+          scripts/ci/verify-source-coverage-reproducibility.sh \
+            "$RUNNER_TEMP/swiftql-coverage-run-1" \
+            "$RUNNER_TEMP/swiftql-coverage-run-2" \
+            "$RUNNER_TEMP/swiftql-coverage-run-1/reproducibility.json"
+          cat "$RUNNER_TEMP/swiftql-coverage-run-1/summary.md" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prepare retained source coverage evidence
+        if: ${{ always() && !cancelled() }}
+        env:
+          FIRST_CAPTURE_OUTCOME: ${{ steps.coverage-run-1.outcome }}
+          SECOND_CAPTURE_OUTCOME: ${{ steps.coverage-run-2.outcome }}
+          REPRODUCIBILITY_OUTCOME: ${{ steps.coverage-reproducibility.outcome }}
+        run: |
+          set -euo pipefail
+          for run in 1 2; do
+            directory="$RUNNER_TEMP/swiftql-coverage-run-$run"
+            mkdir -p "$directory"
+            if [[ ! -e "$directory/first-party-coverage.json" ]]; then
+              printf 'Capture did not produce a normalized report.\n' \
+                > "$directory/capture-status.txt"
+            fi
+          done
+          {
+            printf 'first_capture=%s\n' "$FIRST_CAPTURE_OUTCOME"
+            printf 'second_capture=%s\n' "$SECOND_CAPTURE_OUTCOME"
+            printf 'reproducibility=%s\n' "$REPRODUCIBILITY_OUTCOME"
+          } > "$RUNNER_TEMP/swiftql-coverage-run-1/workflow-step-outcomes.txt"
+
+      - name: Upload retained source coverage evidence
+        id: coverage-artifact
+        if: ${{ always() && !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: swiftql-source-coverage-${{ github.sha }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/swiftql-coverage-run-1
+            ${{ runner.temp }}/swiftql-coverage-run-2
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 9
+
+      - name: Link retained evidence from the job summary
+        if: ${{ always() && !cancelled() && steps.coverage-artifact.outcome == 'success' }}
+        env:
+          ARTIFACT_URL: ${{ steps.coverage-artifact.outputs.artifact-url }}
+          ARTIFACT_DIGEST: ${{ steps.coverage-artifact.outputs.artifact-digest }}
+        run: |
+          printf '\n## Retained raw evidence\n\n' >> "$GITHUB_STEP_SUMMARY"
+          printf -- '- [Download the source coverage artifact](%s)\n' \
+            "$ARTIFACT_URL" >> "$GITHUB_STEP_SUMMARY"
+          printf -- '- Artifact SHA-256: `%s`\n' \
+            "$ARTIFACT_DIGEST" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify checkout remains clean
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -52,16 +52,17 @@ jobs:
     timeout-minutes: 60
     env:
       DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+      COVERAGE_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
     steps:
       - name: Check out exact source commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ env.COVERAGE_SOURCE_SHA }}
           persist-credentials: false
 
       - name: Verify exact source commit
-        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+        run: test "$(git rev-parse HEAD)" = "$COVERAGE_SOURCE_SHA"
 
       - name: Validate pinned Swift 6 coverage environment
         env:
@@ -128,7 +129,7 @@ jobs:
         if: ${{ always() && !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: swiftql-source-coverage-${{ github.sha }}-${{ github.run_attempt }}
+          name: swiftql-source-coverage-${{ env.COVERAGE_SOURCE_SHA }}-${{ github.run_attempt }}
           path: |
             ${{ runner.temp }}/swiftql-coverage-run-1
             ${{ runner.temp }}/swiftql-coverage-run-2

--- a/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/README.md
+++ b/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/README.md
@@ -1,0 +1,73 @@
+# Initial Xcode 16.2 source-coverage baseline
+
+This directory is the compact, checked-in baseline produced by the dedicated
+Swift 6 coverage lane for issue [#189](https://github.com/lukevanin/swiftql/issues/189).
+The raw LLVM JSON, LCOV, and test logs remain in the retained workflow artifact
+rather than in Git.
+
+## Provenance
+
+- Source commit: `9152d8409aa55df5bc96e9c74411b3c4fb166429`
+- Source tree: clean
+- Workflow: [Swift compatibility run 118](https://github.com/lukevanin/swiftql/actions/runs/29580545409)
+- Artifact: [ID 8406963181](https://github.com/lukevanin/swiftql/actions/runs/29580545409/artifacts/8406963181),
+  `swiftql-source-coverage-9152d8409aa55df5bc96e9c74411b3c4fb166429-1`
+- Artifact SHA-256: `c090061ab72580296bd0e6600bb868209181c661fb251c70c096c11d3325dc56`
+- Artifact retention: created 2026-07-17; scheduled to expire 2026-08-16
+- Runner image: `macos15 20260715.0234.1`, arm64
+- Xcode: 16.2 (`16C5032a`)
+- Swift: 6.0.3
+- macOS SDK: 15.2
+- Apple LLVM coverage tools: 16.0.0 (`clang-1600.0.26.6`)
+- Command: `xcrun swift test --scratch-path <scratch-path> --enable-code-coverage`
+- `Package.resolved` SHA-256: `69015064d53cbf9f4682b3d690bb34fcb59f9fc229f9e20f898b6399fb6c75f6`
+- Included-source digest: `af252c4cb1d2aa86edc0b301d1f0334b6e2032962b5a2b372899b79ed5645fe2`
+
+Two clean runs used independent SwiftPM scratch directories. Their normalized
+reports, included-source manifests, explicit uninstrumented-source manifests,
+toolchains, commands, source commits, and dependency-resolution digests were
+identical.
+
+## First-party totals
+
+| Target | Instrumented sources | Allowed uninstrumented | Lines | Functions |
+| --- | ---: | ---: | ---: | ---: |
+| SQLMacros | 4 | 0 | 2164/2218 (97.57%) | 154/157 (98.09%) |
+| SwiftQL | 45 | 2 | 2822/3628 (77.78%) | 703/939 (74.87%) |
+
+The two allowed uninstrumented sources are `Sources/SwiftQL/SQL.swift` and
+`Sources/SwiftQL/SQLScalarResult.swift`; the pinned LLVM export reports no
+executable regions for them. The reporter fails if another tracked production
+source disappears or either allowance becomes stale.
+
+These totals are evidence, not a percentage gate. Real SQLite execution,
+compiler diagnostics, and semantic assertions remain the acceptance criteria
+for production changes.
+
+## Checked-in files
+
+- `first-party-coverage.json`: normalized target and per-file metrics plus full
+  toolchain and filtering provenance;
+- `included-sources.txt` and `repeated-included-sources.txt`: the two matching
+  first-party source manifests;
+- `allowed-uninstrumented-sources.txt`: the explicit zero-region exceptions;
+- `reproducibility.json`: the two-clean-run verdict and shared provenance;
+- `resolved-dependencies.txt`: the resolved dependency graph;
+- `summary.md`: the concise CI table and ranked uncovered files.
+
+## Gap triage
+
+The baseline produced two non-duplicate atomic follow-ups in milestone v1.2:
+
+- [#195](https://github.com/lukevanin/swiftql/issues/195) (P3) covers the 32
+  zero-count public fluent `INSERT ... SELECT` transitions with exact rendering
+  and real SQLite execution.
+- [#194](https://github.com/lukevanin/swiftql/issues/194) (P4) covers
+  `QueryBuilder`'s documented missing-`FROM` rejection path.
+
+Other large uncovered areas already have direct owners, notably
+[#131](https://github.com/lukevanin/swiftql/issues/131) for dialect/driver
+boundaries, [#82](https://github.com/lukevanin/swiftql/issues/82) for immutable
+invocation bindings, and [#191](https://github.com/lukevanin/swiftql/issues/191)
+for generated combinatorial SQLite conformance cases. Duplicate umbrella issues
+were intentionally not created.

--- a/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/allowed-uninstrumented-sources.txt
+++ b/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/allowed-uninstrumented-sources.txt
@@ -1,0 +1,2 @@
+SwiftQL	Sources/SwiftQL/SQL.swift
+SwiftQL	Sources/SwiftQL/SQLScalarResult.swift

--- a/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/first-party-coverage.json
+++ b/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/first-party-coverage.json
@@ -1,0 +1,1566 @@
+{
+  "coverage_command": "xcrun swift test --scratch-path <scratch-path> --enable-code-coverage",
+  "filtering": {
+    "allowed_uninstrumented_source_files": 2,
+    "excluded_raw_file_entries": 358,
+    "excluded_raw_file_entries_by_category": {
+      "benchmarks": 6,
+      "outside_repository": 325,
+      "tests_or_fixtures": 27
+    },
+    "included_source_files": 49,
+    "included_sources_sha256": "af252c4cb1d2aa86edc0b301d1f0334b6e2032962b5a2b372899b79ed5645fe2",
+    "rule": "Only tracked .swift files under configured first-party target roots are included."
+  },
+  "largest_uncovered_files": [
+    {
+      "functions": {
+        "count": 41,
+        "covered": 9,
+        "percent": 21.95,
+        "uncovered": 32
+      },
+      "lines": {
+        "count": 140,
+        "covered": 44,
+        "percent": 31.43,
+        "uncovered": 96
+      },
+      "path": "Sources/SwiftQL/Statements/SQLInsertStatement.swift",
+      "regions": {
+        "count": 47,
+        "covered": 15,
+        "percent": 31.91,
+        "uncovered": 32
+      }
+    },
+    {
+      "functions": {
+        "count": 15,
+        "covered": 3,
+        "percent": 20.0,
+        "uncovered": 12
+      },
+      "lines": {
+        "count": 68,
+        "covered": 9,
+        "percent": 13.24,
+        "uncovered": 59
+      },
+      "path": "Sources/SwiftQL/SQLDatabase.swift",
+      "regions": {
+        "count": 15,
+        "covered": 3,
+        "percent": 20.0,
+        "uncovered": 12
+      }
+    },
+    {
+      "functions": {
+        "count": 44,
+        "covered": 31,
+        "percent": 70.45,
+        "uncovered": 13
+      },
+      "lines": {
+        "count": 198,
+        "covered": 142,
+        "percent": 71.72,
+        "uncovered": 56
+      },
+      "path": "Sources/SwiftQL/Builders/QueryBuilder.swift",
+      "regions": {
+        "count": 70,
+        "covered": 54,
+        "percent": 77.14,
+        "uncovered": 16
+      }
+    },
+    {
+      "functions": {
+        "count": 92,
+        "covered": 73,
+        "percent": 79.35,
+        "uncovered": 19
+      },
+      "lines": {
+        "count": 271,
+        "covered": 217,
+        "percent": 80.07,
+        "uncovered": 54
+      },
+      "path": "Sources/SwiftQL/SQLStatements.swift",
+      "regions": {
+        "count": 104,
+        "covered": 84,
+        "percent": 80.77,
+        "uncovered": 20
+      }
+    },
+    {
+      "functions": {
+        "count": 50,
+        "covered": 33,
+        "percent": 66.0,
+        "uncovered": 17
+      },
+      "lines": {
+        "count": 171,
+        "covered": 120,
+        "percent": 70.18,
+        "uncovered": 51
+      },
+      "path": "Sources/SwiftQL/Statements/SQLQueryStatement.swift",
+      "regions": {
+        "count": 58,
+        "covered": 41,
+        "percent": 70.69,
+        "uncovered": 17
+      }
+    },
+    {
+      "functions": {
+        "count": 22,
+        "covered": 7,
+        "percent": 31.82,
+        "uncovered": 15
+      },
+      "lines": {
+        "count": 67,
+        "covered": 22,
+        "percent": 32.84,
+        "uncovered": 45
+      },
+      "path": "Sources/SwiftQL/Expression Builder/SQLInsertExpressionBuilder.swift",
+      "regions": {
+        "count": 22,
+        "covered": 7,
+        "percent": 31.82,
+        "uncovered": 15
+      }
+    },
+    {
+      "functions": {
+        "count": 16,
+        "covered": 1,
+        "percent": 6.25,
+        "uncovered": 15
+      },
+      "lines": {
+        "count": 48,
+        "covered": 3,
+        "percent": 6.25,
+        "uncovered": 45
+      },
+      "path": "Sources/SwiftQL/Operators/RealOperators.swift",
+      "regions": {
+        "count": 16,
+        "covered": 1,
+        "percent": 6.25,
+        "uncovered": 15
+      }
+    },
+    {
+      "functions": {
+        "count": 56,
+        "covered": 43,
+        "percent": 76.79,
+        "uncovered": 13
+      },
+      "lines": {
+        "count": 235,
+        "covered": 191,
+        "percent": 81.28,
+        "uncovered": 44
+      },
+      "path": "Sources/SwiftQL/SQLExpression.swift",
+      "regions": {
+        "count": 80,
+        "covered": 65,
+        "percent": 81.25,
+        "uncovered": 15
+      }
+    },
+    {
+      "functions": {
+        "count": 69,
+        "covered": 55,
+        "percent": 79.71,
+        "uncovered": 14
+      },
+      "lines": {
+        "count": 238,
+        "covered": 198,
+        "percent": 83.19,
+        "uncovered": 40
+      },
+      "path": "Sources/SwiftQL/SQLMeta.swift",
+      "regions": {
+        "count": 95,
+        "covered": 74,
+        "percent": 77.89,
+        "uncovered": 21
+      }
+    },
+    {
+      "functions": {
+        "count": 22,
+        "covered": 9,
+        "percent": 40.91,
+        "uncovered": 13
+      },
+      "lines": {
+        "count": 66,
+        "covered": 27,
+        "percent": 40.91,
+        "uncovered": 39
+      },
+      "path": "Sources/SwiftQL/Operators/IntegerOperators.swift",
+      "regions": {
+        "count": 22,
+        "covered": 9,
+        "percent": 40.91,
+        "uncovered": 13
+      }
+    },
+    {
+      "functions": {
+        "count": 31,
+        "covered": 20,
+        "percent": 64.52,
+        "uncovered": 11
+      },
+      "lines": {
+        "count": 107,
+        "covered": 70,
+        "percent": 65.42,
+        "uncovered": 37
+      },
+      "path": "Sources/SwiftQL/Expression Builder/SQLQueryExpressionBuilder.swift",
+      "regions": {
+        "count": 31,
+        "covered": 20,
+        "percent": 64.52,
+        "uncovered": 11
+      }
+    },
+    {
+      "functions": {
+        "count": 16,
+        "covered": 4,
+        "percent": 25.0,
+        "uncovered": 12
+      },
+      "lines": {
+        "count": 48,
+        "covered": 12,
+        "percent": 25.0,
+        "uncovered": 36
+      },
+      "path": "Sources/SwiftQL/Operators/ComparableExpressionOperators.swift",
+      "regions": {
+        "count": 16,
+        "covered": 4,
+        "percent": 25.0,
+        "uncovered": 12
+      }
+    },
+    {
+      "functions": {
+        "count": 39,
+        "covered": 32,
+        "percent": 82.05,
+        "uncovered": 7
+      },
+      "lines": {
+        "count": 167,
+        "covered": 135,
+        "percent": 80.84,
+        "uncovered": 32
+      },
+      "path": "Sources/SwiftQL/SQLFunctionalSyntax.swift",
+      "regions": {
+        "count": 39,
+        "covered": 32,
+        "percent": 82.05,
+        "uncovered": 7
+      }
+    },
+    {
+      "functions": {
+        "count": 135,
+        "covered": 135,
+        "percent": 100.0,
+        "uncovered": 0
+      },
+      "lines": {
+        "count": 2093,
+        "covered": 2062,
+        "percent": 98.52,
+        "uncovered": 31
+      },
+      "path": "Sources/SQLMacros/MetaBuilder.swift",
+      "regions": {
+        "count": 345,
+        "covered": 333,
+        "percent": 96.52,
+        "uncovered": 12
+      }
+    },
+    {
+      "functions": {
+        "count": 73,
+        "covered": 69,
+        "percent": 94.52,
+        "uncovered": 4
+      },
+      "lines": {
+        "count": 297,
+        "covered": 268,
+        "percent": 90.24,
+        "uncovered": 29
+      },
+      "path": "Sources/SwiftQL/SQLEncoder.swift",
+      "regions": {
+        "count": 91,
+        "covered": 84,
+        "percent": 92.31,
+        "uncovered": 7
+      }
+    },
+    {
+      "functions": {
+        "count": 12,
+        "covered": 3,
+        "percent": 25.0,
+        "uncovered": 9
+      },
+      "lines": {
+        "count": 36,
+        "covered": 9,
+        "percent": 25.0,
+        "uncovered": 27
+      },
+      "path": "Sources/SwiftQL/Operators/TextOperators.swift",
+      "regions": {
+        "count": 12,
+        "covered": 3,
+        "percent": 25.0,
+        "uncovered": 9
+      }
+    },
+    {
+      "functions": {
+        "count": 8,
+        "covered": 5,
+        "percent": 62.5,
+        "uncovered": 3
+      },
+      "lines": {
+        "count": 64,
+        "covered": 41,
+        "percent": 64.06,
+        "uncovered": 23
+      },
+      "path": "Sources/SQLMacros/SQLMacro.swift",
+      "regions": {
+        "count": 26,
+        "covered": 13,
+        "percent": 50.0,
+        "uncovered": 13
+      }
+    },
+    {
+      "functions": {
+        "count": 66,
+        "covered": 63,
+        "percent": 95.45,
+        "uncovered": 3
+      },
+      "lines": {
+        "count": 387,
+        "covered": 366,
+        "percent": 94.57,
+        "uncovered": 21
+      },
+      "path": "Sources/SwiftQL/GRDBSQLDatabase.swift",
+      "regions": {
+        "count": 123,
+        "covered": 112,
+        "percent": 91.06,
+        "uncovered": 11
+      }
+    },
+    {
+      "functions": {
+        "count": 13,
+        "covered": 7,
+        "percent": 53.85,
+        "uncovered": 6
+      },
+      "lines": {
+        "count": 39,
+        "covered": 21,
+        "percent": 53.85,
+        "uncovered": 18
+      },
+      "path": "Sources/SwiftQL/Functions/AggregateFunctions.swift",
+      "regions": {
+        "count": 13,
+        "covered": 7,
+        "percent": 53.85,
+        "uncovered": 6
+      }
+    },
+    {
+      "functions": {
+        "count": 10,
+        "covered": 4,
+        "percent": 40.0,
+        "uncovered": 6
+      },
+      "lines": {
+        "count": 30,
+        "covered": 12,
+        "percent": 40.0,
+        "uncovered": 18
+      },
+      "path": "Sources/SwiftQL/Operators/BooleanOperators.swift",
+      "regions": {
+        "count": 10,
+        "covered": 4,
+        "percent": 40.0,
+        "uncovered": 6
+      }
+    }
+  ],
+  "overall": {
+    "functions": {
+      "count": 1096,
+      "covered": 857,
+      "percent": 78.19,
+      "uncovered": 239
+    },
+    "lines": {
+      "count": 5846,
+      "covered": 4986,
+      "percent": 85.29,
+      "uncovered": 860
+    },
+    "regions": {
+      "count": 1552,
+      "covered": 1259,
+      "percent": 81.12,
+      "uncovered": 293
+    }
+  },
+  "package_resolved_sha256": "69015064d53cbf9f4682b3d690bb34fcb59f9fc229f9e20f898b6399fb6c75f6",
+  "raw_llvm_report": {
+    "file_entries": 407,
+    "type": "llvm.coverage.json.export",
+    "version": "2.0.1"
+  },
+  "schema_version": 1,
+  "source_commit": "9152d8409aa55df5bc96e9c74411b3c4fb166429",
+  "source_tree_state": "clean",
+  "targets": {
+    "SQLMacros": {
+      "allowed_uninstrumented_source_files": [],
+      "files": [
+        {
+          "functions": {
+            "count": 2,
+            "covered": 2,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 8,
+            "covered": 8,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SQLMacros/Diagnostics.swift",
+          "regions": {
+            "count": 2,
+            "covered": 2,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 135,
+            "covered": 135,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 2093,
+            "covered": 2062,
+            "percent": 98.52,
+            "uncovered": 31
+          },
+          "path": "Sources/SQLMacros/MetaBuilder.swift",
+          "regions": {
+            "count": 345,
+            "covered": 333,
+            "percent": 96.52,
+            "uncovered": 12
+          }
+        },
+        {
+          "functions": {
+            "count": 8,
+            "covered": 5,
+            "percent": 62.5,
+            "uncovered": 3
+          },
+          "lines": {
+            "count": 64,
+            "covered": 41,
+            "percent": 64.06,
+            "uncovered": 23
+          },
+          "path": "Sources/SQLMacros/SQLMacro.swift",
+          "regions": {
+            "count": 26,
+            "covered": 13,
+            "percent": 50.0,
+            "uncovered": 13
+          }
+        },
+        {
+          "functions": {
+            "count": 12,
+            "covered": 12,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 53,
+            "covered": 53,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SQLMacros/SwiftSyntaxBuilder.swift",
+          "regions": {
+            "count": 20,
+            "covered": 20,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        }
+      ],
+      "instrumented_source_files": 4,
+      "source_files": 4,
+      "source_root": "Sources/SQLMacros",
+      "totals": {
+        "functions": {
+          "count": 157,
+          "covered": 154,
+          "percent": 98.09,
+          "uncovered": 3
+        },
+        "lines": {
+          "count": 2218,
+          "covered": 2164,
+          "percent": 97.57,
+          "uncovered": 54
+        },
+        "regions": {
+          "count": 393,
+          "covered": 368,
+          "percent": 93.64,
+          "uncovered": 25
+        }
+      }
+    },
+    "SwiftQL": {
+      "allowed_uninstrumented_source_files": [
+        "Sources/SwiftQL/SQL.swift",
+        "Sources/SwiftQL/SQLScalarResult.swift"
+      ],
+      "files": [
+        {
+          "functions": {
+            "count": 9,
+            "covered": 9,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 38,
+            "covered": 38,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Builders/InsertBuilder.swift",
+          "regions": {
+            "count": 11,
+            "covered": 11,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 44,
+            "covered": 31,
+            "percent": 70.45,
+            "uncovered": 13
+          },
+          "lines": {
+            "count": 198,
+            "covered": 142,
+            "percent": 71.72,
+            "uncovered": 56
+          },
+          "path": "Sources/SwiftQL/Builders/QueryBuilder.swift",
+          "regions": {
+            "count": 70,
+            "covered": 54,
+            "percent": 77.14,
+            "uncovered": 16
+          }
+        },
+        {
+          "functions": {
+            "count": 3,
+            "covered": 3,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 12,
+            "covered": 12,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Expression Builder/SQLCreateExpressionBuilder.swift",
+          "regions": {
+            "count": 3,
+            "covered": 3,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 5,
+            "covered": 5,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 16,
+            "covered": 16,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Expression Builder/SQLDeleteExpressionBuilder.swift",
+          "regions": {
+            "count": 5,
+            "covered": 5,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 22,
+            "covered": 7,
+            "percent": 31.82,
+            "uncovered": 15
+          },
+          "lines": {
+            "count": 67,
+            "covered": 22,
+            "percent": 32.84,
+            "uncovered": 45
+          },
+          "path": "Sources/SwiftQL/Expression Builder/SQLInsertExpressionBuilder.swift",
+          "regions": {
+            "count": 22,
+            "covered": 7,
+            "percent": 31.82,
+            "uncovered": 15
+          }
+        },
+        {
+          "functions": {
+            "count": 31,
+            "covered": 20,
+            "percent": 64.52,
+            "uncovered": 11
+          },
+          "lines": {
+            "count": 107,
+            "covered": 70,
+            "percent": 65.42,
+            "uncovered": 37
+          },
+          "path": "Sources/SwiftQL/Expression Builder/SQLQueryExpressionBuilder.swift",
+          "regions": {
+            "count": 31,
+            "covered": 20,
+            "percent": 64.52,
+            "uncovered": 11
+          }
+        },
+        {
+          "functions": {
+            "count": 7,
+            "covered": 7,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 25,
+            "covered": 25,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Expression Builder/SQLUpdateExpressionBuilder.swift",
+          "regions": {
+            "count": 7,
+            "covered": 7,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 2,
+            "covered": 2,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 9,
+            "covered": 9,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/FoundationExtensions.swift",
+          "regions": {
+            "count": 2,
+            "covered": 2,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 13,
+            "covered": 7,
+            "percent": 53.85,
+            "uncovered": 6
+          },
+          "lines": {
+            "count": 39,
+            "covered": 21,
+            "percent": 53.85,
+            "uncovered": 18
+          },
+          "path": "Sources/SwiftQL/Functions/AggregateFunctions.swift",
+          "regions": {
+            "count": 13,
+            "covered": 7,
+            "percent": 53.85,
+            "uncovered": 6
+          }
+        },
+        {
+          "functions": {
+            "count": 2,
+            "covered": 2,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 6,
+            "covered": 6,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Functions/ComparableFunctions.swift",
+          "regions": {
+            "count": 2,
+            "covered": 2,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 4,
+            "covered": 4,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 12,
+            "covered": 12,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Functions/ConditionalFunctions.swift",
+          "regions": {
+            "count": 4,
+            "covered": 4,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 4,
+            "covered": 4,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 16,
+            "covered": 16,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Functions/DateFunctions.swift",
+          "regions": {
+            "count": 6,
+            "covered": 6,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 2,
+            "covered": 2,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 6,
+            "covered": 6,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Functions/ExpressionFunctions.swift",
+          "regions": {
+            "count": 2,
+            "covered": 2,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 3,
+            "covered": 3,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 9,
+            "covered": 9,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Functions/JSONFunctions.swift",
+          "regions": {
+            "count": 3,
+            "covered": 3,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 5,
+            "covered": 5,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 15,
+            "covered": 15,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Functions/NumericFunctions.swift",
+          "regions": {
+            "count": 5,
+            "covered": 5,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 4,
+            "covered": 4,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 12,
+            "covered": 12,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Functions/StringFunctions.swift",
+          "regions": {
+            "count": 4,
+            "covered": 4,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 18,
+            "covered": 18,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 54,
+            "covered": 54,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Functions/TypeCastFunctions.swift",
+          "regions": {
+            "count": 18,
+            "covered": 18,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 25,
+            "covered": 25,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 162,
+            "covered": 161,
+            "percent": 99.38,
+            "uncovered": 1
+          },
+          "path": "Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift",
+          "regions": {
+            "count": 37,
+            "covered": 34,
+            "percent": 91.89,
+            "uncovered": 3
+          }
+        },
+        {
+          "functions": {
+            "count": 66,
+            "covered": 63,
+            "percent": 95.45,
+            "uncovered": 3
+          },
+          "lines": {
+            "count": 387,
+            "covered": 366,
+            "percent": 94.57,
+            "uncovered": 21
+          },
+          "path": "Sources/SwiftQL/GRDBSQLDatabase.swift",
+          "regions": {
+            "count": 123,
+            "covered": 112,
+            "percent": 91.06,
+            "uncovered": 11
+          }
+        },
+        {
+          "functions": {
+            "count": 10,
+            "covered": 4,
+            "percent": 40.0,
+            "uncovered": 6
+          },
+          "lines": {
+            "count": 30,
+            "covered": 12,
+            "percent": 40.0,
+            "uncovered": 18
+          },
+          "path": "Sources/SwiftQL/Operators/BooleanOperators.swift",
+          "regions": {
+            "count": 10,
+            "covered": 4,
+            "percent": 40.0,
+            "uncovered": 6
+          }
+        },
+        {
+          "functions": {
+            "count": 16,
+            "covered": 4,
+            "percent": 25.0,
+            "uncovered": 12
+          },
+          "lines": {
+            "count": 48,
+            "covered": 12,
+            "percent": 25.0,
+            "uncovered": 36
+          },
+          "path": "Sources/SwiftQL/Operators/ComparableExpressionOperators.swift",
+          "regions": {
+            "count": 16,
+            "covered": 4,
+            "percent": 25.0,
+            "uncovered": 12
+          }
+        },
+        {
+          "functions": {
+            "count": 8,
+            "covered": 4,
+            "percent": 50.0,
+            "uncovered": 4
+          },
+          "lines": {
+            "count": 24,
+            "covered": 12,
+            "percent": 50.0,
+            "uncovered": 12
+          },
+          "path": "Sources/SwiftQL/Operators/EquatableExpressionOperators.swift",
+          "regions": {
+            "count": 8,
+            "covered": 4,
+            "percent": 50.0,
+            "uncovered": 4
+          }
+        },
+        {
+          "functions": {
+            "count": 6,
+            "covered": 5,
+            "percent": 83.33,
+            "uncovered": 1
+          },
+          "lines": {
+            "count": 28,
+            "covered": 22,
+            "percent": 78.57,
+            "uncovered": 6
+          },
+          "path": "Sources/SwiftQL/Operators/InOperator.swift",
+          "regions": {
+            "count": 6,
+            "covered": 5,
+            "percent": 83.33,
+            "uncovered": 1
+          }
+        },
+        {
+          "functions": {
+            "count": 22,
+            "covered": 9,
+            "percent": 40.91,
+            "uncovered": 13
+          },
+          "lines": {
+            "count": 66,
+            "covered": 27,
+            "percent": 40.91,
+            "uncovered": 39
+          },
+          "path": "Sources/SwiftQL/Operators/IntegerOperators.swift",
+          "regions": {
+            "count": 22,
+            "covered": 9,
+            "percent": 40.91,
+            "uncovered": 13
+          }
+        },
+        {
+          "functions": {
+            "count": 4,
+            "covered": 2,
+            "percent": 50.0,
+            "uncovered": 2
+          },
+          "lines": {
+            "count": 12,
+            "covered": 6,
+            "percent": 50.0,
+            "uncovered": 6
+          },
+          "path": "Sources/SwiftQL/Operators/NumericOperators.swift",
+          "regions": {
+            "count": 4,
+            "covered": 2,
+            "percent": 50.0,
+            "uncovered": 2
+          }
+        },
+        {
+          "functions": {
+            "count": 4,
+            "covered": 4,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 12,
+            "covered": 12,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Operators/OptionalOperators.swift",
+          "regions": {
+            "count": 4,
+            "covered": 4,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 16,
+            "covered": 1,
+            "percent": 6.25,
+            "uncovered": 15
+          },
+          "lines": {
+            "count": 48,
+            "covered": 3,
+            "percent": 6.25,
+            "uncovered": 45
+          },
+          "path": "Sources/SwiftQL/Operators/RealOperators.swift",
+          "regions": {
+            "count": 16,
+            "covered": 1,
+            "percent": 6.25,
+            "uncovered": 15
+          }
+        },
+        {
+          "functions": {
+            "count": 12,
+            "covered": 3,
+            "percent": 25.0,
+            "uncovered": 9
+          },
+          "lines": {
+            "count": 36,
+            "covered": 9,
+            "percent": 25.0,
+            "uncovered": 27
+          },
+          "path": "Sources/SwiftQL/Operators/TextOperators.swift",
+          "regions": {
+            "count": 12,
+            "covered": 3,
+            "percent": 25.0,
+            "uncovered": 9
+          }
+        },
+        {
+          "functions": {
+            "count": 36,
+            "covered": 36,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 147,
+            "covered": 147,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/SQLCaseWhenThen.swift",
+          "regions": {
+            "count": 40,
+            "covered": 40,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 1,
+            "covered": 1,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 4,
+            "covered": 4,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/SQLCustomFunction.swift",
+          "regions": {
+            "count": 1,
+            "covered": 1,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 15,
+            "covered": 3,
+            "percent": 20.0,
+            "uncovered": 12
+          },
+          "lines": {
+            "count": 68,
+            "covered": 9,
+            "percent": 13.24,
+            "uncovered": 59
+          },
+          "path": "Sources/SwiftQL/SQLDatabase.swift",
+          "regions": {
+            "count": 15,
+            "covered": 3,
+            "percent": 20.0,
+            "uncovered": 12
+          }
+        },
+        {
+          "functions": {
+            "count": 73,
+            "covered": 69,
+            "percent": 94.52,
+            "uncovered": 4
+          },
+          "lines": {
+            "count": 297,
+            "covered": 268,
+            "percent": 90.24,
+            "uncovered": 29
+          },
+          "path": "Sources/SwiftQL/SQLEncoder.swift",
+          "regions": {
+            "count": 91,
+            "covered": 84,
+            "percent": 92.31,
+            "uncovered": 7
+          }
+        },
+        {
+          "functions": {
+            "count": 56,
+            "covered": 43,
+            "percent": 76.79,
+            "uncovered": 13
+          },
+          "lines": {
+            "count": 235,
+            "covered": 191,
+            "percent": 81.28,
+            "uncovered": 44
+          },
+          "path": "Sources/SwiftQL/SQLExpression.swift",
+          "regions": {
+            "count": 80,
+            "covered": 65,
+            "percent": 81.25,
+            "uncovered": 15
+          }
+        },
+        {
+          "functions": {
+            "count": 39,
+            "covered": 32,
+            "percent": 82.05,
+            "uncovered": 7
+          },
+          "lines": {
+            "count": 167,
+            "covered": 135,
+            "percent": 80.84,
+            "uncovered": 32
+          },
+          "path": "Sources/SwiftQL/SQLFunctionalSyntax.swift",
+          "regions": {
+            "count": 39,
+            "covered": 32,
+            "percent": 82.05,
+            "uncovered": 7
+          }
+        },
+        {
+          "functions": {
+            "count": 4,
+            "covered": 2,
+            "percent": 50.0,
+            "uncovered": 2
+          },
+          "lines": {
+            "count": 12,
+            "covered": 6,
+            "percent": 50.0,
+            "uncovered": 6
+          },
+          "path": "Sources/SwiftQL/SQLLogger.swift",
+          "regions": {
+            "count": 4,
+            "covered": 2,
+            "percent": 50.0,
+            "uncovered": 2
+          }
+        },
+        {
+          "functions": {
+            "count": 69,
+            "covered": 55,
+            "percent": 79.71,
+            "uncovered": 14
+          },
+          "lines": {
+            "count": 238,
+            "covered": 198,
+            "percent": 83.19,
+            "uncovered": 40
+          },
+          "path": "Sources/SwiftQL/SQLMeta.swift",
+          "regions": {
+            "count": 95,
+            "covered": 74,
+            "percent": 77.89,
+            "uncovered": 21
+          }
+        },
+        {
+          "functions": {
+            "count": 49,
+            "covered": 49,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 200,
+            "covered": 200,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/SQLOperators.swift",
+          "regions": {
+            "count": 49,
+            "covered": 49,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 92,
+            "covered": 73,
+            "percent": 79.35,
+            "uncovered": 19
+          },
+          "lines": {
+            "count": 271,
+            "covered": 217,
+            "percent": 80.07,
+            "uncovered": 54
+          },
+          "path": "Sources/SwiftQL/SQLStatements.swift",
+          "regions": {
+            "count": 104,
+            "covered": 84,
+            "percent": 80.77,
+            "uncovered": 20
+          }
+        },
+        {
+          "functions": {
+            "count": 5,
+            "covered": 4,
+            "percent": 80.0,
+            "uncovered": 1
+          },
+          "lines": {
+            "count": 27,
+            "covered": 22,
+            "percent": 81.48,
+            "uncovered": 5
+          },
+          "path": "Sources/SwiftQL/Statements/SQLCreateTableStatement.swift",
+          "regions": {
+            "count": 7,
+            "covered": 6,
+            "percent": 85.71,
+            "uncovered": 1
+          }
+        },
+        {
+          "functions": {
+            "count": 6,
+            "covered": 6,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 32,
+            "covered": 32,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Statements/SQLDeleteStatement.swift",
+          "regions": {
+            "count": 12,
+            "covered": 12,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 41,
+            "covered": 9,
+            "percent": 21.95,
+            "uncovered": 32
+          },
+          "lines": {
+            "count": 140,
+            "covered": 44,
+            "percent": 31.43,
+            "uncovered": 96
+          },
+          "path": "Sources/SwiftQL/Statements/SQLInsertStatement.swift",
+          "regions": {
+            "count": 47,
+            "covered": 15,
+            "percent": 31.91,
+            "uncovered": 32
+          }
+        },
+        {
+          "functions": {
+            "count": 50,
+            "covered": 33,
+            "percent": 66.0,
+            "uncovered": 17
+          },
+          "lines": {
+            "count": 171,
+            "covered": 120,
+            "percent": 70.18,
+            "uncovered": 51
+          },
+          "path": "Sources/SwiftQL/Statements/SQLQueryStatement.swift",
+          "regions": {
+            "count": 58,
+            "covered": 41,
+            "percent": 70.69,
+            "uncovered": 17
+          }
+        },
+        {
+          "functions": {
+            "count": 10,
+            "covered": 8,
+            "percent": 80.0,
+            "uncovered": 2
+          },
+          "lines": {
+            "count": 46,
+            "covered": 32,
+            "percent": 69.57,
+            "uncovered": 14
+          },
+          "path": "Sources/SwiftQL/Statements/SQLUpdateStatement.swift",
+          "regions": {
+            "count": 16,
+            "covered": 11,
+            "percent": 68.75,
+            "uncovered": 5
+          }
+        },
+        {
+          "functions": {
+            "count": 5,
+            "covered": 5,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "lines": {
+            "count": 16,
+            "covered": 16,
+            "percent": 100.0,
+            "uncovered": 0
+          },
+          "path": "Sources/SwiftQL/Statements/SQLWithStatement.swift",
+          "regions": {
+            "count": 5,
+            "covered": 5,
+            "percent": 100.0,
+            "uncovered": 0
+          }
+        },
+        {
+          "functions": {
+            "count": 21,
+            "covered": 18,
+            "percent": 85.71,
+            "uncovered": 3
+          },
+          "lines": {
+            "count": 63,
+            "covered": 54,
+            "percent": 85.71,
+            "uncovered": 9
+          },
+          "path": "Sources/SwiftQL/Types/Intrinsic.swift",
+          "regions": {
+            "count": 30,
+            "covered": 25,
+            "percent": 83.33,
+            "uncovered": 5
+          }
+        }
+      ],
+      "instrumented_source_files": 45,
+      "source_files": 47,
+      "source_root": "Sources/SwiftQL",
+      "totals": {
+        "functions": {
+          "count": 939,
+          "covered": 703,
+          "percent": 74.87,
+          "uncovered": 236
+        },
+        "lines": {
+          "count": 3628,
+          "covered": 2822,
+          "percent": 77.78,
+          "uncovered": 806
+        },
+        "regions": {
+          "count": 1159,
+          "covered": 891,
+          "percent": 76.88,
+          "uncovered": 268
+        }
+      }
+    }
+  },
+  "toolchain": {
+    "architecture": "arm64",
+    "llvm_cov": "/Applications/Xcode_16.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov\nApple LLVM version 16.0.0\n   (clang-1600.0.26.6)Optimized build.",
+    "llvm_profdata": "/Applications/Xcode_16.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-profdata\nllvm-profdata\nApple LLVM version 16.0.0\n   (clang-1600.0.26.6)Optimized build.",
+    "platform": "Darwin sjc22-bt149-2e5508f3-31b0-41fa-9aac-775963c4771c-D2602A6413A5.local 24.6.0 Darwin Kernel Version 24.6.0: Tue Apr 21 20:18:00 PDT 2026; root:xnu-11417.140.69.710.16~1/RELEASE_ARM64_VMAPPLE arm64",
+    "runner_image": "macos15 20260715.0234.1",
+    "sdk": "15.2",
+    "swift": "Apple Swift version 6.0.3 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)\nTarget: arm64-apple-macosx15.0",
+    "xcode": "Xcode 16.2\nBuild version 16C5032a"
+  }
+}

--- a/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/included-sources.txt
+++ b/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/included-sources.txt
@@ -1,0 +1,49 @@
+SQLMacros	Sources/SQLMacros/Diagnostics.swift
+SQLMacros	Sources/SQLMacros/MetaBuilder.swift
+SQLMacros	Sources/SQLMacros/SQLMacro.swift
+SQLMacros	Sources/SQLMacros/SwiftSyntaxBuilder.swift
+SwiftQL	Sources/SwiftQL/Builders/InsertBuilder.swift
+SwiftQL	Sources/SwiftQL/Builders/QueryBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLCreateExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLDeleteExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLInsertExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLQueryExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLUpdateExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/FoundationExtensions.swift
+SwiftQL	Sources/SwiftQL/Functions/AggregateFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/ComparableFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/ConditionalFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/DateFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/ExpressionFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/JSONFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/NumericFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/StringFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/TypeCastFunctions.swift
+SwiftQL	Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift
+SwiftQL	Sources/SwiftQL/GRDBSQLDatabase.swift
+SwiftQL	Sources/SwiftQL/Operators/BooleanOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/ComparableExpressionOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/EquatableExpressionOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/InOperator.swift
+SwiftQL	Sources/SwiftQL/Operators/IntegerOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/NumericOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/OptionalOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/RealOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/TextOperators.swift
+SwiftQL	Sources/SwiftQL/SQLCaseWhenThen.swift
+SwiftQL	Sources/SwiftQL/SQLCustomFunction.swift
+SwiftQL	Sources/SwiftQL/SQLDatabase.swift
+SwiftQL	Sources/SwiftQL/SQLEncoder.swift
+SwiftQL	Sources/SwiftQL/SQLExpression.swift
+SwiftQL	Sources/SwiftQL/SQLFunctionalSyntax.swift
+SwiftQL	Sources/SwiftQL/SQLLogger.swift
+SwiftQL	Sources/SwiftQL/SQLMeta.swift
+SwiftQL	Sources/SwiftQL/SQLOperators.swift
+SwiftQL	Sources/SwiftQL/SQLStatements.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLCreateTableStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLDeleteStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLInsertStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLQueryStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLUpdateStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLWithStatement.swift
+SwiftQL	Sources/SwiftQL/Types/Intrinsic.swift

--- a/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/repeated-included-sources.txt
+++ b/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/repeated-included-sources.txt
@@ -1,0 +1,49 @@
+SQLMacros	Sources/SQLMacros/Diagnostics.swift
+SQLMacros	Sources/SQLMacros/MetaBuilder.swift
+SQLMacros	Sources/SQLMacros/SQLMacro.swift
+SQLMacros	Sources/SQLMacros/SwiftSyntaxBuilder.swift
+SwiftQL	Sources/SwiftQL/Builders/InsertBuilder.swift
+SwiftQL	Sources/SwiftQL/Builders/QueryBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLCreateExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLDeleteExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLInsertExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLQueryExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/Expression Builder/SQLUpdateExpressionBuilder.swift
+SwiftQL	Sources/SwiftQL/FoundationExtensions.swift
+SwiftQL	Sources/SwiftQL/Functions/AggregateFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/ComparableFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/ConditionalFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/DateFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/ExpressionFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/JSONFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/NumericFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/StringFunctions.swift
+SwiftQL	Sources/SwiftQL/Functions/TypeCastFunctions.swift
+SwiftQL	Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift
+SwiftQL	Sources/SwiftQL/GRDBSQLDatabase.swift
+SwiftQL	Sources/SwiftQL/Operators/BooleanOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/ComparableExpressionOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/EquatableExpressionOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/InOperator.swift
+SwiftQL	Sources/SwiftQL/Operators/IntegerOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/NumericOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/OptionalOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/RealOperators.swift
+SwiftQL	Sources/SwiftQL/Operators/TextOperators.swift
+SwiftQL	Sources/SwiftQL/SQLCaseWhenThen.swift
+SwiftQL	Sources/SwiftQL/SQLCustomFunction.swift
+SwiftQL	Sources/SwiftQL/SQLDatabase.swift
+SwiftQL	Sources/SwiftQL/SQLEncoder.swift
+SwiftQL	Sources/SwiftQL/SQLExpression.swift
+SwiftQL	Sources/SwiftQL/SQLFunctionalSyntax.swift
+SwiftQL	Sources/SwiftQL/SQLLogger.swift
+SwiftQL	Sources/SwiftQL/SQLMeta.swift
+SwiftQL	Sources/SwiftQL/SQLOperators.swift
+SwiftQL	Sources/SwiftQL/SQLStatements.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLCreateTableStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLDeleteStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLInsertStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLQueryStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLUpdateStatement.swift
+SwiftQL	Sources/SwiftQL/Statements/SQLWithStatement.swift
+SwiftQL	Sources/SwiftQL/Types/Intrinsic.swift

--- a/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/reproducibility.json
+++ b/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/reproducibility.json
@@ -1,0 +1,23 @@
+{
+  "allowed_uninstrumented_source_sets_match": true,
+  "clean_runs_compared": 2,
+  "coverage_command": "xcrun swift test --scratch-path <scratch-path> --enable-code-coverage",
+  "included_source_files": 49,
+  "included_source_sets_match": true,
+  "included_sources_sha256": "af252c4cb1d2aa86edc0b301d1f0334b6e2032962b5a2b372899b79ed5645fe2",
+  "normalized_reports_match": true,
+  "package_resolved_sha256": "69015064d53cbf9f4682b3d690bb34fcb59f9fc229f9e20f898b6399fb6c75f6",
+  "schema_version": 1,
+  "source_commit": "9152d8409aa55df5bc96e9c74411b3c4fb166429",
+  "source_tree_state": "clean",
+  "toolchain": {
+    "architecture": "arm64",
+    "llvm_cov": "/Applications/Xcode_16.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov\nApple LLVM version 16.0.0\n   (clang-1600.0.26.6)Optimized build.",
+    "llvm_profdata": "/Applications/Xcode_16.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-profdata\nllvm-profdata\nApple LLVM version 16.0.0\n   (clang-1600.0.26.6)Optimized build.",
+    "platform": "Darwin sjc22-bt149-2e5508f3-31b0-41fa-9aac-775963c4771c-D2602A6413A5.local 24.6.0 Darwin Kernel Version 24.6.0: Tue Apr 21 20:18:00 PDT 2026; root:xnu-11417.140.69.710.16~1/RELEASE_ARM64_VMAPPLE arm64",
+    "runner_image": "macos15 20260715.0234.1",
+    "sdk": "15.2",
+    "swift": "Apple Swift version 6.0.3 (swiftlang-6.0.3.1.10 clang-1600.0.30.1)\nTarget: arm64-apple-macosx15.0",
+    "xcode": "Xcode 16.2\nBuild version 16C5032a"
+  }
+}

--- a/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/resolved-dependencies.txt
+++ b/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/resolved-dependencies.txt
@@ -1,0 +1,8 @@
+Resolved dependency graph:
+.
+├── swift-syntax<https://github.com/apple/swift-syntax.git@509.1.1>
+├── grdb.swift<https://github.com/groue/GRDB.swift.git@6.29.3>
+└── swift-docc-plugin<https://github.com/apple/swift-docc-plugin.git@1.4.5>
+    └── swift-docc-symbolkit<https://github.com/swiftlang/swift-docc-symbolkit@1.0.0>
+Resolved GRDB: ├── grdb.swift<https://github.com/groue/GRDB.swift.git@6.29.3>
+Resolved SwiftSyntax: ├── swift-syntax<https://github.com/apple/swift-syntax.git@509.1.1>

--- a/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/summary.md
+++ b/Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/summary.md
@@ -1,0 +1,40 @@
+# First-party Swift source coverage
+
+- Source commit: `9152d8409aa55df5bc96e9c74411b3c4fb166429`
+- Command: `xcrun swift test --scratch-path <scratch-path> --enable-code-coverage`
+- Xcode: `Xcode 16.2 / Build version 16C5032a`
+- Swift: `Apple Swift version 6.0.3 (swiftlang-6.0.3.1.10 clang-1600.0.30.1) / Target: arm64-apple-macosx15.0`
+- SDK: `15.2`
+- LLVM coverage: `/Applications/Xcode_16.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov / Apple LLVM version 16.0.0 /    (clang-1600.0.26.6)Optimized build.`
+- Source tree: `clean`
+- Filtering: only tracked `.swift` files under `Sources/SwiftQL` and `Sources/SQLMacros`; dependencies, tests, benchmarks, build products, and generated expansion files are excluded.
+- This report is evidence only; it does not enforce a percentage threshold.
+
+| Target | Instrumented sources | Allowed uninstrumented | Lines | Functions |
+| --- | ---: | ---: | ---: | ---: |
+| SQLMacros | 4 | 0 | 2164/2218 (97.57%) | 154/157 (98.09%) |
+| SwiftQL | 45 | 2 | 2822/3628 (77.78%) | 703/939 (74.87%) |
+
+## Largest uncovered files
+
+This ranking identifies follow-up candidates; it is not a release gate.
+
+| Source | Uncovered lines | Uncovered functions |
+| --- | ---: | ---: |
+| `Sources/SwiftQL/Statements/SQLInsertStatement.swift` | 96 | 32 |
+| `Sources/SwiftQL/SQLDatabase.swift` | 59 | 12 |
+| `Sources/SwiftQL/Builders/QueryBuilder.swift` | 56 | 13 |
+| `Sources/SwiftQL/SQLStatements.swift` | 54 | 19 |
+| `Sources/SwiftQL/Statements/SQLQueryStatement.swift` | 51 | 17 |
+| `Sources/SwiftQL/Expression Builder/SQLInsertExpressionBuilder.swift` | 45 | 15 |
+| `Sources/SwiftQL/Operators/RealOperators.swift` | 45 | 15 |
+| `Sources/SwiftQL/SQLExpression.swift` | 44 | 13 |
+| `Sources/SwiftQL/SQLMeta.swift` | 40 | 14 |
+| `Sources/SwiftQL/Operators/IntegerOperators.swift` | 39 | 13 |
+
+## Allowed uninstrumented sources
+
+- `Sources/SwiftQL/SQL.swift`
+- `Sources/SwiftQL/SQLScalarResult.swift`
+
+These files have no executable regions in the current LLVM export. The explicit allowlist prevents other production sources from disappearing silently.

--- a/Coverage/README.md
+++ b/Coverage/README.md
@@ -75,7 +75,19 @@ such reports.
 
 ## Baselines and follow-ups
 
-The initial pinned Xcode 16.2 baseline is stored under `Coverage/Baselines/`.
-Large uncovered areas are ranked as follow-up candidates, not treated as an
-automatic failure. Material gaps are tracked in linked atomic GitHub issues so
-coverage work cannot silently expand the architecture PRs.
+The [initial pinned Xcode 16.2 baseline](Baselines/2026-07-17-xcode-16.2-swift-6.0/README.md)
+records two byte-identical clean reports from source commit
+`9152d8409aa55df5bc96e9c74411b3c4fb166429`, including the source manifests,
+resolved dependencies, full toolchain provenance, target totals, retained
+artifact identity, and two-run verdict.
+
+The first baseline reports SQLMacros at 2164/2218 lines and 154/157 functions,
+and SwiftQL at 2822/3628 lines and 703/939 functions. Those numbers rank
+follow-up candidates; they are not an automatic failure threshold.
+
+Material non-duplicate gaps are tracked by
+[#195](https://github.com/lukevanin/swiftql/issues/195) for the public fluent
+`INSERT ... SELECT` transition matrix and
+[#194](https://github.com/lukevanin/swiftql/issues/194) for QueryBuilder's
+missing-`FROM` rejection. Both issues carry an explicit priority and the v1.2
+milestone so coverage work cannot silently expand unrelated architecture PRs.

--- a/Coverage/README.md
+++ b/Coverage/README.md
@@ -1,0 +1,81 @@
+# SwiftQL Source Coverage
+
+SwiftQL records first-party source coverage before the v1.2 dialect, codec,
+binding, and descriptor refactors. Coverage is diagnostic evidence: it does not
+replace SQLite prepare/execution tests, macro expansion and diagnostic tests, or
+establish an arbitrary percentage release gate.
+
+## Pinned CI environment
+
+The `Swift 6.0 / first-party source coverage` job in
+`.github/workflows/swift.yml` runs on `macos-15` with Xcode 16.2
+(`DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer`) and the
+committed `Package.resolved`. The job records the source commit and clean-tree
+state; Xcode, Swift, SDK, `llvm-cov`, and `llvm-profdata` versions; runner
+platform and architecture; dependency graph; package-resolution digest; and
+exact coverage command in its retained artifact.
+
+Every coverage job performs two clean builds in independent SwiftPM scratch
+directories. The job fails if their normalized first-party source manifests
+differ.
+
+## Filtering contract
+
+The raw SwiftPM LLVM JSON contains dependencies, tests, build products, and
+generated files. `scripts/ci/source-coverage-report.py` includes only tracked
+`.swift` files found under the target roots declared in
+`scripts/ci/source-coverage-config.json`:
+
+- `Sources/SwiftQL`
+- `Sources/SQLMacros`
+
+Tests, temporary fixtures, benchmarks, package checkouts, build products, and
+generated macro expansion files therefore cannot contribute to the reported
+first-party totals. Fixture tests inject each excluded category and verify that
+the totals and manifest remain unchanged.
+
+LLVM does not currently report executable regions for `Sources/SwiftQL/SQL.swift`
+or `Sources/SwiftQL/SQLScalarResult.swift`. They are explicit exceptions in the
+configuration. Any other production source missing from LLVM data fails the
+report, and an exception that starts reporting coverage also fails until the
+stale allowance is removed.
+
+## Local reproduction
+
+Run the fixture tests first:
+
+```bash
+python3 scripts/ci/test-source-coverage-report.py
+```
+
+Then run the real package tests with coverage into a clean output and scratch
+directory:
+
+```bash
+SWIFTQL_COVERAGE_SCRATCH_PATH="${TMPDIR}/swiftql-coverage-build" \
+  scripts/ci/run-source-coverage.sh \
+  "${TMPDIR}/swiftql-coverage-report"
+```
+
+The output directory contains:
+
+- `llvm-coverage.json`: SwiftPM's unfiltered machine-readable LLVM export;
+- `llvm-coverage.lcov`: the same profile exported in standard LCOV form;
+- `first-party-coverage.json`: normalized per-target and per-file evidence;
+- `included-sources.txt`: deterministic source manifest used by the two-run check;
+- `allowed-uninstrumented-sources.txt`: explicit zero-region exceptions;
+- `summary.md`: the same concise target totals shown in the GitHub job summary;
+- toolchain, dependency, command, source-commit, and test-log provenance.
+
+Use a new output directory for every run. The script refuses to overwrite a
+prior report and refuses to assign a commit to dirty source content. During
+coverage-tool development only, `SWIFTQL_ALLOW_DIRTY_COVERAGE=1` permits a
+diagnostic report marked `dirty`; the two-run reproducibility verifier rejects
+such reports.
+
+## Baselines and follow-ups
+
+The initial pinned Xcode 16.2 baseline is stored under `Coverage/Baselines/`.
+Large uncovered areas are ranked as follow-up candidates, not treated as an
+automatic failure. Material gaps are tracked in linked atomic GitHub issues so
+coverage work cannot silently expand the architecture PRs.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ toolchains and reproducible CI matrix.
 See [performance benchmarks](BENCHMARKS.md) for the reproducible query
 construction, preparation, cache, binding, execution, and decoding baselines.
 
+See [first-party source coverage](Coverage/README.md) for the pinned Swift 6
+capture, filtering contract, retained raw evidence, and checked-in baseline.
+
 See [releasing SwiftQL](RELEASING.md) for the exact-tag validation, safe dry-run,
 artifact provenance, publication, verification, and recovery procedure.
 

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -147,6 +147,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             [
                 "BENCHMARKS.md",
                 "COMPATIBILITY.md",
+                "Coverage/README.md",
                 "LICENSE.md",
                 "RELEASING.md",
                 "ROADMAP.md",

--- a/scripts/ci/run-source-coverage.sh
+++ b/scripts/ci/run-source-coverage.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+    printf 'error: source coverage: %s\n' "$*" >&2
+    exit 1
+}
+
+script_directory="$(cd "$(dirname "$0")" && pwd -P)"
+repository_root="$(cd "$script_directory/../.." && pwd -P)"
+
+if [[ "$#" -ne 1 ]]; then
+    printf 'usage: %s OUTPUT_DIRECTORY\n' "$0" >&2
+    exit 64
+fi
+
+output_directory="$1"
+scratch_path="${SWIFTQL_COVERAGE_SCRATCH_PATH:-$repository_root/.build/source-coverage}"
+mkdir -p "$output_directory" "$scratch_path"
+output_directory="$(cd "$output_directory" && pwd -P)"
+scratch_path="$(cd "$scratch_path" && pwd -P)"
+
+if [[ -n "$(find "$output_directory" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    fail "output directory is not clean: $output_directory"
+fi
+
+for output in \
+    llvm-coverage.json \
+    llvm-coverage.lcov \
+    first-party-coverage.json \
+    included-sources.txt \
+    allowed-uninstrumented-sources.txt \
+    summary.md \
+    swift-test.log \
+    xcode-version.txt \
+    swift-version.txt \
+    sdk-version.txt \
+    llvm-cov-version.txt \
+    llvm-profdata-version.txt \
+    platform.txt \
+    architecture.txt \
+    runner-image.txt \
+    resolved-dependencies.txt; do
+    [[ ! -e "$output_directory/$output" ]] || \
+        fail "output directory is not clean: $output_directory/$output already exists"
+done
+
+cd "$repository_root"
+source_commit="$(git rev-parse HEAD)"
+[[ -n "$source_commit" ]] || fail "could not determine source commit"
+if [[ -z "$(git status --porcelain)" ]]; then
+    source_tree_state="clean"
+else
+    source_tree_state="dirty"
+fi
+if [[ "$source_tree_state" != "clean" && "${SWIFTQL_ALLOW_DIRTY_COVERAGE:-0}" != "1" ]]; then
+    fail "source tree is dirty; commit the capture inputs or set SWIFTQL_ALLOW_DIRTY_COVERAGE=1 for diagnostic-only output"
+fi
+
+xcodebuild -version > "$output_directory/xcode-version.txt"
+xcrun swift --version > "$output_directory/swift-version.txt"
+xcrun --sdk macosx --show-sdk-version > "$output_directory/sdk-version.txt"
+{
+    xcrun --find llvm-cov
+    xcrun llvm-cov --version
+} > "$output_directory/llvm-cov-version.txt"
+{
+    xcrun --find llvm-profdata
+    xcrun llvm-profdata --version
+} > "$output_directory/llvm-profdata-version.txt"
+uname -a > "$output_directory/platform.txt"
+uname -m > "$output_directory/architecture.txt"
+printf '%s %s\n' "${ImageOS:-local}" "${ImageVersion:-unavailable}" \
+    > "$output_directory/runner-image.txt"
+
+xcrun swift package --scratch-path "$scratch_path" resolve
+git diff --exit-code -- Package.resolved
+SWIFTQL_SCRATCH_PATH="$scratch_path" \
+    "$script_directory/report-resolved-dependencies.sh" \
+    > "$output_directory/resolved-dependencies.txt"
+xcrun swift package --scratch-path "$scratch_path" clean
+
+coverage_command='xcrun swift test --scratch-path <scratch-path> --enable-code-coverage'
+xcrun swift test \
+        --scratch-path "$scratch_path" \
+        --enable-code-coverage \
+        2>&1 | tee "$output_directory/swift-test.log"
+
+raw_coverage_json="$(
+    xcrun swift test \
+        --scratch-path "$scratch_path" \
+        --show-codecov-path
+)"
+[[ -s "$raw_coverage_json" ]] || \
+    fail "SwiftPM did not produce a non-empty LLVM JSON report: $raw_coverage_json"
+cp "$raw_coverage_json" "$output_directory/llvm-coverage.json"
+
+profile_data="$(dirname "$raw_coverage_json")/default.profdata"
+[[ -s "$profile_data" ]] || \
+    fail "SwiftPM did not produce profile data: $profile_data"
+binary_directory="$(
+    xcrun swift build \
+        --scratch-path "$scratch_path" \
+        --show-bin-path
+)"
+test_binary="$binary_directory/SwiftQLPackageTests.xctest/Contents/MacOS/SwiftQLPackageTests"
+[[ -x "$test_binary" ]] || fail "could not find coverage test binary: $test_binary"
+xcrun llvm-cov export \
+    "$test_binary" \
+    -instr-profile "$profile_data" \
+    -format=lcov \
+    > "$output_directory/llvm-coverage.lcov"
+[[ -s "$output_directory/llvm-coverage.lcov" ]] || \
+    fail "llvm-cov produced an empty LCOV export"
+
+python3 "$script_directory/source-coverage-report.py" \
+    --llvm-json "$output_directory/llvm-coverage.json" \
+    --repository-root "$repository_root" \
+    --config "$script_directory/source-coverage-config.json" \
+    --output-directory "$output_directory" \
+    --source-commit "$source_commit" \
+    --xcode-version "$(cat "$output_directory/xcode-version.txt")" \
+    --swift-version "$(cat "$output_directory/swift-version.txt")" \
+    --sdk-version "$(cat "$output_directory/sdk-version.txt")" \
+    --llvm-cov-version "$(cat "$output_directory/llvm-cov-version.txt")" \
+    --llvm-profdata-version "$(cat "$output_directory/llvm-profdata-version.txt")" \
+    --platform "$(cat "$output_directory/platform.txt")" \
+    --architecture "$(cat "$output_directory/architecture.txt")" \
+    --runner-image "$(cat "$output_directory/runner-image.txt")" \
+    --source-tree-state "$source_tree_state" \
+    --coverage-command "$coverage_command"
+
+printf 'SWIFTQL_SOURCE_COVERAGE %s\n' "$output_directory/first-party-coverage.json"

--- a/scripts/ci/source-coverage-config.json
+++ b/scripts/ci/source-coverage-config.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "targets": [
+    {
+      "name": "SQLMacros",
+      "source_root": "Sources/SQLMacros",
+      "allowed_uninstrumented_sources": []
+    },
+    {
+      "name": "SwiftQL",
+      "source_root": "Sources/SwiftQL",
+      "allowed_uninstrumented_sources": [
+        "Sources/SwiftQL/SQL.swift",
+        "Sources/SwiftQL/SQLScalarResult.swift"
+      ]
+    }
+  ]
+}

--- a/scripts/ci/source-coverage-report.py
+++ b/scripts/ci/source-coverage-report.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+
+"""Extract deterministic first-party coverage from SwiftPM's LLVM JSON export."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+METRICS = ("lines", "functions", "regions")
+
+
+class CoverageError(RuntimeError):
+    """Raised when coverage inputs violate the reporting contract."""
+
+
+def load_json(path: Path) -> Mapping[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CoverageError(f"could not read JSON {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise CoverageError(f"expected a JSON object in {path}")
+    return value
+
+
+def relative_config_path(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise CoverageError(f"{field} must be a non-empty relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or "." in path.parts:
+        raise CoverageError(f"{field} must stay within the repository: {value}")
+    return path.as_posix()
+
+
+def load_config(path: Path) -> List[Dict[str, Any]]:
+    config = load_json(path)
+    if config.get("schema_version") != 1:
+        raise CoverageError("coverage config schema_version must be 1")
+    raw_targets = config.get("targets")
+    if not isinstance(raw_targets, list) or not raw_targets:
+        raise CoverageError("coverage config must define at least one target")
+
+    targets: List[Dict[str, Any]] = []
+    seen_names = set()
+    seen_roots = set()
+    for raw_target in raw_targets:
+        if not isinstance(raw_target, dict):
+            raise CoverageError("every coverage target must be an object")
+        name = raw_target.get("name")
+        if not isinstance(name, str) or not name:
+            raise CoverageError("every coverage target needs a non-empty name")
+        if name in seen_names:
+            raise CoverageError(f"duplicate coverage target name: {name}")
+        source_root = relative_config_path(
+            raw_target.get("source_root"), f"{name}.source_root"
+        )
+        if not source_root.startswith("Sources/"):
+            raise CoverageError(
+                f"{name}.source_root must identify a first-party Sources directory"
+            )
+        if source_root in seen_roots:
+            raise CoverageError(f"duplicate coverage source root: {source_root}")
+
+        raw_allowed = raw_target.get("allowed_uninstrumented_sources", [])
+        if not isinstance(raw_allowed, list):
+            raise CoverageError(
+                f"{name}.allowed_uninstrumented_sources must be an array"
+            )
+        allowed = sorted(
+            relative_config_path(value, f"{name}.allowed_uninstrumented_sources")
+            for value in raw_allowed
+        )
+        if len(allowed) != len(set(allowed)):
+            raise CoverageError(f"duplicate uninstrumented source allowance in {name}")
+        for allowed_path in allowed:
+            if not (
+                allowed_path == source_root
+                or allowed_path.startswith(source_root + "/")
+            ):
+                raise CoverageError(
+                    f"allowed source is outside {name}'s root: {allowed_path}"
+                )
+
+        seen_names.add(name)
+        seen_roots.add(source_root)
+        targets.append(
+            {
+                "name": name,
+                "source_root": source_root,
+                "allowed_uninstrumented_sources": allowed,
+            }
+        )
+    return sorted(targets, key=lambda target: target["name"])
+
+
+def repository_relative_path(filename: str, repository_root: Path) -> Optional[str]:
+    path = Path(filename)
+    if not path.is_absolute():
+        path = repository_root / path
+    try:
+        relative = path.resolve().relative_to(repository_root)
+    except ValueError:
+        return None
+    return relative.as_posix()
+
+
+def raw_coverage_files(report: Mapping[str, Any]) -> List[Mapping[str, Any]]:
+    if report.get("type") != "llvm.coverage.json.export":
+        raise CoverageError("input is not an LLVM coverage JSON export")
+    if not isinstance(report.get("version"), str) or not report["version"].strip():
+        raise CoverageError("LLVM coverage report has no non-empty string version")
+    data = report.get("data")
+    if not isinstance(data, list) or not data:
+        raise CoverageError("LLVM coverage report has no data entries")
+    if len(data) != 1:
+        raise CoverageError(
+            "SwiftPM coverage export must contain exactly one data entry"
+        )
+    files: List[Mapping[str, Any]] = []
+    for entry in data:
+        if not isinstance(entry, dict) or not isinstance(entry.get("files"), list):
+            raise CoverageError("LLVM coverage data entry has no files array")
+        for file_entry in entry["files"]:
+            if not isinstance(file_entry, dict):
+                raise CoverageError("LLVM coverage file entry must be an object")
+            if not isinstance(file_entry.get("filename"), str):
+                raise CoverageError("LLVM coverage file entry has no filename")
+            files.append(file_entry)
+    return files
+
+
+def metric(summary: Mapping[str, Any], metric_name: str) -> Dict[str, Any]:
+    raw_metric = summary.get(metric_name)
+    if not isinstance(raw_metric, dict):
+        raise CoverageError(f"coverage file is missing {metric_name} summary")
+    count = raw_metric.get("count")
+    covered = raw_metric.get("covered")
+    if (
+        not isinstance(count, int)
+        or isinstance(count, bool)
+        or not isinstance(covered, int)
+        or isinstance(covered, bool)
+        or count < 0
+        or covered < 0
+        or covered > count
+    ):
+        raise CoverageError(f"invalid {metric_name} count/covered values")
+    percent = 0.0 if count == 0 else round((covered * 100.0) / count, 2)
+    return {
+        "count": count,
+        "covered": covered,
+        "uncovered": count - covered,
+        "percent": percent,
+    }
+
+
+def file_metrics(file_entry: Mapping[str, Any]) -> Dict[str, Any]:
+    summary = file_entry.get("summary")
+    if not isinstance(summary, dict):
+        raise CoverageError(
+            f"coverage file has no summary: {file_entry.get('filename', '<unknown>')}"
+        )
+    return {metric_name: metric(summary, metric_name) for metric_name in METRICS}
+
+
+def aggregate(file_reports: Iterable[Mapping[str, Any]]) -> Dict[str, Any]:
+    totals = {
+        metric_name: {"count": 0, "covered": 0}
+        for metric_name in METRICS
+    }
+    for file_report in file_reports:
+        for metric_name in METRICS:
+            file_metric = file_report[metric_name]
+            totals[metric_name]["count"] += file_metric["count"]
+            totals[metric_name]["covered"] += file_metric["covered"]
+    result: Dict[str, Any] = {}
+    for metric_name in METRICS:
+        count = totals[metric_name]["count"]
+        covered = totals[metric_name]["covered"]
+        result[metric_name] = {
+            "count": count,
+            "covered": covered,
+            "uncovered": count - covered,
+            "percent": 0.0 if count == 0 else round((covered * 100.0) / count, 2),
+        }
+    return result
+
+
+def expected_sources(repository_root: Path, source_root: str) -> List[str]:
+    directory = repository_root / source_root
+    if not directory.is_dir():
+        raise CoverageError(f"configured source root does not exist: {source_root}")
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repository_root),
+                "ls-files",
+                "-z",
+                "--",
+                source_root,
+            ],
+            check=False,
+            capture_output=True,
+        )
+    except OSError as error:
+        raise CoverageError(f"could not enumerate tracked sources: {error}") from error
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise CoverageError(f"could not enumerate tracked sources: {detail}")
+
+    try:
+        tracked_paths = result.stdout.decode("utf-8").split("\0")
+    except UnicodeDecodeError as error:
+        raise CoverageError("tracked source paths are not valid UTF-8") from error
+    sources = sorted(path for path in tracked_paths if path.endswith(".swift"))
+    if not sources:
+        raise CoverageError(
+            f"configured source root has no tracked Swift files: {source_root}"
+        )
+    for source in sources:
+        if not source.startswith(source_root + "/"):
+            raise CoverageError(f"tracked source escaped configured root: {source}")
+        source_path = repository_root / source
+        if not source_path.is_file():
+            raise CoverageError(f"tracked source is not a regular file: {source}")
+        if repository_relative_path(str(source_path), repository_root) != source:
+            raise CoverageError(
+                f"tracked source resolves through an alias or outside the repository: {source}"
+            )
+    return sources
+
+
+def excluded_category(relative_path: Optional[str]) -> str:
+    if relative_path is None:
+        return "outside_repository"
+    if relative_path.startswith(".build/") or relative_path.startswith(".swiftpm/"):
+        return "build_or_dependency"
+    if relative_path.startswith("Tests/") or "/Tests/" in relative_path:
+        return "tests_or_fixtures"
+    if relative_path.startswith("Benchmarks/"):
+        return "benchmarks"
+    if ".derived/" in relative_path or "/DerivedSources/" in relative_path:
+        return "generated"
+    return "other_repository_sources"
+
+
+def sha256_text(lines: Sequence[str]) -> str:
+    payload = "".join(line + "\n" for line in lines).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def package_resolution_sha256(repository_root: Path) -> str:
+    path = repository_root / "Package.resolved"
+    if not path.is_file():
+        raise CoverageError("Package.resolved is required for coverage provenance")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def build_report(
+    raw_report: Mapping[str, Any],
+    repository_root: Path,
+    targets: Sequence[Mapping[str, Any]],
+    source_commit: str,
+    xcode_version: str,
+    swift_version: str,
+    sdk_version: str,
+    llvm_cov_version: str,
+    llvm_profdata_version: str,
+    platform: str,
+    architecture: str,
+    runner_image: str,
+    source_tree_state: str,
+    coverage_command: str,
+) -> Tuple[Dict[str, Any], List[str], List[str]]:
+    if re.fullmatch(r"[0-9a-f]{40}", source_commit) is None:
+        raise CoverageError("source commit must be a full 40-character Git SHA")
+    toolchain_fields = {
+        "xcode": xcode_version,
+        "swift": swift_version,
+        "sdk": sdk_version,
+        "llvm_cov": llvm_cov_version,
+        "llvm_profdata": llvm_profdata_version,
+        "platform": platform,
+        "architecture": architecture,
+        "runner_image": runner_image,
+    }
+    for name, value in toolchain_fields.items():
+        if not value.strip():
+            raise CoverageError(f"toolchain provenance is empty: {name}")
+    raw_files = raw_coverage_files(raw_report)
+    expected_by_target: Dict[str, List[str]] = {}
+    owner_by_path: Dict[str, str] = {}
+    roots_by_target: Dict[str, str] = {}
+    allowed_by_target: Dict[str, List[str]] = {}
+    for target in targets:
+        name = target["name"]
+        roots_by_target[name] = target["source_root"]
+        expected_by_target[name] = expected_sources(
+            repository_root, target["source_root"]
+        )
+        allowed_by_target[name] = list(target["allowed_uninstrumented_sources"])
+        for source in expected_by_target[name]:
+            if source in owner_by_path:
+                raise CoverageError(f"source belongs to multiple targets: {source}")
+            owner_by_path[source] = name
+
+    selected: Dict[str, Mapping[str, Any]] = {}
+    excluded = Counter()
+    unexpected_target_paths: List[str] = []
+    for raw_file in raw_files:
+        relative = repository_relative_path(raw_file["filename"], repository_root)
+        if relative in owner_by_path:
+            if relative in selected:
+                raise CoverageError(f"duplicate first-party coverage entry: {relative}")
+            selected[relative] = raw_file
+            continue
+        if relative is not None and relative.startswith("Sources/"):
+            unexpected_target_paths.append(relative)
+        excluded[excluded_category(relative)] += 1
+    if unexpected_target_paths:
+        raise CoverageError(
+            "coverage reported untracked files inside target roots: "
+            + ", ".join(sorted(set(unexpected_target_paths)))
+        )
+
+    target_reports: Dict[str, Any] = {}
+    included_manifest: List[str] = []
+    uninstrumented_manifest: List[str] = []
+    all_file_reports: List[Mapping[str, Any]] = []
+    for name in sorted(expected_by_target):
+        expected = expected_by_target[name]
+        instrumented = sorted(source for source in expected if source in selected)
+        missing = sorted(source for source in expected if source not in selected)
+        allowed = allowed_by_target[name]
+        unexpected_missing = sorted(set(missing) - set(allowed))
+        stale_allowances = sorted(set(allowed) - set(missing))
+        if unexpected_missing:
+            raise CoverageError(
+                f"{name} sources disappeared from LLVM coverage without an allowance: "
+                + ", ".join(unexpected_missing)
+            )
+        if stale_allowances:
+            raise CoverageError(
+                f"{name} uninstrumented allowances are stale or missing from disk: "
+                + ", ".join(stale_allowances)
+            )
+
+        file_reports: List[Dict[str, Any]] = []
+        for source in instrumented:
+            report = {"path": source, **file_metrics(selected[source])}
+            file_reports.append(report)
+            all_file_reports.append(report)
+            included_manifest.append(f"{name}\t{source}")
+        for source in missing:
+            uninstrumented_manifest.append(f"{name}\t{source}")
+
+        target_reports[name] = {
+            "source_root": roots_by_target[name],
+            "source_files": len(expected),
+            "instrumented_source_files": len(instrumented),
+            "allowed_uninstrumented_source_files": missing,
+            "totals": aggregate(file_reports),
+            "files": file_reports,
+        }
+
+    largest_gaps = sorted(
+        (
+            report
+            for report in all_file_reports
+            if report["lines"]["uncovered"] > 0
+            or report["functions"]["uncovered"] > 0
+        ),
+        key=lambda report: (
+            -report["lines"]["uncovered"],
+            -report["functions"]["uncovered"],
+            report["path"],
+        ),
+    )[:20]
+
+    report = {
+        "schema_version": 1,
+        "source_commit": source_commit,
+        "source_tree_state": source_tree_state.strip(),
+        "toolchain": {
+            name: value.strip() for name, value in toolchain_fields.items()
+        },
+        "coverage_command": coverage_command,
+        "package_resolved_sha256": package_resolution_sha256(repository_root),
+        "raw_llvm_report": {
+            "type": raw_report.get("type"),
+            "version": raw_report.get("version"),
+            "file_entries": len(raw_files),
+        },
+        "filtering": {
+            "rule": "Only tracked .swift files under configured first-party target roots are included.",
+            "included_source_files": len(included_manifest),
+            "included_sources_sha256": sha256_text(included_manifest),
+            "allowed_uninstrumented_source_files": len(uninstrumented_manifest),
+            "excluded_raw_file_entries": sum(excluded.values()),
+            "excluded_raw_file_entries_by_category": dict(sorted(excluded.items())),
+        },
+        "targets": target_reports,
+        "overall": aggregate(all_file_reports),
+        "largest_uncovered_files": largest_gaps,
+    }
+    return report, included_manifest, uninstrumented_manifest
+
+
+def summary_markdown(report: Mapping[str, Any]) -> str:
+    lines = [
+        "# First-party Swift source coverage",
+        "",
+        f"- Source commit: `{report['source_commit']}`",
+        f"- Command: `{report['coverage_command']}`",
+        f"- Xcode: `{report['toolchain']['xcode'].replace(chr(10), ' / ')}`",
+        f"- Swift: `{report['toolchain']['swift'].replace(chr(10), ' / ')}`",
+        f"- SDK: `{report['toolchain']['sdk'].replace(chr(10), ' / ')}`",
+        f"- LLVM coverage: `{report['toolchain']['llvm_cov'].replace(chr(10), ' / ')}`",
+        f"- Source tree: `{report['source_tree_state']}`",
+        "- Filtering: only tracked `.swift` files under `Sources/SwiftQL` and "
+        "`Sources/SQLMacros`; dependencies, tests, benchmarks, build products, "
+        "and generated expansion files are excluded.",
+        "- This report is evidence only; it does not enforce a percentage threshold.",
+        "",
+        "| Target | Instrumented sources | Allowed uninstrumented | Lines | Functions |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for name, target in sorted(report["targets"].items()):
+        line_metric = target["totals"]["lines"]
+        function_metric = target["totals"]["functions"]
+        lines.append(
+            f"| {name} | {target['instrumented_source_files']} | "
+            f"{len(target['allowed_uninstrumented_source_files'])} | "
+            f"{line_metric['covered']}/{line_metric['count']} "
+            f"({line_metric['percent']:.2f}%) | "
+            f"{function_metric['covered']}/{function_metric['count']} "
+            f"({function_metric['percent']:.2f}%) |"
+        )
+
+    lines.extend(["", "## Largest uncovered files", ""])
+    gaps = report["largest_uncovered_files"]
+    if gaps:
+        lines.extend(
+            [
+                "This ranking identifies follow-up candidates; it is not a release gate.",
+                "",
+                "| Source | Uncovered lines | Uncovered functions |",
+                "| --- | ---: | ---: |",
+            ]
+        )
+        for file_report in gaps[:10]:
+            lines.append(
+                f"| `{file_report['path']}` | "
+                f"{file_report['lines']['uncovered']} | "
+                f"{file_report['functions']['uncovered']} |"
+            )
+    else:
+        lines.append("No uncovered first-party lines or functions were reported.")
+
+    uninstrumented = [
+        source
+        for target in report["targets"].values()
+        for source in target["allowed_uninstrumented_source_files"]
+    ]
+    lines.extend(["", "## Allowed uninstrumented sources", ""])
+    if uninstrumented:
+        lines.extend(f"- `{source}`" for source in sorted(uninstrumented))
+        lines.extend(
+            [
+                "",
+                "These files have no executable regions in the current LLVM export. "
+                "The explicit allowlist prevents other production sources from "
+                "disappearing silently.",
+            ]
+        )
+    else:
+        lines.append("None.")
+    return "\n".join(lines) + "\n"
+
+
+def parse_arguments(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--llvm-json", required=True, type=Path)
+    parser.add_argument("--repository-root", required=True, type=Path)
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--output-directory", required=True, type=Path)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--xcode-version", required=True)
+    parser.add_argument("--swift-version", required=True)
+    parser.add_argument("--sdk-version", required=True)
+    parser.add_argument("--llvm-cov-version", required=True)
+    parser.add_argument("--llvm-profdata-version", required=True)
+    parser.add_argument("--platform", required=True)
+    parser.add_argument("--architecture", required=True)
+    parser.add_argument("--runner-image", required=True)
+    parser.add_argument("--source-tree-state", choices=("clean", "dirty"), required=True)
+    parser.add_argument("--coverage-command", required=True)
+    return parser.parse_args(argv)
+
+
+def run(arguments: argparse.Namespace) -> None:
+    repository_root = arguments.repository_root.resolve()
+    if not repository_root.is_dir():
+        raise CoverageError(
+            f"repository root does not exist: {arguments.repository_root}"
+        )
+    output_directory = arguments.output_directory.resolve()
+    output_directory.mkdir(parents=True, exist_ok=True)
+    report, included, uninstrumented = build_report(
+        raw_report=load_json(arguments.llvm_json),
+        repository_root=repository_root,
+        targets=load_config(arguments.config),
+        source_commit=arguments.source_commit,
+        xcode_version=arguments.xcode_version,
+        swift_version=arguments.swift_version,
+        sdk_version=arguments.sdk_version,
+        llvm_cov_version=arguments.llvm_cov_version,
+        llvm_profdata_version=arguments.llvm_profdata_version,
+        platform=arguments.platform,
+        architecture=arguments.architecture,
+        runner_image=arguments.runner_image,
+        source_tree_state=arguments.source_tree_state,
+        coverage_command=arguments.coverage_command,
+    )
+    (output_directory / "first-party-coverage.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (output_directory / "included-sources.txt").write_text(
+        "".join(line + "\n" for line in included), encoding="utf-8"
+    )
+    (output_directory / "allowed-uninstrumented-sources.txt").write_text(
+        "".join(line + "\n" for line in uninstrumented), encoding="utf-8"
+    )
+    (output_directory / "summary.md").write_text(
+        summary_markdown(report), encoding="utf-8"
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    try:
+        run(parse_arguments(argv))
+    except CoverageError as error:
+        print(f"error: source coverage report: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test-source-coverage-report.py
+++ b/scripts/ci/test-source-coverage-report.py
@@ -495,6 +495,7 @@ class CoverageWorkflowTests(unittest.TestCase):
             )
         )
         included = (INITIAL_BASELINE / "included-sources.txt").read_bytes()
+        included_lines = included.decode("utf-8").splitlines()
         repeated = (
             INITIAL_BASELINE / "repeated-included-sources.txt"
         ).read_bytes()
@@ -510,12 +511,20 @@ class CoverageWorkflowTests(unittest.TestCase):
         self.assertEqual(report["source_commit"], reproducibility["source_commit"])
         self.assertTrue(reproducibility["normalized_reports_match"])
         self.assertEqual(included, repeated)
+        included_sha256 = hashlib.sha256(included).hexdigest()
         self.assertEqual(
-            hashlib.sha256(included).hexdigest(),
+            included_sha256,
             report["filtering"]["included_sources_sha256"],
         )
         self.assertEqual(
-            len(included.decode("utf-8").splitlines()),
+            included_sha256, reproducibility["included_sources_sha256"]
+        )
+        self.assertEqual(
+            report["package_resolved_sha256"],
+            reproducibility["package_resolved_sha256"],
+        )
+        self.assertEqual(
+            len(included_lines),
             report["filtering"]["included_source_files"],
         )
         self.assertEqual(
@@ -523,6 +532,39 @@ class CoverageWorkflowTests(unittest.TestCase):
             report["filtering"]["allowed_uninstrumented_source_files"],
         )
         self.assertEqual(set(report["targets"]), {"SQLMacros", "SwiftQL"})
+
+        tracked_result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(SCRIPT.parents[2]),
+                "ls-files",
+                "--",
+                "Sources/SQLMacros",
+                "Sources/SwiftQL",
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        tracked_sources = {
+            path
+            for path in tracked_result.stdout.splitlines()
+            if path.endswith(".swift")
+        }
+        accounted_lines = included_lines + allowed
+        accounted_sources = set()
+        for line in accounted_lines:
+            target, source = line.split("\t", maxsplit=1)
+            expected_target = (
+                "SQLMacros"
+                if source.startswith("Sources/SQLMacros/")
+                else "SwiftQL"
+            )
+            self.assertEqual(target, expected_target)
+            self.assertNotIn(source, accounted_sources)
+            accounted_sources.add(source)
+        self.assertEqual(accounted_sources, tracked_sources)
         self.assertFalse(list(INITIAL_BASELINE.glob("llvm-coverage.*")))
 
 

--- a/scripts/ci/test-source-coverage-report.py
+++ b/scripts/ci/test-source-coverage-report.py
@@ -18,6 +18,7 @@ SCRIPT = Path(__file__).with_name("source-coverage-report.py")
 VERIFY_SCRIPT = Path(__file__).with_name(
     "verify-source-coverage-reproducibility.sh"
 )
+WORKFLOW = SCRIPT.parents[2] / ".github/workflows/swift.yml"
 
 
 def metric(count: int, covered: int) -> Dict[str, Any]:
@@ -460,6 +461,23 @@ class SourceCoverageReportTests(unittest.TestCase):
         )
         self.assertNotEqual(failure.returncode, 0)
         self.assertIn("did not capture a clean tree", failure.stderr)
+
+
+class CoverageWorkflowTests(unittest.TestCase):
+    def test_pull_request_capture_uses_durable_head_commit(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "COVERAGE_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}",
+            workflow,
+        )
+        self.assertIn("ref: ${{ env.COVERAGE_SOURCE_SHA }}", workflow)
+        self.assertIn(
+            'test "$(git rev-parse HEAD)" = "$COVERAGE_SOURCE_SHA"', workflow
+        )
+        self.assertIn(
+            "name: swiftql-source-coverage-${{ env.COVERAGE_SOURCE_SHA }}-",
+            workflow,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test-source-coverage-report.py
+++ b/scripts/ci/test-source-coverage-report.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+
+"""Fixture tests for the first-party source coverage reporter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+
+SCRIPT = Path(__file__).with_name("source-coverage-report.py")
+VERIFY_SCRIPT = Path(__file__).with_name(
+    "verify-source-coverage-reproducibility.sh"
+)
+
+
+def metric(count: int, covered: int) -> Dict[str, Any]:
+    return {
+        "count": count,
+        "covered": covered,
+        "notcovered": count - covered,
+        "percent": 0 if count == 0 else (covered * 100.0) / count,
+    }
+
+
+def file_entry(
+    path: Path, lines: Sequence[int] = (10, 5), functions: Sequence[int] = (2, 1)
+) -> Dict[str, Any]:
+    return {
+        "filename": str(path),
+        "summary": {
+            "lines": metric(lines[0], lines[1]),
+            "functions": metric(functions[0], functions[1]),
+            "regions": metric(lines[0] + functions[0], lines[1] + functions[1]),
+        },
+    }
+
+
+class SourceCoverageReportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory(
+            prefix="swiftql-source-coverage-test."
+        )
+        self.root = Path(self.temporary_directory.name) / "repo"
+        self.root.mkdir()
+        (self.root / "Package.resolved").write_text(
+            '{"pins":[],"version":2}\n', encoding="utf-8"
+        )
+        self.sql_macros = self.make_source("Sources/SQLMacros/Macro.swift")
+        self.swiftql = self.make_source("Sources/SwiftQL/Query.swift")
+        self.test_source = self.make_source("Tests/SQLTests/QueryTests.swift")
+        self.dependency = self.make_source(
+            ".build/checkouts/Dependency/Sources/Dependency.swift"
+        )
+        self.generated = self.make_source(
+            ".build/arm64/debug/SwiftQLPackageTests.derived/runner.swift"
+        )
+        self.benchmark = self.make_source(
+            "Benchmarks/Sources/SwiftQLBenchmarks/Runner.swift"
+        )
+        self.integration_fixture = self.make_source(
+            "IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift"
+        )
+        self.config = self.root / "coverage-config.json"
+        self.write_config()
+        subprocess.run(
+            ["git", "-C", str(self.root), "init", "-q"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.root),
+                "add",
+                "--",
+                "Sources/SQLMacros/Macro.swift",
+                "Sources/SwiftQL/Query.swift",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def make_source(self, relative_path: str) -> Path:
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("func coveredFixture() {}\n", encoding="utf-8")
+        return path
+
+    def write_config(self, allowed: Optional[List[str]] = None) -> None:
+        self.config.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "targets": [
+                        {
+                            "name": "SQLMacros",
+                            "source_root": "Sources/SQLMacros",
+                            "allowed_uninstrumented_sources": [],
+                        },
+                        {
+                            "name": "SwiftQL",
+                            "source_root": "Sources/SwiftQL",
+                            "allowed_uninstrumented_sources": allowed or [],
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def write_raw_report(
+        self,
+        entries: Sequence[Dict[str, Any]],
+        name: str = "coverage.json",
+        document: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        path = self.root / name
+        path.write_text(
+            json.dumps(
+                document
+                or {
+                    "type": "llvm.coverage.json.export",
+                    "version": "fixture",
+                    "data": [{"files": list(entries)}],
+                },
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def run_report(
+        self,
+        entries: Sequence[Dict[str, Any]],
+        output_name: str = "output",
+        expect_success: bool = True,
+        document: Optional[Dict[str, Any]] = None,
+    ) -> subprocess.CompletedProcess[str]:
+        raw_report = self.write_raw_report(
+            entries, f"{output_name}-raw.json", document=document
+        )
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            "--llvm-json",
+            str(raw_report),
+            "--repository-root",
+            str(self.root),
+            "--config",
+            str(self.config),
+            "--output-directory",
+            str(self.root / output_name),
+            "--source-commit",
+            "0123456789abcdef0123456789abcdef01234567",
+            "--xcode-version",
+            "Xcode fixture",
+            "--swift-version",
+            "Swift fixture",
+            "--sdk-version",
+            "SDK fixture",
+            "--llvm-cov-version",
+            "llvm-cov fixture",
+            "--llvm-profdata-version",
+            "llvm-profdata fixture",
+            "--platform",
+            "platform fixture",
+            "--architecture",
+            "architecture fixture",
+            "--runner-image",
+            "runner fixture",
+            "--source-tree-state",
+            "clean",
+            "--coverage-command",
+            "swift test --enable-code-coverage",
+        ]
+        result = subprocess.run(command, text=True, capture_output=True, check=False)
+        if expect_success and result.returncode != 0:
+            self.fail(f"report failed: {result.stderr}")
+        if not expect_success and result.returncode == 0:
+            self.fail("report unexpectedly succeeded")
+        return result
+
+    def test_filters_dependencies_tests_generated_sources_and_benchmarks(self) -> None:
+        outside_dependency = (
+            Path(self.temporary_directory.name)
+            / "dependency/Sources/SwiftQL/Lookalike.swift"
+        )
+        entries = [
+            file_entry(self.dependency, (100, 100), (50, 50)),
+            file_entry(outside_dependency, (100, 100), (50, 50)),
+            file_entry(self.test_source, (100, 100), (50, 50)),
+            file_entry(self.generated, (100, 100), (50, 50)),
+            file_entry(self.benchmark, (100, 100), (50, 50)),
+            file_entry(self.integration_fixture, (100, 100), (50, 50)),
+            file_entry(Path("<macro expansion>"), (100, 100), (50, 50)),
+            file_entry(
+                Path("@__swiftmacro_7SwiftQL5QueryfMp_.swift"),
+                (100, 100),
+                (50, 50),
+            ),
+            file_entry(self.sql_macros, (8, 4), (4, 2)),
+            file_entry(self.swiftql, (10, 5), (2, 1)),
+        ]
+        self.run_report(entries)
+        report = json.loads(
+            (self.root / "output/first-party-coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(report["overall"]["lines"]["count"], 18)
+        self.assertEqual(report["overall"]["lines"]["covered"], 9)
+        self.assertEqual(report["filtering"]["included_source_files"], 2)
+        manifest = (self.root / "output/included-sources.txt").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("Sources/SQLMacros/Macro.swift", manifest)
+        self.assertIn("Sources/SwiftQL/Query.swift", manifest)
+        self.assertNotIn("Dependency.swift", manifest)
+        self.assertNotIn("QueryTests.swift", manifest)
+        self.assertNotIn("runner.swift", manifest)
+        self.assertNotIn("Runner.swift", manifest)
+        self.assertNotIn("SwiftQLSwift5Client", manifest)
+        self.assertNotIn("Lookalike.swift", manifest)
+        self.assertNotIn("macro expansion", manifest)
+        self.assertNotIn("@__swiftmacro_", manifest)
+
+    def test_large_dependency_input_cannot_change_first_party_totals(self) -> None:
+        outside_root = Path(self.temporary_directory.name) / "dependencies"
+        dependency_entries = [
+            file_entry(
+                outside_root / f"Dependency{index}/Sources/SwiftQL/Fake.swift",
+                (1_000, 1_000),
+                (500, 500),
+            )
+            for index in range(1_000)
+        ]
+        self.run_report(
+            dependency_entries
+            + [file_entry(self.sql_macros, (8, 4)), file_entry(self.swiftql, (10, 5))],
+            "large-dependencies",
+        )
+        report = json.loads(
+            (self.root / "large-dependencies/first-party-coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(report["overall"]["lines"]["count"], 18)
+        self.assertEqual(report["overall"]["lines"]["covered"], 9)
+        self.assertEqual(
+            report["filtering"]["excluded_raw_file_entries"], 1_000
+        )
+
+    def test_output_is_deterministic_when_raw_entries_are_reordered(self) -> None:
+        entries = [file_entry(self.swiftql), file_entry(self.sql_macros)]
+        self.run_report(entries, "first")
+        self.run_report(list(reversed(entries)), "second")
+        for filename in (
+            "first-party-coverage.json",
+            "included-sources.txt",
+            "allowed-uninstrumented-sources.txt",
+            "summary.md",
+        ):
+            self.assertEqual(
+                (self.root / "first" / filename).read_bytes(),
+                (self.root / "second" / filename).read_bytes(),
+            )
+
+    def test_unexpected_missing_production_source_fails(self) -> None:
+        result = self.run_report(
+            [file_entry(self.sql_macros)], "missing", expect_success=False
+        )
+        self.assertIn("disappeared from LLVM coverage", result.stderr)
+        self.assertIn("Sources/SwiftQL/Query.swift", result.stderr)
+
+    def test_explicit_uninstrumented_source_is_reported(self) -> None:
+        self.write_config(["Sources/SwiftQL/Query.swift"])
+        self.run_report([file_entry(self.sql_macros)], "allowed")
+        manifest = (
+            self.root / "allowed/allowed-uninstrumented-sources.txt"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(manifest, "SwiftQL\tSources/SwiftQL/Query.swift\n")
+
+    def test_stale_uninstrumented_allowance_fails(self) -> None:
+        self.write_config(["Sources/SwiftQL/Query.swift"])
+        result = self.run_report(
+            [file_entry(self.sql_macros), file_entry(self.swiftql)],
+            "stale",
+            expect_success=False,
+        )
+        self.assertIn("allowances are stale", result.stderr)
+
+    def test_duplicate_first_party_entry_fails(self) -> None:
+        result = self.run_report(
+            [
+                file_entry(self.sql_macros),
+                file_entry(self.swiftql),
+                file_entry(self.swiftql),
+            ],
+            "duplicate",
+            expect_success=False,
+        )
+        self.assertIn("duplicate first-party coverage entry", result.stderr)
+
+    def test_canonical_traversal_alias_is_detected_as_a_duplicate(self) -> None:
+        alias = self.root / "Sources/SwiftQL/../SwiftQL/Query.swift"
+        result = self.run_report(
+            [
+                file_entry(self.sql_macros),
+                file_entry(self.swiftql),
+                file_entry(alias),
+            ],
+            "traversal-alias",
+            expect_success=False,
+        )
+        self.assertIn("duplicate first-party coverage entry", result.stderr)
+
+    def test_symlink_alias_is_detected_as_a_duplicate(self) -> None:
+        alias_directory = self.root / "Sources/Alias"
+        alias_directory.symlink_to(self.root / "Sources/SwiftQL", target_is_directory=True)
+        result = self.run_report(
+            [
+                file_entry(self.sql_macros),
+                file_entry(self.swiftql),
+                file_entry(alias_directory / "Query.swift"),
+            ],
+            "symlink-alias",
+            expect_success=False,
+        )
+        self.assertIn("duplicate first-party coverage entry", result.stderr)
+
+    def test_untracked_file_inside_configured_root_fails(self) -> None:
+        untracked = self.make_source("Sources/SwiftQL/Untracked.swift")
+        result = self.run_report(
+            [
+                file_entry(self.sql_macros),
+                file_entry(self.swiftql),
+                file_entry(untracked),
+            ],
+            "untracked-source",
+            expect_success=False,
+        )
+        self.assertIn("untracked files inside target roots", result.stderr)
+
+    def test_malformed_llvm_schema_fails_closed(self) -> None:
+        valid_files = [file_entry(self.sql_macros), file_entry(self.swiftql)]
+        cases = {
+            "wrong-type": {
+                "type": "not.llvm.coverage",
+                "version": "fixture",
+                "data": [{"files": valid_files}],
+            },
+            "empty-version": {
+                "type": "llvm.coverage.json.export",
+                "version": "",
+                "data": [{"files": valid_files}],
+            },
+            "multiple-data": {
+                "type": "llvm.coverage.json.export",
+                "version": "fixture",
+                "data": [{"files": valid_files}, {"files": []}],
+            },
+            "missing-files": {
+                "type": "llvm.coverage.json.export",
+                "version": "fixture",
+                "data": [{}],
+            },
+        }
+        for name, document in cases.items():
+            with self.subTest(name=name):
+                result = self.run_report(
+                    [], name, expect_success=False, document=document
+                )
+                self.assertIn("error: source coverage report", result.stderr)
+
+    def test_unknown_repository_source_target_fails(self) -> None:
+        unknown = self.make_source("Sources/NewProductionTarget/New.swift")
+        result = self.run_report(
+            [
+                file_entry(self.sql_macros),
+                file_entry(self.swiftql),
+                file_entry(unknown),
+            ],
+            "unknown-target",
+            expect_success=False,
+        )
+        self.assertIn("untracked files inside target roots", result.stderr)
+        self.assertIn("Sources/NewProductionTarget/New.swift", result.stderr)
+
+    def test_reproducibility_verifier_accepts_equal_and_rejects_different_sets(
+        self,
+    ) -> None:
+        entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
+        self.run_report(entries, "repro-first")
+        self.run_report(entries, "repro-second")
+        first = self.root / "repro-first"
+        second = self.root / "repro-second"
+        success = subprocess.run(
+            [str(VERIFY_SCRIPT), str(first), str(second), str(first / "result.json")],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(success.returncode, 0, success.stderr)
+        evidence = json.loads((first / "result.json").read_text(encoding="utf-8"))
+        self.assertTrue(evidence["included_source_sets_match"])
+        self.assertTrue(evidence["normalized_reports_match"])
+        different_manifest = (
+            "SQLMacros\tSources/SQLMacros/Macro.swift\n"
+            "SwiftQL\tSources/SwiftQL/Alternative.swift\n"
+        )
+        (second / "included-sources.txt").write_text(
+            different_manifest, encoding="utf-8"
+        )
+        second_report_path = second / "first-party-coverage.json"
+        second_report = json.loads(second_report_path.read_text(encoding="utf-8"))
+        second_report["filtering"]["included_sources_sha256"] = hashlib.sha256(
+            different_manifest.encode("utf-8")
+        ).hexdigest()
+        second_report_path.write_text(
+            json.dumps(second_report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        failure = subprocess.run(
+            [str(VERIFY_SCRIPT), str(first), str(second), str(first / "failure.json")],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(failure.returncode, 0)
+        self.assertIn("included source manifests differ", failure.stderr)
+
+    def test_reproducibility_verifier_rejects_dirty_or_different_reports(self) -> None:
+        entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
+        self.run_report(entries, "dirty-first")
+        self.run_report(entries, "dirty-second")
+        first = self.root / "dirty-first"
+        second = self.root / "dirty-second"
+        second_report_path = second / "first-party-coverage.json"
+        second_report = json.loads(second_report_path.read_text(encoding="utf-8"))
+        second_report["source_tree_state"] = "dirty"
+        second_report_path.write_text(
+            json.dumps(second_report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        failure = subprocess.run(
+            [str(VERIFY_SCRIPT), str(first), str(second), str(first / "failure.json")],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(failure.returncode, 0)
+        self.assertIn("did not capture a clean tree", failure.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-source-coverage-report.py
+++ b/scripts/ci/test-source-coverage-report.py
@@ -19,6 +19,10 @@ VERIFY_SCRIPT = Path(__file__).with_name(
     "verify-source-coverage-reproducibility.sh"
 )
 WORKFLOW = SCRIPT.parents[2] / ".github/workflows/swift.yml"
+INITIAL_BASELINE = (
+    SCRIPT.parents[2]
+    / "Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0"
+)
 
 
 def metric(count: int, covered: int) -> Dict[str, Any]:
@@ -478,6 +482,48 @@ class CoverageWorkflowTests(unittest.TestCase):
             "name: swiftql-source-coverage-${{ env.COVERAGE_SOURCE_SHA }}-",
             workflow,
         )
+
+    def test_checked_in_initial_baseline_is_internally_consistent(self) -> None:
+        report = json.loads(
+            (INITIAL_BASELINE / "first-party-coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        reproducibility = json.loads(
+            (INITIAL_BASELINE / "reproducibility.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        included = (INITIAL_BASELINE / "included-sources.txt").read_bytes()
+        repeated = (
+            INITIAL_BASELINE / "repeated-included-sources.txt"
+        ).read_bytes()
+        allowed = (
+            INITIAL_BASELINE / "allowed-uninstrumented-sources.txt"
+        ).read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(
+            report["source_commit"],
+            "9152d8409aa55df5bc96e9c74411b3c4fb166429",
+        )
+        self.assertEqual(report["source_tree_state"], "clean")
+        self.assertEqual(report["source_commit"], reproducibility["source_commit"])
+        self.assertTrue(reproducibility["normalized_reports_match"])
+        self.assertEqual(included, repeated)
+        self.assertEqual(
+            hashlib.sha256(included).hexdigest(),
+            report["filtering"]["included_sources_sha256"],
+        )
+        self.assertEqual(
+            len(included.decode("utf-8").splitlines()),
+            report["filtering"]["included_source_files"],
+        )
+        self.assertEqual(
+            len(allowed),
+            report["filtering"]["allowed_uninstrumented_source_files"],
+        )
+        self.assertEqual(set(report["targets"]), {"SQLMacros", "SwiftQL"})
+        self.assertFalse(list(INITIAL_BASELINE.glob("llvm-coverage.*")))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/verify-source-coverage-reproducibility.py
+++ b/scripts/ci/verify-source-coverage-reproducibility.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+
+"""Verify two first-party coverage captures came from the same clean source."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+
+class ReproducibilityError(RuntimeError):
+    """Raised when two coverage captures are not reproducible peers."""
+
+
+def load_json(path: Path) -> Mapping[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReproducibilityError(f"could not read {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ReproducibilityError(f"expected a JSON object in {path}")
+    return value
+
+
+def load_manifest(path: Path) -> Tuple[bytes, int, str]:
+    try:
+        contents = path.read_bytes()
+    except OSError as error:
+        raise ReproducibilityError(f"could not read {path}: {error}") from error
+    if not contents or not contents.endswith(b"\n"):
+        raise ReproducibilityError(f"manifest must be non-empty and newline-terminated: {path}")
+    try:
+        lines = contents.decode("utf-8").splitlines()
+    except UnicodeDecodeError as error:
+        raise ReproducibilityError(f"manifest is not UTF-8: {path}") from error
+    if lines != sorted(set(lines)):
+        raise ReproducibilityError(f"manifest is not sorted and unique: {path}")
+    return contents, len(lines), hashlib.sha256(contents).hexdigest()
+
+
+def require_clean_report(report: Mapping[str, Any], path: Path) -> None:
+    if report.get("schema_version") != 1:
+        raise ReproducibilityError(f"unsupported report schema in {path}")
+    if report.get("source_tree_state") != "clean":
+        raise ReproducibilityError(f"coverage report did not capture a clean tree: {path}")
+    for field in (
+        "source_commit",
+        "coverage_command",
+        "package_resolved_sha256",
+        "toolchain",
+        "filtering",
+        "targets",
+        "overall",
+    ):
+        if field not in report:
+            raise ReproducibilityError(f"coverage report is missing {field}: {path}")
+
+
+def verify_run(directory: Path) -> Tuple[Mapping[str, Any], bytes, bytes, int, str]:
+    report_path = directory / "first-party-coverage.json"
+    report = load_json(report_path)
+    require_clean_report(report, report_path)
+    included, source_count, source_sha256 = load_manifest(
+        directory / "included-sources.txt"
+    )
+    try:
+        allowed = (directory / "allowed-uninstrumented-sources.txt").read_bytes()
+    except OSError as error:
+        raise ReproducibilityError(
+            f"could not read allowed-source manifest in {directory}: {error}"
+        ) from error
+    filtering = report["filtering"]
+    if not isinstance(filtering, dict):
+        raise ReproducibilityError(f"coverage filtering block is invalid: {report_path}")
+    if filtering.get("included_source_files") != source_count:
+        raise ReproducibilityError(
+            f"included-source count does not match manifest: {report_path}"
+        )
+    if filtering.get("included_sources_sha256") != source_sha256:
+        raise ReproducibilityError(
+            f"included-source digest does not match manifest: {report_path}"
+        )
+    try:
+        allowed_lines = allowed.decode("utf-8").splitlines()
+    except UnicodeDecodeError as error:
+        raise ReproducibilityError(
+            f"allowed-source manifest is not UTF-8: {directory}"
+        ) from error
+    if allowed and not allowed.endswith(b"\n"):
+        raise ReproducibilityError(
+            f"allowed-source manifest is not newline-terminated: {directory}"
+        )
+    if allowed_lines != sorted(set(allowed_lines)):
+        raise ReproducibilityError(
+            f"allowed-source manifest is not sorted and unique: {directory}"
+        )
+    allowed_count = len(allowed_lines)
+    if filtering.get("allowed_uninstrumented_source_files") != allowed_count:
+        raise ReproducibilityError(
+            f"allowed-source count does not match manifest: {report_path}"
+        )
+    return report, included, allowed, source_count, source_sha256
+
+
+def differing_top_level_keys(
+    first: Mapping[str, Any], second: Mapping[str, Any]
+) -> Sequence[str]:
+    return sorted(
+        key
+        for key in set(first) | set(second)
+        if first.get(key) != second.get(key)
+    )
+
+
+def run(first_directory: Path, second_directory: Path, output_json: Path) -> None:
+    first = verify_run(first_directory)
+    second = verify_run(second_directory)
+    first_report, first_included, first_allowed, source_count, source_sha256 = first
+    second_report, second_included, second_allowed, _, _ = second
+
+    if first_included != second_included:
+        raise ReproducibilityError("included source manifests differ between clean runs")
+    if first_allowed != second_allowed:
+        raise ReproducibilityError(
+            "allowed-uninstrumented source manifests differ between clean runs"
+        )
+    if first_report != second_report:
+        keys = ", ".join(differing_top_level_keys(first_report, second_report))
+        raise ReproducibilityError(
+            f"normalized coverage reports differ between clean runs: {keys}"
+        )
+
+    evidence: Dict[str, Any] = {
+        "schema_version": 1,
+        "clean_runs_compared": 2,
+        "source_commit": first_report["source_commit"],
+        "source_tree_state": "clean",
+        "package_resolved_sha256": first_report["package_resolved_sha256"],
+        "coverage_command": first_report["coverage_command"],
+        "toolchain": first_report["toolchain"],
+        "included_source_sets_match": True,
+        "allowed_uninstrumented_source_sets_match": True,
+        "normalized_reports_match": True,
+        "included_source_files": source_count,
+        "included_sources_sha256": source_sha256,
+    }
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    shutil.copyfile(
+        second_directory / "included-sources.txt",
+        output_json.parent / "repeated-included-sources.txt",
+    )
+    print(f"SWIFTQL_SOURCE_COVERAGE_REPRODUCIBLE {source_sha256}")
+
+
+def parse_arguments(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("first_run", type=Path)
+    parser.add_argument("second_run", type=Path)
+    parser.add_argument("output_json", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    arguments = parse_arguments(argv)
+    try:
+        run(arguments.first_run, arguments.second_run, arguments.output_json)
+    except ReproducibilityError as error:
+        print(f"error: source coverage reproducibility: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/verify-source-coverage-reproducibility.sh
+++ b/scripts/ci/verify-source-coverage-reproducibility.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_directory="$(cd "$(dirname "$0")" && pwd -P)"
+exec python3 "$script_directory/verify-source-coverage-reproducibility.py" "$@"


### PR DESCRIPTION
Closes #189

## Task identity

- Repository: `lukevanin/swiftql`
- Issue: #189 — Capture reproducible first-party Swift source coverage
- Branch: `codex/189-capture-reproducible-first-party-swift-source-coverage`
- Worktree: `/Users/lukevanin/Developer/Luke/swiftql-worktrees/189-capture-reproducible-first-party-swift-source-coverage`
- Codex task: `lukevanin/swiftql#189 - Capture reproducible first-party Swift source coverage`
- Codex session ID: `019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa`

## Summary

- add a pinned macOS 15 / Xcode 16.2 / Swift 6.0 coverage lane using committed dependency resolution
- capture two independent clean SwiftPM coverage runs and fail unless normalized reports, source manifests, commits, toolchains, commands, and dependency resolution agree
- retain raw LLVM JSON, LCOV, test logs, manifests, and provenance as a CI artifact while checking in a compact reproducible baseline
- restrict totals to all tracked production Swift files in `SwiftQL` and `SQLMacros`, with explicit zero-region allowances and fail-closed handling for missing, unknown, aliased, untracked, dependency, test, benchmark, fixture, and generated paths
- document exact local reproduction and add 16 deterministic/adversarial fixtures

## Requirement mapping

- Pinned Swift 6 environment and two-clean-run artifact: `.github/workflows/swift.yml`
- Normal test suite with coverage and full provenance: `scripts/ci/run-source-coverage.sh`
- Deterministic first-party normalization and filtering: `scripts/ci/source-coverage-report.py` plus `source-coverage-config.json`
- Reproducibility proof: `verify-source-coverage-reproducibility.{sh,py}`
- Local reproduction and evidence policy: `Coverage/README.md`
- Checked-in baseline: `Coverage/Baselines/2026-07-17-xcode-16.2-swift-6.0/`

## Authoritative pinned baseline

- Source commit: `9152d8409aa55df5bc96e9c74411b3c4fb166429`
- [Swift compatibility run 118](https://github.com/lukevanin/swiftql/actions/runs/29580545409)
- Artifact [8406963181](https://github.com/lukevanin/swiftql/actions/runs/29580545409/artifacts/8406963181): `swiftql-source-coverage-9152d8409aa55df5bc96e9c74411b3c4fb166429-1`
- Artifact SHA-256: `c090061ab72580296bd0e6600bb868209181c661fb251c70c096c11d3325dc56`; retained through 2026-08-16
- Runner: macOS 15 arm64 image `20260715.0234.1`; Xcode 16.2 (`16C5032a`); Swift 6.0.3; macOS SDK 15.2; LLVM 16.0.0
- Two independent clean captures produced byte-identical normalized reports and source manifests
- Exact tracked-source accounting: 49 instrumented plus 2 explicit zero-region allowances = all 51 production Swift sources
- SQLMacros: 2,164/2,218 lines (97.57%), 154/157 functions (98.09%)
- SwiftQL: 2,822/3,628 lines (77.78%), 703/939 functions (74.87%)

These figures are evidence, not a percentage gate. SQLite execution, compiler diagnostics, and semantic assertions remain the acceptance criteria for production changes.

## Gap triage

- #195 (P3, v1.2): exercise fluent `INSERT ... SELECT` clause-chain transitions with exact rendering and real SQLite execution
- #194 (P4, v1.2): test `QueryBuilder`'s documented missing-`FROM` rejection path
- Existing owners such as #131, #82, and #191 retain their established scope; no duplicate umbrella issues were added

## Validation

- 392 Swift tests passed locally under Xcode 26.5 / Swift 6.3.2 with coverage enabled
- raw 13 MB LLVM JSON and 7.2 MB LCOV exports generated locally
- all 16 coverage reporter, provenance, reproducibility, and workflow fixtures passed
- release workflow fixtures passed
- focused documentation-catalog test passed
- shell syntax, Python AST parsing, workflow YAML parsing, and `git diff --check` passed
- independent final acceptance and coverage-tooling audits found no P1/P2 blocker
- Final head validation: [Swift compatibility run 120](https://github.com/lukevanin/swiftql/actions/runs/29581781569) and [Documentation run 24](https://github.com/lukevanin/swiftql/actions/runs/29581781711)

## Environment note

Xcode 16.2 is not installed locally. Local Xcode 26.5 results are diagnostic; the successful pinned Xcode 16.2 run above is the authoritative baseline.