### PR TITLE
Replace mutable request arguments with immutable invocation bindings

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Add an immutable contextual value-codec registry and configuration",
-  "issue_number": 188,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/188",
+  "task_name": "Replace mutable request arguments with immutable invocation bindings",
+  "issue_number": 82,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/82",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#188 - Add an immutable contextual value-codec registry and configuration",
+  "codex_session_title": "lukevanin/swiftql#82 - Replace mutable request arguments with immutable invocation bindings",
   "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
   "codex_session_url": null,
-  "task_branch": "codex/188-add-an-immutable-contextual-value-codec-registry-and-configuration",
-  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/188-add-an-immutable-contextual-value-codec-registry-and-configuration"
+  "task_branch": "codex/82-replace-mutable-request-arguments-with-immutable-invocation-bindings",
+  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/82-replace-mutable-request-arguments-with-immutable-invocation-bindings"
 }

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -43,10 +43,12 @@ Each case contains all six phase slots. The current five-case harness therefore
 contains 30 slots and 25 measurements. `bounded_write × row_decoding` is not
 applicable because the UPDATE has no `RETURNING` clause. The contextual-codec
 case measures only `statement_reset_and_binding` and `row_decoding`; SQL DSL
-construction, statement preparation/cache lookup, and execution do not exercise
-the conversion contract it isolates. The three historical baseline JSON files
-predate that case and intentionally remain valid four-case, 23-measurement
-reports rather than being rewritten.
+construction and statement preparation/cache lookup do not exercise the
+conversion contract it isolates. Its execution slot is not applicable because
+the public request API necessarily decodes the scalar result and therefore
+cannot satisfy the SQLite-only execution boundary. The three historical
+baseline JSON files predate that case and intentionally remain valid four-case,
+23-measurement reports rather than being rewritten.
 
 ## Phase boundaries
 
@@ -62,8 +64,8 @@ overhead, trim outliers, or combine phases.
 | `swiftql_construction_and_rendering` | Complete schema/meta construction and `XLiteEncoder.makeSQL`. | GRDB and database work. |
 | `cold_statement_preparation` | Uncached `Database.makeStatement(sql:)` on one open, schema-warm connection. | Connection acquisition and statement finalization. This is not application cold start. |
 | `cached_statement_lookup` | A primed, same-connection `Database.cachedStatement(sql:)` hit. | Initial preparation. Returned object identity is verified. |
-| `statement_reset_and_binding` | Public `Statement.setArguments`, including validation, reset, clear, and bind. The contextual-codec case additionally includes pre-resolved encode and storage validation. | SwiftQL request construction, registry/default resolution, and argument creation. |
-| `execution` | GRDB's required pre-execution reset and SQLite stepping through all result rows, or the bounded UPDATE. | Preparation, explicit binding, GRDB row materialization, SwiftQL decoding, savepoint entry, and rollback. |
+| `statement_reset_and_binding` | Public `Statement.setArguments`, including validation, reset, clear, and bind. As an explicit contextual-case exception, `contextual_value_codec` also includes pre-resolved encode, declared-storage validation, immutable invocation-packet construction/completeness validation, and `StatementArguments` construction from the normalized packet value. | SwiftQL request construction and registry/default resolution. Argument-container construction is excluded for the four SQL cases but deliberately included for the contextual-case exception. |
+| `execution` | GRDB's required pre-execution reset and SQLite stepping through all result rows, or the bounded UPDATE. The contextual-codec case is not applicable because its public request path also decodes the scalar result. | Preparation, explicit binding, GRDB row materialization, SwiftQL decoding, savepoint entry, and rollback. |
 | `row_decoding` | For SQL result cases, the complete captured result set decoded into an output array through the production `GRDBRowAdapter` → `XLColumnValuesRowReader` path shared by a package-private decoder. For `contextual_value_codec`, one captured GRDB INTEGER is normalized to `XLSQLiteValue`, then storage-validated and decoded through a pre-resolved immutable codec slot. | SQL execution, captured GRDB-row creation, semantic verification, checksumming, and decoded-value destruction. |
 
 Phase medians are not additive. In particular, public GRDB execution performs
@@ -96,10 +98,12 @@ match. Run at least three independent release processes; use the spread of
 their medians to distinguish repeatable changes from process and system noise.
 
 The codec case resolves its parameter and result slots once before sampling.
-Its binding measurement then compares resolved encode, storage validation, and
-transport binding with the existing pre-encoded binding baseline; registry
-lookup and argument-container construction remain setup. Its decoding
-measurement is a one-scalar resolved contextual path, whereas
+Its binding measurement then compares resolved encode, storage validation,
+immutable invocation-packet construction/completeness validation,
+`StatementArguments` construction, and transport binding with the existing
+pre-encoded binding baseline; only registry/default resolution, layout
+construction, and request construction remain setup. Its decoding measurement
+is a one-scalar resolved contextual path, whereas
 `deterministic_row_decode` decodes two wide result-macro rows. Compare those
 workload medians as integration evidence, not as a per-field ratio.
 

--- a/Benchmarks/Issue188/README.md
+++ b/Benchmarks/Issue188/README.md
@@ -42,10 +42,12 @@ python3 Benchmarks/Issue188/compare_codec.py \
 The script also rejects mixed repository revisions, toolchains, dependencies,
 SQLite sources, fixtures, schemas, and benchmark case contracts. It recomputes
 each compared median from the raw 500-sample array before printing a ratio. Its
-binding ratio compares pre-resolved contextual encode, storage validation, and
-public `Statement.setArguments` against the existing pre-encoded binding
-workload; registry/default resolution and argument construction remain outside
-that phase. Its decode ratio compares a one-scalar resolved contextual decode
+binding ratio compares pre-resolved contextual encode, storage validation,
+immutable invocation-packet construction/completeness validation,
+`StatementArguments` construction, and public `Statement.setArguments` against
+the existing pre-encoded binding workload; registry/default resolution, layout
+construction, and request construction remain outside that phase. Its decode
+ratio compares a one-scalar resolved contextual decode
 with two wide result-macro rows, so it is workload-level integration evidence,
 not a per-field overhead claim.
 
@@ -71,3 +73,9 @@ Median of per-run ratios: bind 1.994x; decode 0.104x. These are intentionally
 workload-level integration comparisons: the bind numerator adds pre-resolved
 codec conversion and validation, while the decode denominator covers two wide
 rows rather than one scalar.
+
+These recorded reports predate issue #82's immutable invocation packet. Their
+bind numerator therefore uses the earlier codec-plus-bind boundary and does not
+include packet or `StatementArguments` construction. New reports produced by
+the recipe above use the current, broader contextual binding boundary and must
+not be compared numerically with this recorded set.

--- a/Benchmarks/Sources/SwiftQLBenchmarks/SwiftQLBenchmarkRunner.swift
+++ b/Benchmarks/Sources/SwiftQLBenchmarks/SwiftQLBenchmarkRunner.swift
@@ -43,7 +43,7 @@ public final class SwiftQLBenchmarkRunner {
         }
 
         let environment = BenchmarkEnvironmentCollector.collect(packageRoot: packageRoot)
-        let report = try databasePool.writeWithoutTransaction { database in
+        let fixture = try databasePool.writeWithoutTransaction { database in
             try setupFixture(in: database)
 
             let databaseMetadata = try collectDatabaseMetadata(from: database)
@@ -135,30 +135,34 @@ public final class SwiftQLBenchmarkRunner {
                 consumeDecoded: Self.consumeDecodeFixture
             )
 
-            let contextualCodec = try makeContextualCodecCase(
-                configuration: configuration,
-                database: database
-            )
-
-            return BenchmarkReport(
-                formatVersion: 1,
-                generatedAt: Self.timestamp(),
-                monotonicClock: "DispatchTime.uptimeNanoseconds",
-                sampleUnit: "nanoseconds_per_operation",
-                configuration: configuration,
-                environment: environment,
-                database: databaseMetadata,
-                fixture: BenchmarkFixtureMetadata(
-                    version: 1,
-                    companyCount: 8,
-                    departmentCount: 32,
-                    personCount: 512,
-                    decodeFixtureRowCount: 2
-                ),
-                schemaSQL: Self.schemaSQL,
-                cases: [simple, joined, write, decode, contextualCodec]
+            return (
+                databaseMetadata: databaseMetadata,
+                cases: [simple, joined, write, decode]
             )
         }
+
+        let contextualCodec = try makeContextualCodecCase(
+            configuration: configuration,
+            databasePool: databasePool
+        )
+        let report = BenchmarkReport(
+            formatVersion: 1,
+            generatedAt: Self.timestamp(),
+            monotonicClock: "DispatchTime.uptimeNanoseconds",
+            sampleUnit: "nanoseconds_per_operation",
+            configuration: configuration,
+            environment: environment,
+            database: fixture.databaseMetadata,
+            fixture: BenchmarkFixtureMetadata(
+                version: 1,
+                companyCount: 8,
+                departmentCount: 32,
+                personCount: 512,
+                decodeFixtureRowCount: 2
+            ),
+            schemaSQL: Self.schemaSQL,
+            cases: fixture.cases + [contextualCodec]
+        )
 
         try report.validate()
         return report
@@ -356,9 +360,8 @@ public final class SwiftQLBenchmarkRunner {
 
     private func makeContextualCodecCase(
         configuration benchmarkConfiguration: BenchmarkConfiguration,
-        database: Database
+        databasePool: DatabasePool
     ) throws -> BenchmarkCaseReport {
-        let dialect = XLSQLiteDialect()
         let codecKey = XLValueCodecKey(
             id: "swiftql.benchmark.contextual-integer",
             version: 1
@@ -389,84 +392,115 @@ public final class SwiftQLBenchmarkRunner {
             registry: registry,
             defaultCodecKeys: [codecKey]
         )
+        let swiftQLDatabase = try GRDBDatabase(
+            databasePool: databasePool,
+            codingConfiguration: valueCodingConfiguration,
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
         let input = BenchmarkCodecValue(rawValue: 257)
-        let parameterCodec = try valueCodingConfiguration.resolvedCodec(
-            for: BenchmarkCodecValue.self,
-            using: dialect,
-            context: XLValueCodingContext(
-                site: .parameter,
-                path: XLValueCodingPath("codecValue")
-            )
+        let parameterReference = try swiftQLDatabase.contextualBinding(
+            BenchmarkCodecValue.self,
+            expressedAs: Int.self,
+            named: "codecValue"
+        )
+        let query = sql { _ in Select(parameterReference) }
+        let parameterLayout = swiftQLDatabase.makeRequest(with: query).parameterLayout
+        let parameter = try parameterReference.preparedParameter(
+            in: parameterLayout
         )
         let resultCodec = try valueCodingConfiguration.resolvedCodec(
             for: BenchmarkCodecValue.self,
-            using: dialect,
+            using: swiftQLDatabase.dialect,
             context: XLValueCodingContext(
                 site: .result,
                 path: XLValueCodingPath("codecValue")
             )
         )
-        let encodedFixture = try parameterCodec.encode(input)
-        guard encodedFixture == .integer(input.rawValue) else {
+        let fixturePacket = try XLInvocationBindings(
+            layout: parameterLayout,
+            bindings: [parameter.encode(input)]
+        ).validatingComplete()
+        guard fixturePacket.bindings.map(\.value) == [.integer(input.rawValue)] else {
             throw BenchmarkError.decoding(
                 "contextual codec did not produce its declared INTEGER representation"
             )
         }
 
-        let sql = "SELECT :codecValue AS codecValue"
-        let encodedRawValue: Int64
-        switch encodedFixture {
-        case .integer(let rawValue):
-            encodedRawValue = rawValue
-        default:
-            throw BenchmarkError.decoding(
-                "contextual codec did not normalize to INTEGER before driver binding"
-            )
-        }
-        let arguments: StatementArguments = ["codecValue": encodedRawValue]
-        let bindingStatement = try database.makeStatement(sql: sql)
-        let binding = try BenchmarkSampler(configuration: benchmarkConfiguration).measure(
-            notes: [
-                "Includes one pre-resolved contextual encode, declared-storage validation, and public Statement.setArguments for the codec-produced INTEGER.",
-                "Excludes registry/default resolution and StatementArguments construction, which are static-slot and invocation-container setup rather than repeated binding work.",
-            ],
-            operation: {
-                let encoded = try parameterCodec.encode(input)
-                try bindingStatement.setArguments(arguments)
-                return encoded
-            },
-            consume: { encoded in
-                guard encoded == encodedFixture else {
-                    throw BenchmarkError.decoding(
-                        "contextual codec changed its normalized value while sampling"
-                    )
-                }
-                guard bindingStatement.arguments == arguments else {
-                    throw BenchmarkError.invalidReport(
-                        "contextual codec binding produced unexpected arguments"
-                    )
-                }
-                return UInt64(input.rawValue)
+        let sql = swiftQLDatabase.encoder.makeSQL(query).sql
+        let statementArguments = { (packet: XLInvocationBindings<XLSQLiteValue>) throws
+            -> StatementArguments in
+            guard packet.bindings.count == 1,
+                  let binding = packet.bindings.first,
+                  binding.slot.key == .named("codecValue"),
+                  case .integer(let rawValue) = binding.value else {
+                throw BenchmarkError.decoding(
+                    "contextual invocation packet did not contain its normalized named INTEGER"
+                )
             }
-        )
+            return ["codecValue": rawValue]
+        }
+        let fixtureArguments = try statementArguments(fixturePacket)
+        let rawPhases = try databasePool.read { database in
+            let bindingStatement = try database.makeStatement(sql: sql)
+            let binding = try BenchmarkSampler(
+                configuration: benchmarkConfiguration
+            ).measure(
+                notes: [
+                    "Includes pre-resolved XLPreparedParameter encode and declared-storage validation, immutable XLInvocationBindings construction/completeness validation, StatementArguments construction from the packet's normalized value, and public Statement.setArguments.",
+                    "Excludes registry/default resolution, parameter-layout construction, request construction, and execution; the measured boundary is the production invocation packet followed by direct GRDB binding.",
+                ],
+                operation: {
+                    let packet = try XLInvocationBindings(
+                        layout: parameterLayout,
+                        bindings: [parameter.encode(input)]
+                    ).validatingComplete()
+                    try bindingStatement.setArguments(statementArguments(packet))
+                    return packet
+                },
+                consume: { packet in
+                    guard packet == fixturePacket else {
+                        throw BenchmarkError.decoding(
+                            "contextual invocation packet changed while sampling"
+                        )
+                    }
+                    guard bindingStatement.arguments == fixtureArguments else {
+                        throw BenchmarkError.invalidReport(
+                            "contextual packet binding produced unexpected arguments"
+                        )
+                    }
+                    return UInt64(input.rawValue)
+                }
+            )
 
-        let capturedRow = try Row.fetchOne(
-            database,
-            sql: sql,
-            arguments: arguments
-        )
-        guard let capturedRow else {
-            throw BenchmarkError.missingFixture(
-                "contextual codec SELECT did not return its deterministic row"
+            let capturedRow = try Row.fetchOne(
+                database,
+                sql: sql,
+                arguments: fixtureArguments
+            )
+            guard let capturedRow else {
+                throw BenchmarkError.missingFixture(
+                    "contextual codec SELECT did not return its deterministic row"
+                )
+            }
+            return (
+                binding: binding,
+                capturedRow: capturedRow,
+                queryPlan: try queryPlan(
+                    database: database,
+                    sql: sql,
+                    arguments: fixtureArguments
+                )
             )
         }
+
         let decoding = try BenchmarkSampler(configuration: benchmarkConfiguration).measure(
             notes: [
                 "Includes extraction of one INTEGER from a captured GRDB Row, normalization to XLSQLiteValue, pre-resolved storage validation, and throwing decode.",
                 "Excludes SQL execution, row creation, semantic verification, checksumming, and decoded-value destruction; this is a one-scalar contextual comparison, not the multi-field result-macro baseline.",
             ],
             operation: {
-                let rawValue: Int64 = capturedRow["codecValue"]
+                let rawValue: Int64 = rawPhases.capturedRow[0]
                 return try resultCodec.decode(.integer(rawValue))
             },
             consume: { decoded in
@@ -494,11 +528,11 @@ public final class SwiftQLBenchmarkRunner {
             ),
             .statementResetAndBinding: .measured(
                 .statementResetAndBinding,
-                measurement: binding
+                measurement: rawPhases.binding
             ),
             .execution: .notApplicable(
                 .execution,
-                reason: "SQLite execution is independent of the contextual conversion isolated by this case."
+                reason: "Public request execution also decodes its scalar result, so it cannot satisfy the execution phase's SQLite-only boundary."
             ),
             .rowDecoding: .measured(.rowDecoding, measurement: decoding),
         ]
@@ -515,11 +549,7 @@ public final class SwiftQLBenchmarkRunner {
                     value: String(input.rawValue)
                 ),
             ],
-            queryPlan: try queryPlan(
-                database: database,
-                sql: sql,
-                arguments: arguments
-            ),
+            queryPlan: rawPhases.queryPlan,
             expectedResultRowCount: 1,
             expectedAffectedRowCount: nil,
             phases: orderedPhases(phases)

--- a/Benchmarks/Tests/SwiftQLBenchmarkTests/BenchmarkRunnerTests.swift
+++ b/Benchmarks/Tests/SwiftQLBenchmarkTests/BenchmarkRunnerTests.swift
@@ -49,7 +49,21 @@ final class BenchmarkRunnerTests: XCTestCase {
         XCTAssertTrue(
             try XCTUnwrap(
                 contextualCodec.phases.first { $0.phase == .statementResetAndBinding }?.measurement
-            ).notes.contains { $0.contains("pre-resolved contextual encode") }
+            ).notes.contains { $0.contains("XLInvocationBindings construction") }
+        )
+        XCTAssertTrue(
+            try XCTUnwrap(
+                contextualCodec.phases.first { $0.phase == .statementResetAndBinding }?.measurement
+            ).notes.contains { $0.contains("StatementArguments construction") }
+        )
+        XCTAssertEqual(
+            contextualCodec.phases.first { $0.phase == .execution }?.applicability,
+            .notApplicable
+        )
+        XCTAssertTrue(
+            try XCTUnwrap(
+                contextualCodec.phases.first { $0.phase == .execution }?.reason
+            ).contains("decodes its scalar result")
         )
         XCTAssertTrue(
             try XCTUnwrap(

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -30,6 +30,7 @@ private struct DownstreamToken: Equatable {
 enum FixtureError: Error {
     case invalidCoreContract
     case invalidCodecValue(XLSQLiteValue)
+    case unexpectedPacketResult(Int?)
     case unexpectedResult(PersonSummary?)
 }
 
@@ -131,6 +132,28 @@ private func executeFixture(
     try database.makeRequest(
         with: sqlInsert(Person(id: "grace", name: "Grace Hopper", age: 85))
     ).execute()
+
+    let token = try database.contextualBinding(
+        DownstreamToken.self,
+        expressedAs: Int.self,
+        named: "token"
+    )
+    let tokenRequest = database.makeRequest(
+        with: sql { _ in Select(token) }
+    )
+    let tokenPacket = try XLInvocationBindings<XLSQLiteValue>(
+        layout: tokenRequest.parameterLayout,
+        bindings: [
+            token.encode(
+                DownstreamToken(rawValue: 42),
+                in: tokenRequest.parameterLayout
+            ),
+        ]
+    )
+    let tokenResult = try tokenRequest.fetchOne(bindings: tokenPacket)
+    guard tokenResult == 42 else {
+        throw FixtureError.unexpectedPacketResult(tokenResult)
+    }
 
     let id = XLNamedBindingReference<String>(name: "id")
     let statement = sql { schema in

--- a/Sources/SwiftQL/GRDBDatabaseDriver.swift
+++ b/Sources/SwiftQL/GRDBDatabaseDriver.swift
@@ -10,7 +10,7 @@ import GRDB
 ///
 /// The driver is internal to the v1 compatibility facade. Public code depends
 /// on the adapter-neutral contracts from `SwiftQLCore`.
-struct GRDBDatabaseDriver: XLDatabaseDriver {
+struct GRDBDatabaseDriver: XLDatabaseDriver, Sendable {
 
     typealias Dialect = XLSQLiteDialect
 
@@ -68,6 +68,216 @@ struct GRDBDatabaseDriver: XLDatabaseDriver {
             driverIdentifier: driverIdentifier,
             dialect: dialect
         )
+    }
+}
+
+
+/// Immutable, Sendable execution seam between prepared logical statements and
+/// GRDB connections. Typed row decoding remains outside this value because the
+/// legacy row-reader graph is not Sendable.
+struct GRDBInvocationExecutor: Sendable {
+
+    let driver: GRDBDatabaseDriver
+
+    let logicalStatement: XLLogicalPreparedStatement
+
+    let parameterLayoutError: XLInvocationBindingError?
+
+    init(
+        driver: GRDBDatabaseDriver,
+        logicalStatement: XLLogicalPreparedStatement,
+        parameterLayoutError: XLInvocationBindingError? = nil
+    ) {
+        self.driver = driver
+        self.logicalStatement = logicalStatement
+        self.parameterLayoutError = parameterLayoutError
+    }
+
+    var parameterLayout: XLParameterLayout {
+        logicalStatement.parameterLayout
+    }
+
+    func fetchAll(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [[XLSQLiteValue]] {
+        let packet = try sqlitePacket(bindings)
+        var driver = driver
+        return try driver.withReadConnection { connection in
+            try fetchAll(packet: packet, in: &connection)
+        }
+    }
+
+    func fetchAll(
+        packet: XLInvocationBindings<XLSQLiteValue>,
+        in connection: inout GRDBDatabaseDriverConnection
+    ) throws -> [[XLSQLiteValue]] {
+        try connection.fetchAll(boundStatement(packet: packet, in: &connection))
+    }
+
+    func fetchOne(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [XLSQLiteValue]? {
+        let packet = try sqlitePacket(bindings)
+        var driver = driver
+        return try driver.withReadConnection { connection in
+            try fetchOne(packet: packet, in: &connection)
+        }
+    }
+
+    func fetchOne(
+        packet: XLInvocationBindings<XLSQLiteValue>,
+        in connection: inout GRDBDatabaseDriverConnection
+    ) throws -> [XLSQLiteValue]? {
+        try connection.fetchOne(boundStatement(packet: packet, in: &connection))
+    }
+
+    func execute(
+        bindings: any XLInvocationBindingPacket
+    ) throws {
+        let packet = try sqlitePacket(bindings)
+        var driver = driver
+        try driver.withTransaction { connection in
+            try execute(packet: packet, in: &connection)
+        }
+    }
+
+    func execute(
+        packet: XLInvocationBindings<XLSQLiteValue>,
+        in connection: inout GRDBDatabaseDriverConnection
+    ) throws {
+        try connection.execute(boundStatement(packet: packet, in: &connection))
+    }
+
+    func sqlitePacket(
+        _ bindings: any XLInvocationBindingPacket
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        if let parameterLayoutError {
+            throw parameterLayoutError
+        }
+        guard let packet = bindings as? XLInvocationBindings<XLSQLiteValue> else {
+            throw XLRequestBindingError.incompatibleInvocationPacket(
+                requestType: String(reflecting: Self.self),
+                expectedDialect: XLSQLiteDialect.identity,
+                expectedValueType: String(reflecting: XLSQLiteValue.self),
+                actualPacketType: String(reflecting: type(of: bindings))
+            )
+        }
+        guard packet.layout == parameterLayout else {
+            throw XLInvocationBindingError.packetLayoutMismatch(
+                expected: parameterLayout,
+                actual: packet.layout
+            )
+        }
+        let validatedPacket = try packet.validatingComplete()
+        for binding in validatedPacket.bindings {
+            if let codecIdentity = binding.slot.codecIdentity,
+               codecIdentity.dialectIdentifier != driver.dialect.descriptor.identity {
+                throw XLInvocationBindingError.preparedCodecDialectMismatch(
+                    slot: binding.slot,
+                    codecIdentity: codecIdentity,
+                    expectedDialectIdentifier: driver.dialect.descriptor.identity
+                )
+            }
+            if driver.dialect.isNull(binding.value) {
+                guard binding.slot.nullability == .nullable else {
+                    throw XLInvocationBindingError.nullForRequiredParameter(
+                        slot: binding.slot
+                    )
+                }
+                continue
+            }
+            if let codecIdentity = binding.slot.codecIdentity {
+                let actualStorage = driver.dialect.stableStorageIdentifier(
+                    for: binding.value
+                )
+                guard actualStorage == codecIdentity.storageIdentifier else {
+                    throw XLInvocationBindingError.dialectValueStorageMismatch(
+                        slot: binding.slot,
+                        expectedCodecIdentity: codecIdentity,
+                        actualStorageIdentifier: actualStorage
+                    )
+                }
+            }
+        }
+        return validatedPacket
+    }
+
+    private func boundStatement(
+        packet: XLInvocationBindings<XLSQLiteValue>,
+        in connection: inout GRDBDatabaseDriverConnection
+    ) throws -> GRDBPhysicalStatement {
+        let packet = try sqlitePacket(packet)
+        var statement = try connection.prepare(logicalStatement)
+        for binding in packet.bindings {
+            do {
+                statement = try connection.bindValidated(
+                    binding.value,
+                    to: binding.slot.key,
+                    in: statement
+                )
+            }
+            catch {
+                throw XLInvocationBindingError.driverBindingFailed(
+                    slot: binding.slot,
+                    codecIdentity: binding.slot.codecIdentity,
+                    context: binding.slot.codingContext,
+                    message: String(describing: error)
+                )
+            }
+        }
+        do {
+            try connection.validateBindings(in: statement)
+        }
+        catch {
+            throw XLInvocationBindingError.driverArgumentValidationFailed(
+                layout: packet.layout,
+                message: String(describing: error)
+            )
+        }
+        return statement
+    }
+}
+
+
+/// An immutable, concurrency-safe GRDB runtime handle for one rendered SQL
+/// statement.
+///
+/// This handle deliberately exposes normalized SQLite rows instead of
+/// retaining SwiftQL's legacy row-reader graph, which is not `Sendable`.
+/// Static, database-independent query identity and typed result metadata are
+/// layered on top by the descriptor API rather than captured here.
+public struct GRDBPreparedInvocation: Sendable {
+
+    private let executor: GRDBInvocationExecutor
+
+    init(executor: GRDBInvocationExecutor) {
+        self.executor = executor
+    }
+
+    /// The static parameter slots shared by every invocation of this handle.
+    public var parameterLayout: XLParameterLayout {
+        executor.parameterLayout
+    }
+
+    /// Fetches all normalized SQLite rows for one immutable binding packet.
+    public func fetchAllValues(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [[XLSQLiteValue]] {
+        try executor.fetchAll(bindings: bindings)
+    }
+
+    /// Fetches the first normalized SQLite row for one immutable binding packet.
+    public func fetchOneValues(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [XLSQLiteValue]? {
+        try executor.fetchOne(bindings: bindings)
+    }
+
+    /// Executes a command with one immutable binding packet.
+    public func execute(
+        bindings: any XLInvocationBindingPacket
+    ) throws {
+        try executor.execute(bindings: bindings)
     }
 }
 
@@ -130,13 +340,23 @@ struct GRDBDatabaseDriverConnection: XLDatabaseDriverConnection {
         return result
     }
 
+    /// Validates the complete logical packet against GRDB's physical
+    /// placeholder table before execution. This moves missing, extra, or
+    /// otherwise invalid driver arguments into the contextual bind boundary.
+    func validateBindings(in statement: GRDBPhysicalStatement) throws {
+        try validateOwnership(of: statement)
+        try statement.statement.validateArguments(
+            statementArguments(statement)
+        )
+    }
+
     mutating func fetchAll(
         _ statement: GRDBPhysicalStatement
     ) throws -> [[XLSQLiteValue]] {
         try validateOwnership(of: statement)
         return try Row.fetchAll(
             statement.statement,
-            arguments: statementArguments(statement.bindings)
+            arguments: statementArguments(statement)
         ).map { row in
             row.databaseValues.map(\.sqliteDialectValue)
         }
@@ -148,14 +368,14 @@ struct GRDBDatabaseDriverConnection: XLDatabaseDriverConnection {
         try validateOwnership(of: statement)
         return try Row.fetchOne(
             statement.statement,
-            arguments: statementArguments(statement.bindings)
+            arguments: statementArguments(statement)
         )?.databaseValues.map(\.sqliteDialectValue)
     }
 
     mutating func execute(_ statement: GRDBPhysicalStatement) throws {
         try validateOwnership(of: statement)
         try statement.statement.execute(
-            arguments: statementArguments(statement.bindings)
+            arguments: statementArguments(statement)
         )
     }
 
@@ -169,6 +389,55 @@ struct GRDBDatabaseDriverConnection: XLDatabaseDriverConnection {
     }
 
     private func statementArguments(
+        _ statement: GRDBPhysicalStatement
+    ) -> StatementArguments {
+        let bindings = statement.bindings
+
+        // Legacy direct driver clients predate static layouts. Preserve their
+        // original argument construction when no layout metadata is present.
+        guard !statement.logicalStatement.parameterLayout.isEmpty else {
+            return legacyStatementArguments(bindings)
+        }
+
+        var physicalIndexByKey: [XLBindingKey: Int] = [:]
+        var largestPhysicalIndex = 0
+
+        for slot in statement.logicalStatement.parameterLayout.slots {
+            let physicalIndex: Int
+            switch slot.key {
+            case .named:
+                physicalIndex = largestPhysicalIndex + 1
+            case .indexed(let zeroBasedIndex):
+                physicalIndex = zeroBasedIndex + 1
+            }
+            physicalIndexByKey[slot.key] = physicalIndex
+            largestPhysicalIndex = max(largestPhysicalIndex, physicalIndex)
+        }
+
+        // SQLite's physical parameter table is positional even when the SQL
+        // spells a placeholder by name. Supplying the complete table as one
+        // positional array avoids two GRDB normalization hazards:
+        //
+        // - a named placeholder before `?NNN` must not shift `?NNN`; and
+        // - distinct `:3` and `?3` placeholders must not collapse to the same
+        //   GRDB argument name after their prefixes are stripped.
+        //
+        // Explicit-index gaps are real SQLite slots, so preserve them as NULL.
+        var positional: [(any DatabaseValueConvertible)?] = Array(
+            repeating: DatabaseValue.null,
+            count: largestPhysicalIndex
+        )
+        for (key, value) in bindings {
+            guard let physicalIndex = physicalIndexByKey[key] else {
+                continue
+            }
+            positional[physicalIndex - 1] = value.databaseValue
+        }
+
+        return StatementArguments(positional)
+    }
+
+    private func legacyStatementArguments(
         _ bindings: [XLBindingKey: XLSQLiteValue]
     ) -> StatementArguments {
         var indexed: [Int: DatabaseValue] = [:]

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -128,14 +128,12 @@ fileprivate struct BindingContext: XLBindingContext {
 
 struct GRDBRequest<Row>: XLRequest {
 
-    private let driver: GRDBDatabaseDriver
+    private let executor: GRDBInvocationExecutor
 
     /// Immutable value-coding policy captured when this request is created.
     let codingConfiguration: XLValueCodingConfiguration
     
     private let logger: XLLogger?
-    
-    private let logicalStatement: XLLogicalPreparedStatement
     
     private let reader: any XLRowReadable<Row>
 
@@ -143,7 +141,9 @@ struct GRDBRequest<Row>: XLRequest {
 
     private let liveQueryRetryScheduler: GRDBLiveQueryRetryScheduler
 
-    private var arguments: [XLBindingKey: XLSQLiteValue] = [:]
+    private var compatibilityBindings: XLInvocationBindings<XLSQLiteValue>
+
+    private var compatibilityBindingError: XLInvocationBindingError?
     
     init(
         driver: GRDBDatabaseDriver,
@@ -151,20 +151,37 @@ struct GRDBRequest<Row>: XLRequest {
         logger: XLLogger?,
         reader: any XLRowReadable<Row>,
         logicalStatement: XLLogicalPreparedStatement,
+        parameterLayoutError: XLInvocationBindingError? = nil,
         liveQueryRetryPolicy: GRDBLiveQueryRetryPolicy,
         liveQueryRetryScheduler: GRDBLiveQueryRetryScheduler
     ) {
-        self.driver = driver
+        self.executor = GRDBInvocationExecutor(
+            driver: driver,
+            logicalStatement: logicalStatement,
+            parameterLayoutError: parameterLayoutError
+        )
         self.codingConfiguration = codingConfiguration
         self.logger = logger
         self.reader = reader
-        self.logicalStatement = logicalStatement
         self.liveQueryRetryPolicy = liveQueryRetryPolicy
         self.liveQueryRetryScheduler = liveQueryRetryScheduler
+        self.compatibilityBindings = XLInvocationBindings(
+            layout: logicalStatement.parameterLayout
+        )
+        self.compatibilityBindingError = parameterLayoutError
+    }
+
+    var parameterLayout: XLParameterLayout {
+        executor.parameterLayout
     }
     
     public mutating func set<T>(parameter reference: XLNamedBindingReference<Optional<T>>, value: T?) where T: XLBindable {
-        bindValue(named: reference.name.rawValue) { context in
+        bindValue(
+            declaration: _xlLegacyParameterDeclaration(
+                for: Optional<T>.self,
+                key: .named(reference.name.rawValue)
+            )
+        ) { context in
             if let value {
                 value.bind(context: &context)
             }
@@ -175,30 +192,71 @@ struct GRDBRequest<Row>: XLRequest {
     }
 
     public mutating func set<T>(parameter reference: XLNamedBindingReference<T>, value: T) where T: XLBindable {
-        bindValue(named: reference.name.rawValue) { context in
+        bindValue(
+            declaration: _xlLegacyParameterDeclaration(
+                for: T.self,
+                key: .named(reference.name.rawValue)
+            )
+        ) { context in
             value.bind(context: &context)
         }
     }
     
-    private mutating func bindValue(named name: String, bind: (inout XLBindingContext) -> Void) {
+    private mutating func bindValue(
+        declaration: XLParameterDeclaration,
+        bind: (inout XLBindingContext) -> Void
+    ) {
+        guard let slot = parameterLayout.slot(for: declaration.key) else {
+            if compatibilityBindingError == nil {
+                compatibilityBindingError = .parameterDeclarationNotInLayout(
+                    declaration: declaration
+                )
+            }
+            return
+        }
+        guard slot.acceptsLegacySet(declaration) else {
+            if compatibilityBindingError == nil {
+                compatibilityBindingError = .parameterMetadataMismatch(
+                    expected: slot,
+                    actual: declaration.slot(at: slot.index)
+                )
+            }
+            return
+        }
         var context: any XLBindingContext = BindingContext()
         bind(&context)
-        arguments[.named(name)] = (context as! BindingContext).value
+        let value = (context as! BindingContext).value
+        do {
+            compatibilityBindings = try replacingBinding(
+                value,
+                at: slot,
+                in: compatibilityBindings
+            )
+        }
+        catch let error as XLInvocationBindingError {
+            if compatibilityBindingError == nil {
+                compatibilityBindingError = error
+            }
+        }
+        catch {
+            preconditionFailure("Unexpected invocation binding error: \(error)")
+        }
     }
     
     func fetchAll() throws -> [Row] {
-        var driver = driver
-        return try driver.withReadConnection { connection in
-            try fetchAll(in: &connection)
-        }
+        try fetchAll(bindings: compatibilityPacket())
     }
 
-    private func fetchAll(
-        in connection: inout GRDBDatabaseDriverConnection
+    func fetchAll(
+        bindings: any XLInvocationBindingPacket
     ) throws -> [Row] {
-        logger?.debug("fetchAll: <<<\(logicalStatement.sql)>>> parameters: <<<\(arguments)>>>")
-        let rows = try connection.fetchAll(boundStatement(in: &connection))
+        let packet = try executor.sqlitePacket(bindings)
+        logger?.debug(
+            "fetchAll: <<<\(executor.logicalStatement.sql)>>> parameters: <<<\(packet.bindings)>>>")
+        return try decodeRows(executor.fetchAll(bindings: packet))
+    }
 
+    private func decodeRows(_ rows: [[XLSQLiteValue]]) throws -> [Row] {
         let rowDecoder = GRDBRowDecoder(reader: reader)
         var items: [Row] = []
 
@@ -216,17 +274,16 @@ struct GRDBRequest<Row>: XLRequest {
     }
     
     func fetchOne() throws -> Row? {
-        var driver = driver
-        return try driver.withReadConnection { connection in
-            try fetchOne(in: &connection)
-        }
+        try fetchOne(bindings: compatibilityPacket())
     }
 
-    private func fetchOne(
-        in connection: inout GRDBDatabaseDriverConnection
+    func fetchOne(
+        bindings: any XLInvocationBindingPacket
     ) throws -> Row? {
-        logger?.debug("fetchOne: <<<\(logicalStatement.sql)>>> parameters: <<<\(arguments)>>>")
-        guard let values = try connection.fetchOne(boundStatement(in: &connection)) else {
+        let packet = try executor.sqlitePacket(bindings)
+        logger?.debug(
+            "fetchOne: <<<\(executor.logicalStatement.sql)>>> parameters: <<<\(packet.bindings)>>>")
+        guard let values = try executor.fetchOne(bindings: packet) else {
             return nil
         }
 
@@ -234,16 +291,62 @@ struct GRDBRequest<Row>: XLRequest {
     }
     
     func publish() -> AnyPublisher<[Row], Error> {
-        publisher { database in
-            var connection = driver.makeConnection(database)
-            return try fetchAll(in: &connection)
+        do {
+            return publish(bindings: try compatibilityPacket())
+        }
+        catch {
+            return Fail(error: error).eraseToAnyPublisher()
         }
     }
-    
+
+    func publish(
+        bindings: any XLInvocationBindingPacket
+    ) -> AnyPublisher<[Row], Error> {
+        do {
+            let packet = try executor.sqlitePacket(bindings)
+            return publisher { database in
+                logger?.debug(
+                    "fetchAll: <<<\(executor.logicalStatement.sql)>>> parameters: <<<\(packet.bindings)>>>")
+                var connection = executor.driver.makeConnection(database)
+                return try decodeRows(
+                    executor.fetchAll(packet: packet, in: &connection)
+                )
+            }
+        }
+        catch {
+            return Fail(error: error).eraseToAnyPublisher()
+        }
+    }
+
     func publishOne() -> AnyPublisher<Row?, Error> {
-        publisher { database in
-            var connection = driver.makeConnection(database)
-            return try fetchOne(in: &connection)
+        do {
+            return publishOne(bindings: try compatibilityPacket())
+        }
+        catch {
+            return Fail(error: error).eraseToAnyPublisher()
+        }
+    }
+
+    func publishOne(
+        bindings: any XLInvocationBindingPacket
+    ) -> AnyPublisher<Row?, Error> {
+        do {
+            let packet = try executor.sqlitePacket(bindings)
+            return publisher { database in
+                logger?.debug(
+                    "fetchOne: <<<\(executor.logicalStatement.sql)>>> parameters: <<<\(packet.bindings)>>>")
+                var connection = executor.driver.makeConnection(database)
+                guard let values = try executor.fetchOne(
+                    packet: packet,
+                    in: &connection
+                ) else {
+                    return nil
+                }
+                return try GRDBRowDecoder(reader: reader).decode(values: values)
+            }
+        }
+        catch {
+            return Fail(error: error).eraseToAnyPublisher()
         }
     }
     
@@ -251,7 +354,7 @@ struct GRDBRequest<Row>: XLRequest {
         let makeSource = {
             ValueObservation
                 .tracking(fetch)
-                .publisher(in: driver.databasePool)
+                .publisher(in: executor.driver.databasePool)
                 .eraseToAnyPublisher()
         }
 
@@ -267,45 +370,59 @@ struct GRDBRequest<Row>: XLRequest {
         }
     }
 
-    private func boundStatement(
-        in connection: inout GRDBDatabaseDriverConnection
-    ) throws -> GRDBPhysicalStatement {
-        var statement = try connection.prepare(logicalStatement)
-        for (key, value) in arguments {
-            statement = try connection.bind(value, to: key, in: statement)
+    private func compatibilityPacket() throws -> XLInvocationBindings<XLSQLiteValue> {
+        if let compatibilityBindingError {
+            throw compatibilityBindingError
         }
-        return statement
+        return compatibilityBindings
     }
 }
 
 
 struct GRDBWriteRequest: XLWriteRequest {
 
-    private let driver: GRDBDatabaseDriver
+    private let executor: GRDBInvocationExecutor
 
     /// Immutable value-coding policy captured when this request is created.
     let codingConfiguration: XLValueCodingConfiguration
     
     private let logger: XLLogger?
     
-    private let logicalStatement: XLLogicalPreparedStatement
-    
-    private var arguments: [XLBindingKey: XLSQLiteValue] = [:]
+    private var compatibilityBindings: XLInvocationBindings<XLSQLiteValue>
+
+    private var compatibilityBindingError: XLInvocationBindingError?
     
     init(
         driver: GRDBDatabaseDriver,
         codingConfiguration: XLValueCodingConfiguration,
         logger: XLLogger?,
-        logicalStatement: XLLogicalPreparedStatement
+        logicalStatement: XLLogicalPreparedStatement,
+        parameterLayoutError: XLInvocationBindingError? = nil
     ) {
-        self.driver = driver
+        self.executor = GRDBInvocationExecutor(
+            driver: driver,
+            logicalStatement: logicalStatement,
+            parameterLayoutError: parameterLayoutError
+        )
         self.codingConfiguration = codingConfiguration
         self.logger = logger
-        self.logicalStatement = logicalStatement
+        self.compatibilityBindings = XLInvocationBindings(
+            layout: logicalStatement.parameterLayout
+        )
+        self.compatibilityBindingError = parameterLayoutError
+    }
+
+    var parameterLayout: XLParameterLayout {
+        executor.parameterLayout
     }
     
     public mutating func set<T>(parameter reference: XLNamedBindingReference<Optional<T>>, value: T?) where T: XLBindable {
-        bindValue(named: reference.name.rawValue) { context in
+        bindValue(
+            declaration: _xlLegacyParameterDeclaration(
+                for: Optional<T>.self,
+                key: .named(reference.name.rawValue)
+            )
+        ) { context in
             if let value {
                 value.bind(context: &context)
             }
@@ -316,28 +433,111 @@ struct GRDBWriteRequest: XLWriteRequest {
     }
 
     public mutating func set<T>(parameter reference: XLNamedBindingReference<T>, value: T) where T: XLBindable {
-        bindValue(named: reference.name.rawValue) { context in
+        bindValue(
+            declaration: _xlLegacyParameterDeclaration(
+                for: T.self,
+                key: .named(reference.name.rawValue)
+            )
+        ) { context in
             value.bind(context: &context)
         }
     }
     
-    private mutating func bindValue(named name: String, bind: (inout XLBindingContext) -> Void) {
+    private mutating func bindValue(
+        declaration: XLParameterDeclaration,
+        bind: (inout XLBindingContext) -> Void
+    ) {
+        guard let slot = parameterLayout.slot(for: declaration.key) else {
+            if compatibilityBindingError == nil {
+                compatibilityBindingError = .parameterDeclarationNotInLayout(
+                    declaration: declaration
+                )
+            }
+            return
+        }
+        guard slot.acceptsLegacySet(declaration) else {
+            if compatibilityBindingError == nil {
+                compatibilityBindingError = .parameterMetadataMismatch(
+                    expected: slot,
+                    actual: declaration.slot(at: slot.index)
+                )
+            }
+            return
+        }
         var context: any XLBindingContext = BindingContext()
         bind(&context)
-        arguments[.named(name)] = (context as! BindingContext).value
+        let value = (context as! BindingContext).value
+        do {
+            compatibilityBindings = try replacingBinding(
+                value,
+                at: slot,
+                in: compatibilityBindings
+            )
+        }
+        catch let error as XLInvocationBindingError {
+            if compatibilityBindingError == nil {
+                compatibilityBindingError = error
+            }
+        }
+        catch {
+            preconditionFailure("Unexpected invocation binding error: \(error)")
+        }
     }
     
     func execute() throws {
-        var driver = driver
-        try driver.withTransaction { connection in
-            logger?.debug("execute: <<<\(logicalStatement.sql)>>> parameters: <<<\(arguments)>>>")
-            var statement = try connection.prepare(logicalStatement)
-            for (key, value) in arguments {
-                statement = try connection.bind(value, to: key, in: statement)
-            }
-            try connection.execute(statement)
+        if let compatibilityBindingError {
+            throw compatibilityBindingError
         }
+        try execute(bindings: compatibilityBindings)
     }
+
+    func execute(
+        bindings: any XLInvocationBindingPacket
+    ) throws {
+        let packet = try executor.sqlitePacket(bindings)
+        logger?.debug(
+            "execute: <<<\(executor.logicalStatement.sql)>>> parameters: <<<\(packet.bindings)>>>")
+        try executor.execute(bindings: packet)
+    }
+}
+
+
+private extension XLParameterSlot {
+
+    func acceptsLegacySet(_ declaration: XLParameterDeclaration) -> Bool {
+        self.declaration == declaration || isRendererLegacyBindingWildcard
+    }
+
+    /// `XLBuilder.namedBinding` and `indexedBinding` predate typed parameter
+    /// declarations. The renderer records this exact sentinel so the v1
+    /// mutating `set` facade can still normalize a value for custom expressions
+    /// that emit placeholders directly. Typed and contextual slots never take
+    /// this path and continue to require an exact declaration match.
+    private var isRendererLegacyBindingWildcard: Bool {
+        valueTypeIdentifier == XLValueTypeIdentifier(
+            rawValue: "swiftql.legacy-binding-value"
+        )
+            && valueTypeName == "SwiftQL.XLBindable"
+            && nullability == .nullable
+            && codecIdentity == nil
+    }
+}
+
+
+private func replacingBinding(
+    _ value: XLSQLiteValue,
+    at slot: XLParameterSlot,
+    in packet: XLInvocationBindings<XLSQLiteValue>
+) throws -> XLInvocationBindings<XLSQLiteValue> {
+    if value == .null, slot.nullability == .required {
+        throw XLInvocationBindingError.nullForRequiredParameter(slot: slot)
+    }
+    return try XLInvocationBindings(
+        layout: packet.layout,
+        bindings: packet.bindings.filter { $0.slot.index != slot.index } + [
+            XLInvocationBinding(slot: slot, value: value)
+        ]
+    )
 }
 
 
@@ -621,8 +821,28 @@ public struct GRDBDatabase: XLDatabase {
             logger: logger,
             reader: statement,
             logicalStatement: logicalStatement(for: encoding),
+            parameterLayoutError: preparedParameterLayoutError(for: encoding),
             liveQueryRetryPolicy: liveQueryRetryPolicy,
             liveQueryRetryScheduler: liveQueryRetryScheduler
+        )
+    }
+
+    /// Prepares an immutable raw-value runtime handle for concurrent
+    /// invocations of one rendered statement.
+    ///
+    /// The handle intentionally does not retain the typed v1 row-reader graph.
+    /// Callers that need typed decoding can use `makeRequest(with:)`; static
+    /// typed descriptors build on this raw execution seam separately.
+    public func prepareInvocation(
+        with statement: any XLEncodable
+    ) -> GRDBPreparedInvocation {
+        let encoding = encoder.makeSQL(statement)
+        return GRDBPreparedInvocation(
+            executor: GRDBInvocationExecutor(
+                driver: driver,
+                logicalStatement: logicalStatement(for: encoding),
+                parameterLayoutError: preparedParameterLayoutError(for: encoding)
+            )
         )
     }
     
@@ -648,8 +868,50 @@ public struct GRDBDatabase: XLDatabase {
             driver: driver,
             codingConfiguration: codingConfiguration,
             logger: logger,
-            logicalStatement: logicalStatement(for: encoding)
+            logicalStatement: logicalStatement(for: encoding),
+            parameterLayoutError: preparedParameterLayoutError(for: encoding)
         )
+    }
+
+    /// Confirms that every contextual parameter retained by the rendered
+    /// statement belongs to this database's immutable coding snapshot. A
+    /// reference resolved by another database is accepted only when the same
+    /// durable codec identity is registered for the same dialect.
+    private func preparedParameterLayoutError(
+        for encoding: XLEncoding
+    ) -> XLInvocationBindingError? {
+        if let parameterLayoutError = encoding.parameterLayoutError {
+            return parameterLayoutError
+        }
+
+        for slot in encoding.parameterLayout.slots {
+            guard let expected = slot.codecIdentity else {
+                continue
+            }
+            guard expected.dialectIdentifier == dialect.descriptor.identity else {
+                return .preparedCodecDialectMismatch(
+                    slot: slot,
+                    codecIdentity: expected,
+                    expectedDialectIdentifier: dialect.descriptor.identity
+                )
+            }
+            guard let actual = codingConfiguration.registry.identity(
+                for: expected.key
+            ) else {
+                return .preparedCodecUnavailable(
+                    slot: slot,
+                    codecIdentity: expected
+                )
+            }
+            guard actual == expected else {
+                return .preparedCodecIdentityMismatch(
+                    slot: slot,
+                    expected: expected,
+                    actual: actual
+                )
+            }
+        }
+        return nil
     }
 
     private func logicalStatement(for encoding: XLEncoding) -> XLLogicalPreparedStatement {
@@ -657,7 +919,8 @@ public struct GRDBDatabase: XLDatabase {
             databaseIdentifier: driver.databaseIdentifier,
             dialectRequirement: encoding.dialectRequirement,
             sql: encoding.sql,
-            entities: encoding.entities
+            entities: encoding.entities,
+            parameterLayout: encoding.parameterLayout
         )
     }
 }

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -106,13 +106,19 @@ public struct XLRequestBuilder<Row> {
 ///
 /// A prepared select query statement.
 ///
-/// Use the set methods to assign variables parameters to the query.
+/// Read ``parameterLayout`` to construct an immutable `XLInvocationBindings` packet, then pass
+/// that packet to the binding-aware fetch or publish method for each execution. This keeps the
+/// prepared request's static SQL separate from its per-invocation values.
 ///
-/// Use the fetch methods to execute the query, or use the publish methods to create an adapter-backed
-/// Combine publisher that observes the query's database region.
+/// The mutating `set` methods remain available as v1 source-compatibility shims while callers migrate
+/// to invocation packets. Use the fetch methods to execute the query, or the publish methods to create
+/// an adapter-backed Combine publisher that observes the query's database region.
 ///
 public protocol XLRequest<Row> {
     associatedtype Row
+
+    /// Immutable static parameter metadata captured when the request was prepared.
+    var parameterLayout: XLParameterLayout { get }
     
     ///
     /// Assigns a literal value to an optional named variable parameter.
@@ -138,6 +144,9 @@ public protocol XLRequest<Row> {
     /// - Throws: The original query-execution or row-decoding error.
     ///
     func fetchAll() throws -> [Row]
+
+    /// Fetches all rows with one immutable per-invocation binding packet.
+    func fetchAll(bindings: any XLInvocationBindingPacket) throws -> [Row]
     
     ///
     /// Fetches the first row returned by the query.
@@ -145,6 +154,9 @@ public protocol XLRequest<Row> {
     /// - Throws: The original query-execution or row-decoding error.
     ///
     func fetchOne() throws -> Row?
+
+    /// Fetches the first row with one immutable per-invocation binding packet.
+    func fetchOne(bindings: any XLInvocationBindingPacket) throws -> Row?
     
     ///
     /// Creates a Combine Publisher that observes and emits all rows from the query.
@@ -158,6 +170,9 @@ public protocol XLRequest<Row> {
     /// by default and retry only when their database is configured to do so.
     ///
     func publish() -> AnyPublisher<[Row], Error>
+
+    /// Observes all rows using one immutable packet for every retry and refresh.
+    func publish(bindings: any XLInvocationBindingPacket) -> AnyPublisher<[Row], Error>
     
     ///
     /// Creates a Combine Publisher that observes and emits the first row from the query.
@@ -171,9 +186,77 @@ public protocol XLRequest<Row> {
     /// database is configured to do so.
     ///
     func publishOne() -> AnyPublisher<Row?, Error>
+
+    /// Observes the first row using one immutable packet for every retry and refresh.
+    func publishOne(bindings: any XLInvocationBindingPacket) -> AnyPublisher<Row?, Error>
 }
 
 extension XLRequest {
+
+    /// Compatibility default for request adapters that do not yet expose static
+    /// parameter metadata.
+    public var parameterLayout: XLParameterLayout {
+        .empty
+    }
+
+    /// Compatibility default for existing adapters. Empty packets preserve the
+    /// original zero-argument execution path; nonempty packets fail explicitly.
+    public func fetchAll(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [Row] {
+        try validateCompatibilityBindings(bindings)
+        return try fetchAll()
+    }
+
+    /// Compatibility default for existing adapters. Empty packets preserve the
+    /// original zero-argument execution path; nonempty packets fail explicitly.
+    public func fetchOne(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> Row? {
+        try validateCompatibilityBindings(bindings)
+        return try fetchOne()
+    }
+
+    /// Compatibility default for existing adapters. Invalid packets fail on
+    /// subscription instead of being silently ignored.
+    public func publish(
+        bindings: any XLInvocationBindingPacket
+    ) -> AnyPublisher<[Row], Error> {
+        do {
+            try validateCompatibilityBindings(bindings)
+            return publish()
+        }
+        catch {
+            return Fail(error: error).eraseToAnyPublisher()
+        }
+    }
+
+    /// Compatibility default for existing adapters. Invalid packets fail on
+    /// subscription instead of being silently ignored.
+    public func publishOne(
+        bindings: any XLInvocationBindingPacket
+    ) -> AnyPublisher<Row?, Error> {
+        do {
+            try validateCompatibilityBindings(bindings)
+            return publishOne()
+        }
+        catch {
+            return Fail(error: error).eraseToAnyPublisher()
+        }
+    }
+
+    private func validateCompatibilityBindings(
+        _ bindings: any XLInvocationBindingPacket
+    ) throws {
+        guard bindings.layout.isEmpty,
+              bindings.bindingCount == 0,
+              bindings.isComplete else {
+            throw XLRequestBindingError.unsupportedInvocationBindings(
+                requestType: String(reflecting: Self.self),
+                layout: bindings.layout
+            )
+        }
+    }
     
     ///
     /// Convenience method used to set an optional named parameter on the request.
@@ -205,6 +288,9 @@ extension XLRequest {
 /// from executing the request.
 ///
 public protocol XLWriteRequest {
+
+    /// Immutable static parameter metadata captured when the request was prepared.
+    var parameterLayout: XLParameterLayout { get }
     
     ///
     /// Assigns a literal value to an optional named variable parameter.
@@ -226,9 +312,34 @@ public protocol XLWriteRequest {
     /// Executes the statement.
     ///
     func execute() throws
+
+    /// Executes the statement with one immutable per-invocation binding packet.
+    func execute(bindings: any XLInvocationBindingPacket) throws
 }
 
 extension XLWriteRequest {
+
+    /// Compatibility default for request adapters that do not yet expose static
+    /// parameter metadata.
+    public var parameterLayout: XLParameterLayout {
+        .empty
+    }
+
+    /// Compatibility default for existing adapters. Empty packets preserve the
+    /// original zero-argument execution path; nonempty packets fail explicitly.
+    public func execute(
+        bindings: any XLInvocationBindingPacket
+    ) throws {
+        guard bindings.layout.isEmpty,
+              bindings.bindingCount == 0,
+              bindings.isComplete else {
+            throw XLRequestBindingError.unsupportedInvocationBindings(
+                requestType: String(reflecting: Self.self),
+                layout: bindings.layout
+            )
+        }
+        try execute()
+    }
     
     ///
     /// Convenience method used to set an optional named parameter on the request.

--- a/Sources/SwiftQL/SQLEncoder.swift
+++ b/Sources/SwiftQL/SQLEncoder.swift
@@ -100,14 +100,26 @@ public struct XLEncoding {
     /// Dialect identity and syntax capabilities required by this SQL.
     public let dialectRequirement: XLDialectRequirement
 
+    /// The immutable static parameter metadata captured while rendering SQL.
+    public let parameterLayout: XLParameterLayout
+
+    /// The first deterministic conflict encountered while capturing parameter
+    /// metadata. Legacy nonthrowing encoders retain this error so an execution
+    /// boundary can reject the statement before preparing it.
+    public let parameterLayoutError: XLInvocationBindingError?
+
     public init(
         sql: String,
         entities: Set<String>,
-        dialectRequirement: XLDialectRequirement
+        dialectRequirement: XLDialectRequirement,
+        parameterLayout: XLParameterLayout = .empty,
+        parameterLayoutError: XLInvocationBindingError? = nil
     ) {
         self.sql = sql
         self.entities = entities
         self.dialectRequirement = dialectRequirement
+        self.parameterLayout = parameterLayout
+        self.parameterLayoutError = parameterLayoutError
     }
 }
 
@@ -172,8 +184,20 @@ public struct XLiteEncoder: XLEncoder {
             dialectRequirement: XLDialectRequirement(
                 identity: dialect.descriptor.identity,
                 capabilities: requirementRecorder.capabilities
-            )
+            ),
+            parameterLayout: requirementRecorder.parameterLayout,
+            parameterLayoutError: requirementRecorder.parameterLayoutError
         )
+    }
+
+    /// Renders SQL and rejects conflicting or invalid static parameter
+    /// declarations before a prepared handle is created.
+    public func makeValidatedSQL(_ expression: XLEncodable) throws -> XLEncoding {
+        let encoding = makeSQL(expression)
+        if let error = encoding.parameterLayoutError {
+            throw error
+        }
+        return encoding
     }
 }
 
@@ -234,10 +258,164 @@ public protocol XLFormatter {
 private final class XLiteDialectRequirementRecorder {
 
     var capabilities: XLDialectCapabilities = []
+
+    private(set) var parameterLayout: XLParameterLayout = .empty
+
+    private(set) var parameterLayoutError: XLInvocationBindingError?
+
+    private var physicalIndexByKey: [XLBindingKey: Int] = [:]
+
+    private var slotByPhysicalIndex: [Int: XLParameterSlot] = [:]
+
+    private var largestPhysicalIndex = 0
+
+    func recordLegacyParameter(key: XLBindingKey) {
+        let existing = parameterLayout.slot(for: key)
+        let slot = XLParameterSlot(
+            index: existing?.index ?? nextLogicalIndex(),
+            key: key,
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: "swiftql.legacy-binding-value"
+            ),
+            valueTypeName: "SwiftQL.XLBindable",
+            nullability: .nullable,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath(key.parameterPathComponent)
+            )
+        )
+
+        if let existing {
+            guard existing.declaration == slot.declaration else {
+                if parameterLayoutError == nil {
+                    parameterLayoutError = .conflictingParameterKey(
+                        key: key,
+                        existing: existing,
+                        incoming: slot
+                    )
+                }
+                return
+            }
+            return
+        }
+        recordParameter(slot)
+    }
+
+    func recordParameter(_ slot: XLParameterSlot) {
+        recordPhysicalParameter(slot)
+        do {
+            parameterLayout = try XLParameterLayout(
+                slots: parameterLayout.slots + [slot]
+            )
+        }
+        catch let error as XLInvocationBindingError {
+            if parameterLayoutError == nil {
+                parameterLayoutError = error
+            }
+        }
+        catch {
+            preconditionFailure("XLParameterLayout produced an unexpected error: \(error)")
+        }
+    }
+
+    func recordParameter(_ declaration: XLParameterDeclaration) {
+        let existing = parameterLayout.slot(for: declaration.key)
+        if let existing,
+           existing.isRendererLegacyBindingWildcard,
+           existing.declaration != declaration {
+            if parameterLayoutError == nil {
+                parameterLayoutError = .conflictingParameterKey(
+                    key: declaration.key,
+                    existing: existing,
+                    incoming: declaration.slot(at: existing.index)
+                )
+            }
+            return
+        }
+        let index = existing?.index ?? nextLogicalIndex()
+        recordParameter(declaration.slot(at: index))
+    }
+
+    /// SQLite assigns named parameters the next physical index, while `?NNN`
+    /// uses `NNN` directly. A named parameter followed by an explicit index can
+    /// therefore alias the same physical slot even though SwiftQL has two
+    /// distinct logical keys. Reject that shape during rendering.
+    private func recordPhysicalParameter(_ slot: XLParameterSlot) {
+        let physicalIndex: Int
+        if let recorded = physicalIndexByKey[slot.key] {
+            physicalIndex = recorded
+        }
+        else {
+            switch slot.key {
+            case .named:
+                physicalIndex = largestPhysicalIndex + 1
+            case .indexed(let zeroBasedIndex):
+                physicalIndex = zeroBasedIndex + 1
+            }
+            physicalIndexByKey[slot.key] = physicalIndex
+            largestPhysicalIndex = max(largestPhysicalIndex, physicalIndex)
+        }
+
+        if let existing = slotByPhysicalIndex[physicalIndex],
+           existing.key != slot.key {
+            if parameterLayoutError == nil {
+                parameterLayoutError = .conflictingPhysicalParameterIndex(
+                    index: physicalIndex,
+                    existing: existing,
+                    incoming: slot
+                )
+            }
+            return
+        }
+        slotByPhysicalIndex[physicalIndex] = slot
+    }
+
+    private func nextLogicalIndex() -> XLLogicalParameterIndex {
+        var rawValue = 0
+        while parameterLayout.slot(at: XLLogicalParameterIndex(rawValue)) != nil {
+            rawValue += 1
+        }
+        return XLLogicalParameterIndex(rawValue)
+    }
 }
 
 
-private struct XLiteRequirementRecordingFormatter: XLFormatter {
+private extension XLParameterSlot {
+
+    var isRendererLegacyBindingWildcard: Bool {
+        valueTypeIdentifier == XLValueTypeIdentifier(
+            rawValue: "swiftql.legacy-binding-value"
+        )
+            && valueTypeName == "SwiftQL.XLBindable"
+            && nullability == .nullable
+            && codecIdentity == nil
+    }
+}
+
+
+private extension XLBindingKey {
+
+    var parameterPathComponent: String {
+        switch self {
+        case .named(let name):
+            return name
+        case .indexed(let index):
+            return String(index)
+        }
+    }
+}
+
+
+private protocol XLiteParameterRecordingFormatter: XLFormatter {
+
+    func formatParameter(_ slot: XLParameterSlot) -> String
+
+    func formatParameter(_ declaration: XLParameterDeclaration) -> String
+}
+
+
+private struct XLiteRequirementRecordingFormatter: XLiteParameterRecordingFormatter {
 
     let base: XLFormatter
 
@@ -273,12 +451,38 @@ private struct XLiteRequirementRecordingFormatter: XLFormatter {
 
     func namedBinding(_ named: String) -> String {
         recorder.capabilities.insert(.namedBindings)
+        recorder.recordLegacyParameter(key: .named(named))
         return base.namedBinding(named)
     }
 
     func indexedBinding(_ index: Int) -> String {
         recorder.capabilities.insert(.indexedBindings)
+        recorder.recordLegacyParameter(key: .indexed(index))
         return base.indexedBinding(index)
+    }
+
+    func formatParameter(_ slot: XLParameterSlot) -> String {
+        recorder.recordParameter(slot)
+        switch slot.key {
+        case .named(let name):
+            recorder.capabilities.insert(.namedBindings)
+            return base.namedBinding(name)
+        case .indexed(let index):
+            recorder.capabilities.insert(.indexedBindings)
+            return base.indexedBinding(index)
+        }
+    }
+
+    func formatParameter(_ declaration: XLParameterDeclaration) -> String {
+        recorder.recordParameter(declaration)
+        switch declaration.key {
+        case .named(let name):
+            recorder.capabilities.insert(.namedBindings)
+            return base.namedBinding(name)
+        case .indexed(let index):
+            recorder.capabilities.insert(.indexedBindings)
+            return base.indexedBinding(index)
+        }
     }
 }
 
@@ -456,6 +660,17 @@ public protocol XLBuilder {
     /// - Parameter index: Ordinal index of the parameter.
     ///
     mutating func indexedBinding(_ index: Int)
+
+    /// Adds a variable binding with immutable static parameter metadata.
+    ///
+    /// Builders that do not capture parameter layouts remain source-compatible:
+    /// the default implementation renders the placeholder identified by
+    /// `slot.key`.
+    mutating func parameter(_ slot: XLParameterSlot)
+
+    /// Adds a parameter declaration whose deterministic logical index is
+    /// assigned from its first occurrence in the rendered statement.
+    mutating func parameter(_ declaration: XLParameterDeclaration)
     
     ///
     /// Adds a list. The list is constructed using a specialised `XLListBuilder`.
@@ -583,6 +798,24 @@ public protocol XLBuilder {
 }
 
 extension XLBuilder {
+
+    public mutating func parameter(_ slot: XLParameterSlot) {
+        switch slot.key {
+        case .named(let name):
+            namedBinding(XLName(name))
+        case .indexed(let index):
+            indexedBinding(index)
+        }
+    }
+
+    public mutating func parameter(_ declaration: XLParameterDeclaration) {
+        switch declaration.key {
+        case .named(let name):
+            namedBinding(XLName(name))
+        case .indexed(let index):
+            indexedBinding(index)
+        }
+    }
     
     ///
     /// Convenience method used to add a sub-expression with leading and trailing paranthesis.
@@ -741,6 +974,34 @@ public struct XLiteBuilder: XLBuilder {
     
     public mutating func indexedBinding(_ index: Int) {
         append(formatter.indexedBinding(index))
+    }
+
+    public mutating func parameter(_ slot: XLParameterSlot) {
+        if let recordingFormatter = formatter as? any XLiteParameterRecordingFormatter {
+            append(recordingFormatter.formatParameter(slot))
+            return
+        }
+
+        switch slot.key {
+        case .named(let name):
+            append(formatter.namedBinding(name))
+        case .indexed(let index):
+            append(formatter.indexedBinding(index))
+        }
+    }
+
+    public mutating func parameter(_ declaration: XLParameterDeclaration) {
+        if let recordingFormatter = formatter as? any XLiteParameterRecordingFormatter {
+            append(recordingFormatter.formatParameter(declaration))
+            return
+        }
+
+        switch declaration.key {
+        case .named(let name):
+            append(formatter.namedBinding(name))
+        case .indexed(let index):
+            append(formatter.indexedBinding(index))
+        }
     }
     
     public mutating func list(separator: String, items: (inout XLListBuilder) -> Void) {

--- a/Sources/SwiftQL/SQLExpression.swift
+++ b/Sources/SwiftQL/SQLExpression.swift
@@ -195,7 +195,12 @@ public struct XLNamedBindingReference<T>: XLBindingReference, Sendable where T: 
     
     public func makeSQL(context: inout XLBuilder) {
         T.wrapSQL(context: &context) { context in
-            context.namedBinding(name)
+            context.parameter(
+                _xlLegacyParameterDeclaration(
+                    for: T.self,
+                    key: .named(name.rawValue)
+                )
+            )
         }
     }
 }

--- a/Sources/SwiftQL/SQLInvocationBindings.swift
+++ b/Sources/SwiftQL/SQLInvocationBindings.swift
@@ -54,9 +54,11 @@ public enum XLRequestBindingError: Error, Equatable, Sendable, LocalizedError {
 /// `XLContextualBindingReference<Date, String, XLSQLiteDialect>` without making
 /// `Date` conform to `XLLiteral`.
 public struct XLContextualBindingReference<Value, Literal, Dialect>:
-    XLBindingReference<Literal>,
+    XLBindingReference,
     Sendable
 where Literal: XLLiteral, Dialect: XLValueCodingDialect {
+
+    public typealias T = Literal
 
     public let declaration: XLParameterDeclaration
 

--- a/Sources/SwiftQL/SQLInvocationBindings.swift
+++ b/Sources/SwiftQL/SQLInvocationBindings.swift
@@ -1,0 +1,341 @@
+import Foundation
+
+
+/// Request-facade failures that occur before a dialect-specific packet reaches
+/// a database driver.
+public enum XLRequestBindingError: Error, Equatable, Sendable, LocalizedError {
+
+    case unsupportedInvocationBindings(
+        requestType: String,
+        layout: XLParameterLayout
+    )
+
+    case incompatibleInvocationPacket(
+        requestType: String,
+        expectedDialect: XLDialectIdentifier,
+        expectedValueType: String,
+        actualPacketType: String
+    )
+
+    case expressionNullabilityMismatch(
+        key: XLBindingKey,
+        parameterNullability: XLParameterNullability,
+        literalType: String
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedInvocationBindings(let requestType, let layout):
+            return "Request \(requestType) does not support an invocation packet with \(layout.count) parameters."
+        case .incompatibleInvocationPacket(
+            let requestType,
+            let expectedDialect,
+            let expectedValueType,
+            let actualPacketType
+        ):
+            return "Request \(requestType) requires \(expectedValueType) values for dialect \(expectedDialect), not packet \(actualPacketType)."
+        case .expressionNullabilityMismatch(
+            let key,
+            let parameterNullability,
+            let literalType
+        ):
+            return "Parameter \(key) is \(parameterNullability.rawValue), but SQL expression type \(literalType) has different nullability."
+        }
+    }
+}
+
+
+/// A contextual runtime value paired with the literal type used by SQL
+/// expression checking.
+///
+/// `Value` is converted by a resolved contextual codec. `Literal` describes
+/// how the placeholder participates in the existing SwiftQL expression DSL.
+/// For example, a `Date` encoded as SQLite text can use
+/// `XLContextualBindingReference<Date, String, XLSQLiteDialect>` without making
+/// `Date` conform to `XLLiteral`.
+public struct XLContextualBindingReference<Value, Literal, Dialect>:
+    XLBindingReference<Literal>,
+    Sendable
+where Literal: XLLiteral, Dialect: XLValueCodingDialect {
+
+    public let declaration: XLParameterDeclaration
+
+    private let codec: XLResolvedValueCodec<Value, Dialect>
+
+    /// Creates an index-free contextual parameter declaration.
+    ///
+    /// SQL traversal assigns its logical index on first use. The resolved codec
+    /// is retained as an immutable snapshot and reused for every invocation.
+    public init(
+        key: XLBindingKey,
+        nullability: XLParameterNullability = .required,
+        codec: XLResolvedValueCodec<Value, Dialect>
+    ) {
+        self.declaration = XLParameterDeclaration(
+            key: key,
+            valueTypeIdentifier: codec.identity.valueTypeIdentifier,
+            valueTypeName: String(reflecting: Value.self),
+            nullability: nullability,
+            codecIdentity: codec.identity,
+            codingContext: codec.context
+        )
+        self.codec = codec
+    }
+
+    public func makeSQL(context: inout XLBuilder) {
+        Literal.wrapSQL(context: &context) { context in
+            context.parameter(declaration)
+        }
+    }
+
+    /// Resolves the renderer-assigned logical index without consulting a
+    /// mutable registry or changing the selected codec.
+    public func preparedParameter(
+        in layout: XLParameterLayout
+    ) throws -> XLPreparedParameter<Value, Dialect> {
+        guard let slot = layout.slot(for: declaration.key) else {
+            throw XLInvocationBindingError.parameterDeclarationNotInLayout(
+                declaration: declaration
+            )
+        }
+
+        let parameter = XLPreparedParameter(
+            index: slot.index,
+            key: declaration.key,
+            nullability: declaration.nullability,
+            codec: codec
+        )
+        guard parameter.slot == slot else {
+            throw XLInvocationBindingError.parameterMetadataMismatch(
+                expected: slot,
+                actual: parameter.slot
+            )
+        }
+        return parameter
+    }
+
+    /// Encodes a nonoptional runtime value for one rendered layout.
+    public func encode(
+        _ value: Value,
+        in layout: XLParameterLayout
+    ) throws -> XLInvocationBinding<Dialect.Value> {
+        try preparedParameter(in: layout).encode(value)
+    }
+
+    /// Encodes an optional runtime value, retaining explicit SQL `NULL` as a
+    /// present binding.
+    public func encodeOptional(
+        _ value: Value?,
+        in layout: XLParameterLayout
+    ) throws -> XLInvocationBinding<Dialect.Value> {
+        try preparedParameter(in: layout).encodeOptional(value)
+    }
+}
+
+
+extension GRDBDatabase {
+
+    /// Resolves a named contextual parameter against this database's immutable
+    /// coding snapshot.
+    public func contextualBinding<Value, Literal>(
+        _ valueType: Value.Type,
+        expressedAs literalType: Literal.Type,
+        named name: XLName,
+        nullability: XLParameterNullability = .required,
+        context: XLValueCodingContext? = nil,
+        selection: XLValueCodecSelection = XLValueCodecSelection()
+    ) throws -> XLContextualBindingReference<Value, Literal, XLSQLiteDialect>
+    where Literal: XLLiteral {
+        try contextualBinding(
+            valueType,
+            expressedAs: literalType,
+            key: .named(name.rawValue),
+            nullability: nullability,
+            context: context,
+            selection: selection
+        )
+    }
+
+    /// Resolves an indexed contextual parameter against this database's
+    /// immutable coding snapshot.
+    public func contextualBinding<Value, Literal>(
+        _ valueType: Value.Type,
+        expressedAs literalType: Literal.Type,
+        indexed index: Int,
+        nullability: XLParameterNullability = .required,
+        context: XLValueCodingContext? = nil,
+        selection: XLValueCodecSelection = XLValueCodecSelection()
+    ) throws -> XLContextualBindingReference<Value, Literal, XLSQLiteDialect>
+    where Literal: XLLiteral {
+        try contextualBinding(
+            valueType,
+            expressedAs: literalType,
+            key: .indexed(index),
+            nullability: nullability,
+            context: context,
+            selection: selection
+        )
+    }
+
+    /// Resolves a contextual parameter for an explicit logical binding key.
+    public func contextualBinding<Value, Literal>(
+        _ valueType: Value.Type,
+        expressedAs literalType: Literal.Type,
+        key: XLBindingKey,
+        nullability: XLParameterNullability = .required,
+        context: XLValueCodingContext? = nil,
+        selection: XLValueCodecSelection = XLValueCodecSelection()
+    ) throws -> XLContextualBindingReference<Value, Literal, XLSQLiteDialect>
+    where Literal: XLLiteral {
+        let expressionIsOptional = literalType is any _XLOptionalLiteralType.Type
+        guard expressionIsOptional == (nullability == .nullable) else {
+            throw XLRequestBindingError.expressionNullabilityMismatch(
+                key: key,
+                parameterNullability: nullability,
+                literalType: String(reflecting: literalType)
+            )
+        }
+        let codingContext = context ?? XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(key.contextPathComponent)
+        )
+        let codec = try codingConfiguration.resolvedCodec(
+            for: valueType,
+            using: dialect,
+            context: codingContext,
+            selection: selection
+        )
+        try validateLiteralStorage(
+            literalType,
+            codecIdentity: codec.identity,
+            context: codingContext
+        )
+        return XLContextualBindingReference(
+            key: key,
+            nullability: nullability,
+            codec: codec
+        )
+    }
+
+    private func validateLiteralStorage<Literal>(
+        _ literalType: Literal.Type,
+        codecIdentity: XLValueCodecIdentity,
+        context: XLValueCodingContext
+    ) throws where Literal: XLLiteral {
+        guard let storageClass = sqliteStorageClass(for: literalType) else {
+            return
+        }
+        let actual = XLValueStorageIdentifier(rawValue: storageClass.rawValue)
+        guard codecIdentity.storageIdentifier == actual else {
+            throw XLValueCodecError.storageMismatch(
+                codec: codecIdentity.key,
+                expected: codecIdentity.storageIdentifier,
+                actual: actual,
+                context: context
+            )
+        }
+    }
+}
+
+
+func _xlLegacyParameterDeclaration<Value>(
+    for type: Value.Type,
+    key: XLBindingKey
+) -> XLParameterDeclaration {
+    let metadata = legacyValueMetadata(for: type)
+    return XLParameterDeclaration(
+        key: key,
+        valueTypeIdentifier: metadata.identifier,
+        valueTypeName: metadata.typeName,
+        nullability: metadata.isOptional ? .nullable : .required,
+        codecIdentity: nil,
+        codingContext: XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(key.contextPathComponent)
+        )
+    )
+}
+
+
+private protocol _XLOptionalLiteralType {
+    static var wrappedType: Any.Type { get }
+}
+
+
+extension Optional: _XLOptionalLiteralType {
+    static var wrappedType: Any.Type {
+        Wrapped.self
+    }
+}
+
+
+private func sqliteStorageClass(
+    for type: Any.Type
+) -> XLSQLiteStorageClass? {
+    if let optional = type as? any _XLOptionalLiteralType.Type {
+        return sqliteStorageClass(for: optional.wrappedType)
+    }
+    if type == Bool.self || type == Int.self {
+        return .integer
+    }
+    if type == Double.self {
+        return .real
+    }
+    if type == String.self {
+        return .text
+    }
+    if type == Data.self {
+        return .blob
+    }
+    return nil
+}
+
+
+private func legacyValueMetadata(
+    for type: Any.Type
+) -> (identifier: XLValueTypeIdentifier, typeName: String, isOptional: Bool) {
+    if let optional = type as? any _XLOptionalLiteralType.Type {
+        let wrapped = legacyValueMetadata(for: optional.wrappedType)
+        return (wrapped.identifier, wrapped.typeName, true)
+    }
+
+    let identifier: String
+    if type == Bool.self {
+        identifier = "swift.bool"
+    }
+    else if type == Int.self {
+        identifier = "swift.int"
+    }
+    else if type == Double.self {
+        identifier = "swift.double"
+    }
+    else if type == String.self {
+        identifier = "swift.string"
+    }
+    else if type == Data.self {
+        identifier = "foundation.data"
+    }
+    else {
+        // v1 custom literals have no durable identifier contract. Keep one
+        // explicit compatibility sentinel and retain the reflected spelling
+        // only in the diagnostic `valueTypeName` field.
+        identifier = "swiftql.v1.legacy-custom"
+    }
+    return (
+        XLValueTypeIdentifier(rawValue: identifier),
+        String(reflecting: type),
+        false
+    )
+}
+
+
+private extension XLBindingKey {
+    var contextPathComponent: String {
+        switch self {
+        case .named(let name):
+            return name
+        case .indexed(let index):
+            return String(index)
+        }
+    }
+}

--- a/Sources/SwiftQL/SwiftQL.docc/CustomFunctions.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomFunctions.md
@@ -167,12 +167,34 @@ let query = sqlQuery { schema in
 let distanceToRestaurantsRequest = database.makeRequest(with: query)
 ```
 
-We can execute the query passing in our latitude and longitude:
+We can execute the query with an immutable packet containing the two values for
+this invocation:
 
 <!-- test: XLDocumentationTests.testDocumentationCustomFunctionRegistrationAndExecution -->
 ```swift
-var request = distanceToRestaurantsRequest
-request.set(myLatitude, -33.877873677687894)
-request.set(myLongitude, 18.488075015723)
-let restaurants = try request.fetchAll()
+let layout = distanceToRestaurantsRequest.parameterLayout
+let coordinates = try XLInvocationBindings<XLSQLiteValue>(
+    layout: layout,
+    bindings: [
+        try XLInvocationBinding(
+            slot: layout.slot(for: .named("myLatitude"))!,
+            value: .real(-33.877873677687894)
+        ),
+        try XLInvocationBinding(
+            slot: layout.slot(for: .named("myLongitude"))!,
+            value: .real(18.488075015723)
+        )
+    ]
+).validatingComplete()
+let restaurants = try distanceToRestaurantsRequest.fetchAll(
+    bindings: coordinates
+)
 ```
+
+The parameter layout belongs to the rendered function call and remains fixed;
+the coordinates belong only to this execution. A later call can pass another
+packet without mutating or copying `distanceToRestaurantsRequest`. The legacy
+`set` methods still work for v1 literal parameters, but an explicit packet
+makes value isolation visible. Packets are `Sendable` when their normalized
+dialect values are; the current request facade does not itself promise
+cross-task use.

--- a/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
@@ -172,6 +172,106 @@ let decodedDate: Date? = try dateCoding.decodeOptional(
 )
 ```
 
+### Contextual parameters and invocation packets
+
+Create a contextual binding from the same database that will prepare the
+request. `contextualBinding` resolves the codec once from that database's
+immutable coding snapshot. Rendering then records the declaration in the
+request's static `XLParameterLayout`; encoding a runtime value produces one
+`XLInvocationBinding` for a per-call packet.
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+let codecDatabase = try GRDBDatabase(
+    url: databaseURL,
+    codingConfiguration: dateCoding,
+    logger: nil
+)
+let cutoffDate = try codecDatabase.contextualBinding(
+    Date.self,
+    expressedAs: String.self,
+    named: "cutoffDate"
+)
+let cutoffQuery = sql { _ in
+    Select(cutoffDate)
+}
+let cutoffRequest = codecDatabase.makeRequest(with: cutoffQuery)
+let cutoffBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: cutoffRequest.parameterLayout,
+    bindings: [
+        cutoffDate.encode(
+            Date(timeIntervalSince1970: 86_400),
+            in: cutoffRequest.parameterLayout
+        )
+    ]
+).validatingComplete()
+let storedCutoff = try cutoffRequest.fetchOne(bindings: cutoffBindings)
+```
+
+Here `Value` is `Date`, while the reference's `Literal` is `String` because the
+selected codec stores SQLite `TEXT`. The `expressedAs` literal controls SQL
+expression typing and any literal wrapping; it does not make `Date` conform to
+`XLLiteral`, choose a different codec at execution time, or become part of the
+runtime packet. SwiftQL rejects a known storage mismatch between the literal
+and codec when the contextual reference is created.
+
+Nullability is equally explicit. A nullable contextual reference must use an
+optional literal expression type, and `encodeOptional(nil, in:)` produces a
+present SQLite `.null` binding:
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+let optionalDate = try codecDatabase.contextualBinding(
+    Date.self,
+    expressedAs: Optional<String>.self,
+    named: "optionalDate",
+    nullability: .nullable
+)
+let nullQuery = sql { _ in Select(optionalDate.isNull()) }
+let nullRequest = codecDatabase.makeRequest(with: nullQuery)
+let nullBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: nullRequest.parameterLayout,
+    bindings: [
+        optionalDate.encodeOptional(nil, in: nullRequest.parameterLayout)
+    ]
+).validatingComplete()
+let isNull = try nullRequest.fetchOne(bindings: nullBindings)
+```
+
+An empty packet for `nullRequest` is missing a binding and fails
+`validatingComplete()`; it is not interpreted as SQL `NULL`. Encoding `nil` for
+a required slot fails with parameter, codec, and coding-path context before the
+driver binds anything.
+
+Foundation `UUID` and application-owned values use the same API without
+retroactive literal conformances. Suppose `applicationCodecDatabase` was opened
+with registered defaults whose storage identifiers match `BLOB` and `INTEGER`,
+respectively:
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+struct InvoiceToken {
+    let rawValue: Int64
+}
+
+let uuidParameter = try applicationCodecDatabase.contextualBinding(
+    UUID.self,
+    expressedAs: Data.self,
+    named: "invoiceID"
+)
+let tokenParameter = try applicationCodecDatabase.contextualBinding(
+    InvoiceToken.self,
+    expressedAs: Int.self,
+    named: "token"
+)
+```
+
+Each reference retains its resolved codec identity and context. Call
+`encode(_:in:)` with the prepared request's layout, collect the returned
+bindings in one `XLInvocationBindings` value, validate completeness, and pass
+that packet to the request. Only normalized `XLSQLiteValue` values enter the
+packet; the original `Date`, `UUID`, or custom value is not retained.
+
 ## Legacy `XLCustomType` wrappers
 
 For existing v1 code, a custom scalar value satisfies the `XLCustomType`
@@ -440,6 +540,12 @@ var request = database.makeRequest(with: query)
 request.set(dateParameter, SQLDate(Date(timeIntervalSince1970: 0)))
 let invoices = try request.fetchAll()
 ```
+
+This last example deliberately shows the v1 `set` migration shim. It converts
+the `SQLDate` literal immediately into a compatibility invocation packet on the
+request copy. It cannot select or bypass a contextual codec. New code that has
+a registered `Date` codec should use `contextualBinding`, encode a fresh packet,
+and keep the prepared request immutable as shown above.
 
 ## Migrating v1 literals
 

--- a/Sources/SwiftQL/SwiftQL.docc/Enums.md
+++ b/Sources/SwiftQL/SwiftQL.docc/Enums.md
@@ -77,8 +77,9 @@ Enum columns can be required or optional. They can also appear in an
 }
 ```
 
-Use enum values when inserting rows and bind them to prepared requests in the
-same way as intrinsic values:
+Use enum values when inserting rows. For a reusable prepared request, keep the
+enum parameter in the static layout and put its normalized raw value in an
+immutable packet for each invocation:
 
 <!-- test: XLDocumentationTests.testDocumentationEnumValues -->
 ```swift
@@ -108,10 +109,31 @@ let runningJobs = sql { schema in
     Where(job.state == stateParameter)
 }
 
-var request = database.makeRequest(with: runningJobs)
-request.set(stateParameter, .running)
-let summaries = try request.fetchAll()
+let request = database.makeRequest(with: runningJobs)
+let stateSlot = request.parameterLayout.slot(for: .named("state"))!
+let runningBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: request.parameterLayout,
+    bindings: [
+        try XLInvocationBinding(
+            slot: stateSlot,
+            value: .text(JobState.running.rawValue)
+        )
+    ]
+).validatingComplete()
+let summaries = try request.fetchAll(bindings: runningBindings)
 ```
+
+The `JobState` declaration is still the expression's literal type, so its
+operators and column comparisons remain type checked. The invocation packet
+does not carry a mutable `JobState`; it carries the SQLite `TEXT` value that the
+driver binds. The layout, including the parameter's type and nullability, does
+not change when `.queued` and `.running` are used in separate calls.
+
+The mutating `set(stateParameter, .running)` form remains available for v1
+source compatibility. It immediately normalizes the enum into a compatibility
+packet stored in that request copy. Prefer an explicit packet for repeated
+calls or when composing bindings from multiple call sites. The packet is
+`Sendable`; the current request facade does not itself promise cross-task use.
 
 For an optional enum, SQL `NULL` decodes as `nil`; a recognized non-`NULL` raw
 value decodes as the matching case.

--- a/Sources/SwiftQL/SwiftQL.docc/FunctionalSyntax.md
+++ b/Sources/SwiftQL/SwiftQL.docc/FunctionalSyntax.md
@@ -81,7 +81,23 @@ let statement = sqlQuery { schema in
     let person = schema.table(Person.self)
     return select(person).from(person).where(person.name == nameParameter)
 }
+
+let request = database.makeRequest(with: statement)
+let bindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: request.parameterLayout,
+    bindings: [
+        try XLInvocationBinding(
+            slot: request.parameterLayout.slot(for: .named("name"))!,
+            value: .text("John Doe")
+        )
+    ]
+).validatingComplete()
+let peopleNamedJohn = try request.fetchAll(bindings: bindings)
 ```
+
+Functional and result-builder statements produce the same immutable static
+parameter layout. Values are supplied separately in a per-call packet; the
+syntax used to construct the statement does not change binding semantics.
 
 ### Example: Where
 
@@ -206,11 +222,27 @@ let statement: any XLUpdateStatement<ExampleValue> = sqlUpdate { schema in
     .where(table.id == idParameter)
 }
 
-var request = database.makeRequest(with: statement)
-request.set(idParameter, id)
-request.set(valueParameter, value)
-try request.execute()
+let request = database.makeRequest(with: statement)
+let bindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: request.parameterLayout,
+    bindings: [
+        try XLInvocationBinding(
+            slot: request.parameterLayout.slot(for: .named("id"))!,
+            value: .text(id)
+        ),
+        try XLInvocationBinding(
+            slot: request.parameterLayout.slot(for: .named("value"))!,
+            value: .integer(Int64(value))
+        )
+    ]
+).validatingComplete()
+try request.execute(bindings: bindings)
 ```
+
+`validatingComplete()` distinguishes an omitted parameter from a present SQL
+`NULL` value. Use `.null` only for a slot declared nullable; leaving a slot out
+is always a missing binding. The mutating `set` API remains available as a
+source-compatible migration shim for older literal-based code.
 
 ### Example: Create
 

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -191,11 +191,15 @@ This guide uses the explicit `schema` name for clarity.
 
 ### Reusing requests
 
-Requests are value types that contain the generated SQL and its bound values,
-so you can store and reuse them. Creating a request translates the SwiftQL
-statement into SQL but does not prepare it immediately. On execution, GRDB
-obtains a cached SQLite statement for that SQL on the connection performing the
-work.
+Requests retain the generated SQL and an immutable `XLParameterLayout`. The
+layout is static metadata: it records each logical parameter's deterministic
+index, binding key, value type, nullability, coding context, and selected codec
+identity. Runtime values are separate. Put them in a fresh
+`XLInvocationBindings` packet for each call, then pass that packet to
+`fetchAll(bindings:)`, `fetchOne(bindings:)`, `execute(bindings:)`, or a
+packet-backed publisher. Creating a request translates the SwiftQL statement
+into SQL but does not prepare it immediately. On execution, GRDB obtains a
+cached SQLite statement for that SQL on the connection performing the work.
 
 #### Dialect and driver responsibilities
 
@@ -237,10 +241,20 @@ transaction. Code inside that transaction must use the pinned connection and
 must not re-enter the root pool, which could lease another connection and break
 the transaction boundary or deadlock while waiting for itself.
 
-Each request copy or invocation carries fresh bindings. Reusing a logical
-request or prepared handle does not share mutable binding state between
-concurrent executions, and obtaining a cached physical statement does not move
-bindings into the connection-wide cache.
+Each invocation packet carries normalized dialect values in logical-index
+order, so every call has fresh bindings. Packet-backed execution does not move
+those values into the logical request or connection-wide statement cache.
+Packets and layouts are value-semantic and `Sendable` when their dialect values
+are. The current `XLRequest` facade itself is not `Sendable` and does not yet
+promise that one request can be shared across tasks; use packets to separate
+values across repeated calls in the request's supported isolation context.
+
+For cross-task raw-value execution with GRDB, call
+`GRDBDatabase.prepareInvocation(with:)`. Its `GRDBPreparedInvocation` result is
+`Sendable` and accepts an independent packet in `fetchAllValues`,
+`fetchOneValues`, or `execute`. It deliberately returns normalized SQLite
+values instead of retaining the legacy typed row-reader graph. A public static
+typed descriptor layer is separate from this runtime handle.
 
 Driver integrations can use the `prepareValidated`, `bindValidated`,
 `fetchAllValidated`, `fetchOneValidated`, `executeValidated`, and
@@ -300,18 +314,36 @@ FROM Person AS t0
 WHERE (t0.name == :name)
 ```
 
-The binding has no value until you set one on the request. Copy a reusable
-request before setting its values so each execution can be configured
-independently:
+The request's layout describes the placeholder, but it does not contain a
+runtime value. Build a SQLite packet from that layout and the normalized value
+for this call:
 
 <!-- test: XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings -->
 ```swift
-var fredRequest = peopleByNameRequest
-fredRequest.set(nameParameter, "Fred")
-let fredResults = try fredRequest.fetchAll()
+let nameSlot = peopleByNameRequest.parameterLayout
+    .slot(for: .named("name"))!
+let fredBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: peopleByNameRequest.parameterLayout,
+    bindings: [
+        try XLInvocationBinding(slot: nameSlot, value: .text("Fred"))
+    ]
+).validatingComplete()
+let fredResults = try peopleByNameRequest.fetchAll(bindings: fredBindings)
 ```
 
-Set every binding referenced by a statement before executing its request.
+Constructing and validating a packet rejects values for the wrong layout,
+duplicate bindings, and missing parameters before driver execution. Missing is
+not the same as SQL `NULL`: omitting a binding fails completeness validation,
+while `.null` is a present value accepted only by a `.nullable` slot. Repeated
+uses of the same named reference share one logical slot and one value.
+
+The mutating `set` methods remain as a migration shim for v1 literal bindings.
+They immediately normalize each value into a compatibility packet stored in
+that request copy. Existing code can continue to copy, set, and execute a
+request, but new code should keep the prepared request immutable and pass an
+explicit packet for each call. The shim cannot override a contextual
+parameter's selected codec. A public cross-task prepared-descriptor API is
+separate from this packet migration.
 
 ## Update statements
 
@@ -356,10 +388,20 @@ let updateAgeStatement = sql { schema in
 let updateAgeRequest = database.makeRequest(with: updateAgeStatement)
 
 // Later, when the update is needed:
-var fredAgeRequest = updateAgeRequest
-fredAgeRequest.set(personIDParameter, "fred")
-fredAgeRequest.set(ageParameter, 42)
-try fredAgeRequest.execute()
+let updateBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: updateAgeRequest.parameterLayout,
+    bindings: [
+        try XLInvocationBinding(
+            slot: updateAgeRequest.parameterLayout.slot(for: .named("id"))!,
+            value: .text("fred")
+        ),
+        try XLInvocationBinding(
+            slot: updateAgeRequest.parameterLayout.slot(for: .named("age"))!,
+            value: .integer(42)
+        )
+    ]
+).validatingComplete()
+try updateAgeRequest.execute(bindings: updateBindings)
 ```
 
 ## Delete statements
@@ -379,9 +421,17 @@ let deletePersonStatement = sql { schema in
 let deletePersonRequest = database.makeRequest(with: deletePersonStatement)
 
 // Later, when the deletion is needed:
-var deleteFredRequest = deletePersonRequest
-deleteFredRequest.set(deleteIDParameter, "fred")
-try deleteFredRequest.execute()
+let deleteBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: deletePersonRequest.parameterLayout,
+    bindings: [
+        try XLInvocationBinding(
+            slot: deletePersonRequest.parameterLayout
+                .slot(for: .named("id"))!,
+            value: .text("fred")
+        )
+    ]
+).validatingComplete()
+try deletePersonRequest.execute(bindings: deleteBindings)
 ```
 
 > Warning: A delete without a `Where` clause removes every row in the table.

--- a/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
@@ -45,6 +45,54 @@ let cancellable = request.publishOne().sink(
 Fetching is all-or-nothing. If the query cannot execute or any row cannot be decoded, the publisher
 finishes with the original error and does not emit a truncated result.
 
+### Packet-backed observations
+
+A parameterized request exposes a static `parameterLayout`; its values belong
+to an immutable packet supplied to `publish(bindings:)` or
+`publishOne(bindings:)`. This observation selects one `Person` by its text ID:
+
+<!-- test: XLDocumentationTests.testDocumentationLiveQueryPublishers -->
+```swift
+let idParameter = XLNamedBindingReference<String>(name: "id")
+let personByID = sql { schema in
+    let person = schema.table(Person.self)
+    Select(person)
+    From(person)
+    Where(person.id == idParameter)
+}
+let request = database.makeRequest(with: personByID)
+let layout = request.parameterLayout
+let idBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: layout,
+    bindings: [
+        try XLInvocationBinding(
+            slot: layout.slot(for: .named("id"))!,
+            value: .text("per-1")
+        )
+    ]
+).validatingComplete()
+
+let cancellable = request.publish(bindings: idBindings).sink(
+    receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Query failed: \(error)")
+        }
+    },
+    receiveValue: { results in
+        print("Fetched results: \(results)")
+    }
+)
+```
+
+SwiftQL validates and captures the packet when it constructs the GRDB
+observation. Every initial fetch, database refresh, and BUSY retry for that
+publisher uses the same values; the request is never mutated. A separately
+constructed packet-backed publisher captures its own values without
+cross-triggering or leaking values. A missing binding fails the publisher,
+whereas `.null` is a present value and is accepted only for a nullable slot.
+This packet isolation does not make the current request facade `Sendable` or
+promise that one request can be shared directly across tasks.
+
 ### Retry Policy
 
 Live queries are terminal by default. Configure a GRDB database or builder with
@@ -75,7 +123,9 @@ database pool, so GRDB discovers and tracks the query's database region again. A
 overlap. Cancelling during backoff cancels the pending delay and starts no new fetch; cancelling an
 active observation suppresses later values even though SQLite work already executing internally may
 finish. Writes committed during backoff may coalesce into the next snapshot because live queries are
-state streams, not commit logs.
+state streams, not commit logs. For a packet-backed observation, starting that
+new GRDB observation reuses the publisher's captured packet rather than reading
+mutable values from the request or connection.
 
 ### Observation Semantics
 
@@ -84,6 +134,8 @@ GRDB-backed observations have these behaviors:
 - Observation starts on subscription, not when `publish()` or `publishOne()` creates the publisher.
 - Each subscriber owns an independent observation and receives a fresh initial value. A publisher does
   not replay a snapshot captured for an earlier subscriber.
+- Parameterized publishers retain the immutable packet passed at construction;
+  all refreshes and retries use that packet.
 - Relevant writes performed through the same `DatabasePool` are observed, including direct GRDB writes
   and migrations. Writes from another process or an unrelated connection pool are not observed.
 - Initial and updated values are delivered asynchronously on the main dispatch queue by default. Apply

--- a/Sources/SwiftQLCore/SQLDialect.swift
+++ b/Sources/SwiftQLCore/SQLDialect.swift
@@ -228,16 +228,21 @@ public struct XLLogicalPreparedStatement: Hashable, Sendable {
 
     public let entities: Set<String>
 
+    /// Immutable static parameter metadata captured while rendering `sql`.
+    public let parameterLayout: XLParameterLayout
+
     public init(
         databaseIdentifier: XLDatabaseIdentifier,
         dialectRequirement: XLDialectRequirement,
         sql: String,
-        entities: Set<String> = []
+        entities: Set<String> = [],
+        parameterLayout: XLParameterLayout = .empty
     ) {
         self.databaseIdentifier = databaseIdentifier
         self.dialectRequirement = dialectRequirement
         self.sql = sql
         self.entities = entities
+        self.parameterLayout = parameterLayout
     }
 }
 

--- a/Sources/SwiftQLCore/SQLInvocationBindings.swift
+++ b/Sources/SwiftQLCore/SQLInvocationBindings.swift
@@ -1,0 +1,643 @@
+import Foundation
+
+
+/// The stable zero-based position of one logical parameter in a statement.
+///
+/// Rendering may encounter the same named parameter more than once. Those
+/// occurrences share one logical index and one invocation value.
+public struct XLLogicalParameterIndex:
+    RawRepresentable,
+    Comparable,
+    Hashable,
+    Sendable,
+    CustomStringConvertible
+{
+
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: Int) {
+        self.init(rawValue: rawValue)
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    public var description: String {
+        String(rawValue)
+    }
+}
+
+
+/// Whether a parameter accepts the dialect's explicit SQL `NULL` value.
+public enum XLParameterNullability: String, Hashable, Sendable {
+    case required
+    case nullable
+}
+
+
+/// Static parameter metadata before SQL traversal assigns a logical index.
+///
+/// Public contextual references declare this value without guessing how many
+/// parameters precede them. The shared renderer recorder assigns the stable
+/// first-encounter index by calling `slot(at:)`.
+public struct XLParameterDeclaration: Hashable, Sendable {
+
+    public let key: XLBindingKey
+
+    public let valueTypeIdentifier: XLValueTypeIdentifier
+
+    /// A diagnostic Swift type name. Stable identity uses
+    /// `valueTypeIdentifier`, not this process-local spelling.
+    public let valueTypeName: String
+
+    public let nullability: XLParameterNullability
+
+    public let codecIdentity: XLValueCodecIdentity?
+
+    public let codingContext: XLValueCodingContext
+
+    public init(
+        key: XLBindingKey,
+        valueTypeIdentifier: XLValueTypeIdentifier,
+        valueTypeName: String,
+        nullability: XLParameterNullability,
+        codecIdentity: XLValueCodecIdentity?,
+        codingContext: XLValueCodingContext
+    ) {
+        self.key = key
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.valueTypeName = valueTypeName
+        self.nullability = nullability
+        self.codecIdentity = codecIdentity
+        self.codingContext = codingContext
+    }
+
+    public func slot(at index: XLLogicalParameterIndex) -> XLParameterSlot {
+        XLParameterSlot(
+            index: index,
+            key: key,
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codecIdentity: codecIdentity,
+            codingContext: codingContext
+        )
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.key == rhs.key
+            && lhs.valueTypeIdentifier == rhs.valueTypeIdentifier
+            && lhs.nullability == rhs.nullability
+            && lhs.codecIdentity == rhs.codecIdentity
+            && lhs.codingContext == rhs.codingContext
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(key)
+        hasher.combine(valueTypeIdentifier)
+        hasher.combine(nullability)
+        hasher.combine(codecIdentity)
+        hasher.combine(codingContext)
+    }
+}
+
+
+/// Immutable metadata for one logical parameter in a rendered statement.
+public struct XLParameterSlot: Hashable, Sendable {
+
+    public let index: XLLogicalParameterIndex
+
+    public let key: XLBindingKey
+
+    public let valueTypeIdentifier: XLValueTypeIdentifier
+
+    /// A diagnostic Swift type name. Stable identity uses
+    /// `valueTypeIdentifier`, not this process-local spelling.
+    public let valueTypeName: String
+
+    public let nullability: XLParameterNullability
+
+    /// The codec selected when the prepared handle snapshots its coding
+    /// configuration. Legacy declarations that have not selected a contextual
+    /// codec may leave this `nil` while migrating through the compatibility shim.
+    public let codecIdentity: XLValueCodecIdentity?
+
+    public let codingContext: XLValueCodingContext
+
+    public init(
+        index: XLLogicalParameterIndex,
+        key: XLBindingKey,
+        valueTypeIdentifier: XLValueTypeIdentifier,
+        valueTypeName: String,
+        nullability: XLParameterNullability,
+        codecIdentity: XLValueCodecIdentity?,
+        codingContext: XLValueCodingContext
+    ) {
+        self.index = index
+        self.key = key
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.valueTypeName = valueTypeName
+        self.nullability = nullability
+        self.codecIdentity = codecIdentity
+        self.codingContext = codingContext
+    }
+
+    public var declaration: XLParameterDeclaration {
+        XLParameterDeclaration(
+            key: key,
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codecIdentity: codecIdentity,
+            codingContext: codingContext
+        )
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.index == rhs.index
+            && lhs.key == rhs.key
+            && lhs.valueTypeIdentifier == rhs.valueTypeIdentifier
+            && lhs.nullability == rhs.nullability
+            && lhs.codecIdentity == rhs.codecIdentity
+            && lhs.codingContext == rhs.codingContext
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(index)
+        hasher.combine(key)
+        hasher.combine(valueTypeIdentifier)
+        hasher.combine(nullability)
+        hasher.combine(codecIdentity)
+        hasher.combine(codingContext)
+    }
+}
+
+
+/// Deterministic failures while declaring, encoding, or assembling invocation
+/// bindings.
+public enum XLInvocationBindingError: Error, Equatable, Sendable, LocalizedError {
+    case invalidParameterIndex(slot: XLParameterSlot)
+    case noncontiguousParameterIndex(
+        slot: XLParameterSlot,
+        expected: XLLogicalParameterIndex
+    )
+    case conflictingParameterIndex(
+        index: XLLogicalParameterIndex,
+        existing: XLParameterSlot,
+        incoming: XLParameterSlot
+    )
+    case conflictingParameterKey(
+        key: XLBindingKey,
+        existing: XLParameterSlot,
+        incoming: XLParameterSlot
+    )
+    case conflictingPhysicalParameterIndex(
+        index: Int,
+        existing: XLParameterSlot,
+        incoming: XLParameterSlot
+    )
+    case codecValueTypeMismatch(
+        slot: XLParameterSlot,
+        codecValueTypeIdentifier: XLValueTypeIdentifier
+    )
+    case codecBindingRequiresPreparedParameter(
+        slot: XLParameterSlot,
+        codecIdentity: XLValueCodecIdentity
+    )
+    case preparedCodecUnavailable(
+        slot: XLParameterSlot,
+        codecIdentity: XLValueCodecIdentity
+    )
+    case preparedCodecIdentityMismatch(
+        slot: XLParameterSlot,
+        expected: XLValueCodecIdentity,
+        actual: XLValueCodecIdentity
+    )
+    case preparedCodecDialectMismatch(
+        slot: XLParameterSlot,
+        codecIdentity: XLValueCodecIdentity,
+        expectedDialectIdentifier: XLDialectIdentifier
+    )
+    case dialectValueStorageMismatch(
+        slot: XLParameterSlot,
+        expectedCodecIdentity: XLValueCodecIdentity,
+        actualStorageIdentifier: XLValueStorageIdentifier
+    )
+    case packetLayoutMismatch(
+        expected: XLParameterLayout,
+        actual: XLParameterLayout
+    )
+    case parameterDeclarationNotInLayout(declaration: XLParameterDeclaration)
+    case parameterNotInLayout(slot: XLParameterSlot)
+    case parameterMetadataMismatch(
+        expected: XLParameterSlot,
+        actual: XLParameterSlot
+    )
+    case duplicateBinding(slot: XLParameterSlot)
+    case missingBindings(slots: [XLParameterSlot])
+    case nullForRequiredParameter(slot: XLParameterSlot)
+    case codecEncodingFailed(
+        slot: XLParameterSlot,
+        codecIdentity: XLValueCodecIdentity,
+        context: XLValueCodingContext,
+        message: String
+    )
+    case driverBindingFailed(
+        slot: XLParameterSlot,
+        codecIdentity: XLValueCodecIdentity?,
+        context: XLValueCodingContext,
+        message: String
+    )
+    case driverArgumentValidationFailed(
+        layout: XLParameterLayout,
+        message: String
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidParameterIndex(let slot):
+            return "Parameter \(slot.key) has invalid logical index \(slot.index)."
+        case .noncontiguousParameterIndex(let slot, let expected):
+            return "Parameter \(slot.key) has noncontiguous logical index \(slot.index); expected \(expected)."
+        case .conflictingParameterIndex(let index, let existing, let incoming):
+            return "Logical parameter index \(index) is declared by both \(existing.key) and \(incoming.key)."
+        case .conflictingParameterKey(let key, let existing, let incoming):
+            return "Parameter \(key) has conflicting declarations at logical indices \(existing.index) and \(incoming.index)."
+        case .conflictingPhysicalParameterIndex(let index, let existing, let incoming):
+            return "Dialect parameter index \(index) aliases distinct logical parameters \(existing.key) and \(incoming.key)."
+        case .codecValueTypeMismatch(let slot, let codecValueTypeIdentifier):
+            let codec = slot.codecIdentity?.key.description ?? "unknown"
+            return "Parameter \(slot.key) declares value type \(slot.valueTypeIdentifier), but codec \(codec) targets \(codecValueTypeIdentifier)."
+        case .codecBindingRequiresPreparedParameter(let slot, let codecIdentity):
+            return "Parameter \(slot.key) selects codec \(codecIdentity.key) at \(slot.codingContext); encode it through its prepared parameter instead of supplying a raw dialect value."
+        case .preparedCodecUnavailable(let slot, let codecIdentity):
+            return "Prepared codec \(codecIdentity.key) is unavailable for parameter \(slot.key) at \(slot.codingContext)."
+        case .preparedCodecIdentityMismatch(let slot, let expected, let actual):
+            return "Parameter \(slot.key) expects prepared codec \(expected.key), but the registered codec is \(actual.key) at \(slot.codingContext)."
+        case .preparedCodecDialectMismatch(let slot, let codecIdentity, let expectedDialectIdentifier):
+            return "Prepared codec \(codecIdentity.key) for parameter \(slot.key) targets dialect \(codecIdentity.dialectIdentifier), not \(expectedDialectIdentifier), at \(slot.codingContext)."
+        case .dialectValueStorageMismatch(let slot, let expectedCodecIdentity, let actualStorageIdentifier):
+            return "Parameter \(slot.key) encoded by codec \(expectedCodecIdentity.key) expects storage \(expectedCodecIdentity.storageIdentifier), but the dialect value uses \(actualStorageIdentifier), at \(slot.codingContext)."
+        case .packetLayoutMismatch(let expected, let actual):
+            if actual.count != expected.count {
+                return "Invocation parameter count \(actual.count) does not match prepared parameter count \(expected.count)."
+            }
+            return "Invocation parameter layout does not match the prepared layout; both contain the same number of parameters (\(expected.count))."
+        case .parameterDeclarationNotInLayout(let declaration):
+            let codec = declaration.codecIdentity?.key.description ?? "legacy/unselected"
+            return "Parameter \(declaration.key) with codec \(codec) at \(declaration.codingContext) is not in the prepared layout."
+        case .parameterNotInLayout(let slot):
+            return "Parameter \(slot.key) at logical index \(slot.index) is not in the prepared layout."
+        case .parameterMetadataMismatch(let expected, let actual):
+            return "Parameter \(actual.key) does not match the prepared metadata for \(expected.key) at logical index \(expected.index)."
+        case .duplicateBinding(let slot):
+            return "Parameter \(slot.key) at logical index \(slot.index) is bound more than once."
+        case .missingBindings(let slots):
+            let parameters = slots.map { "\($0.key)@\($0.index)" }.joined(separator: ", ")
+            return "Invocation is missing values for \(parameters)."
+        case .nullForRequiredParameter(let slot):
+            return "Required parameter \(slot.key) at \(slot.codingContext) cannot be SQL NULL."
+        case .codecEncodingFailed(let slot, let codecIdentity, let context, let message):
+            return "Codec \(codecIdentity.key) could not encode parameter \(slot.key) at \(context): \(message)"
+        case .driverBindingFailed(let slot, let codecIdentity, let context, let message):
+            let codec = codecIdentity?.key.description ?? "legacy/unselected"
+            return "Driver could not bind parameter \(slot.key) with codec \(codec) at \(context): \(message)"
+        case .driverArgumentValidationFailed(let layout, let message):
+            return "Driver could not validate the physical argument table for the \(layout.count)-parameter layout: \(message)"
+        }
+    }
+}
+
+
+/// Canonical immutable metadata for every logical parameter in one statement.
+public struct XLParameterLayout: Hashable, Sendable {
+
+    public static let empty = Self(canonicalSlots: [])
+
+    public let slots: [XLParameterSlot]
+
+    public init(slots declarations: [XLParameterSlot] = []) throws {
+        var slotsByIndex: [XLLogicalParameterIndex: XLParameterSlot] = [:]
+        var slotsByKey: [XLBindingKey: XLParameterSlot] = [:]
+
+        for slot in declarations {
+            guard slot.index.rawValue >= 0 else {
+                throw XLInvocationBindingError.invalidParameterIndex(slot: slot)
+            }
+
+            if let codecIdentity = slot.codecIdentity,
+               codecIdentity.valueTypeIdentifier != slot.valueTypeIdentifier {
+                throw XLInvocationBindingError.codecValueTypeMismatch(
+                    slot: slot,
+                    codecValueTypeIdentifier: codecIdentity.valueTypeIdentifier
+                )
+            }
+
+            if let existing = slotsByIndex[slot.index] {
+                guard existing == slot else {
+                    throw XLInvocationBindingError.conflictingParameterIndex(
+                        index: slot.index,
+                        existing: existing,
+                        incoming: slot
+                    )
+                }
+                continue
+            }
+
+            if let existing = slotsByKey[slot.key] {
+                guard existing == slot else {
+                    throw XLInvocationBindingError.conflictingParameterKey(
+                        key: slot.key,
+                        existing: existing,
+                        incoming: slot
+                    )
+                }
+                continue
+            }
+
+            slotsByIndex[slot.index] = slot
+            slotsByKey[slot.key] = slot
+        }
+
+        let canonicalSlots = slotsByIndex.values.sorted { lhs, rhs in
+            lhs.index < rhs.index
+        }
+        for (offset, slot) in canonicalSlots.enumerated() {
+            let expected = XLLogicalParameterIndex(offset)
+            guard slot.index == expected else {
+                throw XLInvocationBindingError.noncontiguousParameterIndex(
+                    slot: slot,
+                    expected: expected
+                )
+            }
+        }
+        slots = canonicalSlots
+    }
+
+    private init(canonicalSlots: [XLParameterSlot]) {
+        self.slots = canonicalSlots
+    }
+
+    public var isEmpty: Bool {
+        slots.isEmpty
+    }
+
+    public var count: Int {
+        slots.count
+    }
+
+    public func slot(at index: XLLogicalParameterIndex) -> XLParameterSlot? {
+        slots.first { $0.index == index }
+    }
+
+    public func slot(for key: XLBindingKey) -> XLParameterSlot? {
+        slots.first { $0.key == key }
+    }
+}
+
+
+/// One present, normalized dialect value for a static parameter slot.
+///
+/// A dialect's SQL `NULL` value is a present value here. Missing bindings are
+/// represented only by the absence of an `XLInvocationBinding` from a packet.
+public struct XLInvocationBinding<Value: XLDialectValue>: Hashable, Sendable {
+
+    public let slot: XLParameterSlot
+
+    public let value: Value
+
+    public init(slot: XLParameterSlot, value: Value) throws {
+        if let codecIdentity = slot.codecIdentity {
+            throw XLInvocationBindingError.codecBindingRequiresPreparedParameter(
+                slot: slot,
+                codecIdentity: codecIdentity
+            )
+        }
+        self.slot = slot
+        self.value = value
+    }
+
+    package init(preparedCodecSlot slot: XLParameterSlot, value: Value) {
+        self.slot = slot
+        self.value = value
+    }
+}
+
+
+/// Adapter-neutral metadata exposed by every immutable invocation packet.
+///
+/// Drivers downcast the packet to their dialect's concrete
+/// `XLInvocationBindings` specialization before accessing normalized values.
+public protocol XLInvocationBindingPacket: Sendable {
+
+    var layout: XLParameterLayout { get }
+
+    var bindingCount: Int { get }
+
+    var isComplete: Bool { get }
+}
+
+
+/// Immutable per-call values paired with one prepared parameter layout.
+///
+/// `bindings` is always ordered by logical parameter index, regardless of the
+/// order in which callers supplied values.
+public struct XLInvocationBindings<Value: XLDialectValue>:
+    Hashable,
+    Sendable,
+    XLInvocationBindingPacket
+{
+
+    public let layout: XLParameterLayout
+
+    public let bindings: [XLInvocationBinding<Value>]
+
+    public init(layout: XLParameterLayout) {
+        self.layout = layout
+        self.bindings = []
+    }
+
+    public init(
+        layout: XLParameterLayout,
+        bindings: [XLInvocationBinding<Value>]
+    ) throws {
+        var packet = Self(layout: layout)
+        for binding in bindings {
+            packet = try packet.binding(binding)
+        }
+        self = packet
+    }
+
+    private init(
+        layout: XLParameterLayout,
+        canonicalBindings: [XLInvocationBinding<Value>]
+    ) {
+        self.layout = layout
+        self.bindings = canonicalBindings
+    }
+
+    public var isComplete: Bool {
+        bindings.count == layout.count
+    }
+
+    public var bindingCount: Int {
+        bindings.count
+    }
+
+    public var missingSlots: [XLParameterSlot] {
+        layout.slots.filter { binding(at: $0.index) == nil }
+    }
+
+    public func binding(
+        at index: XLLogicalParameterIndex
+    ) -> XLInvocationBinding<Value>? {
+        bindings.first { $0.slot.index == index }
+    }
+
+    public func binding(for key: XLBindingKey) -> XLInvocationBinding<Value>? {
+        bindings.first { $0.slot.key == key }
+    }
+
+    /// Returns a new packet with `binding` appended after validating its static
+    /// metadata against the prepared layout.
+    public func binding(
+        _ binding: XLInvocationBinding<Value>
+    ) throws -> Self {
+        let expected: XLParameterSlot
+        if let indexedSlot = layout.slot(at: binding.slot.index) {
+            expected = indexedSlot
+        }
+        else if let keyedSlot = layout.slot(for: binding.slot.key) {
+            expected = keyedSlot
+        }
+        else {
+            throw XLInvocationBindingError.parameterNotInLayout(slot: binding.slot)
+        }
+
+        guard expected == binding.slot else {
+            throw XLInvocationBindingError.parameterMetadataMismatch(
+                expected: expected,
+                actual: binding.slot
+            )
+        }
+
+        guard self.binding(at: binding.slot.index) == nil else {
+            throw XLInvocationBindingError.duplicateBinding(slot: binding.slot)
+        }
+
+        let canonicalBindings = (bindings + [binding]).sorted { lhs, rhs in
+            lhs.slot.index < rhs.slot.index
+        }
+        return Self(layout: layout, canonicalBindings: canonicalBindings)
+    }
+
+    public func binding(_ value: Value, to slot: XLParameterSlot) throws -> Self {
+        try binding(try XLInvocationBinding(slot: slot, value: value))
+    }
+
+    /// Returns this packet when all declared slots are present, or throws a
+    /// canonical missing-slot list.
+    @discardableResult
+    public func validatingComplete() throws -> Self {
+        let missingSlots = missingSlots
+        guard missingSlots.isEmpty else {
+            throw XLInvocationBindingError.missingBindings(slots: missingSlots)
+        }
+        return self
+    }
+}
+
+
+/// A statically resolved parameter codec reusable across independent calls.
+///
+/// `Source` deliberately has no `Sendable` requirement. Values are consumed by
+/// `encode` and never retained; invocation packets store only normalized dialect
+/// values, which are `Sendable` by contract.
+public struct XLPreparedParameter<Source, Dialect>: Sendable
+where Dialect: XLValueCodingDialect {
+
+    public let slot: XLParameterSlot
+
+    private let codec: XLResolvedValueCodec<Source, Dialect>
+
+    public init(
+        index: XLLogicalParameterIndex,
+        key: XLBindingKey,
+        nullability: XLParameterNullability,
+        codec: XLResolvedValueCodec<Source, Dialect>
+    ) {
+        self.slot = XLParameterSlot(
+            index: index,
+            key: key,
+            valueTypeIdentifier: codec.identity.valueTypeIdentifier,
+            valueTypeName: String(reflecting: Source.self),
+            nullability: nullability,
+            codecIdentity: codec.identity,
+            codingContext: codec.context
+        )
+        self.codec = codec
+    }
+
+    public var codecIdentity: XLValueCodecIdentity {
+        codec.identity
+    }
+
+    public var codingContext: XLValueCodingContext {
+        codec.context
+    }
+
+    public func encode(
+        _ value: Source
+    ) throws -> XLInvocationBinding<Dialect.Value> {
+        do {
+            return XLInvocationBinding(
+                preparedCodecSlot: slot,
+                value: try codec.encode(value)
+            )
+        }
+        catch {
+            throw encodingError(error)
+        }
+    }
+
+    public func encodeOptional(
+        _ value: Source?
+    ) throws -> XLInvocationBinding<Dialect.Value> {
+        guard value != nil || slot.nullability == .nullable else {
+            throw XLInvocationBindingError.nullForRequiredParameter(slot: slot)
+        }
+
+        do {
+            return XLInvocationBinding(
+                preparedCodecSlot: slot,
+                value: try codec.encodeOptional(value)
+            )
+        }
+        catch {
+            throw encodingError(error)
+        }
+    }
+
+    private func encodingError(_ error: Error) -> XLInvocationBindingError {
+        XLInvocationBindingError.codecEncodingFailed(
+            slot: slot,
+            codecIdentity: codec.identity,
+            context: codec.context,
+            message: _xlInvocationErrorMessage(error)
+        )
+    }
+}
+
+
+private func _xlInvocationErrorMessage(_ error: Error) -> String {
+    if let localizedError = error as? LocalizedError,
+       let description = localizedError.errorDescription {
+        return description
+    }
+    return String(describing: error)
+}

--- a/Tests/SQLTests/SQLDialectEncodingContractTests.swift
+++ b/Tests/SQLTests/SQLDialectEncodingContractTests.swift
@@ -22,7 +22,126 @@ private struct DialectCapabilityProbe: XLEncodable {
 }
 
 
+private struct NestedParameterLayoutProbe: XLEncodable {
+
+    func makeSQL(context: inout XLBuilder) {
+        context.namedBinding("name")
+        context.block(
+            beginsWith: "(",
+            endsWith: ")",
+            separator: .elided
+        ) { nested in
+            nested.indexedBinding(2)
+            nested.namedBinding("name")
+        }
+    }
+}
+
+
+private struct LegacyReferenceMetadataProbe: XLEncodable {
+
+    let required = XLNamedBindingReference<Int>(name: "required")
+
+    let nullable = XLNamedBindingReference<Optional<String>>(name: "nullable")
+
+    func makeSQL(context: inout XLBuilder) {
+        required.makeSQL(context: &context)
+        nullable.makeSQL(context: &context)
+        required.makeSQL(context: &context)
+    }
+}
+
+
+private struct TypedParameterLayoutProbe: XLEncodable {
+
+    let slots: [XLParameterSlot]
+
+    func makeSQL(context: inout XLBuilder) {
+        for slot in slots {
+            context.parameter(slot)
+        }
+    }
+}
+
+
+private struct ParameterDeclarationProbe: XLEncodable {
+
+    let declarations: [XLParameterDeclaration]
+
+    func makeSQL(context: inout XLBuilder) {
+        for declaration in declarations {
+            context.parameter(declaration)
+        }
+    }
+}
+
+
+private struct MixedLegacyAndTypedParameterProbe: XLEncodable {
+
+    let legacyFirst: Bool
+
+    let reference = XLNamedBindingReference<Int>(name: "value")
+
+    func makeSQL(context: inout XLBuilder) {
+        if legacyFirst {
+            context.namedBinding("value")
+            reference.makeSQL(context: &context)
+        }
+        else {
+            reference.makeSQL(context: &context)
+            context.namedBinding("value")
+        }
+    }
+}
+
+
 final class SQLDialectEncodingContractTests: XCTestCase {
+
+    private func parameterSlot(
+        index: Int,
+        key: XLBindingKey,
+        valueTypeIdentifier: String = "example.user-id",
+        valueTypeName: String = "Example.UserID",
+        nullability: XLParameterNullability = .required,
+        codecIdentity: XLValueCodecIdentity? = nil
+    ) -> XLParameterSlot {
+        XLParameterSlot(
+            index: XLLogicalParameterIndex(index),
+            key: key,
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: valueTypeIdentifier
+            ),
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codecIdentity: codecIdentity,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("probe")
+            )
+        )
+    }
+
+    private func parameterDeclaration(
+        key: XLBindingKey,
+        valueTypeIdentifier: String = "example.user-id",
+        valueTypeName: String = "Example.UserID",
+        nullability: XLParameterNullability = .required,
+        codecIdentity: XLValueCodecIdentity? = nil
+    ) -> XLParameterDeclaration {
+        XLParameterDeclaration(
+            key: key,
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: valueTypeIdentifier
+            ),
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codecIdentity: codecIdentity,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("declaration-probe")
+            )
+        )
+    }
 
     func testEncoderDerivesPlaceholderCapabilitiesFromRenderedSQL() {
         let encoder = XLiteEncoder(
@@ -71,6 +190,226 @@ final class SQLDialectEncodingContractTests: XCTestCase {
                     required: [.namedBindings],
                     available: [.indexedBindings]
                 )
+            )
+        }
+    }
+
+    func testEncoderCapturesLegacyParametersAcrossNestedBuildersInFirstUseOrder() {
+        let encoding = XLiteEncoder(formatter: XLiteFormatter()).makeSQL(
+            NestedParameterLayoutProbe()
+        )
+
+        XCTAssertNil(encoding.parameterLayoutError)
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.index),
+            [XLLogicalParameterIndex(0), XLLogicalParameterIndex(1)]
+        )
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.key),
+            [.named("name"), .indexed(2)]
+        )
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.nullability),
+            [.nullable, .nullable]
+        )
+        XCTAssertTrue(
+            encoding.parameterLayout.slots.allSatisfy {
+                $0.codecIdentity == nil
+            }
+        )
+    }
+
+    func testNamedReferencesCaptureConcreteTypeAndNullabilityMetadata() throws {
+        let encoding = try XLiteEncoder(formatter: XLiteFormatter())
+            .makeValidatedSQL(LegacyReferenceMetadataProbe())
+
+        XCTAssertEqual(encoding.parameterLayout.count, 2)
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.key),
+            [.named("required"), .named("nullable")]
+        )
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.valueTypeIdentifier),
+            [
+                XLValueTypeIdentifier(rawValue: "swift.int"),
+                XLValueTypeIdentifier(rawValue: "swift.string"),
+            ]
+        )
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.nullability),
+            [.required, .nullable]
+        )
+        XCTAssertTrue(
+            encoding.parameterLayout.slots.allSatisfy {
+                $0.codecIdentity == nil
+            }
+        )
+    }
+
+    func testEncoderPreservesTypedParameterMetadataAndCoalescesRepeatedOccurrences() throws {
+        let valueTypeIdentifier = XLValueTypeIdentifier(rawValue: "example.user-id")
+        let codecIdentity = XLValueCodecIdentity(
+            key: XLValueCodecKey(id: "example.user-id.text", version: 1),
+            valueTypeIdentifier: valueTypeIdentifier,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "sqlite.text")
+        )
+        let slot = parameterSlot(
+            index: 0,
+            key: .named("userID"),
+            valueTypeIdentifier: valueTypeIdentifier.rawValue,
+            nullability: .nullable,
+            codecIdentity: codecIdentity
+        )
+
+        let encoding = try XLiteEncoder(formatter: XLiteFormatter()).makeValidatedSQL(
+            TypedParameterLayoutProbe(slots: [slot, slot])
+        )
+
+        XCTAssertEqual(encoding.parameterLayout.slots, [slot])
+        XCTAssertEqual(encoding.sql, ":userID :userID")
+        XCTAssertEqual(
+            encoding.dialectRequirement.capabilities,
+            [.namedBindings]
+        )
+    }
+
+    func testEncoderAssignsDeclarationIndicesByFirstUseAndCoalescesRepeats() throws {
+        let named = parameterDeclaration(key: .named("userID"))
+        let indexed = parameterDeclaration(
+            key: .indexed(4),
+            valueTypeIdentifier: "example.limit",
+            valueTypeName: "Swift.Int"
+        )
+
+        let encoding = try XLiteEncoder(formatter: XLiteFormatter()).makeValidatedSQL(
+            ParameterDeclarationProbe(declarations: [named, indexed, named])
+        )
+
+        XCTAssertEqual(
+            encoding.parameterLayout.slots,
+            [
+                named.slot(at: XLLogicalParameterIndex(0)),
+                indexed.slot(at: XLLogicalParameterIndex(1)),
+            ]
+        )
+        XCTAssertEqual(encoding.sql, ":userID ?5 :userID")
+    }
+
+    func testEncoderRejectsDistinctLogicalKeysThatAliasOneSQLiteParameter() {
+        let named = parameterDeclaration(key: .named("value"))
+        let indexed = parameterDeclaration(
+            key: .indexed(0),
+            valueTypeIdentifier: "example.other-value"
+        )
+        let encoder = XLiteEncoder(formatter: XLiteFormatter())
+
+        let encoding = encoder.makeSQL(
+            ParameterDeclarationProbe(declarations: [named, indexed])
+        )
+
+        let namedSlot = named.slot(at: XLLogicalParameterIndex(0))
+        let indexedSlot = indexed.slot(at: XLLogicalParameterIndex(1))
+        XCTAssertEqual(encoding.sql, ":value ?1")
+        XCTAssertEqual(
+            encoding.parameterLayoutError,
+            .conflictingPhysicalParameterIndex(
+                index: 1,
+                existing: namedSlot,
+                incoming: indexedSlot
+            )
+        )
+        XCTAssertThrowsError(
+            try encoder.makeValidatedSQL(
+                ParameterDeclarationProbe(declarations: [named, indexed])
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLInvocationBindingError,
+                encoding.parameterLayoutError
+            )
+        }
+    }
+
+    func testEncoderRejectsMixedLegacyAndTypedAliasesInEitherOrder() {
+        let encoder = XLiteEncoder(formatter: XLiteFormatter())
+
+        for legacyFirst in [true, false] {
+            let encoding = encoder.makeSQL(
+                MixedLegacyAndTypedParameterProbe(legacyFirst: legacyFirst)
+            )
+
+            guard case .conflictingParameterKey(let key, _, _)? =
+                encoding.parameterLayoutError else {
+                return XCTFail(
+                    "Expected a deterministic key conflict when legacyFirst=\(legacyFirst), received \(String(describing: encoding.parameterLayoutError))"
+                )
+            }
+            XCTAssertEqual(key, .named("value"))
+            XCTAssertThrowsError(
+                try encoder.makeValidatedSQL(
+                    MixedLegacyAndTypedParameterProbe(
+                        legacyFirst: legacyFirst
+                    )
+                )
+            ) { error in
+                guard case .conflictingParameterKey(let key, _, _)? =
+                    error as? XLInvocationBindingError else {
+                    return XCTFail(
+                        "Expected a deterministic key conflict, received \(error)"
+                    )
+                }
+                XCTAssertEqual(key, .named("value"))
+            }
+        }
+    }
+
+    func testEncoderRetainsConflictingRepeatedDeclarationMetadata() {
+        let first = parameterDeclaration(key: .named("userID"))
+        let conflict = parameterDeclaration(
+            key: .named("userID"),
+            valueTypeIdentifier: "example.account-id",
+            valueTypeName: "Example.AccountID"
+        )
+        let encoder = XLiteEncoder(formatter: XLiteFormatter())
+
+        let encoding = encoder.makeSQL(
+            ParameterDeclarationProbe(declarations: [first, conflict])
+        )
+
+        let firstSlot = first.slot(at: XLLogicalParameterIndex(0))
+        XCTAssertEqual(encoding.parameterLayout.slots, [firstSlot])
+        XCTAssertEqual(
+            encoding.parameterLayoutError,
+            .conflictingParameterIndex(
+                index: XLLogicalParameterIndex(0),
+                existing: firstSlot,
+                incoming: conflict.slot(at: XLLogicalParameterIndex(0))
+            )
+        )
+    }
+
+    func testNonthrowingEncodingRetainsFirstTypedParameterConflict() throws {
+        let first = parameterSlot(index: 0, key: .named("userID"))
+        let conflict = parameterSlot(index: 1, key: .named("userID"))
+        let probe = TypedParameterLayoutProbe(slots: [first, conflict])
+        let encoder = XLiteEncoder(formatter: XLiteFormatter())
+
+        let encoding = encoder.makeSQL(probe)
+
+        XCTAssertEqual(encoding.parameterLayout.slots, [first])
+        XCTAssertEqual(
+            encoding.parameterLayoutError,
+            .conflictingParameterKey(
+                key: .named("userID"),
+                existing: first,
+                incoming: conflict
+            )
+        )
+        XCTAssertThrowsError(try encoder.makeValidatedSQL(probe)) { error in
+            XCTAssertEqual(
+                error as? XLInvocationBindingError,
+                encoding.parameterLayoutError
             )
         }
     }

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -142,6 +142,9 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             "reuse its own statement cache",
             "must not re-enter the root pool",
             "fresh bindings",
+            "current `XLRequest` facade itself is not `Sendable`",
+            "Its `GRDBPreparedInvocation` result is",
+            "not the same as SQL `NULL`",
             "normalize transport failures",
             "keeps raw `DatabaseError` and `XLColumnReadError`",
             "fail later on a newly leased connection",
@@ -162,6 +165,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             "## Contextual value codecs",
             "### Selection and errors",
             "### SQL NULL and optional values",
+            "### Contextual parameters and invocation packets",
             "## Legacy `XLCustomType` wrappers",
             "## Migrating v1 literals",
         ] {
@@ -177,6 +181,9 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             "The first populated tier is authoritative",
             "first resolve and validate the selected codec",
             "The codec closure never receives either optional state",
+            "resolves the codec once from that database's",
+            "is missing a binding",
+            "compatibility invocation packet",
             "`XLV1LiteralCodec` exposes an existing `Sendable` `XLLiteral` implementation",
             "This is a compatibility bridge",
         ] {

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 import XCTest
 import GRDB
 import SwiftQL
@@ -230,6 +231,14 @@ enum JobState: String, XLEnum {
     let state: JobState
 
     let previousState: JobState?
+}
+
+
+@SQLTable struct ExampleValue: Equatable {
+
+    let id: String
+
+    let value: Int
 }
 
 
@@ -1010,10 +1019,26 @@ final class XLDocumentationTests: XCTestCase {
             return select(result).from(restaurant).orderBy(result.distance.ascending())
         }
         let sql = encoder.makeSQL(statement).sql
-        var request = database.makeRequest(with: statement)
-        request.set(myLatitude, -33.877873677687894)
-        request.set(myLongitude, 18.488075015723)
-        let rows = try request.fetchAll()
+        let request = database.makeRequest(with: statement)
+        let layout = request.parameterLayout
+        let coordinates = try XLInvocationBindings<XLSQLiteValue>(
+            layout: layout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(
+                        layout.slot(for: .named("myLatitude"))
+                    ),
+                    value: .real(-33.877873677687894)
+                ),
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(
+                        layout.slot(for: .named("myLongitude"))
+                    ),
+                    value: .real(18.488075015723)
+                ),
+            ]
+        ).validatingComplete()
+        let rows = try request.fetchAll(bindings: coordinates)
         XCTAssertEqual(sql, "SELECT t0.name AS name, ROUND(haversineDistance(:myLatitude, :myLongitude, t0.latitude, t0.longitude), 2) AS distance FROM Restaurant AS t0 ORDER BY distance ASC")
         XCTAssertEqual(rows, [NearbyRestaurant(name: "Magica Roma", distance: 6.95)])
     }
@@ -1131,9 +1156,19 @@ extension XLDocumentationTests {
             encoder.makeSQL(peopleByNameQuery).sql,
             "SELECT t0.id AS id, t0.occupationId AS occupationId, t0.name AS name, t0.age AS age FROM Person AS t0 WHERE (t0.name == :name)"
         )
-        var fredRequest = peopleByNameRequest
-        fredRequest.set(nameParameter, "Fred")
-        XCTAssertEqual(try fredRequest.fetchAll(), [fredPerson])
+        let nameSlot = try XCTUnwrap(
+            peopleByNameRequest.parameterLayout.slot(for: .named("name"))
+        )
+        let fredBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: peopleByNameRequest.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(slot: nameSlot, value: .text("Fred"))
+            ]
+        ).validatingComplete()
+        XCTAssertEqual(
+            try peopleByNameRequest.fetchAll(bindings: fredBindings),
+            [fredPerson]
+        )
 
         let updateFredStatement = sql { schema in
             let person = schema.into(Person.self)
@@ -1155,15 +1190,28 @@ extension XLDocumentationTests {
             }
             Where(person.id == personIDParameter)
         }
-        var fredAgeRequest = database.makeRequest(with: updateAgeStatement)
-        fredAgeRequest.set(personIDParameter, "fred")
-        fredAgeRequest.set(ageParameter, 42)
-        try fredAgeRequest.execute()
+        let updateAgeRequest = database.makeRequest(with: updateAgeStatement)
+        let updateBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: updateAgeRequest.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(
+                        updateAgeRequest.parameterLayout.slot(for: .named("id"))
+                    ),
+                    value: .text("fred")
+                ),
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(
+                        updateAgeRequest.parameterLayout.slot(for: .named("age"))
+                    ),
+                    value: .integer(42)
+                ),
+            ]
+        ).validatingComplete()
+        try updateAgeRequest.execute(bindings: updateBindings)
 
-        var updatedFredRequest = peopleByNameRequest
-        updatedFredRequest.set(nameParameter, "Fred")
         XCTAssertEqual(
-            try updatedFredRequest.fetchOne(),
+            try peopleByNameRequest.fetchOne(bindings: fredBindings),
             Person(id: "fred", occupationId: nil, name: "Fred", age: 42)
         )
 
@@ -1173,13 +1221,23 @@ extension XLDocumentationTests {
             Delete(person)
             Where(person.id == deleteIDParameter)
         }
-        var deleteFredRequest = database.makeRequest(with: deletePersonStatement)
-        deleteFredRequest.set(deleteIDParameter, "fred")
-        try deleteFredRequest.execute()
+        let deletePersonRequest = database.makeRequest(with: deletePersonStatement)
+        let deleteBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: deletePersonRequest.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(
+                        deletePersonRequest.parameterLayout.slot(for: .named("id"))
+                    ),
+                    value: .text("fred")
+                )
+            ]
+        ).validatingComplete()
+        try deletePersonRequest.execute(bindings: deleteBindings)
 
-        var deletedFredRequest = peopleByNameRequest
-        deletedFredRequest.set(nameParameter, "Fred")
-        XCTAssertNil(try deletedFredRequest.fetchOne())
+        XCTAssertNil(
+            try peopleByNameRequest.fetchOne(bindings: fredBindings)
+        )
     }
 
     func testDocumentationExpressions() throws {
@@ -1223,11 +1281,22 @@ extension XLDocumentationTests {
             Where(job.state == stateParameter)
             OrderBy(summary.id.ascending())
         }
-        var request = database.makeRequest(with: runningJobs)
-        request.set(stateParameter, .running)
+        let request = database.makeRequest(with: runningJobs)
+        let stateSlot = try XCTUnwrap(
+            request.parameterLayout.slot(for: .named("state"))
+        )
+        let runningBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: request.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: stateSlot,
+                    value: .text(JobState.running.rawValue)
+                )
+            ]
+        ).validatingComplete()
 
         XCTAssertEqual(
-            try request.fetchAll(),
+            try request.fetchAll(bindings: runningBindings),
             [
                 JobSummary(
                     id: "build-docs",
@@ -1313,8 +1382,35 @@ extension XLDocumentationTests {
 
     func testDocumentationFunctionalQueriesAndMutations() throws {
         try testExample_Select()
-        try testExample_Variable_ExplicitAlias()
         try testExample_LeftJoin_Functional_NullRows()
+
+        let nameParameter = XLNamedBindingReference<String>(name: "name")
+        let peopleByNameStatement = sqlQuery { schema in
+            let person = schema.table(Person.self)
+            return select(person)
+                .from(person)
+                .where(person.name == nameParameter)
+        }
+        let peopleByNameRequest = database.makeRequest(
+            with: peopleByNameStatement
+        )
+        let nameBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: peopleByNameRequest.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(
+                        peopleByNameRequest.parameterLayout.slot(
+                            for: .named("name")
+                        )
+                    ),
+                    value: .text("John Doe")
+                )
+            ]
+        ).validatingComplete()
+        XCTAssertEqual(
+            try peopleByNameRequest.fetchAll(bindings: nameBindings),
+            [johnDoe]
+        )
 
         let groupedStatement = sqlQuery { schema in
             let person = schema.table(Person.self)
@@ -1336,6 +1432,52 @@ extension XLDocumentationTests {
                 OccupationPopulation(occupation: "No occupation", numberOfPeople: 1),
                 OccupationPopulation(occupation: "Scientist", numberOfPeople: 1),
             ]
+        )
+
+        try database.makeRequest(with: sqlCreate(ExampleValue.self)).execute()
+        try database.makeRequest(
+            with: sqlInsert(ExampleValue(id: "example-id", value: 0))
+        ).execute()
+
+        let idParameter = XLNamedBindingReference<String>(name: "id")
+        let valueParameter = XLNamedBindingReference<Int>(name: "value")
+        let updateStatement: any XLUpdateStatement<ExampleValue> = sqlUpdate { schema in
+            let table = schema.into(ExampleValue.self)
+            return update(
+                table,
+                set: ExampleValue.MetaUpdate(value: valueParameter)
+            )
+            .where(table.id == idParameter)
+        }
+        let updateRequest = database.makeRequest(with: updateStatement)
+        let updateBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: updateRequest.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(
+                        updateRequest.parameterLayout.slot(for: .named("id"))
+                    ),
+                    value: .text("example-id")
+                ),
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(
+                        updateRequest.parameterLayout.slot(for: .named("value"))
+                    ),
+                    value: .integer(42)
+                ),
+            ]
+        ).validatingComplete()
+        try updateRequest.execute(bindings: updateBindings)
+
+        let updatedValue = sql { schema in
+            let table = schema.table(ExampleValue.self)
+            Select(table)
+            From(table)
+            Where(table.id == "example-id")
+        }
+        XCTAssertEqual(
+            try database.makeRequest(with: updatedValue).fetchOne(),
+            ExampleValue(id: "example-id", value: 42)
         )
 
         let _: (XLSyntaxTests) -> () -> Void = XLSyntaxTests.testUpdateWhere
@@ -1431,6 +1573,64 @@ extension XLDocumentationTests {
             context: resultContext
         )
         XCTAssertNil(decodedNull)
+
+        let contextualDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftql-contextual-docs-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: contextualDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: contextualDirectory) }
+
+        let codecDatabase = try GRDBDatabase(
+            url: contextualDirectory.appendingPathComponent("fixture.sqlite"),
+            codingConfiguration: codingConfiguration,
+            logger: nil
+        )
+        let cutoffDate = try codecDatabase.contextualBinding(
+            Date.self,
+            expressedAs: String.self,
+            named: "cutoffDate"
+        )
+        let cutoffQuery = sql { _ in
+            Select(cutoffDate)
+        }
+        let cutoffRequest = codecDatabase.makeRequest(with: cutoffQuery)
+        let cutoffBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: cutoffRequest.parameterLayout,
+            bindings: [
+                try cutoffDate.encode(date, in: cutoffRequest.parameterLayout)
+            ]
+        ).validatingComplete()
+        let storedCutoff = try cutoffRequest.fetchOne(bindings: cutoffBindings)
+        XCTAssertEqual(storedCutoff, "86400.0")
+
+        let optionalDate = try codecDatabase.contextualBinding(
+            Date.self,
+            expressedAs: Optional<String>.self,
+            named: "optionalDate",
+            nullability: .nullable
+        )
+        let nullQuery = sql { _ in Select(optionalDate.isNull()) }
+        let nullRequest = codecDatabase.makeRequest(with: nullQuery)
+        let nullBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: nullRequest.parameterLayout,
+            bindings: [
+                try optionalDate.encodeOptional(
+                    nil,
+                    in: nullRequest.parameterLayout
+                )
+            ]
+        ).validatingComplete()
+        XCTAssertEqual(
+            try nullRequest.fetchOne(bindings: nullBindings),
+            true
+        )
+        XCTAssertThrowsError(
+            try XLInvocationBindings<XLSQLiteValue>(
+                layout: nullRequest.parameterLayout
+            ).validatingComplete()
+        )
 
         try testExample_Date()
         try testExample_DateConstant()
@@ -1533,7 +1733,67 @@ extension XLDocumentationTests {
         let _: (XLExecutionTests) -> () throws -> Void = XLExecutionTests.testRecursiveCommonTableExpressionUsingCommonTableExpression
     }
 
-    func testDocumentationLiveQueryPublishers() {
+    func testDocumentationLiveQueryPublishers() throws {
+        let idParameter = XLNamedBindingReference<String>(name: "id")
+        let personByID = sql { schema in
+            let person = schema.table(Person.self)
+            Select(person)
+            From(person)
+            Where(person.id == idParameter)
+        }
+        let request = database.makeRequest(with: personByID)
+        let layout = request.parameterLayout
+        let expectedPerson = johnDoe
+        let idBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: layout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(
+                        layout.slot(for: .named("id"))
+                    ),
+                    value: .text(expectedPerson.id)
+                )
+            ]
+        ).validatingComplete()
+
+        let initialValue = expectation(
+            description: "packet-backed publisher emits the selected person"
+        )
+        let refreshedValue = expectation(
+            description: "packet-backed publisher reuses the packet on refresh"
+        )
+        initialValue.assertForOverFulfill = false
+        refreshedValue.assertForOverFulfill = false
+
+        let cancellable = request.publish(bindings: idBindings).sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("Packet-backed observation failed: \(error)")
+                }
+            },
+            receiveValue: { rows in
+                if rows == [expectedPerson] {
+                    initialValue.fulfill()
+                }
+                else if rows.isEmpty {
+                    refreshedValue.fulfill()
+                }
+                else {
+                    XCTFail("Unexpected packet-backed rows: \(rows)")
+                }
+            }
+        )
+        defer { cancellable.cancel() }
+
+        wait(for: [initialValue], timeout: 2)
+        try databasePool.write { database in
+            try database.execute(
+                sql: "DELETE FROM Person WHERE id = ?",
+                arguments: [expectedPerson.id]
+            )
+        }
+        wait(for: [refreshedValue], timeout: 2)
+
         let _: (XLPublisherTests) -> () throws -> Void = XLPublisherTests.testPublishExistingEntities
         let _: (XLPublisherTests) -> () throws -> Void = XLPublisherTests.testPublishOneObservesDirectWrites
         let _: (XLPublisherTests) -> () throws -> Void = XLPublisherTests.testCancellationStopsObservationFetchesAndValues

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -505,7 +505,6 @@ final class XLExecutionTests: XCTestCase {
         try insertEmployee(EmployeeTable(id: "emp02", name: "Whip", companyId: nil, managerEmployeeId: "emp01"))
         try insertEmployee(EmployeeTable(id: "emp03", name: "Slave", companyId: nil, managerEmployeeId: "emp01"))
         
-        let managerIdParameter = XLNamedBindingReference<String>(name: "id")
         let statement = sql { s in
             let t = s.table(EmployeeTable.self)
             Select(t)
@@ -513,8 +512,7 @@ final class XLExecutionTests: XCTestCase {
             Where(t.managerEmployeeId.notNull())
         }
         
-        var request = database.makeRequest(with: statement)
-        request.set(parameter: managerIdParameter, value: "emp01")
+        let request = database.makeRequest(with: statement)
         
         let results = try request.fetchAll()
         XCTAssertEqual(results.count, 2)
@@ -529,7 +527,6 @@ final class XLExecutionTests: XCTestCase {
         try insertEmployee(EmployeeTable(id: "emp02", name: "Whip", companyId: nil, managerEmployeeId: "emp01"))
         try insertEmployee(EmployeeTable(id: "emp03", name: "Slave", companyId: nil, managerEmployeeId: "emp01"))
         
-        let managerIdParameter = XLNamedBindingReference<String>(name: "id")
         let statement = sql { s in
             let t = s.table(EmployeeTable.self)
             Select(t)
@@ -537,8 +534,7 @@ final class XLExecutionTests: XCTestCase {
             Where(t.managerEmployeeId.isNull())
         }
         
-        var request = database.makeRequest(with: statement)
-        request.set(parameter: managerIdParameter, value: "emp01")
+        let request = database.makeRequest(with: statement)
         
         let results = try request.fetchAll()
         XCTAssertEqual(results.count, 1)

--- a/Tests/SQLTests/SQLRequestCompatibilityTests.swift
+++ b/Tests/SQLTests/SQLRequestCompatibilityTests.swift
@@ -1,0 +1,196 @@
+import Combine
+import Foundation
+import GRDB
+import SwiftQL
+import XCTest
+
+
+final class SQLRequestCompatibilityTests: XCTestCase {
+
+    func testLegacyReadConformerUsesDefaultPacketRequirements() throws {
+        var request = LegacyReadRequest(rows: [82])
+        let parameter = XLNamedBindingReference<Int>(name: "value")
+        request.set(parameter, 41)
+
+        XCTAssertEqual(request.assignedValue, 41)
+        XCTAssertEqual(request.parameterLayout, .empty)
+
+        let packet = XLInvocationBindings<XLSQLiteValue>(layout: .empty)
+        XCTAssertEqual(try request.fetchAll(bindings: packet), [82])
+        XCTAssertEqual(try request.fetchOne(bindings: packet), 82)
+
+        let slot = XLParameterSlot(
+            index: XLLogicalParameterIndex(0),
+            key: .named("value"),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: String(reflecting: Int.self),
+            nullability: .required,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("value")
+            )
+        )
+        let layout = try XLParameterLayout(slots: [slot])
+        let nonemptyPacket = try XLInvocationBindings<XLSQLiteValue>(
+            layout: layout,
+            bindings: [try XLInvocationBinding(slot: slot, value: .integer(1))]
+        )
+
+        XCTAssertThrowsError(try request.fetchOne(bindings: nonemptyPacket)) { error in
+            guard case .unsupportedInvocationBindings(
+                let requestType,
+                let rejectedLayout
+            ) = error as? XLRequestBindingError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(requestType.contains("LegacyReadRequest"))
+            XCTAssertEqual(rejectedLayout, layout)
+        }
+    }
+
+    func testLegacyWriteConformerUsesDefaultPacketRequirement() throws {
+        var request = LegacyWriteRequest()
+        let parameter = XLNamedBindingReference<Int>(name: "value")
+        request.set(parameter, 41)
+
+        XCTAssertEqual(request.assignedValue, 41)
+        XCTAssertEqual(request.parameterLayout, .empty)
+
+        let packet = XLInvocationBindings<XLSQLiteValue>(layout: .empty)
+        try request.execute(bindings: packet)
+    }
+
+    func testLegacyMutatingSetStillExecutesGRDBRequest() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftql-request-compatibility-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let database = try GRDBDatabase(
+            url: directory.appendingPathComponent("fixture.sqlite"),
+            logger: nil
+        )
+        let parameter = XLNamedBindingReference<String>(name: "value")
+        var request = database.makeRequest(
+            with: sql { _ in Select(parameter) }
+        )
+
+        request.set(parameter, "legacy")
+
+        XCTAssertEqual(try request.fetchOne(), "legacy")
+    }
+
+    func testLegacyMutatingSetExecutesCustomDirectNamedBindingExpression() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftql-direct-binding-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let database = try GRDBDatabase(
+            url: directory.appendingPathComponent("fixture.sqlite"),
+            logger: nil
+        )
+        let parameter = XLNamedBindingReference<String>(name: "legacyCustom")
+        let expression = LegacyDirectNamedBindingExpression(name: "legacyCustom")
+        var request = database.makeRequest(
+            with: sql { _ in Select(expression) }
+        )
+
+        let slot = try XCTUnwrap(
+            request.parameterLayout.slot(for: .named("legacyCustom"))
+        )
+        XCTAssertEqual(
+            slot.valueTypeIdentifier,
+            XLValueTypeIdentifier(rawValue: "swiftql.legacy-binding-value")
+        )
+        XCTAssertEqual(slot.nullability, .nullable)
+        XCTAssertNil(slot.codecIdentity)
+
+        request.set(parameter, "direct legacy binding")
+
+        XCTAssertEqual(try request.fetchOne(), "direct legacy binding")
+    }
+}
+
+
+private struct LegacyDirectNamedBindingExpression: XLExpression {
+
+    typealias T = String
+
+    let name: XLName
+
+    func makeSQL(context: inout XLBuilder) {
+        context.namedBinding(name)
+    }
+}
+
+
+private struct LegacyReadRequest: XLRequest {
+
+    let rows: [Int]
+
+    private(set) var assignedValue: Int? = nil
+
+    mutating func set<T>(
+        parameter reference: XLNamedBindingReference<Optional<T>>,
+        value: T?
+    ) where T: XLBindable {
+        assignedValue = value as? Int
+    }
+
+    mutating func set<T>(
+        parameter reference: XLNamedBindingReference<T>,
+        value: T
+    ) where T: XLBindable {
+        assignedValue = value as? Int
+    }
+
+    func fetchAll() throws -> [Int] {
+        rows
+    }
+
+    func fetchOne() throws -> Int? {
+        rows.first
+    }
+
+    func publish() -> AnyPublisher<[Int], Error> {
+        Just(rows)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
+    func publishOne() -> AnyPublisher<Int?, Error> {
+        Just(rows.first)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+}
+
+
+private struct LegacyWriteRequest: XLWriteRequest {
+
+    private(set) var assignedValue: Int? = nil
+
+    mutating func set<T>(
+        parameter reference: XLNamedBindingReference<Optional<T>>,
+        value: T?
+    ) where T: XLBindable {
+        assignedValue = value as? Int
+    }
+
+    mutating func set<T>(
+        parameter reference: XLNamedBindingReference<T>,
+        value: T
+    ) where T: XLBindable {
+        assignedValue = value as? Int
+    }
+
+    func execute() throws {}
+}

--- a/Tests/SwiftQLCodecIntegrationTests/InvocationBindingsGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/InvocationBindingsGRDBTests.swift
@@ -1,0 +1,1021 @@
+import Foundation
+import Combine
+import GRDB
+import XCTest
+@testable import SwiftQL
+
+
+final class InvocationBindingsGRDBTests: XCTestCase {
+
+    func testContextualDateUUIDAndCustomValuesExecuteWithoutV1LiteralConformance() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let dateReference = try fixture.database.contextualBinding(
+            Date.self,
+            expressedAs: String.self,
+            named: "date"
+        )
+        let dateRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(dateReference) }
+        )
+        let datePacket = try packet(
+            layout: dateRequest.parameterLayout,
+            binding: dateReference.encode(date, in: dateRequest.parameterLayout)
+        )
+        XCTAssertEqual(
+            try dateRequest.fetchOne(bindings: datePacket),
+            String(date.timeIntervalSince1970)
+        )
+
+        let uuid = UUID(uuidString: "12345678-1234-5678-9ABC-DEF012345678")!
+        let uuidReference = try fixture.database.contextualBinding(
+            UUID.self,
+            expressedAs: Data.self,
+            named: "uuid"
+        )
+        let uuidRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(uuidReference) }
+        )
+        let uuidPacket = try packet(
+            layout: uuidRequest.parameterLayout,
+            binding: uuidReference.encode(uuid, in: uuidRequest.parameterLayout)
+        )
+        XCTAssertEqual(
+            try uuidRequest.fetchOne(bindings: uuidPacket),
+            uuidData(uuid)
+        )
+
+        let token = InvocationToken(rawValue: 82)
+        let tokenReference = try fixture.database.contextualBinding(
+            InvocationToken.self,
+            expressedAs: Int.self,
+            named: "token"
+        )
+        let tokenRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(tokenReference) }
+        )
+        let tokenPacket = try packet(
+            layout: tokenRequest.parameterLayout,
+            binding: tokenReference.encode(token, in: tokenRequest.parameterLayout)
+        )
+        XCTAssertEqual(try tokenRequest.fetchOne(bindings: tokenPacket), 82)
+
+        let optionalDateReference = try fixture.database.contextualBinding(
+            Date.self,
+            expressedAs: Optional<String>.self,
+            named: "optionalDate",
+            nullability: .nullable
+        )
+        let optionalDateRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(optionalDateReference.isNull()) }
+        )
+        let nullPacket = try packet(
+            layout: optionalDateRequest.parameterLayout,
+            binding: optionalDateReference.encodeOptional(
+                nil,
+                in: optionalDateRequest.parameterLayout
+            )
+        )
+        XCTAssertEqual(
+            try optionalDateRequest.fetchOne(bindings: nullPacket),
+            true
+        )
+    }
+
+    func testIntrinsicPacketsPreserveStorageValuesAndDistinguishMissingFromNull() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let textReference = XLNamedBindingReference<String>(name: "text")
+        let textRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(textReference) }
+        )
+        XCTAssertEqual(
+            try textRequest.fetchOne(
+                bindings: try packet(
+                    layout: textRequest.parameterLayout,
+                    value: .text("O'Brien; DROP TABLE records; --")
+                )
+            ),
+            "O'Brien; DROP TABLE records; --"
+        )
+
+        let integerReference = XLNamedBindingReference<Int>(name: "integer")
+        let integerRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(integerReference) }
+        )
+        XCTAssertEqual(
+            try integerRequest.fetchOne(
+                bindings: try packet(
+                    layout: integerRequest.parameterLayout,
+                    value: .integer(82)
+                )
+            ),
+            82
+        )
+
+        let repeatedRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(integerReference + integerReference) }
+        )
+        XCTAssertEqual(repeatedRequest.parameterLayout.count, 1)
+        XCTAssertEqual(
+            try repeatedRequest.fetchOne(
+                bindings: try packet(
+                    layout: repeatedRequest.parameterLayout,
+                    value: .integer(21)
+                )
+            ),
+            42
+        )
+
+        let realReference = XLNamedBindingReference<Double>(name: "real")
+        let realRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(realReference) }
+        )
+        XCTAssertEqual(
+            try realRequest.fetchOne(
+                bindings: try packet(
+                    layout: realRequest.parameterLayout,
+                    value: .real(1.25)
+                )
+            ),
+            1.25
+        )
+
+        let blobReference = XLNamedBindingReference<Data>(name: "blob")
+        let blobRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(blobReference) }
+        )
+        let blob = Data([0x00, 0x27, 0xFF])
+        XCTAssertEqual(
+            try blobRequest.fetchOne(
+                bindings: try packet(
+                    layout: blobRequest.parameterLayout,
+                    value: .blob(blob)
+                )
+            ),
+            blob
+        )
+
+        let optionalReference = XLNamedBindingReference<Optional<String>>(
+            name: "optional"
+        )
+        let optionalRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(optionalReference.isNull()) }
+        )
+        let missing = XLInvocationBindings<XLSQLiteValue>(
+            layout: optionalRequest.parameterLayout
+        )
+        XCTAssertThrowsError(try optionalRequest.fetchOne(bindings: missing)) { error in
+            guard case .missingBindings? = error as? XLInvocationBindingError else {
+                return XCTFail("Expected missing binding, received \(error)")
+            }
+        }
+        XCTAssertEqual(
+            try optionalRequest.fetchOne(
+                bindings: try packet(
+                    layout: optionalRequest.parameterLayout,
+                    value: .null
+                )
+            ),
+            true
+        )
+    }
+
+    func testPublicPreparedInvocationExecutesContextualCodecPacketsConcurrently() async throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let reference = try fixture.database.contextualBinding(
+            InvocationToken.self,
+            expressedAs: Int.self,
+            named: "value"
+        )
+        let invocation = fixture.database.prepareInvocation(
+            with: sql { _ in Select(reference) }
+        )
+        requireSendable(invocation)
+        let layout = invocation.parameterLayout
+        let parameter = try reference.preparedParameter(in: layout)
+        requireSendable(parameter)
+
+        let values = try await withThrowingTaskGroup(
+            of: XLSQLiteValue.self,
+            returning: [XLSQLiteValue].self
+        ) { group in
+            for value in 0 ..< 32 {
+                group.addTask {
+                    let packet = try XLInvocationBindings(
+                        layout: layout,
+                        bindings: [
+                            parameter.encode(
+                                InvocationToken(rawValue: Int64(value))
+                            )
+                        ]
+                    )
+                    guard let result = try invocation.fetchOneValues(
+                        bindings: packet
+                    )?.first else {
+                        throw InvocationFixtureError.missingRow
+                    }
+                    return result
+                }
+            }
+
+            var results: [XLSQLiteValue] = []
+            for try await result in group {
+                results.append(result)
+            }
+            return results
+        }
+
+        XCTAssertEqual(
+            Set(values),
+            Set((0 ..< 32).map { .integer(Int64($0)) })
+        )
+    }
+
+    func testPreparedInvocationValidatesItsDatabaseCodecSnapshot() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let dateReference = try fixture.database.contextualBinding(
+            Date.self,
+            expressedAs: String.self,
+            named: "date"
+        )
+        let statement = sql { _ in Select(dateReference) }
+
+        let emptyConfiguration = try XLValueCodingConfiguration()
+        let missingCodecDatabase = try GRDBDatabase(
+            databasePool: fixture.database.databasePool,
+            codingConfiguration: emptyConfiguration,
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
+        let missingCodecInvocation = missingCodecDatabase.prepareInvocation(
+            with: statement
+        )
+        let missingCodecPacket = XLInvocationBindings<XLSQLiteValue>(
+            layout: missingCodecInvocation.parameterLayout
+        )
+        XCTAssertThrowsError(
+            try missingCodecInvocation.fetchOneValues(
+                bindings: missingCodecPacket
+            )
+        ) { error in
+            guard case .preparedCodecUnavailable(
+                let slot,
+                let codecIdentity
+            ) = error as? XLInvocationBindingError else {
+                return XCTFail("Expected unavailable prepared codec, received \(error)")
+            }
+            XCTAssertEqual(slot.key, .named("date"))
+            XCTAssertEqual(codecIdentity, dateReference.declaration.codecIdentity)
+        }
+
+        let expectedIdentity = try XCTUnwrap(
+            dateReference.declaration.codecIdentity
+        )
+        let mismatchedCodec = XLValueCodec<Date, XLSQLiteDialect>(
+            key: expectedIdentity.key,
+            valueTypeIdentifier: expectedIdentity.valueTypeIdentifier,
+            dialectIdentifier: expectedIdentity.dialectIdentifier,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "integer"),
+            encode: { value, _, _ in
+                .integer(Int64(value.timeIntervalSince1970))
+            },
+            decode: { value, _, _ in
+                guard case .integer(let seconds) = value else {
+                    throw InvocationFixtureError.invalidValue
+                }
+                return Date(timeIntervalSince1970: TimeInterval(seconds))
+            }
+        )
+        let mismatchedConfiguration = try XLValueCodingConfiguration(
+            registry: XLValueCodecRegistry().registering(mismatchedCodec)
+        )
+        let mismatchedCodecDatabase = try GRDBDatabase(
+            databasePool: fixture.database.databasePool,
+            codingConfiguration: mismatchedConfiguration,
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
+        let mismatchedCodecInvocation = mismatchedCodecDatabase.prepareInvocation(
+            with: statement
+        )
+        let mismatchedCodecPacket = XLInvocationBindings<XLSQLiteValue>(
+            layout: mismatchedCodecInvocation.parameterLayout
+        )
+        XCTAssertThrowsError(
+            try mismatchedCodecInvocation.fetchOneValues(
+                bindings: mismatchedCodecPacket
+            )
+        ) { error in
+            guard case .preparedCodecIdentityMismatch(
+                let slot,
+                let expected,
+                let actual
+            ) = error as? XLInvocationBindingError else {
+                return XCTFail("Expected prepared codec identity mismatch, received \(error)")
+            }
+            XCTAssertEqual(slot.key, .named("date"))
+            XCTAssertEqual(expected, expectedIdentity)
+            XCTAssertEqual(actual, mismatchedCodec.identity)
+        }
+    }
+
+    func testCodecSelectionDialectAndDriverFailuresRetainParameterContext() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let unknownKey = XLValueCodecKey(
+            id: "tests.missing-date-codec",
+            version: 1
+        )
+        let unknownContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(["query", "unknownDate"])
+        )
+        XCTAssertThrowsError(
+            try fixture.database.contextualBinding(
+                Date.self,
+                expressedAs: String.self,
+                named: "unknownDate",
+                context: unknownContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: unknownKey
+                )
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLValueCodecError,
+                .unknownCodec(
+                    key: unknownKey,
+                    source: .explicit,
+                    context: unknownContext
+                )
+            )
+        }
+
+        let foreignIdentity = XLValueCodecIdentity(
+            key: XLValueCodecKey(id: "tests.foreign.text", version: 1),
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: "tests.foreign-value"
+            ),
+            dialectIdentifier: XLDialectIdentifier(
+                rawValue: "tests.foreign-dialect"
+            ),
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "text")
+        )
+        let foreignDeclaration = XLParameterDeclaration(
+            key: .named("foreign"),
+            valueTypeIdentifier: foreignIdentity.valueTypeIdentifier,
+            valueTypeName: "Tests.ForeignValue",
+            nullability: .required,
+            codecIdentity: foreignIdentity,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("foreign")
+            )
+        )
+        let foreignInvocation = fixture.database.prepareInvocation(
+            with: sql { _ in
+                Select(DeclaredParameterExpression<String>(
+                    declaration: foreignDeclaration
+                ))
+            }
+        )
+        let foreignPacket = XLInvocationBindings<XLSQLiteValue>(
+            layout: foreignInvocation.parameterLayout
+        )
+        XCTAssertThrowsError(
+            try foreignInvocation.fetchOneValues(bindings: foreignPacket)
+        ) { error in
+            guard case .preparedCodecDialectMismatch(
+                let slot,
+                let codecIdentity,
+                let expectedDialect
+            ) = error as? XLInvocationBindingError else {
+                return XCTFail("Expected prepared codec dialect mismatch, received \(error)")
+            }
+            XCTAssertEqual(slot.key, .named("foreign"))
+            XCTAssertEqual(codecIdentity, foreignIdentity)
+            XCTAssertEqual(expectedDialect, XLSQLiteDialect.identity)
+        }
+
+        let driver = GRDBDatabaseDriver(
+            databasePool: fixture.database.databasePool,
+            dialect: fixture.database.dialect
+        )
+        let driverSlot = XLParameterSlot(
+            index: XLLogicalParameterIndex(0),
+            key: .indexed(0),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: String(reflecting: Int.self),
+            nullability: .required,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("driverValue")
+            )
+        )
+        let driverLayout = try XLParameterLayout(slots: [driverSlot])
+        let driverExecutor = GRDBInvocationExecutor(
+            driver: driver,
+            logicalStatement: XLLogicalPreparedStatement(
+                databaseIdentifier: driver.databaseIdentifier,
+                dialectRequirement: XLDialectRequirement(
+                    identity: XLSQLiteDialect.identity,
+                    capabilities: [.indexedBindings]
+                ),
+                sql: "SELECT ?1, ?2",
+                parameterLayout: driverLayout
+            )
+        )
+        let driverPacket = try XLInvocationBindings(
+            layout: driverLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: driverSlot,
+                    value: XLSQLiteValue.integer(82)
+                )
+            ]
+        )
+        XCTAssertThrowsError(
+            try driverExecutor.fetchOne(bindings: driverPacket)
+        ) { error in
+            guard case .driverArgumentValidationFailed(
+                let layout,
+                let message
+            ) = error as? XLInvocationBindingError else {
+                return XCTFail("Expected driver argument validation failure, received \(error)")
+            }
+            XCTAssertEqual(layout, driverLayout)
+            XCTAssertFalse(message.isEmpty)
+        }
+
+        let invalidDriverSlot = XLParameterSlot(
+            index: XLLogicalParameterIndex(0),
+            key: .indexed(-1),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: String(reflecting: Int.self),
+            nullability: .required,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("invalidDriverValue")
+            )
+        )
+        let invalidDriverLayout = try XLParameterLayout(
+            slots: [invalidDriverSlot]
+        )
+        let invalidDriverExecutor = GRDBInvocationExecutor(
+            driver: driver,
+            logicalStatement: XLLogicalPreparedStatement(
+                databaseIdentifier: driver.databaseIdentifier,
+                dialectRequirement: XLDialectRequirement(
+                    identity: XLSQLiteDialect.identity,
+                    capabilities: [.indexedBindings]
+                ),
+                sql: "SELECT ?1",
+                parameterLayout: invalidDriverLayout
+            )
+        )
+        let invalidDriverPacket = try XLInvocationBindings(
+            layout: invalidDriverLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: invalidDriverSlot,
+                    value: XLSQLiteValue.integer(82)
+                )
+            ]
+        )
+        XCTAssertThrowsError(
+            try invalidDriverExecutor.fetchOne(bindings: invalidDriverPacket)
+        ) { error in
+            guard case .driverBindingFailed(
+                let slot,
+                let codecIdentity,
+                let context,
+                let message
+            ) = error as? XLInvocationBindingError else {
+                return XCTFail("Expected contextual driver bind failure, received \(error)")
+            }
+            XCTAssertEqual(slot, invalidDriverSlot)
+            XCTAssertNil(codecIdentity)
+            XCTAssertEqual(context, invalidDriverSlot.codingContext)
+            XCTAssertFalse(message.isEmpty)
+        }
+    }
+
+    func testIndexedAndNonaliasingMixedSQLiteParametersExecute() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let indexedDeclaration = intrinsicIntegerDeclaration(
+            key: .indexed(2),
+            path: "indexed"
+        )
+        let indexedInvocation = fixture.database.prepareInvocation(
+            with: sql { _ in
+                Select(DeclaredParameterExpression<Int>(
+                    declaration: indexedDeclaration
+                ))
+            }
+        )
+        let indexedSlot = try XCTUnwrap(
+            indexedInvocation.parameterLayout.slots.first
+        )
+        let indexedPacket = try XLInvocationBindings(
+            layout: indexedInvocation.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: indexedSlot,
+                    value: XLSQLiteValue.integer(82)
+                )
+            ]
+        )
+        XCTAssertEqual(
+            try indexedInvocation.fetchOneValues(
+                bindings: indexedPacket
+            )?.first,
+            .integer(82)
+        )
+
+        let namedDeclaration = intrinsicIntegerDeclaration(
+            key: .named("namedValue"),
+            path: "namedValue"
+        )
+        let mixedInvocation = fixture.database.prepareInvocation(
+            with: sql { _ in
+                Select(MixedIntegerParameterExpression(
+                    lhs: namedDeclaration,
+                    rhs: indexedDeclaration
+                ))
+            }
+        )
+        let mixedSlots = mixedInvocation.parameterLayout.slots
+        XCTAssertEqual(mixedSlots.map(\.key), [
+            .named("namedValue"),
+            .indexed(2),
+        ])
+        let mixedPacket = try XLInvocationBindings(
+            layout: mixedInvocation.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: mixedSlots[0],
+                    value: XLSQLiteValue.integer(20)
+                ),
+                try XLInvocationBinding(
+                    slot: mixedSlots[1],
+                    value: XLSQLiteValue.integer(22)
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            try mixedInvocation.fetchOneValues(bindings: mixedPacket)?.first,
+            .integer(42)
+        )
+
+        let numericNamedDeclaration = intrinsicIntegerDeclaration(
+            key: .named("3"),
+            path: "numericNamed"
+        )
+        let numericNamedAndIndexedInvocation = fixture.database.prepareInvocation(
+            with: sql { _ in
+                Select(MixedIntegerParameterExpression(
+                    lhs: numericNamedDeclaration,
+                    rhs: indexedDeclaration
+                ))
+            }
+        )
+        let numericNamedAndIndexedSlots =
+            numericNamedAndIndexedInvocation.parameterLayout.slots
+        XCTAssertEqual(numericNamedAndIndexedSlots.map(\.key), [
+            .named("3"),
+            .indexed(2),
+        ])
+        let numericNamedAndIndexedPacket = try XLInvocationBindings(
+            layout: numericNamedAndIndexedInvocation.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: numericNamedAndIndexedSlots[0],
+                    value: XLSQLiteValue.integer(30)
+                ),
+                try XLInvocationBinding(
+                    slot: numericNamedAndIndexedSlots[1],
+                    value: XLSQLiteValue.integer(12)
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            try numericNamedAndIndexedInvocation.fetchOneValues(
+                bindings: numericNamedAndIndexedPacket
+            )?.first,
+            .integer(42)
+        )
+    }
+
+    func testLayoutMismatchAndLegacyCodecBypassFailBeforeDriverExecution() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let dateReference = try fixture.database.contextualBinding(
+            Date.self,
+            expressedAs: String.self,
+            named: "date"
+        )
+        let request = fixture.database.makeRequest(
+            with: sql { _ in Select(dateReference) }
+        )
+        let wrongPacket = XLInvocationBindings<XLSQLiteValue>(layout: .empty)
+        XCTAssertThrowsError(try request.fetchOne(bindings: wrongPacket)) { error in
+            guard case .packetLayoutMismatch? = error as? XLInvocationBindingError else {
+                return XCTFail("Expected layout mismatch, received \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(
+            try dateReference.encodeOptional(
+                nil,
+                in: request.parameterLayout
+            )
+        ) { error in
+            guard case .nullForRequiredParameter? = error as? XLInvocationBindingError else {
+                return XCTFail("Expected required-null failure, received \(error)")
+            }
+        }
+
+        let contextualSlot = try XCTUnwrap(request.parameterLayout.slots.first)
+        XCTAssertThrowsError(
+            try XLInvocationBinding(
+                slot: contextualSlot,
+                value: XLSQLiteValue.text("forged-without-codec")
+            )
+        ) { error in
+            guard case .codecBindingRequiresPreparedParameter(
+                let slot,
+                let codecIdentity
+            ) = error as? XLInvocationBindingError else {
+                return XCTFail("Expected contextual codec provenance failure, received \(error)")
+            }
+            XCTAssertEqual(slot, contextualSlot)
+            XCTAssertEqual(codecIdentity, contextualSlot.codecIdentity)
+        }
+
+        // The executor still validates storage defensively for trusted package
+        // producers such as future descriptor adapters.
+        let invalidStorageBinding = XLInvocationBinding(
+            preparedCodecSlot: contextualSlot,
+            value: XLSQLiteValue.integer(82)
+        )
+        let invalidStoragePacket = try XLInvocationBindings(
+            layout: request.parameterLayout,
+            bindings: [invalidStorageBinding]
+        )
+        XCTAssertThrowsError(
+            try request.fetchOne(bindings: invalidStoragePacket)
+        ) { error in
+            guard case .dialectValueStorageMismatch(
+                let slot,
+                let codecIdentity,
+                let actualStorage
+            ) = error as? XLInvocationBindingError else {
+                return XCTFail("Expected contextual storage failure, received \(error)")
+            }
+            XCTAssertEqual(slot, contextualSlot)
+            XCTAssertEqual(codecIdentity, contextualSlot.codecIdentity)
+            XCTAssertEqual(actualStorage.rawValue, "integer")
+        }
+
+        var compatibilityRequest = request
+        compatibilityRequest.set(
+            XLNamedBindingReference<String>(name: "date"),
+            "bypass"
+        )
+        XCTAssertThrowsError(try compatibilityRequest.fetchOne()) { error in
+            guard case .parameterMetadataMismatch? = error as? XLInvocationBindingError else {
+                return XCTFail("Expected contextual codec guard, received \(error)")
+            }
+        }
+
+        let integerReference = XLNamedBindingReference<Int>(name: "typed")
+        var wrongLegacyTypeRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(integerReference) }
+        )
+        wrongLegacyTypeRequest.set(
+            XLNamedBindingReference<String>(name: "typed"),
+            "not-an-integer"
+        )
+        XCTAssertThrowsError(try wrongLegacyTypeRequest.fetchOne()) { error in
+            guard case .parameterMetadataMismatch? = error as? XLInvocationBindingError else {
+                return XCTFail("Expected legacy type mismatch, received \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(
+            try fixture.database.contextualBinding(
+                Date.self,
+                expressedAs: Int.self,
+                named: "date"
+            )
+        ) { error in
+            guard case .storageMismatch? = error as? XLValueCodecError else {
+                return XCTFail("Expected literal storage mismatch, received \(error)")
+            }
+        }
+
+        let firstConflict = try fixture.database.contextualBinding(
+            Date.self,
+            expressedAs: String.self,
+            named: "conflict",
+            context: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("first")
+            )
+        )
+        let secondConflict = try fixture.database.contextualBinding(
+            Date.self,
+            expressedAs: String.self,
+            named: "conflict",
+            context: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("second")
+            )
+        )
+        let conflictRequest = fixture.database.makeRequest(
+            with: sql { _ in Select(firstConflict + secondConflict) }
+        )
+        let conflictPacket = try packet(
+            layout: conflictRequest.parameterLayout,
+            binding: firstConflict.encode(
+                Date(timeIntervalSince1970: 82),
+                in: conflictRequest.parameterLayout
+            )
+        )
+        XCTAssertThrowsError(
+            try conflictRequest.fetchOne(bindings: conflictPacket)
+        ) { error in
+            guard case .conflictingParameterIndex? = error as? XLInvocationBindingError else {
+                return XCTFail("Expected deferred layout conflict, received \(error)")
+            }
+        }
+    }
+
+    func testPublisherRetainsOneImmutablePacketForObservation() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        try fixture.database.makeRequest(
+            with: sqlCreate(InvocationRecord.self)
+        ).execute()
+        try fixture.database.makeRequest(
+            with: sqlInsert(InvocationRecord(id: 1))
+        ).execute()
+        try fixture.database.makeRequest(
+            with: sqlInsert(InvocationRecord(id: 2))
+        ).execute()
+
+        let id = XLNamedBindingReference<Int>(name: "id")
+        let request = fixture.database.makeRequest(
+            with: sql { schema in
+                let record = schema.table(InvocationRecord.self)
+                Select(record)
+                From(record)
+                Where(record.id == id)
+            }
+        )
+        let packet = try packet(
+            layout: request.parameterLayout,
+            value: .integer(2)
+        )
+        let receivedInitial = expectation(
+            description: "packet-backed initial observation"
+        )
+        let receivedRefresh = expectation(
+            description: "packet-backed refreshed observation"
+        )
+        var outputs: [[InvocationRecord]] = []
+        var failure: Error?
+        let cancellable = request.publish(bindings: packet).sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    failure = error
+                    if outputs.isEmpty {
+                        receivedInitial.fulfill()
+                    }
+                    else {
+                        receivedRefresh.fulfill()
+                    }
+                }
+            },
+            receiveValue: { value in
+                outputs.append(value)
+                if outputs.count == 1 {
+                    receivedInitial.fulfill()
+                }
+                else if outputs.count == 2 {
+                    receivedRefresh.fulfill()
+                }
+            }
+        )
+
+        wait(for: [receivedInitial], timeout: 2)
+        XCTAssertEqual(outputs, [[InvocationRecord(id: 2)]])
+
+        try fixture.database.databasePool.write { database in
+            try database.execute(
+                sql: "DELETE FROM InvocationRecord WHERE id = ?",
+                arguments: [2]
+            )
+        }
+
+        wait(for: [receivedRefresh], timeout: 2)
+        cancellable.cancel()
+        XCTAssertNil(failure)
+        XCTAssertEqual(outputs, [
+            [InvocationRecord(id: 2)],
+            [],
+        ])
+    }
+
+    private func packet(
+        layout: XLParameterLayout,
+        value: XLSQLiteValue
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        guard let slot = layout.slots.first else {
+            throw InvocationFixtureError.missingSlot
+        }
+        return try packet(
+            layout: layout,
+            binding: XLInvocationBinding(slot: slot, value: value)
+        )
+    }
+
+    private func packet(
+        layout: XLParameterLayout,
+        binding: XLInvocationBinding<XLSQLiteValue>
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        try XLInvocationBindings(layout: layout, bindings: [binding])
+    }
+}
+
+
+private struct DeclaredParameterExpression<Literal: XLLiteral>: XLExpression {
+    typealias T = Literal
+
+    let declaration: XLParameterDeclaration
+
+    func makeSQL(context: inout XLBuilder) {
+        Literal.wrapSQL(context: &context) { context in
+            context.parameter(declaration)
+        }
+    }
+}
+
+
+private struct MixedIntegerParameterExpression: XLExpression {
+    typealias T = Int
+
+    let lhs: XLParameterDeclaration
+    let rhs: XLParameterDeclaration
+
+    func makeSQL(context: inout XLBuilder) {
+        context.binaryOperator(
+            "+",
+            left: { context in context.parameter(lhs) },
+            right: { context in context.parameter(rhs) }
+        )
+    }
+}
+
+
+private func intrinsicIntegerDeclaration(
+    key: XLBindingKey,
+    path: String
+) -> XLParameterDeclaration {
+    XLParameterDeclaration(
+        key: key,
+        valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+        valueTypeName: String(reflecting: Int.self),
+        nullability: .required,
+        codecIdentity: nil,
+        codingContext: XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(path)
+        )
+    )
+}
+
+
+private func requireSendable<T: Sendable>(_: T) {}
+
+
+@SQLTable(name: "InvocationRecord")
+private struct InvocationRecord: Equatable {
+    let id: Int
+}
+
+
+private struct InvocationToken {
+    let rawValue: Int64
+}
+
+
+private struct InvocationFixture {
+    let directoryURL: URL
+    let database: GRDBDatabase
+
+    func tearDown() {
+        try? database.databasePool.close()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+}
+
+
+private enum InvocationFixtureError: Error {
+    case invalidValue
+    case missingRow
+    case missingSlot
+}
+
+
+private func makeFixture() throws -> InvocationFixture {
+    let directoryURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("swiftql-invocation-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: false
+    )
+
+    let dateCodec = XLValueCodec<Date, XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.date.text", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "foundation.Date"),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: XLValueStorageIdentifier(rawValue: "text"),
+        encode: { value, _, _ in
+            .text(String(value.timeIntervalSince1970))
+        },
+        decode: { value, _, _ in
+            guard case .text(let text) = value,
+                  let seconds = TimeInterval(text) else {
+                throw InvocationFixtureError.invalidValue
+            }
+            return Date(timeIntervalSince1970: seconds)
+        }
+    )
+    let uuidCodec = XLValueCodec<UUID, XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.uuid.blob", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "foundation.UUID"),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: XLValueStorageIdentifier(rawValue: "blob"),
+        encode: { value, _, _ in .blob(uuidData(value)) },
+        decode: { _, _, _ in throw InvocationFixtureError.invalidValue }
+    )
+    let tokenCodec = XLValueCodec<InvocationToken, XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.token.integer", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "tests.InvocationToken"),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: XLValueStorageIdentifier(rawValue: "integer"),
+        encode: { value, _, _ in .integer(value.rawValue) },
+        decode: { value, _, _ in
+            guard case .integer(let rawValue) = value else {
+                throw InvocationFixtureError.invalidValue
+            }
+            return InvocationToken(rawValue: rawValue)
+        }
+    )
+    let registry = try XLValueCodecRegistry()
+        .registering(dateCodec)
+        .registering(uuidCodec)
+        .registering(tokenCodec)
+    let configuration = try XLValueCodingConfiguration(
+        registry: registry,
+        defaultCodecKeys: [
+            dateCodec.identity.key,
+            uuidCodec.identity.key,
+            tokenCodec.identity.key,
+        ]
+    )
+    let databasePool = try DatabasePool(
+        path: directoryURL.appendingPathComponent("database.sqlite").path
+    )
+    return try InvocationFixture(
+        directoryURL: directoryURL,
+        database: GRDBDatabase(
+            databasePool: databasePool,
+            codingConfiguration: configuration,
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
+    )
+}
+
+
+private func uuidData(_ value: UUID) -> Data {
+    var uuid = value.uuid
+    return withUnsafeBytes(of: &uuid) { Data($0) }
+}

--- a/Tests/SwiftQLCoreTests/SQLInvocationBindingsTests.swift
+++ b/Tests/SwiftQLCoreTests/SQLInvocationBindingsTests.swift
@@ -1,0 +1,618 @@
+import Foundation
+import XCTest
+
+import SwiftQLCore
+
+
+final class SQLInvocationBindingsTests: XCTestCase {
+
+    func testIndexFreeDeclarationProducesLosslessIndexedSlot() {
+        let declaration = XLParameterDeclaration(
+            key: .named("token"),
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: String(reflecting: InvocationToken.self),
+            nullability: .nullable,
+            codecIdentity: codecIdentity,
+            codingContext: parameterContext
+        )
+
+        let slot = declaration.slot(at: XLLogicalParameterIndex(7))
+
+        XCTAssertEqual(slot.index, XLLogicalParameterIndex(7))
+        XCTAssertEqual(slot.declaration, declaration)
+
+        let error = XLInvocationBindingError.parameterDeclarationNotInLayout(
+            declaration: declaration
+        )
+        XCTAssertTrue(error.localizedDescription.contains("named(\"token\")"))
+        XCTAssertTrue(error.localizedDescription.contains(codecKey.description))
+        XCTAssertTrue(error.localizedDescription.contains(parameterContext.description))
+    }
+
+    func testDiagnosticTypeNamesDoNotAffectStableParameterIdentity() throws {
+        let firstDeclaration = XLParameterDeclaration(
+            key: .named("token"),
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: "OriginalModule.InvocationToken",
+            nullability: .nullable,
+            codecIdentity: codecIdentity,
+            codingContext: parameterContext
+        )
+        let renamedDeclaration = XLParameterDeclaration(
+            key: .named("token"),
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: "RenamedModule.InvocationToken",
+            nullability: .nullable,
+            codecIdentity: codecIdentity,
+            codingContext: parameterContext
+        )
+
+        XCTAssertEqual(firstDeclaration, renamedDeclaration)
+        XCTAssertEqual(Set([firstDeclaration, renamedDeclaration]).count, 1)
+
+        let firstSlot = firstDeclaration.slot(at: XLLogicalParameterIndex(0))
+        let renamedSlot = renamedDeclaration.slot(at: XLLogicalParameterIndex(0))
+        XCTAssertEqual(firstSlot, renamedSlot)
+        XCTAssertEqual(Set([firstSlot, renamedSlot]).count, 1)
+
+        let coalesced = try XLParameterLayout(slots: [firstSlot, renamedSlot])
+        XCTAssertEqual(coalesced.count, 1)
+        XCTAssertEqual(coalesced.slots[0].valueTypeName, firstDeclaration.valueTypeName)
+        XCTAssertEqual(
+            coalesced,
+            try XLParameterLayout(slots: [renamedSlot])
+        )
+    }
+
+    func testLayoutCanonicalizesIndicesAndCoalescesIdenticalOccurrences() throws {
+        let first = slot(index: 0, key: .named("first"))
+        let second = slot(index: 1, key: .named("second"))
+
+        let layout = try XLParameterLayout(
+            slots: [second, first, first, second]
+        )
+
+        XCTAssertEqual(layout.slots, [first, second])
+        XCTAssertEqual(layout.slot(at: XLLogicalParameterIndex(0)), first)
+        XCTAssertEqual(layout.slot(for: .named("second")), second)
+        XCTAssertEqual(layout.count, 2)
+        XCTAssertFalse(layout.isEmpty)
+        XCTAssertEqual(XLParameterLayout.empty.slots, [])
+    }
+
+    func testLayoutRejectsInvalidAndConflictingDeclarations() throws {
+        let invalid = slot(index: -1, key: .named("invalid"))
+        assertBindingError(
+            try XLParameterLayout(slots: [invalid]),
+            equals: .invalidParameterIndex(slot: invalid)
+        )
+
+        let first = slot(index: 0, key: .named("first"))
+        let conflictingIndex = slot(index: 0, key: .named("second"))
+        assertBindingError(
+            try XLParameterLayout(slots: [first, conflictingIndex]),
+            equals: .conflictingParameterIndex(
+                index: XLLogicalParameterIndex(0),
+                existing: first,
+                incoming: conflictingIndex
+            )
+        )
+
+        let conflictingKey = slot(index: 1, key: .named("first"))
+        assertBindingError(
+            try XLParameterLayout(slots: [first, conflictingKey]),
+            equals: .conflictingParameterKey(
+                key: .named("first"),
+                existing: first,
+                incoming: conflictingKey
+            )
+        )
+    }
+
+    func testLayoutRejectsNoncontiguousCanonicalIndices() {
+        let firstGap = slot(index: 1, key: .named("gap"))
+
+        assertBindingError(
+            try XLParameterLayout(slots: [firstGap]),
+            equals: .noncontiguousParameterIndex(
+                slot: firstGap,
+                expected: XLLogicalParameterIndex(0)
+            )
+        )
+
+        let first = slot(index: 0, key: .named("first"))
+        let laterGap = slot(index: 2, key: .named("laterGap"))
+        assertBindingError(
+            try XLParameterLayout(slots: [laterGap, first]),
+            equals: .noncontiguousParameterIndex(
+                slot: laterGap,
+                expected: XLLogicalParameterIndex(1)
+            )
+        )
+    }
+
+    func testLayoutRejectsCodecWhoseStableValueTypeDoesNotMatchSlot() throws {
+        let identity = XLValueCodecIdentity(
+            key: codecKey,
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "other-type"),
+            dialectIdentifier: InvocationTestDialect.identity,
+            storageIdentifier: storageIdentifier(.text)
+        )
+        let mismatched = slot(
+            index: 0,
+            key: .named("value"),
+            codecIdentity: identity
+        )
+
+        assertBindingError(
+            try XLParameterLayout(slots: [mismatched]),
+            equals: .codecValueTypeMismatch(
+                slot: mismatched,
+                codecValueTypeIdentifier: identity.valueTypeIdentifier
+            )
+        )
+    }
+
+    func testPacketIsCanonicalAndDistinguishesMissingFromExplicitNull() throws {
+        let first = slot(index: 0, key: .named("first"))
+        let second = slot(
+            index: 1,
+            key: .named("second"),
+            nullability: .nullable
+        )
+        let layout = try XLParameterLayout(slots: [second, first])
+        let empty = XLInvocationBindings<InvocationTestValue>(layout: layout)
+
+        XCTAssertNil(empty.binding(at: first.index))
+        XCTAssertEqual(empty.missingSlots, [first, second])
+        XCTAssertFalse(empty.isComplete)
+
+        let packet = try XLInvocationBindings<InvocationTestValue>(
+            layout: layout,
+            bindings: [
+                try XLInvocationBinding<InvocationTestValue>(
+                    slot: second,
+                    value: .null
+                ),
+                try XLInvocationBinding<InvocationTestValue>(
+                    slot: first,
+                    value: .text("present")
+                ),
+            ]
+        )
+
+        XCTAssertEqual(packet.bindings.map(\.slot), [first, second])
+        XCTAssertEqual(packet.binding(for: .named("second"))?.value, .null)
+        XCTAssertEqual(packet.missingSlots, [])
+        XCTAssertTrue(packet.isComplete)
+        XCTAssertEqual(try packet.validatingComplete(), packet)
+
+        let erased: any XLInvocationBindingPacket = packet
+        XCTAssertEqual(erased.layout, layout)
+        XCTAssertEqual(erased.bindingCount, 2)
+        XCTAssertTrue(erased.isComplete)
+        XCTAssertNotNil(erased as? XLInvocationBindings<InvocationTestValue>)
+    }
+
+    func testPacketRejectsUnknownMismatchedDuplicateAndMissingBindings() throws {
+        let declared = slot(index: 0, key: .named("declared"))
+        let layout = try XLParameterLayout(slots: [declared])
+        let empty = XLInvocationBindings<InvocationTestValue>(layout: layout)
+        let unknown = slot(index: 1, key: .named("unknown"))
+
+        let mismatch = XLInvocationBindingError.packetLayoutMismatch(
+            expected: layout,
+            actual: .empty
+        )
+        XCTAssertEqual(
+            mismatch.localizedDescription,
+            "Invocation parameter count 0 does not match prepared parameter count 1."
+        )
+
+        let equalCountLayout = try XLParameterLayout(
+            slots: [slot(index: 0, key: .named("other"))]
+        )
+        let equalCountMismatch = XLInvocationBindingError.packetLayoutMismatch(
+            expected: layout,
+            actual: equalCountLayout
+        )
+        XCTAssertEqual(
+            equalCountMismatch.localizedDescription,
+            "Invocation parameter layout does not match the prepared layout; both contain the same number of parameters (1)."
+        )
+
+        assertBindingError(
+            try empty.binding(.text("unknown"), to: unknown),
+            equals: .parameterNotInLayout(slot: unknown)
+        )
+
+        let mismatched = XLParameterSlot(
+            index: declared.index,
+            key: declared.key,
+            valueTypeIdentifier: declared.valueTypeIdentifier,
+            valueTypeName: declared.valueTypeName,
+            nullability: .nullable,
+            codecIdentity: declared.codecIdentity,
+            codingContext: declared.codingContext
+        )
+        assertBindingError(
+            try empty.binding(.text("mismatch"), to: mismatched),
+            equals: .parameterMetadataMismatch(
+                expected: declared,
+                actual: mismatched
+            )
+        )
+
+        let bound = try empty.binding(.text("first"), to: declared)
+        assertBindingError(
+            try bound.binding(.text("second"), to: declared),
+            equals: .duplicateBinding(slot: declared)
+        )
+        assertBindingError(
+            try empty.validatingComplete(),
+            equals: .missingBindings(slots: [declared])
+        )
+    }
+
+    func testRawBindingRejectsCodecSlotButAcceptsIntrinsicSlot() throws {
+        let contextual = slot(
+            index: 0,
+            key: .named("contextual"),
+            codecIdentity: codecIdentity
+        )
+        assertBindingError(
+            try XLInvocationBinding(
+                slot: contextual,
+                value: InvocationTestValue.text("forged")
+            ),
+            equals: .codecBindingRequiresPreparedParameter(
+                slot: contextual,
+                codecIdentity: codecIdentity
+            )
+        )
+
+        let intrinsic = slot(
+            index: 0,
+            key: .named("intrinsic"),
+            codecIdentity: nil
+        )
+        let binding = try XLInvocationBinding(
+            slot: intrinsic,
+            value: InvocationTestValue.text("raw")
+        )
+        XCTAssertEqual(binding.slot, intrinsic)
+        XCTAssertEqual(binding.value, .text("raw"))
+    }
+
+    func testSlotBearingCodecValidationErrorsRetainContext() {
+        let contextual = slot(
+            index: 0,
+            key: .named("contextual"),
+            codecIdentity: codecIdentity
+        )
+        let actualIdentity = XLValueCodecIdentity(
+            key: XLValueCodecKey(id: "swiftql.tests.actual", version: 2),
+            valueTypeIdentifier: valueTypeIdentifier,
+            dialectIdentifier: InvocationTestDialect.identity,
+            storageIdentifier: storageIdentifier(.text)
+        )
+        let expectedDialect = XLDialectIdentifier(rawValue: "swiftql.tests.other")
+        let actualStorage = storageIdentifier(.null)
+
+        let errors: [XLInvocationBindingError] = [
+            .preparedCodecUnavailable(
+                slot: contextual,
+                codecIdentity: codecIdentity
+            ),
+            .preparedCodecIdentityMismatch(
+                slot: contextual,
+                expected: codecIdentity,
+                actual: actualIdentity
+            ),
+            .preparedCodecDialectMismatch(
+                slot: contextual,
+                codecIdentity: codecIdentity,
+                expectedDialectIdentifier: expectedDialect
+            ),
+            .dialectValueStorageMismatch(
+                slot: contextual,
+                expectedCodecIdentity: codecIdentity,
+                actualStorageIdentifier: actualStorage
+            ),
+        ]
+
+        for error in errors {
+            XCTAssertTrue(error.localizedDescription.contains("named(\"contextual\")"))
+            XCTAssertTrue(error.localizedDescription.contains(contextual.codingContext.description))
+        }
+    }
+
+    func testPreparedParameterEncodesThroughResolvedCodecAndMakesNullPresent() throws {
+        let nullable = try preparedParameter(
+            index: 0,
+            key: .named("token"),
+            nullability: .nullable
+        )
+
+        let encoded = try nullable.encode(InvocationToken(rawValue: 42))
+        XCTAssertEqual(encoded.slot, nullable.slot)
+        XCTAssertEqual(encoded.value, .text("token:42"))
+        XCTAssertEqual(nullable.codecIdentity, codecIdentity)
+        XCTAssertEqual(nullable.codingContext, parameterContext)
+
+        let encodedNull = try nullable.encodeOptional(nil)
+        XCTAssertEqual(encodedNull.value, .null)
+        let layout = try XLParameterLayout(slots: [nullable.slot])
+        let packet = try XLInvocationBindings(
+            layout: layout,
+            bindings: [encodedNull]
+        )
+        XCTAssertNotNil(packet.binding(at: nullable.slot.index))
+        XCTAssertEqual(packet.binding(at: nullable.slot.index)?.value, .null)
+
+        let required = try preparedParameter(
+            index: 0,
+            key: .named("required"),
+            nullability: .required
+        )
+        assertBindingError(
+            try required.encodeOptional(nil),
+            equals: .nullForRequiredParameter(slot: required.slot)
+        )
+    }
+
+    func testPreparedParameterRetainsSlotCodecAndContextInEncodingFailure() throws {
+        let parameter = try preparedParameter(
+            index: 3,
+            key: .named("failing"),
+            nullability: .required
+        )
+
+        XCTAssertThrowsError(try parameter.encode(InvocationToken(rawValue: -1))) { error in
+            guard case .codecEncodingFailed(
+                let slot,
+                let identity,
+                let context,
+                let message
+            ) = error as? XLInvocationBindingError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(slot, parameter.slot)
+            XCTAssertEqual(identity, codecIdentity)
+            XCTAssertEqual(context, parameterContext)
+            XCTAssertTrue(message.contains("negativeToken"))
+        }
+    }
+
+    func testPreparedParameterBuildsIsolatedPacketsAcrossConcurrentCalls() async throws {
+        let parameter = try preparedParameter(
+            index: 0,
+            key: .named("token"),
+            nullability: .required
+        )
+        let layout = try XLParameterLayout(slots: [parameter.slot])
+
+        let values = try await withThrowingTaskGroup(
+            of: InvocationTestValue.self,
+            returning: [InvocationTestValue].self
+        ) { group in
+            for index in 0 ..< 32 {
+                group.addTask {
+                    let binding = try parameter.encode(
+                        InvocationToken(rawValue: index)
+                    )
+                    let packet = try XLInvocationBindings(
+                        layout: layout,
+                        bindings: [binding]
+                    )
+                    return try packet.validatingComplete().bindings[0].value
+                }
+            }
+
+            var values: [InvocationTestValue] = []
+            for try await value in group {
+                values.append(value)
+            }
+            return values
+        }
+
+        XCTAssertEqual(
+            Set(values),
+            Set((0 ..< 32).map { .text("token:\($0)") })
+        )
+    }
+}
+
+
+private let valueTypeIdentifier = XLValueTypeIdentifier(
+    rawValue: "swiftql.tests.invocation-token"
+)
+
+private let codecKey = XLValueCodecKey(
+    id: "swiftql.tests.invocation-token.text",
+    version: 1
+)
+
+private let parameterContext = XLValueCodingContext(
+    site: .parameter,
+    path: XLValueCodingPath(["query", "token"])
+)
+
+private var codecIdentity: XLValueCodecIdentity {
+    XLValueCodecIdentity(
+        key: codecKey,
+        valueTypeIdentifier: valueTypeIdentifier,
+        dialectIdentifier: InvocationTestDialect.identity,
+        storageIdentifier: storageIdentifier(.text)
+    )
+}
+
+
+private struct InvocationToken {
+    let rawValue: Int
+}
+
+
+private enum InvocationTestFailure: Error {
+    case negativeToken
+    case invalidValue
+}
+
+
+private enum InvocationTestStorage: String, Hashable, Sendable {
+    case null
+    case text
+}
+
+
+private enum InvocationTestValue: Hashable, Sendable, XLDialectValue {
+    case null
+    case text(String)
+
+    var storageType: InvocationTestStorage {
+        switch self {
+        case .null:
+            return .null
+        case .text:
+            return .text
+        }
+    }
+}
+
+
+private struct InvocationTestDialect: XLValueCodingDialect {
+
+    typealias Value = InvocationTestValue
+
+    static let identity = XLDialectIdentifier(
+        rawValue: "swiftql.tests.invocation-dialect"
+    )
+
+    let descriptor = XLDialectDescriptor(
+        identity: identity,
+        capabilities: [.namedBindings, .indexedBindings]
+    )
+
+    func formatIdentifier(_ identifier: String) -> String {
+        identifier
+    }
+
+    func formatQualifiedIdentifier(_ components: [String]) -> String {
+        components.joined(separator: ".")
+    }
+
+    func formatPlaceholder(_ placeholder: XLBindingPlaceholder) -> String {
+        switch placeholder {
+        case .named(let name):
+            return ":\(name)"
+        case .indexed(let index):
+            return "?\(index)"
+        }
+    }
+
+    func isNull(_ value: InvocationTestValue) -> Bool {
+        value == .null
+    }
+
+    var nullValue: InvocationTestValue {
+        .null
+    }
+
+    func stableStorageIdentifier(
+        for value: InvocationTestValue
+    ) -> XLValueStorageIdentifier {
+        storageIdentifier(value.storageType)
+    }
+}
+
+
+private func slot(
+    index: Int,
+    key: XLBindingKey,
+    nullability: XLParameterNullability = .required,
+    codecIdentity: XLValueCodecIdentity? = nil
+) -> XLParameterSlot {
+    XLParameterSlot(
+        index: XLLogicalParameterIndex(index),
+        key: key,
+        valueTypeIdentifier: valueTypeIdentifier,
+        valueTypeName: String(reflecting: InvocationToken.self),
+        nullability: nullability,
+        codecIdentity: codecIdentity,
+        codingContext: XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(String(describing: key))
+        )
+    )
+}
+
+
+private func preparedParameter(
+    index: Int,
+    key: XLBindingKey,
+    nullability: XLParameterNullability
+) throws -> XLPreparedParameter<InvocationToken, InvocationTestDialect> {
+    let codec = XLValueCodec<InvocationToken, InvocationTestDialect>(
+        key: codecKey,
+        valueTypeIdentifier: valueTypeIdentifier,
+        dialectIdentifier: InvocationTestDialect.identity,
+        storageIdentifier: storageIdentifier(.text),
+        encode: { value, _, _ in
+            guard value.rawValue >= 0 else {
+                throw InvocationTestFailure.negativeToken
+            }
+            return .text("token:\(value.rawValue)")
+        },
+        decode: { value, _, _ in
+            guard case .text(let text) = value,
+                  text.hasPrefix("token:"),
+                  let rawValue = Int(text.dropFirst("token:".count)) else {
+                throw InvocationTestFailure.invalidValue
+            }
+            return InvocationToken(rawValue: rawValue)
+        }
+    )
+    let configuration = try XLValueCodingConfiguration(
+        registry: XLValueCodecRegistry().registering(codec)
+    )
+    let resolved = try configuration.resolvedCodec(
+        for: InvocationToken.self,
+        using: InvocationTestDialect(),
+        context: parameterContext,
+        selection: XLValueCodecSelection(explicitCodecKey: codecKey)
+    )
+    return XLPreparedParameter(
+        index: XLLogicalParameterIndex(index),
+        key: key,
+        nullability: nullability,
+        codec: resolved
+    )
+}
+
+
+private func storageIdentifier(
+    _ storage: InvocationTestStorage
+) -> XLValueStorageIdentifier {
+    XLValueStorageIdentifier(rawValue: storage.rawValue)
+}
+
+
+private func assertBindingError<T>(
+    _ expression: @autoclosure () throws -> T,
+    equals expected: XLInvocationBindingError,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    XCTAssertThrowsError(
+        try expression(),
+        file: file,
+        line: line
+    ) { error in
+        XCTAssertEqual(
+            error as? XLInvocationBindingError,
+            expected,
+            file: file,
+            line: line
+        )
+    }
+}


### PR DESCRIPTION
Closes #82

## Summary

- adds deterministic, immutable parameter declarations, layouts, prepared parameters, and value-semantic `XLInvocationBindings` packets in `SwiftQLCore`
- snapshots contextual codec identity/configuration at preparation and encodes each call through its prepared parameter before values cross the driver boundary
- introduces a public `Sendable` `GRDBPreparedInvocation` raw-value handle for independent concurrent calls
- threads packets explicitly through read, write, and observation execution while retaining structured slot, codec, dialect, storage, and driver error context
- reconstructs SQLite's physical parameter table safely for named, indexed, sparse, and mixed placeholders, including distinct `:3` / `?3` names
- keeps legacy mutating `set` behavior as a narrow compatibility shim backed by the packet representation
- updates all public documentation examples, the Swift 5 downstream client, and the contextual benchmark contract

## Correctness coverage

- concurrent invocations use independent values and a snapshotted contextual custom codec
- optional/NULL, text, integer, real, blob, Date, UUID, and custom encoded values
- missing, duplicate, mismatched, conflicting, noncontiguous, and aliased layouts
- unavailable/mismatched codecs, encoding failures, dialect/storage mismatches, statement-level argument validation, and slot-level bind failures
- packet-backed publisher initial delivery and database-triggered refresh
- legacy request and direct-rendered-placeholder compatibility

## Validation

- `swift test` — 464 tests passed
- `scripts/ci/check-strict-concurrency.sh` — clean
- `scripts/ci/check-first-party-warnings.sh` — clean
- `scripts/ci/check-downstream-swift5-client.sh committed` — passed
- `python3 scripts/ci/check-core-contract-boundary.py` — passed
- `./make-docs.sh /private/tmp/swiftql-82-docs-final-20260717b` — warnings-as-errors DocC build passed
- documentation catalog — 5/5 passed
- independent adversarial/public-API review — no P0–P2 blockers

## Scope boundaries

This PR does not implement #30 captured-variable inference or #129 static query descriptors/identity. Those issues reuse this packet as their invocation-value representation.