### PR TITLE
Add immutable static query descriptors with stable identities

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Replace mutable request arguments with immutable invocation bindings",
-  "issue_number": 82,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/82",
+  "task_name": "Add immutable static query descriptors with stable identities",
+  "issue_number": 129,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/129",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#82 - Replace mutable request arguments with immutable invocation bindings",
+  "codex_session_title": "lukevanin/swiftql#129 - Add immutable static query descriptors with stable identities",
   "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
   "codex_session_url": null,
-  "task_branch": "codex/82-replace-mutable-request-arguments-with-immutable-invocation-bindings",
-  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/82-replace-mutable-request-arguments-with-immutable-invocation-bindings"
+  "task_branch": "codex/129-add-immutable-static-query-descriptors-with-stable-identities",
+  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/129-add-immutable-static-query-descriptors-with-stable-identities"
 }

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -31,6 +31,7 @@ enum FixtureError: Error {
     case invalidCoreContract
     case invalidCodecValue(XLSQLiteValue)
     case unexpectedPacketResult(Int?)
+    case unexpectedStaticQueryResult(Int64)
     case unexpectedResult(PersonSummary?)
 }
 
@@ -153,6 +154,81 @@ private func executeFixture(
     let tokenResult = try tokenRequest.fetchOne(bindings: tokenPacket)
     guard tokenResult == 42 else {
         throw FixtureError.unexpectedPacketResult(tokenResult)
+    }
+
+    let staticDialect = XLSQLiteDialect()
+    let staticEncoding = try XLiteEncoder(dialect: staticDialect)
+        .makeValidatedSQL(sql { _ in Select(token) })
+    let staticStatement = try XLStaticStatementDefinition(
+        validating: staticEncoding
+    )
+    let staticParameterIdentity = try XLQuerySlotIdentity(
+        path: ["downstream", "parameter", "token"]
+    )
+    let staticResultIdentity = try XLQuerySlotIdentity(
+        path: ["downstream", "result", "token"]
+    )
+    let staticParameter = try token.staticQueryParameter(
+        identity: staticParameterIdentity,
+        in: staticStatement.parameterLayout
+    )
+    let staticResultContext = XLValueCodingContext(
+        site: .result,
+        path: XLValueCodingPath("downstream.token")
+    )
+    let staticResultCodec = try codingConfiguration.resolvedCodec(
+        for: DownstreamToken.self,
+        using: staticDialect,
+        context: staticResultContext
+    )
+    let staticDescriptor = try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: ["downstream", "token-round-trip"],
+            version: 1
+        ),
+        statement: staticStatement,
+        parameters: [staticParameter],
+        results: try XLStaticQueryResultMetadata(slots: [
+            XLStaticQueryResultSlot(
+                index: XLLogicalResultIndex(0),
+                identity: staticResultIdentity,
+                valueTypeIdentifier: staticResultCodec.identity
+                    .valueTypeIdentifier,
+                valueTypeName: String(reflecting: DownstreamToken.self),
+                nullability: .required,
+                codecIdentity: staticResultCodec.identity,
+                storageIdentifier: staticResultCodec.identity
+                    .storageIdentifier,
+                codingContext: staticResultContext
+            )
+        ]),
+        cardinality: .exactlyOne
+    )
+    let preparedStaticQuery = try database.prepareInvocation(
+        with: staticDescriptor
+    )
+    let preparedStaticParameter = try preparedStaticQuery.preparedParameter(
+        DownstreamToken.self,
+        identifiedBy: staticParameterIdentity
+    )
+    let staticPacket = try XLInvocationBindings<XLSQLiteValue>(
+        layout: preparedStaticQuery.parameterLayout,
+        bindings: [
+            try preparedStaticParameter.encode(
+                DownstreamToken(rawValue: 84)
+            )
+        ]
+    ).validatingComplete()
+    let staticRow = try preparedStaticQuery.fetchExactlyOneValues(
+        bindings: staticPacket
+    )
+    let preparedStaticResultCodec = try preparedStaticQuery.resultCodec(
+        DownstreamToken.self,
+        identifiedBy: staticResultIdentity
+    )
+    let staticResult = try preparedStaticResultCodec.decode(staticRow[0])
+    guard staticResult == DownstreamToken(rawValue: 84) else {
+        throw FixtureError.unexpectedStaticQueryResult(staticResult.rawValue)
     }
 
     let id = XLNamedBindingReference<String>(name: "id")

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -845,6 +845,42 @@ public struct GRDBDatabase: XLDatabase {
             )
         )
     }
+
+    /// Prepares a database-independent static query descriptor against this
+    /// database's dialect and immutable coding snapshot.
+    ///
+    /// Validation happens before a runtime handle is returned. Physical SQLite
+    /// statements remain connection-owned and are created only while executing
+    /// through the GRDB driver.
+    public func prepareInvocation(
+        with descriptor: XLStaticQueryDescriptor
+    ) throws -> GRDBPreparedStaticQuery {
+        try descriptor.statement.dialectRequirement.validate(
+            dialect.descriptor
+        )
+        try validateStaticQueryStorage(descriptor)
+        try validateStaticQueryCodecs(descriptor)
+
+        let statement = XLLogicalPreparedStatement(
+            databaseIdentifier: driver.databaseIdentifier,
+            dialectRequirement: descriptor.statement.dialectRequirement,
+            sql: descriptor.statement.sql,
+            entities: descriptor.statement.entities,
+            parameterLayout: descriptor.statement.parameterLayout
+        )
+        let invocation = GRDBPreparedInvocation(
+            executor: GRDBInvocationExecutor(
+                driver: driver,
+                logicalStatement: statement
+            )
+        )
+        return GRDBPreparedStaticQuery(
+            descriptor: descriptor,
+            invocation: invocation,
+            codingConfiguration: codingConfiguration,
+            dialect: dialect
+        )
+    }
     
     public func makeRequest(with statement: any XLUpdateStatement) -> XLWriteRequest {
         makeWriteRequest(with: statement)
@@ -912,6 +948,96 @@ public struct GRDBDatabase: XLDatabase {
             }
         }
         return nil
+    }
+
+    private func validateStaticQueryCodecs(
+        _ descriptor: XLStaticQueryDescriptor
+    ) throws {
+        for metadata in descriptor.parameters {
+            let slot = metadata.slot
+            guard let expected = slot.codecIdentity else {
+                continue
+            }
+            guard expected.dialectIdentifier == dialect.descriptor.identity else {
+                throw XLInvocationBindingError.preparedCodecDialectMismatch(
+                    slot: slot,
+                    codecIdentity: expected,
+                    expectedDialectIdentifier: dialect.descriptor.identity
+                )
+            }
+            guard let actual = codingConfiguration.registry.identity(
+                for: expected.key
+            ) else {
+                throw XLInvocationBindingError.preparedCodecUnavailable(
+                    slot: slot,
+                    codecIdentity: expected
+                )
+            }
+            guard actual == expected else {
+                throw XLInvocationBindingError.preparedCodecIdentityMismatch(
+                    slot: slot,
+                    expected: expected,
+                    actual: actual
+                )
+            }
+        }
+
+        for slot in descriptor.results.slots {
+            guard let expected = slot.codecIdentity else {
+                continue
+            }
+            guard expected.dialectIdentifier == dialect.descriptor.identity else {
+                throw GRDBStaticQueryError.resultCodecDialectMismatch(
+                    identity: descriptor.identity,
+                    slot: slot,
+                    codecIdentity: expected,
+                    expectedDialectIdentifier: dialect.descriptor.identity
+                )
+            }
+            guard let actual = codingConfiguration.registry.identity(
+                for: expected.key
+            ) else {
+                throw GRDBStaticQueryError.resultCodecUnavailable(
+                    identity: descriptor.identity,
+                    slot: slot,
+                    codecIdentity: expected
+                )
+            }
+            guard actual == expected else {
+                throw GRDBStaticQueryError.resultCodecIdentityMismatch(
+                    identity: descriptor.identity,
+                    slot: slot,
+                    expected: expected,
+                    actual: actual
+                )
+            }
+        }
+    }
+
+    private func validateStaticQueryStorage(
+        _ descriptor: XLStaticQueryDescriptor
+    ) throws {
+        for parameter in descriptor.parameters {
+            guard XLSQLiteStorageClass(
+                rawValue: parameter.storageIdentifier.rawValue
+            ) != nil else {
+                throw GRDBStaticQueryError.unsupportedParameterStorage(
+                    identity: descriptor.identity,
+                    parameter: parameter
+                )
+            }
+        }
+
+        for slot in descriptor.results.slots {
+            guard XLSQLiteStorageClass(
+                rawValue: slot.storageIdentifier.rawValue
+            ) != nil else {
+                throw GRDBStaticQueryError.unsupportedResultStorage(
+                    identity: descriptor.identity,
+                    slot: slot
+                )
+            }
+        }
     }
 
     private func logicalStatement(for encoding: XLEncoding) -> XLLogicalPreparedStatement {

--- a/Sources/SwiftQL/GRDBStaticQuery.swift
+++ b/Sources/SwiftQL/GRDBStaticQuery.swift
@@ -1,0 +1,430 @@
+import Foundation
+
+
+/// Failures while preparing or executing a static query through GRDB.
+public enum GRDBStaticQueryError: Error, Equatable, Sendable, LocalizedError {
+
+    case operationCardinalityMismatch(
+        identity: XLQueryIdentity,
+        expected: XLQueryCardinality,
+        actual: XLQueryCardinality
+    )
+
+    case rowCountMismatch(
+        identity: XLQueryIdentity,
+        cardinality: XLQueryCardinality,
+        actual: Int
+    )
+
+    case resultColumnCountMismatch(
+        identity: XLQueryIdentity,
+        row: Int,
+        expected: Int,
+        actual: Int
+    )
+
+    case nullForRequiredResult(
+        identity: XLQueryIdentity,
+        slot: XLStaticQueryResultSlot
+    )
+
+    case resultStorageMismatch(
+        identity: XLQueryIdentity,
+        slot: XLStaticQueryResultSlot,
+        actual: XLValueStorageIdentifier
+    )
+
+    case parameterStorageMismatch(
+        identity: XLQueryIdentity,
+        parameter: XLStaticQueryParameterMetadata,
+        actual: XLValueStorageIdentifier
+    )
+
+    case unsupportedParameterStorage(
+        identity: XLQueryIdentity,
+        parameter: XLStaticQueryParameterMetadata
+    )
+
+    case unsupportedResultStorage(
+        identity: XLQueryIdentity,
+        slot: XLStaticQueryResultSlot
+    )
+
+    case parameterNotFound(
+        identity: XLQueryIdentity,
+        parameter: XLQuerySlotIdentity
+    )
+
+    case resultNotFound(
+        identity: XLQueryIdentity,
+        result: XLQuerySlotIdentity
+    )
+
+    case parameterHasNoContextualCodec(
+        identity: XLQueryIdentity,
+        parameter: XLQuerySlotIdentity
+    )
+
+    case resultHasNoContextualCodec(
+        identity: XLQueryIdentity,
+        result: XLQuerySlotIdentity
+    )
+
+    case resultCodecUnavailable(
+        identity: XLQueryIdentity,
+        slot: XLStaticQueryResultSlot,
+        codecIdentity: XLValueCodecIdentity
+    )
+
+    case resultCodecIdentityMismatch(
+        identity: XLQueryIdentity,
+        slot: XLStaticQueryResultSlot,
+        expected: XLValueCodecIdentity,
+        actual: XLValueCodecIdentity
+    )
+
+    case resultCodecDialectMismatch(
+        identity: XLQueryIdentity,
+        slot: XLStaticQueryResultSlot,
+        codecIdentity: XLValueCodecIdentity,
+        expectedDialectIdentifier: XLDialectIdentifier
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .operationCardinalityMismatch(let identity, let expected, let actual):
+            return "Static query \(identity) has \(actual.staticQueryDescription) cardinality and cannot execute as \(expected.staticQueryDescription)."
+        case .rowCountMismatch(let identity, let cardinality, let actual):
+            return "Static query \(identity) expected \(cardinality.staticQueryDescription) cardinality but returned \(actual) rows."
+        case .resultColumnCountMismatch(let identity, let row, let expected, let actual):
+            return "Static query \(identity) row \(row) returned \(actual) columns; its result layout requires \(expected)."
+        case .nullForRequiredResult(let identity, let slot):
+            return "Static query \(identity) returned NULL for required result \(slot.identity) at index \(slot.index)."
+        case .resultStorageMismatch(let identity, let slot, let actual):
+            return "Static query \(identity) result \(slot.identity) expects storage \(slot.storageIdentifier), not \(actual)."
+        case .parameterStorageMismatch(let identity, let parameter, let actual):
+            return "Static query \(identity) parameter \(parameter.identity) expects storage \(parameter.storageIdentifier), not \(actual)."
+        case .unsupportedParameterStorage(let identity, let parameter):
+            return "Static query \(identity) parameter \(parameter.identity) declares unsupported SQLite storage \(parameter.storageIdentifier)."
+        case .unsupportedResultStorage(let identity, let slot):
+            return "Static query \(identity) result \(slot.identity) declares unsupported SQLite storage \(slot.storageIdentifier)."
+        case .parameterNotFound(let identity, let parameter):
+            return "Static query \(identity) has no parameter identified by \(parameter)."
+        case .resultNotFound(let identity, let result):
+            return "Static query \(identity) has no result identified by \(result)."
+        case .parameterHasNoContextualCodec(let identity, let parameter):
+            return "Static query \(identity) parameter \(parameter) has no contextual codec."
+        case .resultHasNoContextualCodec(let identity, let result):
+            return "Static query \(identity) result \(result) has no contextual codec."
+        case .resultCodecUnavailable(let identity, let slot, let codecIdentity):
+            return "Static query \(identity) result \(slot.identity) requires unavailable codec \(codecIdentity.key)."
+        case .resultCodecIdentityMismatch(let identity, let slot, let expected, let actual):
+            return "Static query \(identity) result \(slot.identity) requires codec \(expected.key), but the prepared snapshot contains \(actual.key)."
+        case .resultCodecDialectMismatch(let identity, let slot, let codecIdentity, let expectedDialectIdentifier):
+            return "Static query \(identity) result \(slot.identity) codec \(codecIdentity.key) targets \(codecIdentity.dialectIdentifier), not \(expectedDialectIdentifier)."
+        }
+    }
+}
+
+
+private extension XLQueryCardinality {
+
+    var staticQueryDescription: String {
+        switch self {
+        case .command:
+            return "command"
+        case .exactlyOne:
+            return "exactly-one"
+        case .zeroOrOne:
+            return "zero-or-one"
+        case .many:
+            return "many"
+        }
+    }
+}
+
+
+/// A database-bound, concurrency-safe GRDB executor for one immutable static
+/// query descriptor.
+///
+/// The handle retains the database's immutable coding configuration so typed
+/// parameter and result codecs can be resolved from the same snapshot. Its raw
+/// executor never retains a connection-owned SQLite statement.
+public struct GRDBPreparedStaticQuery: Sendable {
+
+    public let descriptor: XLStaticQueryDescriptor
+
+    private let invocation: GRDBPreparedInvocation
+
+    private let codingConfiguration: XLValueCodingConfiguration
+
+    private let dialect: XLSQLiteDialect
+
+    init(
+        descriptor: XLStaticQueryDescriptor,
+        invocation: GRDBPreparedInvocation,
+        codingConfiguration: XLValueCodingConfiguration,
+        dialect: XLSQLiteDialect
+    ) {
+        self.descriptor = descriptor
+        self.invocation = invocation
+        self.codingConfiguration = codingConfiguration
+        self.dialect = dialect
+    }
+
+    public var identity: XLQueryIdentity {
+        descriptor.identity
+    }
+
+    public var parameterLayout: XLParameterLayout {
+        descriptor.statement.parameterLayout
+    }
+
+    /// Resolves one typed parameter from the immutable database coding
+    /// snapshot and verifies its complete durable identity.
+    public func preparedParameter<Value>(
+        _ type: Value.Type,
+        identifiedBy identity: XLQuerySlotIdentity
+    ) throws -> XLPreparedParameter<Value, XLSQLiteDialect> {
+        guard let metadata = descriptor.parameters.first(where: {
+            $0.identity == identity
+        }) else {
+            throw GRDBStaticQueryError.parameterNotFound(
+                identity: descriptor.identity,
+                parameter: identity
+            )
+        }
+        guard let expected = metadata.slot.codecIdentity else {
+            throw GRDBStaticQueryError.parameterHasNoContextualCodec(
+                identity: descriptor.identity,
+                parameter: identity
+            )
+        }
+        let codec = try codingConfiguration.resolvedCodec(
+            for: type,
+            using: dialect,
+            context: metadata.slot.codingContext,
+            selection: XLValueCodecSelection(explicitCodecKey: expected.key)
+        )
+        guard codec.identity == expected else {
+            throw XLInvocationBindingError.preparedCodecIdentityMismatch(
+                slot: metadata.slot,
+                expected: expected,
+                actual: codec.identity
+            )
+        }
+        let parameter = XLPreparedParameter(
+            index: metadata.slot.index,
+            key: metadata.slot.key,
+            nullability: metadata.slot.nullability,
+            codec: codec
+        )
+        guard parameter.slot == metadata.slot else {
+            throw XLInvocationBindingError.parameterMetadataMismatch(
+                expected: metadata.slot,
+                actual: parameter.slot
+            )
+        }
+        return parameter
+    }
+
+    /// Resolves one typed result codec from the immutable database coding
+    /// snapshot and verifies its complete durable identity.
+    public func resultCodec<Value>(
+        _ type: Value.Type,
+        identifiedBy identity: XLQuerySlotIdentity
+    ) throws -> XLResolvedValueCodec<Value, XLSQLiteDialect> {
+        guard let slot = descriptor.results.slots.first(where: {
+            $0.identity == identity
+        }) else {
+            throw GRDBStaticQueryError.resultNotFound(
+                identity: descriptor.identity,
+                result: identity
+            )
+        }
+        guard let expected = slot.codecIdentity else {
+            throw GRDBStaticQueryError.resultHasNoContextualCodec(
+                identity: descriptor.identity,
+                result: identity
+            )
+        }
+        let codec = try codingConfiguration.resolvedCodec(
+            for: type,
+            using: dialect,
+            context: slot.codingContext,
+            selection: XLValueCodecSelection(explicitCodecKey: expected.key)
+        )
+        guard codec.identity == expected else {
+            throw GRDBStaticQueryError.resultCodecIdentityMismatch(
+                identity: descriptor.identity,
+                slot: slot,
+                expected: expected,
+                actual: codec.identity
+            )
+        }
+        return codec
+    }
+
+    /// Executes a descriptor declared with command cardinality.
+    public func execute(
+        bindings: any XLInvocationBindingPacket
+    ) throws {
+        try requireCardinality(.command)
+        try invocation.execute(bindings: validatedBindings(bindings))
+    }
+
+    /// Fetches the sole row and rejects both missing and excess rows.
+    public func fetchExactlyOneValues(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [XLSQLiteValue] {
+        try requireCardinality(.exactlyOne)
+        let rows = try invocation.fetchAllValues(
+            bindings: validatedBindings(bindings)
+        )
+        guard rows.count == 1, let row = rows.first else {
+            throw GRDBStaticQueryError.rowCountMismatch(
+                identity: descriptor.identity,
+                cardinality: .exactlyOne,
+                actual: rows.count
+            )
+        }
+        try validate(row: row, at: 0)
+        return row
+    }
+
+    /// Fetches zero or one row and rejects an excess-row result.
+    public func fetchZeroOrOneValues(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [XLSQLiteValue]? {
+        try requireCardinality(.zeroOrOne)
+        let rows = try invocation.fetchAllValues(
+            bindings: validatedBindings(bindings)
+        )
+        guard rows.count <= 1 else {
+            throw GRDBStaticQueryError.rowCountMismatch(
+                identity: descriptor.identity,
+                cardinality: .zeroOrOne,
+                actual: rows.count
+            )
+        }
+        guard let row = rows.first else {
+            return nil
+        }
+        try validate(row: row, at: 0)
+        return row
+    }
+
+    /// Fetches every row from a descriptor declared with many cardinality.
+    public func fetchAllValues(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [[XLSQLiteValue]] {
+        try requireCardinality(.many)
+        let rows = try invocation.fetchAllValues(
+            bindings: validatedBindings(bindings)
+        )
+        for (index, row) in rows.enumerated() {
+            try validate(row: row, at: index)
+        }
+        return rows
+    }
+
+    private func requireCardinality(
+        _ expected: XLQueryCardinality
+    ) throws {
+        guard descriptor.cardinality == expected else {
+            throw GRDBStaticQueryError.operationCardinalityMismatch(
+                identity: descriptor.identity,
+                expected: expected,
+                actual: descriptor.cardinality
+            )
+        }
+    }
+
+    /// Validates the descriptor's complete parameter contract before the raw
+    /// GRDB invocation performs its own driver-facing checks. This is required
+    /// for intrinsic parameters whose slots intentionally have no contextual
+    /// codec identity but still declare an exact dialect storage mapping.
+    private func validatedBindings(
+        _ bindings: any XLInvocationBindingPacket
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        guard let packet = bindings as? XLInvocationBindings<XLSQLiteValue> else {
+            throw XLRequestBindingError.incompatibleInvocationPacket(
+                requestType: String(reflecting: Self.self),
+                expectedDialect: XLSQLiteDialect.identity,
+                expectedValueType: String(reflecting: XLSQLiteValue.self),
+                actualPacketType: String(reflecting: type(of: bindings))
+            )
+        }
+        guard packet.layout == parameterLayout else {
+            throw XLInvocationBindingError.packetLayoutMismatch(
+                expected: parameterLayout,
+                actual: packet.layout
+            )
+        }
+        let validatedPacket = try packet.validatingComplete()
+
+        for binding in validatedPacket.bindings {
+            guard let parameter = descriptor.parameter(
+                at: binding.slot.index
+            ) else {
+                throw XLInvocationBindingError.parameterNotInLayout(
+                    slot: binding.slot
+                )
+            }
+            if dialect.isNull(binding.value) {
+                guard parameter.slot.nullability == .nullable else {
+                    throw XLInvocationBindingError.nullForRequiredParameter(
+                        slot: parameter.slot
+                    )
+                }
+                continue
+            }
+            let actualStorage = dialect.stableStorageIdentifier(
+                for: binding.value
+            )
+            guard actualStorage == parameter.storageIdentifier else {
+                throw GRDBStaticQueryError.parameterStorageMismatch(
+                    identity: descriptor.identity,
+                    parameter: parameter,
+                    actual: actualStorage
+                )
+            }
+        }
+        return validatedPacket
+    }
+
+    private func validate(
+        row: [XLSQLiteValue],
+        at rowIndex: Int
+    ) throws {
+        let slots = descriptor.results.slots
+        guard row.count == slots.count else {
+            throw GRDBStaticQueryError.resultColumnCountMismatch(
+                identity: descriptor.identity,
+                row: rowIndex,
+                expected: slots.count,
+                actual: row.count
+            )
+        }
+
+        for (slot, value) in zip(slots, row) {
+            if dialect.isNull(value) {
+                guard slot.nullability == .nullable else {
+                    throw GRDBStaticQueryError.nullForRequiredResult(
+                        identity: descriptor.identity,
+                        slot: slot
+                    )
+                }
+                continue
+            }
+            let actualStorage = dialect.stableStorageIdentifier(for: value)
+            guard actualStorage == slot.storageIdentifier else {
+                throw GRDBStaticQueryError.resultStorageMismatch(
+                    identity: descriptor.identity,
+                    slot: slot,
+                    actual: actualStorage
+                )
+            }
+        }
+    }
+}

--- a/Sources/SwiftQL/SQLStaticQueryDescriptor.swift
+++ b/Sources/SwiftQL/SQLStaticQueryDescriptor.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+
+extension XLStaticStatementDefinition {
+
+    /// Creates a database-independent static statement from one validated SQL
+    /// rendering.
+    ///
+    /// The SwiftQL expression graph is deliberately discarded here. Static
+    /// descriptors retain only deterministic SQL, dialect requirements,
+    /// referenced entities, and immutable parameter metadata.
+    public init(validating encoding: XLEncoding) throws {
+        if let parameterLayoutError = encoding.parameterLayoutError {
+            throw parameterLayoutError
+        }
+        self.init(
+            sql: encoding.sql,
+            dialectRequirement: encoding.dialectRequirement,
+            entities: encoding.entities,
+            parameterLayout: encoding.parameterLayout
+        )
+    }
+}
+
+
+extension XLContextualBindingReference {
+
+    /// Describes this contextual parameter in a static query after rendering
+    /// has assigned its deterministic logical index.
+    public func staticQueryParameter(
+        identity: XLQuerySlotIdentity,
+        in layout: XLParameterLayout
+    ) throws -> XLStaticQueryParameterMetadata {
+        let parameter = try preparedParameter(in: layout)
+        return XLStaticQueryParameterMetadata(
+            identity: identity,
+            slot: parameter.slot,
+            storageIdentifier: parameter.codecIdentity.storageIdentifier
+        )
+    }
+}

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -253,8 +253,10 @@ For cross-task raw-value execution with GRDB, call
 `GRDBDatabase.prepareInvocation(with:)`. Its `GRDBPreparedInvocation` result is
 `Sendable` and accepts an independent packet in `fetchAllValues`,
 `fetchOneValues`, or `execute`. It deliberately returns normalized SQLite
-values instead of retaining the legacy typed row-reader graph. A public static
-typed descriptor layer is separate from this runtime handle.
+values instead of retaining the legacy typed row-reader graph. For a durable,
+database-independent SQL and value-layout contract, create an
+`XLStaticQueryDescriptor` and prepare it through the overload described in
+<doc:StaticQueries>.
 
 Driver integrations can use the `prepareValidated`, `bindValidated`,
 `fetchAllValidated`, `fetchOneValidated`, `executeValidated`, and
@@ -342,8 +344,9 @@ They immediately normalize each value into a compatibility packet stored in
 that request copy. Existing code can continue to copy, set, and execute a
 request, but new code should keep the prepared request immutable and pass an
 explicit packet for each call. The shim cannot override a contextual
-parameter's selected codec. A public cross-task prepared-descriptor API is
-separate from this packet migration.
+parameter's selected codec. Static descriptors use the same immutable packet
+contract while adding stable identity, result metadata, cardinality, and a
+cross-task prepared handle; see <doc:StaticQueries>.
 
 ## Update statements
 

--- a/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
@@ -1,0 +1,232 @@
+# Static queries
+
+Define immutable, database-independent SQL contracts with durable identities,
+typed parameter metadata, flat result layouts, and explicit row cardinality.
+
+## Overview
+
+An `XLStaticQueryDescriptor` is the complete static contract for one rendered
+statement. It retains SQL, dialect requirements, referenced entities, parameter
+slots, result slots, and cardinality. It does not retain a database, connection,
+physical statement, codec registry, or invocation value. You can therefore
+construct and register descriptors before opening a database, then prepare the
+same descriptor against a compatible database when it is needed.
+
+Static descriptors complement ordinary SwiftQL requests. Use a request when
+you want the existing typed row-reader facade. Use a descriptor when you need a
+durable query identity, an immutable cross-task prepared handle, an explicit
+result contract, or a registry of query definitions.
+
+## Construct a descriptor
+
+First render a statement and convert its validated encoding into an
+`XLStaticStatementDefinition`. The following example uses the `Date` codec from
+<doc:CustomTypes>. It resolves the contextual codec without a database, records
+one parameter, and declares the selected output as one result slot.
+
+<!-- test: XLDocumentationTests.testDocumentationStaticQueries -->
+```swift
+let staticQueryDialect = XLSQLiteDialect()
+let staticDateCoding = try XLValueCodingConfiguration(
+    registry: try XLValueCodecRegistry().registering(decimalDateCodec),
+    defaultCodecKeys: [decimalDateCodecKey]
+)
+let cutoffContext = XLValueCodingContext(
+    site: .parameter,
+    path: XLValueCodingPath("invoice.cutoffDate")
+)
+let cutoffCodec = try staticDateCoding.resolvedCodec(
+    for: Date.self,
+    using: staticQueryDialect,
+    context: cutoffContext
+)
+let cutoffParameter = XLContextualBindingReference<
+    Date,
+    String,
+    XLSQLiteDialect
+>(
+    key: .named("cutoffDate"),
+    codec: cutoffCodec
+)
+
+let cutoffEncoding = try XLiteEncoder(dialect: staticQueryDialect)
+    .makeValidatedSQL(sql { _ in Select(cutoffParameter) })
+let cutoffStatement = try XLStaticStatementDefinition(
+    validating: cutoffEncoding
+)
+let cutoffParameterIdentity = try XLQuerySlotIdentity(
+    path: ["invoice", "parameter", "cutoffDate"]
+)
+let selectedDateIdentity = try XLQuerySlotIdentity(
+    path: ["invoice", "result", "cutoffDate"]
+)
+let cutoffMetadata = try cutoffParameter.staticQueryParameter(
+    identity: cutoffParameterIdentity,
+    in: cutoffStatement.parameterLayout
+)
+let selectedDate = XLStaticQueryResultSlot(
+    index: XLLogicalResultIndex(0),
+    identity: selectedDateIdentity,
+    valueTypeIdentifier: cutoffCodec.identity.valueTypeIdentifier,
+    valueTypeName: String(reflecting: Date.self),
+    nullability: .required,
+    codecIdentity: cutoffCodec.identity,
+    storageIdentifier: cutoffCodec.identity.storageIdentifier,
+    codingContext: XLValueCodingContext(
+        site: .result,
+        path: XLValueCodingPath("invoice.cutoffDate")
+    )
+)
+let cutoffDescriptor = try XLStaticQueryDescriptor(
+    definitionIdentity: XLQueryDefinitionIdentity(
+        path: ["invoice", "selected-after-cutoff"],
+        version: 1
+    ),
+    statement: cutoffStatement,
+    parameters: [cutoffMetadata],
+    results: try XLStaticQueryResultMetadata(slots: [selectedDate]),
+    cardinality: .exactlyOne
+)
+```
+
+The renderer owns placeholder discovery and logical parameter order. Parameter
+metadata must match the resulting `XLParameterLayout` exactly. Result indices
+are also zero-based, contiguous, and in SQL output-column order.
+
+Each selected property or direct output column is one flat `XLStaticQueryResultSlot`.
+A selection with three columns therefore declares
+three slots, even when a typed request would decode those columns into one
+Swift value. Automatic synthesis of aggregate or nested property/result graphs
+is owned by issue #40; static descriptors currently describe the flat values
+that cross the driver boundary.
+
+## Stable identity
+
+`XLQueryIdentity.canonicalBytes` is the durable identity; `canonicalHex` is its
+diagnostic and persistence-friendly spelling. Never persist Swift's randomized
+`hashValue`.
+
+Identity format v1 includes:
+
+- The identity format version and definition path/version.
+- Exact rendered SQL bytes.
+- Dialect identity, minimum version, and required capabilities.
+- Each parameter's stable slot identity, logical index, binding key, stable
+  value-type identifier, nullability, and dialect storage identifier.
+- Cardinality and each result's stable identity, index, stable value-type
+  identifier, nullability, and dialect storage identifier.
+- The referenced entity set in canonical order.
+
+It deliberately excludes invocation values, database and driver identity,
+connection state, physical statements, codec registries, diagnostic Swift type
+names, coding-context paths, and codec keys or versions when the stable storage
+contract is unchanged. Those excluded codec and diagnostic fields remain in
+the descriptor so preparation and decoding can still validate the exact
+metadata selected by the query.
+
+Metadata strings that participate in identity use Unicode NFC normalization,
+so canonically equivalent definition paths, slot paths, binding names, stable
+identifiers, and entity names produce the same identity material.
+Rendered SQL is different: it remains exact UTF-8 and is never
+Unicode-normalized. Canonically equivalent SQL spellings are still distinct
+SQL contracts.
+
+### Definition versions and registries
+
+`XLQueryDefinitionIdentity` is human assigned. Keep its path stable and
+increment `version` whenever that definition intentionally adopts a different
+canonical contract. If two descriptors reuse the same path and version with
+different canonical material, call
+`validateDefinitionCompatibility(with:)` while registering them; it fails with
+`XLStaticQueryError.definitionIdentityCollision`. A version increment creates a
+new logical definition and does not collide.
+
+An application-owned descriptor registry can be a value-semantic collection
+created before any database exists. Registration should validate definition
+compatibility and retain the descriptor, not just its identity, because codec
+selection and diagnostic metadata are intentionally richer than the stable
+identity projection. This registry is independent of
+`XLValueCodecRegistry`, which supplies value codecs when a descriptor is
+prepared.
+
+## Prepare and invoke
+
+Preparing binds the database-independent descriptor to one `GRDBDatabase` and
+returns a `Sendable` `GRDBPreparedStaticQuery`. Preparation validates dialect
+requirements and every contextual codec against the database's immutable coding
+configuration. The handle retains that exact configuration snapshot; it never
+consults process-global mutable state and does not own a connection-bound
+SQLite statement.
+
+Create a fresh `XLInvocationBindings` packet for every call. The packet owns
+only normalized dialect values and is validated against the descriptor's
+immutable layout. Neither packet construction nor execution mutates the
+descriptor or prepared handle.
+
+<!-- test: XLDocumentationTests.testDocumentationStaticQueries -->
+```swift
+let staticDatabase = try GRDBDatabase(
+    url: databaseURL,
+    codingConfiguration: staticDateCoding,
+    logger: nil
+)
+let preparedCutoff = try staticDatabase.prepareInvocation(
+    with: cutoffDescriptor
+)
+let preparedCutoffParameter = try preparedCutoff.preparedParameter(
+    Date.self,
+    identifiedBy: cutoffParameterIdentity
+)
+let cutoffBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: preparedCutoff.parameterLayout,
+    bindings: [
+        try preparedCutoffParameter.encode(
+            Date(timeIntervalSince1970: 86_400)
+        )
+    ]
+).validatingComplete()
+let cutoffRow = try preparedCutoff.fetchExactlyOneValues(
+    bindings: cutoffBindings
+)
+let cutoffResultCodec = try preparedCutoff.resultCodec(
+    Date.self,
+    identifiedBy: selectedDateIdentity
+)
+let decodedCutoff = try cutoffResultCodec.decode(cutoffRow[0])
+```
+
+The prepared parameter and result codec verify the descriptor's complete codec
+identity against the retained database snapshot. Rebuilding a database with a
+different default does not alter an existing handle.
+
+### Intrinsic and contextual slots
+
+Contextual parameters and results retain an `XLValueCodecIdentity`. Use
+`preparedParameter(_:identifiedBy:)` to encode an application value and
+`resultCodec(_:identifiedBy:)` to decode the returned dialect value. Both
+operations fail if the exact selected codec is absent or incompatible in the
+prepared snapshot.
+
+Intrinsic `Bool`, `Int`, `Double`, `String`, and `Data` slots have no contextual
+codec identity. Build their packet bindings directly from `.integer`, `.real`,
+`.text`, or `.blob` `XLSQLiteValue` values and consume their result values in
+the same raw form. The prepared handle still enforces declared storage and
+nullability. `NULL` must be a present `.null` binding for a nullable slot;
+omitting a binding is an incomplete packet.
+
+### Cardinality
+
+Cardinality is part of stable query identity and selects the only valid
+execution operation:
+
+| Cardinality | Prepared operation | Contract |
+| --- | --- | --- |
+| `.command` | `execute(bindings:)` | Returns no result slots. |
+| `.exactlyOne` | `fetchExactlyOneValues(bindings:)` | Requires exactly one row. |
+| `.zeroOrOne` | `fetchZeroOrOneValues(bindings:)` | Accepts zero or one row and rejects more. |
+| `.many` | `fetchAllValues(bindings:)` | Accepts any number of rows. |
+
+Descriptor construction rejects result slots on a command and rejects an empty
+result layout for every row-returning cardinality. Prepared execution also
+rejects calling an operation that does not match the descriptor cardinality,
+then validates every returned row's column count, storage, and nullability.

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -82,6 +82,7 @@ replacing SQLite's runtime type rules.
 
 - <doc:GettingStarted>
 - <doc:Queries>
+- <doc:StaticQueries>
 - <doc:LiveQueries>
 - <doc:Expressions>
 - <doc:BuiltinFunctions>

--- a/Sources/SwiftQLCore/SQLStaticQueryDescriptor.swift
+++ b/Sources/SwiftQLCore/SQLStaticQueryDescriptor.swift
@@ -1,0 +1,996 @@
+import Foundation
+
+
+/// A durable, human-assigned identity for one static query definition.
+///
+/// The path identifies the declaration independently of Swift module and type
+/// spellings. Increment `version` whenever that named declaration adopts a new
+/// canonical query contract, or when it intentionally becomes a new logical
+/// query even if its current SQL happens to remain unchanged.
+public struct XLQueryDefinitionIdentity:
+    Hashable,
+    Sendable,
+    CustomStringConvertible
+{
+
+    public let path: [String]
+
+    public let version: UInt64
+
+    public init(path: [String], version: UInt64) throws {
+        try _xlValidateStablePath(path, kind: .definition)
+        self.path = path
+        self.version = version
+    }
+
+    public var description: String {
+        "\(path.joined(separator: "/"))@\(version)"
+    }
+}
+
+
+/// A durable logical identity for one property, parameter, or result slot.
+///
+/// This is intentionally separate from ``XLValueCodingContext``. Coding
+/// contexts are diagnostic paths and may change without changing a query's
+/// static SQL or value layout contract.
+public struct XLQuerySlotIdentity:
+    Hashable,
+    Sendable,
+    CustomStringConvertible
+{
+
+    public let path: [String]
+
+    public init(path: [String]) throws {
+        try _xlValidateStablePath(path, kind: .slot)
+        self.path = path
+    }
+
+    public var description: String {
+        path.joined(separator: "/")
+    }
+}
+
+
+/// The number of rows a static query promises to expose to its caller.
+public enum XLQueryCardinality: UInt8, Hashable, Sendable {
+    /// A statement executed for its effects without a returned row layout.
+    case command = 0
+
+    /// A query that must produce exactly one row.
+    case exactlyOne = 1
+
+    /// A query that may produce zero or one row, but never more than one.
+    case zeroOrOne = 2
+
+    /// A query that may produce any number of rows.
+    case many = 3
+}
+
+
+/// The version of SwiftQL's canonical static-query identity representation.
+///
+/// Version 1 is frozen. Changing field inclusion, ordering, tags, integer
+/// encoding, or string canonicalization requires a new format version.
+public struct XLQueryIdentityFormatVersion:
+    RawRepresentable,
+    Hashable,
+    Sendable,
+    CustomStringConvertible
+{
+
+    public static let v1 = Self(rawValue: 1)
+
+    public static let current = Self.v1
+
+    public let rawValue: UInt16
+
+    public init(rawValue: UInt16) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String {
+        String(rawValue)
+    }
+}
+
+
+/// A collision-safe, cross-process identity for one static query contract.
+///
+/// `canonicalBytes` is the durable identity. It is produced by a frozen binary
+/// encoder and contains the complete identity material instead of a truncated
+/// or randomized hash. The `Hashable` conformance is only an in-process
+/// collection convenience; never persist `hashValue`.
+public struct XLQueryIdentity:
+    Hashable,
+    Sendable,
+    CustomStringConvertible
+{
+
+    public let formatVersion: XLQueryIdentityFormatVersion
+
+    public let definitionIdentity: XLQueryDefinitionIdentity
+
+    public let canonicalBytes: [UInt8]
+
+    package init(
+        formatVersion: XLQueryIdentityFormatVersion,
+        definitionIdentity: XLQueryDefinitionIdentity,
+        canonicalBytes: [UInt8]
+    ) {
+        self.formatVersion = formatVersion
+        self.definitionIdentity = definitionIdentity
+        self.canonicalBytes = canonicalBytes
+    }
+
+    /// A stable lowercase hexadecimal spelling suitable for diagnostics and
+    /// persisted cache metadata.
+    public var canonicalHex: String {
+        let digits = Array("0123456789abcdef".utf8)
+        var encoded: [UInt8] = []
+        encoded.reserveCapacity(canonicalBytes.count * 2)
+        for byte in canonicalBytes {
+            encoded.append(digits[Int(byte >> 4)])
+            encoded.append(digits[Int(byte & 0x0f)])
+        }
+        return String(decoding: encoded, as: UTF8.self)
+    }
+
+    public var description: String {
+        "swiftql-query-v\(formatVersion.rawValue)-\(canonicalHex)"
+    }
+
+    /// Verifies that one durable definition path/version still names the same
+    /// canonical query contract.
+    ///
+    /// Reusing a definition identity for different canonical material is an
+    /// explicit collision and fails closed. Incrementing the definition
+    /// version produces a distinct identity and does not conflict.
+    public func validateDefinitionCompatibility(
+        with other: Self
+    ) throws {
+        guard definitionIdentity == other.definitionIdentity else {
+            return
+        }
+        guard canonicalBytes == other.canonicalBytes else {
+            throw XLStaticQueryError.definitionIdentityCollision(
+                definition: definitionIdentity,
+                existing: self,
+                incoming: other
+            )
+        }
+    }
+}
+
+
+/// A rendered, database-independent SQL statement definition.
+///
+/// The statement captures only static SQL and its logical requirements. It
+/// never owns a database, driver, physical statement, codec registry, or
+/// invocation values.
+public struct XLStaticStatementDefinition: Hashable, Sendable {
+
+    public let sql: String
+
+    public let dialectRequirement: XLDialectRequirement
+
+    public let entities: Set<String>
+
+    public let parameterLayout: XLParameterLayout
+
+    public init(
+        sql: String,
+        dialectRequirement: XLDialectRequirement,
+        entities: Set<String> = [],
+        parameterLayout: XLParameterLayout = .empty
+    ) {
+        self.sql = sql
+        self.dialectRequirement = dialectRequirement
+        self.entities = entities
+        self.parameterLayout = parameterLayout
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        _xlExactUTF8Equal(lhs.sql, rhs.sql)
+            && lhs.dialectRequirement == rhs.dialectRequirement
+            && lhs.entities == rhs.entities
+            && lhs.parameterLayout == rhs.parameterLayout
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        _xlHashExactUTF8(sql, into: &hasher)
+        hasher.combine(dialectRequirement)
+        hasher.combine(entities)
+        hasher.combine(parameterLayout)
+    }
+}
+
+
+/// Static descriptor metadata for one invocation parameter.
+///
+/// `slot` retains the complete selected codec identity and coding context used
+/// by prepared handles. Stable query identity projects only the logical slot,
+/// value type, nullability, and storage contract, so changing a codec key or
+/// diagnostic context without changing SQL/layout/capabilities does not churn
+/// query identity.
+public struct XLStaticQueryParameterMetadata: Hashable, Sendable {
+
+    public let identity: XLQuerySlotIdentity
+
+    public let slot: XLParameterSlot
+
+    public let storageIdentifier: XLValueStorageIdentifier
+
+    public init(
+        identity: XLQuerySlotIdentity,
+        slot: XLParameterSlot,
+        storageIdentifier: XLValueStorageIdentifier
+    ) {
+        self.identity = identity
+        self.slot = slot
+        self.storageIdentifier = storageIdentifier
+    }
+}
+
+
+/// The stable zero-based position of one value in a returned row.
+public struct XLLogicalResultIndex:
+    RawRepresentable,
+    Comparable,
+    Hashable,
+    Sendable,
+    CustomStringConvertible
+{
+
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: Int) {
+        self.init(rawValue: rawValue)
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    public var description: String {
+        String(rawValue)
+    }
+}
+
+
+/// Static metadata for one value in a returned row.
+///
+/// Each selected property or direct output column is represented by one flat
+/// result slot. Static aggregate/property graph synthesis remains deferred to
+/// issue #40.
+public struct XLStaticQueryResultSlot: Hashable, Sendable {
+
+    public let index: XLLogicalResultIndex
+
+    public let identity: XLQuerySlotIdentity
+
+    public let valueTypeIdentifier: XLValueTypeIdentifier
+
+    /// A diagnostic Swift type spelling excluded from stable query identity.
+    public let valueTypeName: String
+
+    public let nullability: XLParameterNullability
+
+    /// The selected codec retained for result decoding. Its key and version are
+    /// excluded from query identity when the storage contract is unchanged.
+    public let codecIdentity: XLValueCodecIdentity?
+
+    public let storageIdentifier: XLValueStorageIdentifier
+
+    /// Diagnostic codec context excluded from stable query identity.
+    public let codingContext: XLValueCodingContext
+
+    public init(
+        index: XLLogicalResultIndex,
+        identity: XLQuerySlotIdentity,
+        valueTypeIdentifier: XLValueTypeIdentifier,
+        valueTypeName: String,
+        nullability: XLParameterNullability,
+        codecIdentity: XLValueCodecIdentity?,
+        storageIdentifier: XLValueStorageIdentifier,
+        codingContext: XLValueCodingContext
+    ) {
+        self.index = index
+        self.identity = identity
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.valueTypeName = valueTypeName
+        self.nullability = nullability
+        self.codecIdentity = codecIdentity
+        self.storageIdentifier = storageIdentifier
+        self.codingContext = codingContext
+    }
+}
+
+
+/// Canonical immutable metadata for every value in a returned row.
+public struct XLStaticQueryResultMetadata: Hashable, Sendable {
+
+    public static let empty = Self(canonicalSlots: [])
+
+    public let slots: [XLStaticQueryResultSlot]
+
+    public init(slots: [XLStaticQueryResultSlot] = []) throws {
+        var slotsByIndex: [XLLogicalResultIndex: XLStaticQueryResultSlot] = [:]
+        var slotsByIdentity: [XLQuerySlotIdentity: XLStaticQueryResultSlot] = [:]
+
+        for slot in slots {
+            guard slot.index.rawValue >= 0 else {
+                throw XLStaticQueryError.invalidResultIndex(slot: slot)
+            }
+            guard !slot.valueTypeIdentifier.rawValue.isEmpty else {
+                throw XLStaticQueryError.emptyValueTypeIdentifier(
+                    slot: slot.identity
+                )
+            }
+            guard !slot.storageIdentifier.rawValue.isEmpty else {
+                throw XLStaticQueryError.emptyStorageIdentifier(
+                    slot: slot.identity
+                )
+            }
+            guard slot.codingContext.site == .result
+                    || slot.codingContext.site == .property else {
+                throw XLStaticQueryError.invalidResultCodingSite(
+                    result: slot,
+                    actual: slot.codingContext.site
+                )
+            }
+            if let existing = slotsByIndex[slot.index] {
+                throw XLStaticQueryError.conflictingResultIndex(
+                    index: slot.index,
+                    existing: existing,
+                    incoming: slot
+                )
+            }
+            if let existing = slotsByIdentity[slot.identity] {
+                throw XLStaticQueryError.conflictingResultIdentity(
+                    identity: slot.identity,
+                    existing: existing,
+                    incoming: slot
+                )
+            }
+            if let codecIdentity = slot.codecIdentity {
+                guard codecIdentity.valueTypeIdentifier == slot.valueTypeIdentifier else {
+                    throw XLStaticQueryError.resultCodecValueTypeMismatch(
+                        slot: slot,
+                        codecValueTypeIdentifier: codecIdentity.valueTypeIdentifier
+                    )
+                }
+                guard codecIdentity.storageIdentifier == slot.storageIdentifier else {
+                    throw XLStaticQueryError.resultCodecStorageMismatch(
+                        slot: slot,
+                        codecStorageIdentifier: codecIdentity.storageIdentifier
+                    )
+                }
+            }
+            slotsByIndex[slot.index] = slot
+            slotsByIdentity[slot.identity] = slot
+        }
+
+        let canonicalSlots = slotsByIndex.values.sorted { lhs, rhs in
+            lhs.index < rhs.index
+        }
+        for (offset, slot) in canonicalSlots.enumerated() {
+            let expected = XLLogicalResultIndex(offset)
+            guard slot.index == expected else {
+                throw XLStaticQueryError.noncontiguousResultIndex(
+                    slot: slot,
+                    expected: expected
+                )
+            }
+        }
+        self.slots = canonicalSlots
+    }
+
+    private init(canonicalSlots: [XLStaticQueryResultSlot]) {
+        self.slots = canonicalSlots
+    }
+
+    public var isEmpty: Bool {
+        slots.isEmpty
+    }
+
+    public var count: Int {
+        slots.count
+    }
+
+    public func slot(at index: XLLogicalResultIndex) -> XLStaticQueryResultSlot? {
+        slots.first { $0.index == index }
+    }
+
+    public func slot(
+        for identity: XLQuerySlotIdentity
+    ) -> XLStaticQueryResultSlot? {
+        slots.first { $0.identity == identity }
+    }
+}
+
+
+/// An immutable, database-independent static query contract.
+///
+/// Invocation values are deliberately absent. Callers create a fresh
+/// ``XLInvocationBindings`` packet from `parameterLayout` for each execution.
+public struct XLStaticQueryDescriptor: Hashable, Sendable {
+
+    public let definitionIdentity: XLQueryDefinitionIdentity
+
+    public let statement: XLStaticStatementDefinition
+
+    /// Canonically ordered by logical parameter index.
+    public let parameters: [XLStaticQueryParameterMetadata]
+
+    public let results: XLStaticQueryResultMetadata
+
+    public let cardinality: XLQueryCardinality
+
+    public let identity: XLQueryIdentity
+
+    public init(
+        definitionIdentity: XLQueryDefinitionIdentity,
+        statement: XLStaticStatementDefinition,
+        parameters: [XLStaticQueryParameterMetadata],
+        results: XLStaticQueryResultMetadata,
+        cardinality: XLQueryCardinality,
+        identityFormatVersion: XLQueryIdentityFormatVersion = .current
+    ) throws {
+        guard identityFormatVersion == .v1 else {
+            throw XLStaticQueryError.unsupportedIdentityFormatVersion(
+                identityFormatVersion
+            )
+        }
+        guard !statement.sql.isEmpty else {
+            throw XLStaticQueryError.emptySQL
+        }
+        guard !statement.dialectRequirement.identity.rawValue.isEmpty else {
+            throw XLStaticQueryError.emptyDialectIdentifier
+        }
+        try _xlValidate(statement.dialectRequirement.minimumVersion)
+        for entity in statement.entities where entity.isEmpty {
+            throw XLStaticQueryError.emptyEntity
+        }
+
+        switch cardinality {
+        case .command:
+            guard results.isEmpty else {
+                throw XLStaticQueryError.commandHasResults(results: results)
+            }
+        case .exactlyOne, .zeroOrOne, .many:
+            guard !results.isEmpty else {
+                throw XLStaticQueryError.rowQueryHasNoResults(
+                    cardinality: cardinality
+                )
+            }
+        }
+
+        let canonicalParameters = try Self.validateAndCanonicalize(
+            parameters,
+            for: statement
+        )
+        try Self.validateResultDialects(results, for: statement)
+
+        let canonicalBytes = XLStaticQueryIdentityEncoder.encodeV1(
+            definitionIdentity: definitionIdentity,
+            statement: statement,
+            parameters: canonicalParameters,
+            results: results,
+            cardinality: cardinality
+        )
+
+        self.definitionIdentity = definitionIdentity
+        self.statement = statement
+        self.parameters = canonicalParameters
+        self.results = results
+        self.cardinality = cardinality
+        self.identity = XLQueryIdentity(
+            formatVersion: identityFormatVersion,
+            definitionIdentity: definitionIdentity,
+            canonicalBytes: canonicalBytes
+        )
+    }
+
+    public var sql: String {
+        statement.sql
+    }
+
+    public var dialectRequirement: XLDialectRequirement {
+        statement.dialectRequirement
+    }
+
+    public var entities: Set<String> {
+        statement.entities
+    }
+
+    public var parameterLayout: XLParameterLayout {
+        statement.parameterLayout
+    }
+
+    /// The complete canonical material used as durable query identity.
+    public var canonicalIdentityMaterial: [UInt8] {
+        identity.canonicalBytes
+    }
+
+    public func parameter(
+        at index: XLLogicalParameterIndex
+    ) -> XLStaticQueryParameterMetadata? {
+        parameters.first { $0.slot.index == index }
+    }
+
+    public func parameter(
+        for identity: XLQuerySlotIdentity
+    ) -> XLStaticQueryParameterMetadata? {
+        parameters.first { $0.identity == identity }
+    }
+
+    private static func validateAndCanonicalize(
+        _ parameters: [XLStaticQueryParameterMetadata],
+        for statement: XLStaticStatementDefinition
+    ) throws -> [XLStaticQueryParameterMetadata] {
+        guard parameters.count == statement.parameterLayout.count else {
+            throw XLStaticQueryError.parameterMetadataCountMismatch(
+                expected: statement.parameterLayout.count,
+                actual: parameters.count
+            )
+        }
+
+        var byIndex: [XLLogicalParameterIndex: XLStaticQueryParameterMetadata] = [:]
+        var byIdentity: [XLQuerySlotIdentity: XLStaticQueryParameterMetadata] = [:]
+
+        for parameter in parameters {
+            let slot = parameter.slot
+            guard let expected = statement.parameterLayout.slot(at: slot.index) else {
+                throw XLStaticQueryError.parameterNotInStatement(
+                    parameter: parameter
+                )
+            }
+            guard expected == slot else {
+                throw XLStaticQueryError.parameterSlotMismatch(
+                    expected: expected,
+                    actual: slot
+                )
+            }
+            guard !slot.valueTypeIdentifier.rawValue.isEmpty else {
+                throw XLStaticQueryError.emptyValueTypeIdentifier(
+                    slot: parameter.identity
+                )
+            }
+            guard !parameter.storageIdentifier.rawValue.isEmpty else {
+                throw XLStaticQueryError.emptyStorageIdentifier(
+                    slot: parameter.identity
+                )
+            }
+            guard slot.codingContext.site == .parameter else {
+                throw XLStaticQueryError.invalidParameterCodingSite(
+                    parameter: parameter,
+                    actual: slot.codingContext.site
+                )
+            }
+            guard byIndex[slot.index] == nil else {
+                throw XLStaticQueryError.duplicateParameterIndex(
+                    index: slot.index
+                )
+            }
+            guard byIdentity[parameter.identity] == nil else {
+                throw XLStaticQueryError.duplicateParameterIdentity(
+                    identity: parameter.identity
+                )
+            }
+
+            switch slot.key {
+            case .named(let name):
+                guard !name.isEmpty else {
+                    throw XLStaticQueryError.emptyNamedBindingKey(slot: slot)
+                }
+                guard statement.dialectRequirement.capabilities.contains(
+                    .namedBindings
+                ) else {
+                    throw XLStaticQueryError.parameterCapabilityMissing(
+                        parameter: parameter,
+                        capability: .namedBindings
+                    )
+                }
+            case .indexed(let physicalIndex):
+                guard physicalIndex >= 0 else {
+                    throw XLStaticQueryError.invalidIndexedBindingKey(slot: slot)
+                }
+                guard statement.dialectRequirement.capabilities.contains(
+                    .indexedBindings
+                ) else {
+                    throw XLStaticQueryError.parameterCapabilityMissing(
+                        parameter: parameter,
+                        capability: .indexedBindings
+                    )
+                }
+            }
+
+            if let codecIdentity = slot.codecIdentity {
+                guard codecIdentity.dialectIdentifier
+                    == statement.dialectRequirement.identity else {
+                    throw XLStaticQueryError.parameterCodecDialectMismatch(
+                        parameter: parameter,
+                        expected: statement.dialectRequirement.identity,
+                        actual: codecIdentity.dialectIdentifier
+                    )
+                }
+                guard codecIdentity.storageIdentifier
+                    == parameter.storageIdentifier else {
+                    throw XLStaticQueryError.parameterCodecStorageMismatch(
+                        parameter: parameter,
+                        codecStorageIdentifier: codecIdentity.storageIdentifier
+                    )
+                }
+            }
+
+            byIndex[slot.index] = parameter
+            byIdentity[parameter.identity] = parameter
+        }
+
+        return byIndex.values.sorted { lhs, rhs in
+            lhs.slot.index < rhs.slot.index
+        }
+    }
+
+    private static func validateResultDialects(
+        _ results: XLStaticQueryResultMetadata,
+        for statement: XLStaticStatementDefinition
+    ) throws {
+        for result in results.slots {
+            guard let codecIdentity = result.codecIdentity else {
+                continue
+            }
+            guard codecIdentity.dialectIdentifier
+                == statement.dialectRequirement.identity else {
+                throw XLStaticQueryError.resultCodecDialectMismatch(
+                    result: result,
+                    expected: statement.dialectRequirement.identity,
+                    actual: codecIdentity.dialectIdentifier
+                )
+            }
+        }
+    }
+}
+
+
+/// Deterministic validation failures while constructing static query metadata.
+public enum XLStaticQueryError: Error, Equatable, Sendable, LocalizedError {
+    case emptyDefinitionPath
+    case emptyDefinitionPathComponent(index: Int)
+    case emptySlotPath
+    case emptySlotPathComponent(index: Int)
+    case unsupportedIdentityFormatVersion(XLQueryIdentityFormatVersion)
+    case definitionIdentityCollision(
+        definition: XLQueryDefinitionIdentity,
+        existing: XLQueryIdentity,
+        incoming: XLQueryIdentity
+    )
+    case emptySQL
+    case emptyDialectIdentifier
+    case negativeDialectVersion(XLDialectVersion)
+    case emptyEntity
+    case invalidResultIndex(slot: XLStaticQueryResultSlot)
+    case noncontiguousResultIndex(
+        slot: XLStaticQueryResultSlot,
+        expected: XLLogicalResultIndex
+    )
+    case conflictingResultIndex(
+        index: XLLogicalResultIndex,
+        existing: XLStaticQueryResultSlot,
+        incoming: XLStaticQueryResultSlot
+    )
+    case conflictingResultIdentity(
+        identity: XLQuerySlotIdentity,
+        existing: XLStaticQueryResultSlot,
+        incoming: XLStaticQueryResultSlot
+    )
+    case emptyValueTypeIdentifier(slot: XLQuerySlotIdentity)
+    case emptyStorageIdentifier(slot: XLQuerySlotIdentity)
+    case invalidResultCodingSite(
+        result: XLStaticQueryResultSlot,
+        actual: XLValueCodingSite
+    )
+    case resultCodecValueTypeMismatch(
+        slot: XLStaticQueryResultSlot,
+        codecValueTypeIdentifier: XLValueTypeIdentifier
+    )
+    case resultCodecStorageMismatch(
+        slot: XLStaticQueryResultSlot,
+        codecStorageIdentifier: XLValueStorageIdentifier
+    )
+    case commandHasResults(results: XLStaticQueryResultMetadata)
+    case rowQueryHasNoResults(cardinality: XLQueryCardinality)
+    case parameterMetadataCountMismatch(expected: Int, actual: Int)
+    case parameterNotInStatement(parameter: XLStaticQueryParameterMetadata)
+    case parameterSlotMismatch(expected: XLParameterSlot, actual: XLParameterSlot)
+    case duplicateParameterIndex(index: XLLogicalParameterIndex)
+    case duplicateParameterIdentity(identity: XLQuerySlotIdentity)
+    case invalidParameterCodingSite(
+        parameter: XLStaticQueryParameterMetadata,
+        actual: XLValueCodingSite
+    )
+    case emptyNamedBindingKey(slot: XLParameterSlot)
+    case invalidIndexedBindingKey(slot: XLParameterSlot)
+    case parameterCapabilityMissing(
+        parameter: XLStaticQueryParameterMetadata,
+        capability: XLDialectCapabilities
+    )
+    case parameterCodecDialectMismatch(
+        parameter: XLStaticQueryParameterMetadata,
+        expected: XLDialectIdentifier,
+        actual: XLDialectIdentifier
+    )
+    case parameterCodecStorageMismatch(
+        parameter: XLStaticQueryParameterMetadata,
+        codecStorageIdentifier: XLValueStorageIdentifier
+    )
+    case resultCodecDialectMismatch(
+        result: XLStaticQueryResultSlot,
+        expected: XLDialectIdentifier,
+        actual: XLDialectIdentifier
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyDefinitionPath:
+            return "A static query definition identity requires at least one path component."
+        case .emptyDefinitionPathComponent(let index):
+            return "Static query definition identity has an empty path component at index \(index)."
+        case .emptySlotPath:
+            return "A static query slot identity requires at least one path component."
+        case .emptySlotPathComponent(let index):
+            return "Static query slot identity has an empty path component at index \(index)."
+        case .unsupportedIdentityFormatVersion(let version):
+            return "Static query identity format version \(version) is unsupported."
+        case .definitionIdentityCollision(let definition, _, _):
+            return "Static query definition \(definition) names different canonical query contracts; increment its definition version."
+        case .emptySQL:
+            return "A static query statement cannot have empty SQL."
+        case .emptyDialectIdentifier:
+            return "A static query statement requires a stable dialect identifier."
+        case .negativeDialectVersion(let version):
+            return "Dialect minimum version \(version) cannot contain negative components."
+        case .emptyEntity:
+            return "A referenced entity identity cannot be empty."
+        case .invalidResultIndex(let slot):
+            return "Result slot \(slot.identity) has invalid index \(slot.index)."
+        case .noncontiguousResultIndex(let slot, let expected):
+            return "Result slot \(slot.identity) has noncontiguous index \(slot.index); expected \(expected)."
+        case .conflictingResultIndex(let index, let existing, let incoming):
+            return "Result index \(index) is declared by both \(existing.identity) and \(incoming.identity)."
+        case .conflictingResultIdentity(let identity, let existing, let incoming):
+            return "Result identity \(identity) has conflicting declarations at indices \(existing.index) and \(incoming.index)."
+        case .emptyValueTypeIdentifier(let slot):
+            return "Static query slot \(slot) requires a stable value type identifier."
+        case .emptyStorageIdentifier(let slot):
+            return "Static query slot \(slot) requires a stable storage identifier."
+        case .invalidResultCodingSite(let result, let actual):
+            return "Static result \(result.identity) has coding site \(actual.rawValue); expected result or property."
+        case .resultCodecValueTypeMismatch(let slot, let codecValueTypeIdentifier):
+            return "Result slot \(slot.identity) has value type \(slot.valueTypeIdentifier), but its codec targets \(codecValueTypeIdentifier)."
+        case .resultCodecStorageMismatch(let slot, let codecStorageIdentifier):
+            return "Result slot \(slot.identity) has storage \(slot.storageIdentifier), but its codec uses \(codecStorageIdentifier)."
+        case .commandHasResults(let results):
+            return "Command cardinality cannot declare \(results.count) result slots."
+        case .rowQueryHasNoResults(let cardinality):
+            return "Row cardinality \(cardinality) requires at least one result slot."
+        case .parameterMetadataCountMismatch(let expected, let actual):
+            return "Static query parameter metadata count \(actual) does not match statement parameter count \(expected)."
+        case .parameterNotInStatement(let parameter):
+            return "Static parameter \(parameter.identity) is not in the statement parameter layout."
+        case .parameterSlotMismatch(let expected, let actual):
+            return "Static parameter \(actual.key) does not match statement slot \(expected.key) at logical index \(expected.index)."
+        case .duplicateParameterIndex(let index):
+            return "Static query parameter index \(index) is declared more than once."
+        case .duplicateParameterIdentity(let identity):
+            return "Static query parameter identity \(identity) is declared more than once."
+        case .invalidParameterCodingSite(let parameter, let actual):
+            return "Static parameter \(parameter.identity) has coding site \(actual.rawValue); expected parameter."
+        case .emptyNamedBindingKey:
+            return "A static query parameter cannot use an empty named binding key."
+        case .invalidIndexedBindingKey(let slot):
+            return "Static query parameter \(slot.key) uses a negative indexed binding key."
+        case .parameterCapabilityMissing(let parameter, let capability):
+            return "Static parameter \(parameter.identity) requires dialect capability \(capability.rawValue)."
+        case .parameterCodecDialectMismatch(let parameter, let expected, let actual):
+            return "Static parameter \(parameter.identity) requires codec dialect \(actual), not statement dialect \(expected)."
+        case .parameterCodecStorageMismatch(let parameter, let codecStorageIdentifier):
+            return "Static parameter \(parameter.identity) has storage \(parameter.storageIdentifier), but its codec uses \(codecStorageIdentifier)."
+        case .resultCodecDialectMismatch(let result, let expected, let actual):
+            return "Static result \(result.identity) requires codec dialect \(actual), not statement dialect \(expected)."
+        }
+    }
+}
+
+
+private enum XLStablePathKind {
+    case definition
+    case slot
+}
+
+
+private func _xlValidateStablePath(
+    _ path: [String],
+    kind: XLStablePathKind
+) throws {
+    guard !path.isEmpty else {
+        switch kind {
+        case .definition:
+            throw XLStaticQueryError.emptyDefinitionPath
+        case .slot:
+            throw XLStaticQueryError.emptySlotPath
+        }
+    }
+    for (index, component) in path.enumerated() where component.isEmpty {
+        switch kind {
+        case .definition:
+            throw XLStaticQueryError.emptyDefinitionPathComponent(index: index)
+        case .slot:
+            throw XLStaticQueryError.emptySlotPathComponent(index: index)
+        }
+    }
+}
+
+
+private func _xlValidate(_ version: XLDialectVersion?) throws {
+    guard let version else {
+        return
+    }
+    guard version.major >= 0, version.minor >= 0, version.patch >= 0 else {
+        throw XLStaticQueryError.negativeDialectVersion(version)
+    }
+}
+
+
+private enum XLStaticQueryIdentityEncoder {
+
+    private static let domain = Array("SwiftQL.StaticQueryIdentity".utf8)
+
+    static func encodeV1(
+        definitionIdentity: XLQueryDefinitionIdentity,
+        statement: XLStaticStatementDefinition,
+        parameters: [XLStaticQueryParameterMetadata],
+        results: XLStaticQueryResultMetadata,
+        cardinality: XLQueryCardinality
+    ) -> [UInt8] {
+        var writer = XLCanonicalByteWriter()
+        writer.bytes(domain)
+        writer.byte(0)
+        writer.uint16(XLQueryIdentityFormatVersion.v1.rawValue)
+
+        // Metadata uses NFC so canonical-equivalent Swift strings encode to
+        // the same durable identity material.
+        writer.metadataStringArray(definitionIdentity.path)
+        writer.uint64(definitionIdentity.version)
+
+        // Rendered SQL remains exact and is deliberately not normalized.
+        writer.string(statement.sql)
+        writer.metadataString(statement.dialectRequirement.identity.rawValue)
+        writer.optional(statement.dialectRequirement.minimumVersion) { writer, version in
+            writer.uint64(UInt64(version.major))
+            writer.uint64(UInt64(version.minor))
+            writer.uint64(UInt64(version.patch))
+        }
+        writer.uint64(statement.dialectRequirement.capabilities.rawValue)
+
+        writer.uint64(UInt64(parameters.count))
+        for parameter in parameters {
+            writer.metadataStringArray(parameter.identity.path)
+            writer.uint64(UInt64(parameter.slot.index.rawValue))
+            switch parameter.slot.key {
+            case .named(let name):
+                writer.byte(0)
+                writer.metadataString(name)
+            case .indexed(let index):
+                writer.byte(1)
+                writer.uint64(UInt64(index))
+            }
+            writer.metadataString(parameter.slot.valueTypeIdentifier.rawValue)
+            writer.byte(parameter.slot.nullability == .required ? 0 : 1)
+            writer.metadataString(parameter.storageIdentifier.rawValue)
+        }
+
+        writer.byte(cardinality.rawValue)
+        writer.uint64(UInt64(results.count))
+        for result in results.slots {
+            writer.metadataStringArray(result.identity.path)
+            writer.uint64(UInt64(result.index.rawValue))
+            writer.metadataString(result.valueTypeIdentifier.rawValue)
+            writer.byte(result.nullability == .required ? 0 : 1)
+            writer.metadataString(result.storageIdentifier.rawValue)
+        }
+
+        let entities = statement.entities.map {
+            $0.precomposedStringWithCanonicalMapping
+        }.sorted { lhs, rhs in
+            lhs.utf8.lexicographicallyPrecedes(rhs.utf8)
+        }
+        writer.uint64(UInt64(entities.count))
+        for entity in entities {
+            writer.metadataString(entity)
+        }
+
+        return writer.output
+    }
+}
+
+
+private struct XLCanonicalByteWriter {
+
+    private(set) var output: [UInt8] = []
+
+    mutating func byte(_ value: UInt8) {
+        output.append(value)
+    }
+
+    mutating func bytes(_ values: [UInt8]) {
+        output.append(contentsOf: values)
+    }
+
+    mutating func uint16(_ value: UInt16) {
+        output.append(UInt8((value >> 8) & 0xff))
+        output.append(UInt8(value & 0xff))
+    }
+
+    mutating func uint64(_ value: UInt64) {
+        for shift in stride(from: 56, through: 0, by: -8) {
+            output.append(UInt8((value >> UInt64(shift)) & 0xff))
+        }
+    }
+
+    mutating func string(_ value: String) {
+        let bytes = Array(value.utf8)
+        uint64(UInt64(bytes.count))
+        self.bytes(bytes)
+    }
+
+    mutating func stringArray(_ values: [String]) {
+        uint64(UInt64(values.count))
+        for value in values {
+            string(value)
+        }
+    }
+
+    mutating func metadataString(_ value: String) {
+        string(value.precomposedStringWithCanonicalMapping)
+    }
+
+    mutating func metadataStringArray(_ values: [String]) {
+        uint64(UInt64(values.count))
+        for value in values {
+            metadataString(value)
+        }
+    }
+
+    mutating func optional<Value>(
+        _ value: Value?,
+        write: (inout Self, Value) -> Void
+    ) {
+        guard let value else {
+            byte(0)
+            return
+        }
+        byte(1)
+        write(&self, value)
+    }
+}
+
+
+private func _xlExactUTF8Equal(_ lhs: String, _ rhs: String) -> Bool {
+    Array(lhs.utf8) == Array(rhs.utf8)
+}
+
+
+private func _xlHashExactUTF8(_ value: String, into hasher: inout Hasher) {
+    let bytes = Array(value.utf8)
+    hasher.combine(bytes.count)
+    for byte in bytes {
+        hasher.combine(byte)
+    }
+}

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -26,6 +26,10 @@ private let documentationTests = [
         XLDocumentationTests.testDocumentationQuickStart
     ),
     DocumentationTestReference(
+        "XLDocumentationTests.testDocumentationStaticQueries",
+        XLDocumentationTests.testDocumentationStaticQueries
+    ),
+    DocumentationTestReference(
         "XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings",
         XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings
     ),
@@ -81,6 +85,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         "GettingStarted.md": "XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings",
         "LiveQueries.md": "XLDocumentationTests.testDocumentationLiveQueryPublishers",
         "Queries.md": "XLDocumentationTests.testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs",
+        "StaticQueries.md": "XLDocumentationTests.testDocumentationStaticQueries",
         "SwiftQL.md": "XLDocumentationTests.testDocumentationQuickStart",
     ]
 
@@ -152,6 +157,51 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             XCTAssertTrue(
                 contents.contains(semanticPhrase),
                 "GettingStarted.md is missing prepared-statement guidance for '\(semanticPhrase)'."
+            )
+        }
+    }
+
+    func testStaticQueriesDocumentsIdentityPreparationAndExecutionContracts() throws {
+        let staticQueriesURL = documentationCatalogURL()
+            .appendingPathComponent("StaticQueries.md")
+        let contents = try String(
+            contentsOf: staticQueriesURL,
+            encoding: .utf8
+        )
+
+        for heading in [
+            "## Construct a descriptor",
+            "## Stable identity",
+            "### Definition versions and registries",
+            "## Prepare and invoke",
+            "### Intrinsic and contextual slots",
+            "### Cardinality",
+        ] {
+            XCTAssertTrue(contents.contains(heading), "StaticQueries.md is missing \(heading).")
+        }
+
+        for semanticPhrase in [
+            "construct and register descriptors before opening a database",
+            "one flat `XLStaticQueryResultSlot`",
+            "owned by issue #40",
+            "Exact rendered SQL bytes",
+            "deliberately excludes invocation values",
+            "Metadata strings that participate in identity use Unicode NFC normalization",
+            "Rendered SQL is different: it remains exact UTF-8",
+            "different canonical material",
+            "`XLStaticQueryError.definitionIdentityCollision`",
+            "descriptor registry can be a value-semantic collection",
+            "retains that exact configuration snapshot",
+            "fresh `XLInvocationBindings` packet for every call",
+            "Intrinsic `Bool`, `Int`, `Double`, `String`, and `Data` slots",
+            "| `.command` | `execute(bindings:)` |",
+            "| `.exactlyOne` | `fetchExactlyOneValues(bindings:)` |",
+            "| `.zeroOrOne` | `fetchZeroOrOneValues(bindings:)` |",
+            "| `.many` | `fetchAllValues(bindings:)` |",
+        ] {
+            XCTAssertTrue(
+                contents.contains(semanticPhrase),
+                "StaticQueries.md is missing static-query guidance for '\(semanticPhrase)'."
             )
         }
     }

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1710,6 +1710,190 @@ extension XLDocumentationTests {
         let _: (XLExecutionTests) -> () throws -> Void = XLExecutionTests.testStringToDataRoundTrip
     }
 
+    func testDocumentationStaticQueries() throws {
+        let staticQueryDialect = XLSQLiteDialect()
+        let staticDateCoding = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(decimalDateCodec),
+            defaultCodecKeys: [decimalDateCodecKey]
+        )
+        let cutoffContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath("invoice.cutoffDate")
+        )
+        let cutoffCodec = try staticDateCoding.resolvedCodec(
+            for: Date.self,
+            using: staticQueryDialect,
+            context: cutoffContext
+        )
+        let cutoffParameter = XLContextualBindingReference<
+            Date,
+            String,
+            XLSQLiteDialect
+        >(
+            key: .named("cutoffDate"),
+            codec: cutoffCodec
+        )
+
+        let cutoffEncoding = try XLiteEncoder(dialect: staticQueryDialect)
+            .makeValidatedSQL(sql { _ in Select(cutoffParameter) })
+        let cutoffStatement = try XLStaticStatementDefinition(
+            validating: cutoffEncoding
+        )
+        let cutoffParameterIdentity = try XLQuerySlotIdentity(
+            path: ["invoice", "parameter", "cutoffDate"]
+        )
+        let selectedDateIdentity = try XLQuerySlotIdentity(
+            path: ["invoice", "result", "cutoffDate"]
+        )
+        let cutoffMetadata = try cutoffParameter.staticQueryParameter(
+            identity: cutoffParameterIdentity,
+            in: cutoffStatement.parameterLayout
+        )
+        let selectedDate = XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(0),
+            identity: selectedDateIdentity,
+            valueTypeIdentifier: cutoffCodec.identity.valueTypeIdentifier,
+            valueTypeName: String(reflecting: Date.self),
+            nullability: .required,
+            codecIdentity: cutoffCodec.identity,
+            storageIdentifier: cutoffCodec.identity.storageIdentifier,
+            codingContext: XLValueCodingContext(
+                site: .result,
+                path: XLValueCodingPath("invoice.cutoffDate")
+            )
+        )
+        let cutoffDescriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["invoice", "selected-after-cutoff"],
+                version: 1
+            ),
+            statement: cutoffStatement,
+            parameters: [cutoffMetadata],
+            results: try XLStaticQueryResultMetadata(slots: [selectedDate]),
+            cardinality: .exactlyOne
+        )
+
+        XCTAssertEqual(cutoffDescriptor.sql, "SELECT :cutoffDate")
+        XCTAssertEqual(cutoffDescriptor.parameters, [cutoffMetadata])
+        XCTAssertEqual(cutoffDescriptor.results.slots, [selectedDate])
+        let staticQueryRegistry = [
+            cutoffDescriptor.identity: cutoffDescriptor,
+        ]
+        let registeredDescriptor = try XCTUnwrap(
+            staticQueryRegistry[cutoffDescriptor.identity]
+        )
+        try registeredDescriptor.identity.validateDefinitionCompatibility(
+            with: cutoffDescriptor.identity
+        )
+
+        let staticDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftql-static-query-docs-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: staticDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: staticDirectory) }
+        let databaseURL = staticDirectory.appendingPathComponent("fixture.sqlite")
+        let staticDatabase = try GRDBDatabase(
+            url: databaseURL,
+            codingConfiguration: staticDateCoding,
+            logger: nil
+        )
+        defer { try? staticDatabase.databasePool.close() }
+        let preparedCutoff = try staticDatabase.prepareInvocation(
+            with: cutoffDescriptor
+        )
+        let preparedCutoffParameter = try preparedCutoff.preparedParameter(
+            Date.self,
+            identifiedBy: cutoffParameterIdentity
+        )
+        let expectedDate = Date(timeIntervalSince1970: 86_400)
+        let cutoffBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: preparedCutoff.parameterLayout,
+            bindings: [
+                try preparedCutoffParameter.encode(expectedDate)
+            ]
+        ).validatingComplete()
+        let cutoffRow = try preparedCutoff.fetchExactlyOneValues(
+            bindings: cutoffBindings
+        )
+        let cutoffResultCodec = try preparedCutoff.resultCodec(
+            Date.self,
+            identifiedBy: selectedDateIdentity
+        )
+        let decodedCutoff = try cutoffResultCodec.decode(cutoffRow[0])
+        XCTAssertEqual(decodedCutoff, expectedDate)
+
+        let intrinsicParameter = XLNamedBindingReference<Int>(name: "value")
+        let intrinsicEncoding = try XLiteEncoder(dialect: staticQueryDialect)
+            .makeValidatedSQL(sql { _ in Select(intrinsicParameter) })
+        let intrinsicStatement = try XLStaticStatementDefinition(
+            validating: intrinsicEncoding
+        )
+        let intrinsicSlot = try XCTUnwrap(
+            intrinsicStatement.parameterLayout.slot(for: .named("value"))
+        )
+        let intrinsicParameterIdentity = try XLQuerySlotIdentity(
+            path: ["intrinsic", "parameter", "value"]
+        )
+        let intrinsicResultIdentity = try XLQuerySlotIdentity(
+            path: ["intrinsic", "result", "value"]
+        )
+        let integerStorage = XLValueStorageIdentifier(
+            rawValue: XLSQLiteStorageClass.integer.rawValue
+        )
+        let intrinsicDescriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["documentation", "intrinsic-value"],
+                version: 1
+            ),
+            statement: intrinsicStatement,
+            parameters: [
+                XLStaticQueryParameterMetadata(
+                    identity: intrinsicParameterIdentity,
+                    slot: intrinsicSlot,
+                    storageIdentifier: integerStorage
+                )
+            ],
+            results: try XLStaticQueryResultMetadata(slots: [
+                XLStaticQueryResultSlot(
+                    index: XLLogicalResultIndex(0),
+                    identity: intrinsicResultIdentity,
+                    valueTypeIdentifier: XLValueTypeIdentifier(
+                        rawValue: "swift.int"
+                    ),
+                    valueTypeName: String(reflecting: Int.self),
+                    nullability: .required,
+                    codecIdentity: nil,
+                    storageIdentifier: integerStorage,
+                    codingContext: XLValueCodingContext(
+                        site: .result,
+                        path: XLValueCodingPath("intrinsic.value")
+                    )
+                )
+            ]),
+            cardinality: .exactlyOne
+        )
+        let preparedIntrinsic = try staticDatabase.prepareInvocation(
+            with: intrinsicDescriptor
+        )
+        let intrinsicBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: preparedIntrinsic.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: intrinsicSlot,
+                    value: .integer(7)
+                )
+            ]
+        ).validatingComplete()
+        XCTAssertEqual(
+            try preparedIntrinsic.fetchExactlyOneValues(
+                bindings: intrinsicBindings
+            ),
+            [.integer(7)]
+        )
+    }
+
     func testDocumentationCustomFunctionRegistrationAndExecution() throws {
         try testExample_CustomFunction()
     }

--- a/Tests/SwiftQLCodecIntegrationTests/StaticQueryDescriptorGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/StaticQueryDescriptorGRDBTests.swift
@@ -1,0 +1,920 @@
+import Foundation
+import GRDB
+import XCTest
+
+@testable import SwiftQL
+
+
+final class StaticQueryDescriptorGRDBTests: XCTestCase {
+
+    func testDescriptorPreparedBeforeDatabaseExecutesEveryCardinality() throws {
+        let contract = try makeContract()
+        let definitions = try makeDefinitions(contract: contract)
+
+        // All descriptor state exists before a database or connection pool is
+        // created. Preparation adds only the database-bound executor.
+        let fixture = try makeDatabase(configuration: contract.configuration)
+        defer { fixture.tearDown() }
+
+        let emptyBindings = XLInvocationBindings<XLSQLiteValue>(layout: .empty)
+        let create = try fixture.database.prepareInvocation(
+            with: definitions.create
+        )
+        requireSendable(create)
+        try create.execute(bindings: emptyBindings)
+
+        let insert = try fixture.database.prepareInvocation(
+            with: definitions.insert
+        )
+        let insertParameter = try insert.preparedParameter(
+            DescriptorToken.self,
+            identifiedBy: definitions.parameterIdentity
+        )
+        for rawValue in [7, 7, 9] {
+            try insert.execute(
+                bindings: try tokenPacket(
+                    rawValue,
+                    parameter: insertParameter,
+                    layout: insert.parameterLayout
+                )
+            )
+        }
+
+        let many = try fixture.database.prepareInvocation(with: definitions.many)
+        let manyCodec = try many.resultCodec(
+            DescriptorToken.self,
+            identifiedBy: definitions.resultIdentity
+        )
+        let manyRows = try many.fetchAllValues(bindings: emptyBindings)
+        XCTAssertEqual(
+            try manyRows.map { try manyCodec.decode($0[0]).rawValue },
+            [7, 7, 9]
+        )
+
+        let zeroOrOne = try fixture.database.prepareInvocation(
+            with: definitions.zeroOrOne
+        )
+        let zeroOrOneParameter = try zeroOrOne.preparedParameter(
+            DescriptorToken.self,
+            identifiedBy: definitions.parameterIdentity
+        )
+        let zeroOrOneCodec = try zeroOrOne.resultCodec(
+            DescriptorToken.self,
+            identifiedBy: definitions.resultIdentity
+        )
+        let missing = try zeroOrOne.fetchZeroOrOneValues(
+            bindings: try tokenPacket(
+                42,
+                parameter: zeroOrOneParameter,
+                layout: zeroOrOne.parameterLayout
+            )
+        )
+        XCTAssertNil(missing)
+        let one = try XCTUnwrap(
+            zeroOrOne.fetchZeroOrOneValues(
+                bindings: try tokenPacket(
+                    9,
+                    parameter: zeroOrOneParameter,
+                    layout: zeroOrOne.parameterLayout
+                )
+            )
+        )
+        XCTAssertEqual(try zeroOrOneCodec.decode(one[0]).rawValue, 9)
+        XCTAssertThrowsError(
+            try zeroOrOne.fetchZeroOrOneValues(
+                bindings: try tokenPacket(
+                    7,
+                    parameter: zeroOrOneParameter,
+                    layout: zeroOrOne.parameterLayout
+                )
+            )
+        ) { error in
+            guard case .rowCountMismatch(_, .zeroOrOne, 2) =
+                error as? GRDBStaticQueryError else {
+                return XCTFail("Expected zero-or-one overflow, received \(error)")
+            }
+        }
+
+        let exactlyOne = try fixture.database.prepareInvocation(
+            with: definitions.exactlyOne
+        )
+        let exactlyOneParameter = try exactlyOne.preparedParameter(
+            DescriptorToken.self,
+            identifiedBy: definitions.parameterIdentity
+        )
+        XCTAssertEqual(
+            try exactlyOne.fetchExactlyOneValues(
+                bindings: try tokenPacket(
+                    9,
+                    parameter: exactlyOneParameter,
+                    layout: exactlyOne.parameterLayout
+                )
+            )[0],
+            .integer(9)
+        )
+        for (value, expectedCount) in [(42, 0), (7, 2)] {
+            XCTAssertThrowsError(
+                try exactlyOne.fetchExactlyOneValues(
+                    bindings: try tokenPacket(
+                        value,
+                        parameter: exactlyOneParameter,
+                        layout: exactlyOne.parameterLayout
+                    )
+                )
+            ) { error in
+                guard case .rowCountMismatch(_, .exactlyOne, let actualCount) =
+                    error as? GRDBStaticQueryError else {
+                    return XCTFail("Expected exactly-one row-count failure, received \(error)")
+                }
+                XCTAssertEqual(actualCount, expectedCount)
+            }
+        }
+
+        XCTAssertThrowsError(
+            try many.fetchExactlyOneValues(bindings: emptyBindings)
+        ) { error in
+            guard case .operationCardinalityMismatch(_, .exactlyOne, .many) =
+                error as? GRDBStaticQueryError else {
+                return XCTFail("Expected cardinality mismatch, received \(error)")
+            }
+        }
+    }
+
+    func testOnePreparedDescriptorExecutesContextualPacketsConcurrently() async throws {
+        let contract = try makeContract()
+        let definition = try makeScalarDefinition(contract: contract)
+        let identity = definition.identity
+        let sql = definition.statement.sql
+
+        let fixture = try makeDatabase(configuration: contract.configuration)
+        defer { fixture.tearDown() }
+
+        let prepared = try fixture.database.prepareInvocation(with: definition)
+        let parameter = try prepared.preparedParameter(
+            DescriptorToken.self,
+            identifiedBy: contract.parameterIdentity
+        )
+        let resultCodec = try prepared.resultCodec(
+            DescriptorToken.self,
+            identifiedBy: contract.resultIdentity
+        )
+        requireSendable(prepared)
+        requireSendable(parameter)
+        requireSendable(resultCodec)
+
+        let values = try await withThrowingTaskGroup(
+            of: Int64.self,
+            returning: [Int64].self
+        ) { group in
+            for rawValue in 0 ..< 32 {
+                group.addTask {
+                    let packet = try tokenPacket(
+                        rawValue,
+                        parameter: parameter,
+                        layout: prepared.parameterLayout
+                    )
+                    let row = try prepared.fetchExactlyOneValues(
+                        bindings: packet
+                    )
+                    return try resultCodec.decode(row[0]).rawValue
+                }
+            }
+
+            var results: [Int64] = []
+            for try await value in group {
+                results.append(value)
+            }
+            return results
+        }
+
+        XCTAssertEqual(Set(values), Set((0 ..< 32).map(Int64.init)))
+        XCTAssertEqual(definition.identity, identity)
+        XCTAssertEqual(definition.statement.sql, sql)
+    }
+
+    func testPreparationRejectsDialectAndCodingSnapshotMismatches() throws {
+        let contract = try makeContract()
+        let definition = try makeScalarDefinition(contract: contract)
+
+        let emptyConfiguration = try XLValueCodingConfiguration()
+        let emptyFixture = try makeDatabase(configuration: emptyConfiguration)
+        defer { emptyFixture.tearDown() }
+        XCTAssertThrowsError(
+            try emptyFixture.database.prepareInvocation(with: definition)
+        ) { error in
+            guard case .preparedCodecUnavailable? =
+                error as? XLInvocationBindingError else {
+                return XCTFail("Expected unavailable parameter codec, received \(error)")
+            }
+        }
+
+        let mismatchedCodec = XLValueCodec<DescriptorToken, XLSQLiteDialect>(
+            key: contract.codec.identity.key,
+            valueTypeIdentifier: contract.codec.identity.valueTypeIdentifier,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "text"),
+            encode: { value, _, _ in .text(String(value.rawValue)) },
+            decode: { value, _, _ in
+                guard case .text(let text) = value,
+                      let rawValue = Int64(text) else {
+                    throw DescriptorFixtureError.invalidValue
+                }
+                return DescriptorToken(rawValue: rawValue)
+            }
+        )
+        let mismatchedConfiguration = try XLValueCodingConfiguration(
+            registry: XLValueCodecRegistry().registering(mismatchedCodec),
+            defaultCodecKeys: [mismatchedCodec.identity.key]
+        )
+        let mismatchedFixture = try makeDatabase(
+            configuration: mismatchedConfiguration
+        )
+        defer { mismatchedFixture.tearDown() }
+        XCTAssertThrowsError(
+            try mismatchedFixture.database.prepareInvocation(with: definition)
+        ) { error in
+            guard case .preparedCodecIdentityMismatch? =
+                error as? XLInvocationBindingError else {
+                return XCTFail("Expected mismatched parameter codec, received \(error)")
+            }
+        }
+
+        let resultOnly = try makeResultOnlyDefinition(contract: contract)
+        XCTAssertThrowsError(
+            try emptyFixture.database.prepareInvocation(with: resultOnly)
+        ) { error in
+            guard case .resultCodecUnavailable? =
+                error as? GRDBStaticQueryError else {
+                return XCTFail("Expected unavailable result codec, received \(error)")
+            }
+        }
+
+        let foreignStatement = XLStaticStatementDefinition(
+            sql: "SELECT 1",
+            dialectRequirement: XLDialectRequirement(
+                identity: XLDialectIdentifier(rawValue: "foreign")
+            )
+        )
+        let foreignDescriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "foreign"],
+                version: 1
+            ),
+            statement: foreignStatement,
+            parameters: [],
+            results: .empty,
+            cardinality: .command
+        )
+        let validFixture = try makeDatabase(
+            configuration: contract.configuration
+        )
+        defer { validFixture.tearDown() }
+        XCTAssertThrowsError(
+            try validFixture.database.prepareInvocation(with: foreignDescriptor)
+        ) { error in
+            guard case .dialectMismatch(let expected, let actual) =
+                error as? XLDatabaseContractError else {
+                return XCTFail("Expected dialect mismatch, received \(error)")
+            }
+            XCTAssertEqual(expected, XLDialectIdentifier(rawValue: "foreign"))
+            XCTAssertEqual(actual, XLSQLiteDialect.identity)
+        }
+    }
+
+    func testIntrinsicParameterStorageMismatchFailsBeforeGRDBExecution() throws {
+        let parameterIdentity = try XLQuerySlotIdentity(
+            path: ["tests", "intrinsic", "parameter"]
+        )
+        let resultIdentity = try XLQuerySlotIdentity(
+            path: ["tests", "intrinsic", "result"]
+        )
+        let storage = XLValueStorageIdentifier(rawValue: "integer")
+        let slot = XLParameterSlot(
+            index: XLLogicalParameterIndex(0),
+            key: .named("value"),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: String(reflecting: Int.self),
+            nullability: .required,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("value")
+            )
+        )
+        let layout = try XLParameterLayout(slots: [slot])
+        let result = XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(0),
+            identity: resultIdentity,
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: String(reflecting: Int.self),
+            nullability: .required,
+            codecIdentity: nil,
+            storageIdentifier: storage,
+            codingContext: XLValueCodingContext(
+                site: .result,
+                path: XLValueCodingPath("value")
+            )
+        )
+        let descriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "static-query", "intrinsic-storage"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: "SELECT :value",
+                dialectRequirement: sqliteRequirement,
+                parameterLayout: layout
+            ),
+            parameters: [
+                XLStaticQueryParameterMetadata(
+                    identity: parameterIdentity,
+                    slot: slot,
+                    storageIdentifier: storage
+                )
+            ],
+            results: try XLStaticQueryResultMetadata(slots: [result]),
+            cardinality: .exactlyOne
+        )
+
+        let fixture = try makeDatabase(
+            configuration: XLValueCodingConfiguration()
+        )
+        defer { fixture.tearDown() }
+        let prepared = try fixture.database.prepareInvocation(with: descriptor)
+        let invalidPacket = try XLInvocationBindings(
+            layout: layout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: slot,
+                    value: XLSQLiteValue.text("82")
+                )
+            ]
+        )
+        XCTAssertThrowsError(
+            try prepared.fetchExactlyOneValues(bindings: invalidPacket)
+        ) { error in
+            guard case .parameterStorageMismatch(
+                _,
+                let parameter,
+                let actual
+            ) = error as? GRDBStaticQueryError else {
+                return XCTFail("Expected intrinsic storage mismatch, received \(error)")
+            }
+            XCTAssertEqual(parameter.identity, parameterIdentity)
+            XCTAssertEqual(actual, XLValueStorageIdentifier(rawValue: "text"))
+        }
+
+        let validPacket = try XLInvocationBindings(
+            layout: layout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: slot,
+                    value: XLSQLiteValue.integer(82)
+                )
+            ]
+        )
+        XCTAssertEqual(
+            try prepared.fetchExactlyOneValues(bindings: validPacket),
+            [.integer(82)]
+        )
+    }
+
+    func testPreparationRejectsUnsupportedSQLiteStorageMetadata() throws {
+        let unsupported = XLValueStorageIdentifier(
+            rawValue: "tests.unsupported-sqlite-storage"
+        )
+        let parameterIdentity = try XLQuerySlotIdentity(
+            path: ["tests", "unsupported-storage", "parameter"]
+        )
+        let parameterSlot = XLParameterSlot(
+            index: XLLogicalParameterIndex(0),
+            key: .named("value"),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: String(reflecting: Int.self),
+            nullability: .required,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("value")
+            )
+        )
+        let parameterLayout = try XLParameterLayout(slots: [parameterSlot])
+        let parameterMetadata = XLStaticQueryParameterMetadata(
+            identity: parameterIdentity,
+            slot: parameterSlot,
+            storageIdentifier: unsupported
+        )
+        let parameterDescriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "static-query", "unsupported-parameter-storage"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: "SELECT :value",
+                dialectRequirement: sqliteRequirement,
+                parameterLayout: parameterLayout
+            ),
+            parameters: [parameterMetadata],
+            results: .empty,
+            cardinality: .command
+        )
+
+        let resultIdentity = try XLQuerySlotIdentity(
+            path: ["tests", "unsupported-storage", "result"]
+        )
+        let resultSlot = XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(0),
+            identity: resultIdentity,
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: String(reflecting: Int.self),
+            nullability: .required,
+            codecIdentity: nil,
+            storageIdentifier: unsupported,
+            codingContext: XLValueCodingContext(
+                site: .result,
+                path: XLValueCodingPath("value")
+            )
+        )
+        let emptyManyDescriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "static-query", "unsupported-result-storage"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: "SELECT 1 WHERE 0",
+                dialectRequirement: sqliteRequirement
+            ),
+            parameters: [],
+            results: try XLStaticQueryResultMetadata(slots: [resultSlot]),
+            cardinality: .many
+        )
+
+        let fixture = try makeDatabase(
+            configuration: XLValueCodingConfiguration()
+        )
+        defer { fixture.tearDown() }
+
+        XCTAssertThrowsError(
+            try fixture.database.prepareInvocation(with: parameterDescriptor)
+        ) { error in
+            guard case .unsupportedParameterStorage(
+                let identity,
+                let parameter
+            ) = error as? GRDBStaticQueryError else {
+                return XCTFail(
+                    "Expected unsupported parameter storage, received \(error)"
+                )
+            }
+            XCTAssertEqual(identity, parameterDescriptor.identity)
+            XCTAssertEqual(parameter, parameterMetadata)
+        }
+
+        XCTAssertThrowsError(
+            try fixture.database.prepareInvocation(with: emptyManyDescriptor)
+        ) { error in
+            guard case .unsupportedResultStorage(let identity, let slot) =
+                error as? GRDBStaticQueryError else {
+                return XCTFail(
+                    "Expected unsupported result storage, received \(error)"
+                )
+            }
+            XCTAssertEqual(identity, emptyManyDescriptor.identity)
+            XCTAssertEqual(slot, resultSlot)
+        }
+    }
+
+    func testRawRowsAreValidatedAgainstStaticResultMetadata() throws {
+        let contract = try makeContract()
+        let results = try tokenResults(contract: contract)
+        func descriptor(
+            named name: String,
+            sql: String
+        ) throws -> XLStaticQueryDescriptor {
+            try XLStaticQueryDescriptor(
+                definitionIdentity: XLQueryDefinitionIdentity(
+                    path: ["tests", "static-query", "invalid-result", name],
+                    version: 1
+                ),
+                statement: XLStaticStatementDefinition(
+                    sql: sql,
+                    dialectRequirement: sqliteRequirement
+                ),
+                parameters: [],
+                results: results,
+                cardinality: .exactlyOne
+            )
+        }
+
+        let nullDescriptor = try descriptor(named: "null", sql: "SELECT NULL")
+        let storageDescriptor = try descriptor(
+            named: "storage",
+            sql: "SELECT 'wrong'"
+        )
+        let columnsDescriptor = try descriptor(
+            named: "columns",
+            sql: "SELECT 1, 2"
+        )
+
+        let fixture = try makeDatabase(configuration: contract.configuration)
+        defer { fixture.tearDown() }
+        let emptyBindings = XLInvocationBindings<XLSQLiteValue>(layout: .empty)
+
+        let nullPrepared = try fixture.database.prepareInvocation(
+            with: nullDescriptor
+        )
+        XCTAssertThrowsError(
+            try nullPrepared.fetchExactlyOneValues(bindings: emptyBindings)
+        ) { error in
+            guard case .nullForRequiredResult(_, let slot) =
+                error as? GRDBStaticQueryError else {
+                return XCTFail("Expected required-result NULL failure, received \(error)")
+            }
+            XCTAssertEqual(slot.identity, contract.resultIdentity)
+        }
+
+        let storagePrepared = try fixture.database.prepareInvocation(
+            with: storageDescriptor
+        )
+        XCTAssertThrowsError(
+            try storagePrepared.fetchExactlyOneValues(bindings: emptyBindings)
+        ) { error in
+            guard case .resultStorageMismatch(_, let slot, let actual) =
+                error as? GRDBStaticQueryError else {
+                return XCTFail("Expected result storage failure, received \(error)")
+            }
+            XCTAssertEqual(slot.identity, contract.resultIdentity)
+            XCTAssertEqual(actual, XLValueStorageIdentifier(rawValue: "text"))
+        }
+
+        let columnsPrepared = try fixture.database.prepareInvocation(
+            with: columnsDescriptor
+        )
+        XCTAssertThrowsError(
+            try columnsPrepared.fetchExactlyOneValues(bindings: emptyBindings)
+        ) { error in
+            guard case .resultColumnCountMismatch(_, 0, 1, 2) =
+                error as? GRDBStaticQueryError else {
+                return XCTFail("Expected result column-count failure, received \(error)")
+            }
+        }
+    }
+}
+
+
+private struct DescriptorContract {
+    let dialect: XLSQLiteDialect
+    let codec: XLValueCodec<DescriptorToken, XLSQLiteDialect>
+    let configuration: XLValueCodingConfiguration
+    let parameterIdentity: XLQuerySlotIdentity
+    let resultIdentity: XLQuerySlotIdentity
+}
+
+
+private struct DescriptorDefinitions {
+    let create: XLStaticQueryDescriptor
+    let insert: XLStaticQueryDescriptor
+    let exactlyOne: XLStaticQueryDescriptor
+    let zeroOrOne: XLStaticQueryDescriptor
+    let many: XLStaticQueryDescriptor
+    let parameterIdentity: XLQuerySlotIdentity
+    let resultIdentity: XLQuerySlotIdentity
+}
+
+
+private struct DescriptorToken: Equatable, Sendable {
+    let rawValue: Int64
+}
+
+
+private struct DescriptorDatabaseFixture {
+    let directoryURL: URL
+    let database: GRDBDatabase
+
+    func tearDown() {
+        try? database.databasePool.close()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+}
+
+
+private enum DescriptorFixtureError: Error {
+    case invalidValue
+}
+
+
+private func makeContract() throws -> DescriptorContract {
+    let dialect = XLSQLiteDialect()
+    let codec = XLValueCodec<DescriptorToken, XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.static-query.token", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(
+            rawValue: "tests.DescriptorToken"
+        ),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: XLValueStorageIdentifier(rawValue: "integer"),
+        encode: { value, _, _ in .integer(value.rawValue) },
+        decode: { value, _, _ in
+            guard case .integer(let rawValue) = value else {
+                throw DescriptorFixtureError.invalidValue
+            }
+            return DescriptorToken(rawValue: rawValue)
+        }
+    )
+    let configuration = try XLValueCodingConfiguration(
+        registry: XLValueCodecRegistry().registering(codec),
+        defaultCodecKeys: [codec.identity.key]
+    )
+    return try DescriptorContract(
+        dialect: dialect,
+        codec: codec,
+        configuration: configuration,
+        parameterIdentity: XLQuerySlotIdentity(
+            path: ["tests", "parameter", "token"]
+        ),
+        resultIdentity: XLQuerySlotIdentity(
+            path: ["tests", "result", "token"]
+        )
+    )
+}
+
+
+private func makeDefinitions(
+    contract: DescriptorContract
+) throws -> DescriptorDefinitions {
+    let emptyResults = XLStaticQueryResultMetadata.empty
+    let create = try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: ["tests", "static-query", "create"],
+            version: 1
+        ),
+        statement: XLStaticStatementDefinition(
+            sql: "CREATE TABLE static_query_items (id INTEGER PRIMARY KEY, token INTEGER NOT NULL)",
+            dialectRequirement: sqliteRequirement
+        ),
+        parameters: [],
+        results: emptyResults,
+        cardinality: .command
+    )
+
+    let insertParameter = try preparedTokenParameter(
+        contract: contract,
+        contextPath: ["insert", "token"]
+    )
+    let insertLayout = try XLParameterLayout(slots: [insertParameter.slot])
+    let insert = try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: ["tests", "static-query", "insert"],
+            version: 1
+        ),
+        statement: XLStaticStatementDefinition(
+            sql: "INSERT INTO static_query_items (token) VALUES (:token)",
+            dialectRequirement: sqliteRequirement,
+            entities: ["static_query_items"],
+            parameterLayout: insertLayout
+        ),
+        parameters: [parameterMetadata(
+            contract: contract,
+            parameter: insertParameter
+        )],
+        results: emptyResults,
+        cardinality: .command
+    )
+
+    let filterParameter = try preparedTokenParameter(
+        contract: contract,
+        contextPath: ["filter", "token"]
+    )
+    let filterLayout = try XLParameterLayout(slots: [filterParameter.slot])
+    let filterParameters = [parameterMetadata(
+        contract: contract,
+        parameter: filterParameter
+    )]
+    let results = try tokenResults(contract: contract)
+    let querySQL = "SELECT token FROM static_query_items WHERE token = :token ORDER BY id"
+    let exactlyOne = try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: ["tests", "static-query", "exactly-one"],
+            version: 1
+        ),
+        statement: XLStaticStatementDefinition(
+            sql: querySQL,
+            dialectRequirement: sqliteRequirement,
+            entities: ["static_query_items"],
+            parameterLayout: filterLayout
+        ),
+        parameters: filterParameters,
+        results: results,
+        cardinality: .exactlyOne
+    )
+    let zeroOrOne = try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: ["tests", "static-query", "zero-or-one"],
+            version: 1
+        ),
+        statement: XLStaticStatementDefinition(
+            sql: querySQL,
+            dialectRequirement: sqliteRequirement,
+            entities: ["static_query_items"],
+            parameterLayout: filterLayout
+        ),
+        parameters: filterParameters,
+        results: results,
+        cardinality: .zeroOrOne
+    )
+    let many = try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: ["tests", "static-query", "many"],
+            version: 1
+        ),
+        statement: XLStaticStatementDefinition(
+            sql: "SELECT token FROM static_query_items ORDER BY id",
+            dialectRequirement: sqliteRequirement,
+            entities: ["static_query_items"]
+        ),
+        parameters: [],
+        results: results,
+        cardinality: .many
+    )
+    return DescriptorDefinitions(
+        create: create,
+        insert: insert,
+        exactlyOne: exactlyOne,
+        zeroOrOne: zeroOrOne,
+        many: many,
+        parameterIdentity: contract.parameterIdentity,
+        resultIdentity: contract.resultIdentity
+    )
+}
+
+
+private func makeScalarDefinition(
+    contract: DescriptorContract
+) throws -> XLStaticQueryDescriptor {
+    let parameterContext = XLValueCodingContext(
+        site: .parameter,
+        path: XLValueCodingPath(["scalar", "token"])
+    )
+    let resolved = try contract.configuration.resolvedCodec(
+        for: DescriptorToken.self,
+        using: contract.dialect,
+        context: parameterContext
+    )
+    let reference = XLContextualBindingReference<
+        DescriptorToken,
+        Int,
+        XLSQLiteDialect
+    >(
+        key: .named("token"),
+        codec: resolved
+    )
+    let encoding = try XLiteEncoder(dialect: contract.dialect)
+        .makeValidatedSQL(sql { _ in Select(reference) })
+    let statement = try XLStaticStatementDefinition(validating: encoding)
+    let parameter = try reference.staticQueryParameter(
+        identity: contract.parameterIdentity,
+        in: statement.parameterLayout
+    )
+    return try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: ["tests", "static-query", "scalar"],
+            version: 1
+        ),
+        statement: statement,
+        parameters: [parameter],
+        results: tokenResults(contract: contract),
+        cardinality: .exactlyOne
+    )
+}
+
+
+private func makeResultOnlyDefinition(
+    contract: DescriptorContract
+) throws -> XLStaticQueryDescriptor {
+    try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: ["tests", "static-query", "result-only"],
+            version: 1
+        ),
+        statement: XLStaticStatementDefinition(
+            sql: "SELECT 1",
+            dialectRequirement: sqliteRequirement
+        ),
+        parameters: [],
+        results: tokenResults(contract: contract),
+        cardinality: .many
+    )
+}
+
+
+private func preparedTokenParameter(
+    contract: DescriptorContract,
+    contextPath: [String]
+) throws -> XLPreparedParameter<DescriptorToken, XLSQLiteDialect> {
+    let codec = try contract.configuration.resolvedCodec(
+        for: DescriptorToken.self,
+        using: contract.dialect,
+        context: XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(contextPath)
+        )
+    )
+    return XLPreparedParameter(
+        index: XLLogicalParameterIndex(0),
+        key: .named("token"),
+        nullability: .required,
+        codec: codec
+    )
+}
+
+
+private func parameterMetadata(
+    contract: DescriptorContract,
+    parameter: XLPreparedParameter<DescriptorToken, XLSQLiteDialect>
+) -> XLStaticQueryParameterMetadata {
+    XLStaticQueryParameterMetadata(
+        identity: contract.parameterIdentity,
+        slot: parameter.slot,
+        storageIdentifier: parameter.codecIdentity.storageIdentifier
+    )
+}
+
+
+private func tokenResults(
+    contract: DescriptorContract
+) throws -> XLStaticQueryResultMetadata {
+    try XLStaticQueryResultMetadata(slots: [
+        XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(0),
+            identity: contract.resultIdentity,
+            valueTypeIdentifier: contract.codec.identity.valueTypeIdentifier,
+            valueTypeName: String(reflecting: DescriptorToken.self),
+            nullability: .required,
+            codecIdentity: contract.codec.identity,
+            storageIdentifier: contract.codec.identity.storageIdentifier,
+            codingContext: XLValueCodingContext(
+                site: .result,
+                path: XLValueCodingPath(["result", "token"])
+            )
+        )
+    ])
+}
+
+
+private func tokenPacket(
+    _ rawValue: Int,
+    parameter: XLPreparedParameter<DescriptorToken, XLSQLiteDialect>,
+    layout: XLParameterLayout
+) throws -> XLInvocationBindings<XLSQLiteValue> {
+    try tokenPacket(
+        Int64(rawValue),
+        parameter: parameter,
+        layout: layout
+    )
+}
+
+
+private func tokenPacket(
+    _ rawValue: Int64,
+    parameter: XLPreparedParameter<DescriptorToken, XLSQLiteDialect>,
+    layout: XLParameterLayout
+) throws -> XLInvocationBindings<XLSQLiteValue> {
+    try XLInvocationBindings(
+        layout: layout,
+        bindings: [parameter.encode(DescriptorToken(rawValue: rawValue))]
+    )
+}
+
+
+private func makeDatabase(
+    configuration: XLValueCodingConfiguration
+) throws -> DescriptorDatabaseFixture {
+    let directoryURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("swiftql-static-query-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: false
+    )
+    let databasePool = try DatabasePool(
+        path: directoryURL.appendingPathComponent("database.sqlite").path
+    )
+    let database = try GRDBDatabase(
+        databasePool: databasePool,
+        codingConfiguration: configuration,
+        formatter: XLiteFormatter(),
+        logger: nil
+    )
+    return DescriptorDatabaseFixture(
+        directoryURL: directoryURL,
+        database: database
+    )
+}
+
+
+private var sqliteRequirement: XLDialectRequirement {
+    XLDialectRequirement(
+        identity: XLSQLiteDialect.identity,
+        capabilities: [.namedBindings]
+    )
+}
+
+
+private func requireSendable<T: Sendable>(_: T) {}

--- a/Tests/SwiftQLCoreTests/SQLStaticQueryDescriptorTests.swift
+++ b/Tests/SwiftQLCoreTests/SQLStaticQueryDescriptorTests.swift
@@ -1,0 +1,733 @@
+import Foundation
+import XCTest
+
+import SwiftQLCore
+
+
+final class SQLStaticQueryDescriptorTests: XCTestCase {
+
+    func testCanonicalIdentityIsStableAcrossUnorderedInputAndInvocationValues() throws {
+        let forward = try makeDescriptor(
+            entities: ["zeta", "alpha"],
+            parametersReversed: false
+        )
+        let reversed = try makeDescriptor(
+            entities: ["alpha", "zeta"],
+            parametersReversed: true
+        )
+
+        XCTAssertEqual(forward.identity, reversed.identity)
+        XCTAssertEqual(forward.canonicalIdentityMaterial, reversed.canonicalIdentityMaterial)
+        requireSendable(forward)
+        requireSendable(forward.identity)
+        XCTAssertEqual(
+            forward.parameters.map(\.slot.index),
+            [XLLogicalParameterIndex(0), XLLogicalParameterIndex(1)]
+        )
+
+        let firstPacket = try XLInvocationBindings<XLSQLiteValue>(
+            layout: forward.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(forward.parameterLayout.slot(at: .init(0))),
+                    value: .integer(1)
+                ),
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(forward.parameterLayout.slot(at: .init(1))),
+                    value: .text("first")
+                ),
+            ]
+        )
+        let secondPacket = try XLInvocationBindings<XLSQLiteValue>(
+            layout: forward.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(forward.parameterLayout.slot(at: .init(0))),
+                    value: .integer(99)
+                ),
+                try XLInvocationBinding(
+                    slot: try XCTUnwrap(forward.parameterLayout.slot(at: .init(1))),
+                    value: .text("second")
+                ),
+            ]
+        )
+
+        XCTAssertNotEqual(firstPacket, secondPacket)
+        XCTAssertEqual(forward.identity, reversed.identity)
+    }
+
+    func testSameContractCodecAndDiagnosticChangesDoNotChangeIdentity() throws {
+        let first = try makeContextualDescriptor(
+            codecKey: XLValueCodecKey(id: "tests.token.first", version: 1),
+            valueTypeName: "OriginalModule.Token",
+            codingPath: ["original", "token"],
+            storage: "integer"
+        )
+        let second = try makeContextualDescriptor(
+            codecKey: XLValueCodecKey(id: "tests.token.second", version: 99),
+            valueTypeName: "RenamedModule.Token",
+            codingPath: ["renamed", "value"],
+            storage: "integer"
+        )
+
+        XCTAssertNotEqual(first, second)
+        XCTAssertNotEqual(
+            first.parameters[0].slot.codecIdentity,
+            second.parameters[0].slot.codecIdentity
+        )
+        XCTAssertEqual(first.identity, second.identity)
+        XCTAssertNoThrow(
+            try first.identity.validateDefinitionCompatibility(with: second.identity)
+        )
+    }
+
+    func testStorageSQLCapabilityLayoutAndCardinalityChangesAffectIdentity() throws {
+        let baseline = try makeContextualDescriptor(storage: "integer")
+        let storage = try makeContextualDescriptor(storage: "text")
+        let sql = try makeContextualDescriptor(
+            sql: "SELECT CAST(:token AS TEXT)"
+        )
+        let capabilities = try makeContextualDescriptor(
+            capabilities: [.namedBindings, .indexedBindings]
+        )
+        let nullable = try makeContextualDescriptor(nullability: .nullable)
+        let many = try makeContextualDescriptor(cardinality: .many)
+
+        XCTAssertNotEqual(baseline.identity, storage.identity)
+        XCTAssertNotEqual(baseline.identity, sql.identity)
+        XCTAssertNotEqual(baseline.identity, capabilities.identity)
+        XCTAssertNotEqual(baseline.identity, nullable.identity)
+        XCTAssertNotEqual(baseline.identity, many.identity)
+    }
+
+    func testEveryDialectRequirementComponentAffectsIdentity() throws {
+        let baseline = try makeCommandDescriptor(
+            dialect: "example.custom",
+            minimumVersion: nil,
+            capabilities: []
+        )
+        let dialect = try makeCommandDescriptor(
+            dialect: "example.other",
+            minimumVersion: nil,
+            capabilities: []
+        )
+        let version = try makeCommandDescriptor(
+            dialect: "example.custom",
+            minimumVersion: XLDialectVersion(2, 1, 0),
+            capabilities: []
+        )
+        let capabilities = try makeCommandDescriptor(
+            dialect: "example.custom",
+            minimumVersion: nil,
+            capabilities: [.indexedBindings]
+        )
+
+        XCTAssertNotEqual(baseline.identity, dialect.identity)
+        XCTAssertNotEqual(baseline.identity, version.identity)
+        XCTAssertNotEqual(baseline.identity, capabilities.identity)
+    }
+
+    func testDefinitionCollisionFailsClosedAndVersionBumpIsDistinct() throws {
+        let first = try makeContextualDescriptor(sql: "SELECT :token")
+        let collision = try makeContextualDescriptor(sql: "SELECT +:token")
+
+        XCTAssertThrowsError(
+            try first.identity.validateDefinitionCompatibility(
+                with: collision.identity
+            )
+        ) { error in
+            guard case .definitionIdentityCollision(
+                let definition,
+                let existing,
+                let incoming
+            ) = error as? XLStaticQueryError else {
+                return XCTFail("Expected definition collision, received \(error)")
+            }
+            XCTAssertEqual(definition, first.definitionIdentity)
+            XCTAssertEqual(existing, first.identity)
+            XCTAssertEqual(incoming, collision.identity)
+        }
+
+        let nextVersion = try makeContextualDescriptor(
+            definitionVersion: first.definitionIdentity.version + 1,
+            sql: collision.sql
+        )
+        XCTAssertNotEqual(first.identity, nextVersion.identity)
+        XCTAssertNoThrow(
+            try first.identity.validateDefinitionCompatibility(
+                with: nextVersion.identity
+            )
+        )
+    }
+
+    func testIdentityUsesNFCMetadataExactSQLAndFrozenV1Material() throws {
+        let descriptor = try makeGoldenDescriptor()
+
+        XCTAssertEqual(descriptor.identity.formatVersion, .v1)
+        XCTAssertEqual(
+            descriptor.identity.canonicalHex,
+            "5377696674514c2e53746174696351756572794964656e7469747900000100000000000000010000000000000001710000000000000001000000000000000153000000000000000164000000000000000001000000000000000100000000000000010000000000000001700000000000000000000000000000000001780000000000000001740000000000000000016901000000000000000100000000000000010000000000000001720000000000000000000000000000000174000000000000000001690000000000000001000000000000000165"
+        )
+
+        let composed = try XLQueryDefinitionIdentity(
+            path: ["caf\u{00e9}"],
+            version: 1
+        )
+        let decomposed = try XLQueryDefinitionIdentity(
+            path: ["cafe\u{0301}"],
+            version: 1
+        )
+        XCTAssertEqual(composed, decomposed)
+
+        let composedSlot = try XLQuerySlotIdentity(path: ["caf\u{00e9}"])
+        let decomposedSlot = try XLQuerySlotIdentity(path: ["cafe\u{0301}"])
+        XCTAssertEqual(composedSlot, decomposedSlot)
+
+        func metadataDescriptor(
+            definition: XLQueryDefinitionIdentity,
+            slotIdentity: XLQuerySlotIdentity,
+            suffix: String
+        ) throws -> XLStaticQueryDescriptor {
+            let valueType = XLValueTypeIdentifier(rawValue: "value-\(suffix)")
+            let storage = XLValueStorageIdentifier(rawValue: "storage-\(suffix)")
+            let parameter = XLParameterSlot(
+                index: XLLogicalParameterIndex(0),
+                key: .named("key-\(suffix)"),
+                valueTypeIdentifier: valueType,
+                valueTypeName: "Diagnostic.Value",
+                nullability: .required,
+                codecIdentity: nil,
+                codingContext: XLValueCodingContext(
+                    site: .parameter,
+                    path: XLValueCodingPath("ignored")
+                )
+            )
+            return try XLStaticQueryDescriptor(
+                definitionIdentity: definition,
+                statement: XLStaticStatementDefinition(
+                    sql: "SELECT :value",
+                    dialectRequirement: XLDialectRequirement(
+                        identity: XLDialectIdentifier(rawValue: "dialect-\(suffix)"),
+                        capabilities: [.namedBindings]
+                    ),
+                    entities: ["entity-\(suffix)"],
+                    parameterLayout: try XLParameterLayout(slots: [parameter])
+                ),
+                parameters: [
+                    XLStaticQueryParameterMetadata(
+                        identity: slotIdentity,
+                        slot: parameter,
+                        storageIdentifier: storage
+                    ),
+                ],
+                results: try XLStaticQueryResultMetadata(
+                    slots: [
+                        XLStaticQueryResultSlot(
+                            index: XLLogicalResultIndex(0),
+                            identity: slotIdentity,
+                            valueTypeIdentifier: valueType,
+                            valueTypeName: "Diagnostic.Value",
+                            nullability: .required,
+                            codecIdentity: nil,
+                            storageIdentifier: storage,
+                            codingContext: XLValueCodingContext(
+                                site: .result,
+                                path: XLValueCodingPath("ignored")
+                            )
+                        ),
+                    ]
+                ),
+                cardinality: .exactlyOne
+            )
+        }
+
+        let first = try metadataDescriptor(
+            definition: composed,
+            slotIdentity: composedSlot,
+            suffix: "caf\u{00e9}"
+        )
+        let second = try metadataDescriptor(
+            definition: decomposed,
+            slotIdentity: decomposedSlot,
+            suffix: "cafe\u{0301}"
+        )
+
+        XCTAssertEqual(first.identity.canonicalBytes, second.identity.canonicalBytes)
+        XCTAssertEqual(first.identity, second.identity)
+
+        let sqlDefinition = try XLQueryDefinitionIdentity(
+            path: ["tests", "exact-sql"],
+            version: 1
+        )
+        func sqlDescriptor(_ sql: String) throws -> XLStaticQueryDescriptor {
+            try XLStaticQueryDescriptor(
+                definitionIdentity: sqlDefinition,
+                statement: XLStaticStatementDefinition(
+                    sql: sql,
+                    dialectRequirement: XLDialectRequirement(
+                        identity: XLDialectIdentifier(rawValue: "d")
+                    )
+                ),
+                parameters: [],
+                results: .empty,
+                cardinality: .command
+            )
+        }
+        let composedSQL = try sqlDescriptor("SELECT 'caf\u{00e9}'")
+        let decomposedSQL = try sqlDescriptor("SELECT 'cafe\u{0301}'")
+
+        XCTAssertNotEqual(composedSQL.statement, decomposedSQL.statement)
+        XCTAssertNotEqual(composedSQL.identity.canonicalBytes, decomposedSQL.identity.canonicalBytes)
+        XCTAssertNotEqual(composedSQL.identity, decomposedSQL.identity)
+    }
+
+    func testResultMetadataRejectsDuplicateAndNoncontiguousSlots() throws {
+        let slot = try resultSlot(index: 0, identity: ["result", "value"])
+
+        XCTAssertThrowsError(
+            try XLStaticQueryResultMetadata(slots: [slot, slot])
+        ) { error in
+            guard case .conflictingResultIndex(
+                let index,
+                let existing,
+                let incoming
+            ) =
+                error as? XLStaticQueryError else {
+                return XCTFail("Expected duplicate result index, received \(error)")
+            }
+            XCTAssertEqual(index, slot.index)
+            XCTAssertEqual(existing, slot)
+            XCTAssertEqual(incoming, slot)
+        }
+
+        let gap = try resultSlot(index: 1, identity: ["result", "gap"])
+        XCTAssertThrowsError(
+            try XLStaticQueryResultMetadata(slots: [gap])
+        ) { error in
+            guard case .noncontiguousResultIndex(let actual, let expected) =
+                error as? XLStaticQueryError else {
+                return XCTFail("Expected result index gap, received \(error)")
+            }
+            XCTAssertEqual(actual, gap)
+            XCTAssertEqual(expected, XLLogicalResultIndex(0))
+        }
+    }
+
+    func testDescriptorValidationRejectsIncompleteOrIncompatibleMetadata() throws {
+        let slot = intrinsicSlot(
+            index: 0,
+            key: .named("value"),
+            type: "swift.int"
+        )
+        let statement = XLStaticStatementDefinition(
+            sql: "SELECT :value",
+            dialectRequirement: XLDialectRequirement(
+                identity: XLSQLiteDialect.identity,
+                capabilities: [.namedBindings]
+            ),
+            parameterLayout: try XLParameterLayout(slots: [slot])
+        )
+        let definition = try XLQueryDefinitionIdentity(
+            path: ["tests", "invalid"],
+            version: 1
+        )
+
+        XCTAssertThrowsError(
+            try XLStaticQueryDescriptor(
+                definitionIdentity: definition,
+                statement: statement,
+                parameters: [],
+                results: try XLStaticQueryResultMetadata(
+                    slots: [resultSlot(index: 0)]
+                ),
+                cardinality: .exactlyOne
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLStaticQueryError,
+                .parameterMetadataCountMismatch(expected: 1, actual: 0)
+            )
+        }
+
+        let parameterMetadata = XLStaticQueryParameterMetadata(
+            identity: try XLQuerySlotIdentity(path: ["parameter", "value"]),
+            slot: slot,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "integer")
+        )
+
+        let invalidSiteSlot = intrinsicSlot(
+            index: 0,
+            key: .named("value"),
+            type: "swift.int",
+            codingSite: .property
+        )
+        let invalidSiteParameter = XLStaticQueryParameterMetadata(
+            identity: parameterMetadata.identity,
+            slot: invalidSiteSlot,
+            storageIdentifier: parameterMetadata.storageIdentifier
+        )
+        XCTAssertThrowsError(
+            try XLStaticQueryDescriptor(
+                definitionIdentity: definition,
+                statement: XLStaticStatementDefinition(
+                    sql: statement.sql,
+                    dialectRequirement: statement.dialectRequirement,
+                    parameterLayout: try XLParameterLayout(
+                        slots: [invalidSiteSlot]
+                    )
+                ),
+                parameters: [invalidSiteParameter],
+                results: try XLStaticQueryResultMetadata(
+                    slots: [resultSlot(index: 0)]
+                ),
+                cardinality: .exactlyOne
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLStaticQueryError,
+                .invalidParameterCodingSite(
+                    parameter: invalidSiteParameter,
+                    actual: .property
+                )
+            )
+        }
+
+        let propertyResult = try resultSlot(
+            index: 0,
+            codingSite: .property
+        )
+        XCTAssertNoThrow(
+            try XLStaticQueryResultMetadata(slots: [propertyResult])
+        )
+        for invalidSite in [XLValueCodingSite.parameter, .configuration] {
+            let invalidResult = try resultSlot(
+                index: 0,
+                codingSite: invalidSite
+            )
+            XCTAssertThrowsError(
+                try XLStaticQueryResultMetadata(slots: [invalidResult])
+            ) { error in
+                XCTAssertEqual(
+                    error as? XLStaticQueryError,
+                    .invalidResultCodingSite(
+                        result: invalidResult,
+                        actual: invalidSite
+                    )
+                )
+            }
+        }
+
+        XCTAssertThrowsError(
+            try XLStaticQueryDescriptor(
+                definitionIdentity: definition,
+                statement: XLStaticStatementDefinition(
+                    sql: statement.sql,
+                    dialectRequirement: XLDialectRequirement(
+                        identity: XLSQLiteDialect.identity
+                    ),
+                    parameterLayout: statement.parameterLayout
+                ),
+                parameters: [parameterMetadata],
+                results: try XLStaticQueryResultMetadata(
+                    slots: [resultSlot(index: 0)]
+                ),
+                cardinality: .exactlyOne
+            )
+        ) { error in
+            guard case .parameterCapabilityMissing(
+                let actual,
+                let capability
+            ) = error as? XLStaticQueryError else {
+                return XCTFail("Expected missing capability, received \(error)")
+            }
+            XCTAssertEqual(actual, parameterMetadata)
+            XCTAssertEqual(capability, .namedBindings)
+        }
+
+        XCTAssertThrowsError(
+            try XLStaticQueryDescriptor(
+                definitionIdentity: definition,
+                statement: statement,
+                parameters: [
+                    parameterMetadata,
+                ],
+                results: .empty,
+                cardinality: .many
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLStaticQueryError,
+                .rowQueryHasNoResults(cardinality: .many)
+            )
+        }
+
+        XCTAssertThrowsError(
+            try XLStaticQueryDescriptor(
+                definitionIdentity: definition,
+                statement: XLStaticStatementDefinition(
+                    sql: "SELECT 1",
+                    dialectRequirement: XLDialectRequirement(
+                        identity: XLSQLiteDialect.identity
+                    )
+                ),
+                parameters: [],
+                results: .empty,
+                cardinality: .command,
+                identityFormatVersion: .init(rawValue: 2)
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLStaticQueryError,
+                .unsupportedIdentityFormatVersion(.init(rawValue: 2))
+            )
+        }
+    }
+}
+
+
+private extension SQLStaticQueryDescriptorTests {
+
+    func makeDescriptor(
+        entities: Set<String>,
+        parametersReversed: Bool
+    ) throws -> XLStaticQueryDescriptor {
+        let first = intrinsicSlot(
+            index: 0,
+            key: .named("number"),
+            type: "swift.int"
+        )
+        let second = intrinsicSlot(
+            index: 1,
+            key: .named("text"),
+            type: "swift.string",
+            codingPath: ["parameter", "text"]
+        )
+        let layout = try XLParameterLayout(slots: [second, first])
+        let firstMetadata = XLStaticQueryParameterMetadata(
+            identity: try XLQuerySlotIdentity(path: ["parameter", "number"]),
+            slot: first,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "integer")
+        )
+        let secondMetadata = XLStaticQueryParameterMetadata(
+            identity: try XLQuerySlotIdentity(path: ["parameter", "text"]),
+            slot: second,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "text")
+        )
+        let parameters = parametersReversed
+            ? [secondMetadata, firstMetadata]
+            : [firstMetadata, secondMetadata]
+        return try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "canonical"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: "SELECT :number, :text",
+                dialectRequirement: XLDialectRequirement(
+                    identity: XLSQLiteDialect.identity,
+                    capabilities: [.namedBindings]
+                ),
+                entities: entities,
+                parameterLayout: layout
+            ),
+            parameters: parameters,
+            results: try XLStaticQueryResultMetadata(
+                slots: [resultSlot(index: 0)]
+            ),
+            cardinality: .many
+        )
+    }
+
+    func makeContextualDescriptor(
+        definitionVersion: UInt64 = 1,
+        codecKey: XLValueCodecKey = XLValueCodecKey(
+            id: "tests.token",
+            version: 1
+        ),
+        valueTypeName: String = "Tests.Token",
+        codingPath: [String] = ["query", "token"],
+        storage: String = "integer",
+        sql: String = "SELECT :token",
+        capabilities: XLDialectCapabilities = [.namedBindings],
+        nullability: XLParameterNullability = .required,
+        cardinality: XLQueryCardinality = .exactlyOne
+    ) throws -> XLStaticQueryDescriptor {
+        let valueType = XLValueTypeIdentifier(rawValue: "tests.token")
+        let storageIdentifier = XLValueStorageIdentifier(rawValue: storage)
+        let codec = XLValueCodecIdentity(
+            key: codecKey,
+            valueTypeIdentifier: valueType,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: storageIdentifier
+        )
+        let context = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(codingPath)
+        )
+        let parameterSlot = XLParameterSlot(
+            index: XLLogicalParameterIndex(0),
+            key: .named("token"),
+            valueTypeIdentifier: valueType,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codecIdentity: codec,
+            codingContext: context
+        )
+        let result = XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(0),
+            identity: try XLQuerySlotIdentity(path: ["result", "token"]),
+            valueTypeIdentifier: valueType,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codecIdentity: codec,
+            storageIdentifier: storageIdentifier,
+            codingContext: XLValueCodingContext(
+                site: .result,
+                path: XLValueCodingPath(codingPath)
+            )
+        )
+        return try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "contextual"],
+                version: definitionVersion
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: sql,
+                dialectRequirement: XLDialectRequirement(
+                    identity: XLSQLiteDialect.identity,
+                    capabilities: capabilities
+                ),
+                parameterLayout: try XLParameterLayout(slots: [parameterSlot])
+            ),
+            parameters: [
+                XLStaticQueryParameterMetadata(
+                    identity: try XLQuerySlotIdentity(path: ["parameter", "token"]),
+                    slot: parameterSlot,
+                    storageIdentifier: storageIdentifier
+                ),
+            ],
+            results: try XLStaticQueryResultMetadata(slots: [result]),
+            cardinality: cardinality
+        )
+    }
+
+    func makeGoldenDescriptor() throws -> XLStaticQueryDescriptor {
+        let parameter = intrinsicSlot(
+            index: 0,
+            key: .named("x"),
+            type: "t",
+            codingPath: ["p"]
+        )
+        return try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["q"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: "S",
+                dialectRequirement: XLDialectRequirement(
+                    identity: XLDialectIdentifier(rawValue: "d"),
+                    capabilities: [.namedBindings]
+                ),
+                entities: ["e"],
+                parameterLayout: try XLParameterLayout(slots: [parameter])
+            ),
+            parameters: [
+                XLStaticQueryParameterMetadata(
+                    identity: try XLQuerySlotIdentity(path: ["p"]),
+                    slot: parameter,
+                    storageIdentifier: XLValueStorageIdentifier(rawValue: "i")
+                ),
+            ],
+            results: try XLStaticQueryResultMetadata(
+                slots: [
+                    XLStaticQueryResultSlot(
+                        index: XLLogicalResultIndex(0),
+                        identity: try XLQuerySlotIdentity(path: ["r"]),
+                        valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "t"),
+                        valueTypeName: "Diagnostic.T",
+                        nullability: .required,
+                        codecIdentity: nil,
+                        storageIdentifier: XLValueStorageIdentifier(rawValue: "i"),
+                        codingContext: XLValueCodingContext(
+                            site: .result,
+                            path: XLValueCodingPath("ignored")
+                        )
+                    ),
+                ]
+            ),
+            cardinality: .exactlyOne
+        )
+    }
+
+    func makeCommandDescriptor(
+        dialect: String,
+        minimumVersion: XLDialectVersion?,
+        capabilities: XLDialectCapabilities
+    ) throws -> XLStaticQueryDescriptor {
+        try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "dialect-contract"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: "COMMAND",
+                dialectRequirement: XLDialectRequirement(
+                    identity: XLDialectIdentifier(rawValue: dialect),
+                    minimumVersion: minimumVersion,
+                    capabilities: capabilities
+                )
+            ),
+            parameters: [],
+            results: .empty,
+            cardinality: .command
+        )
+    }
+
+    func intrinsicSlot(
+        index: Int,
+        key: XLBindingKey,
+        type: String,
+        nullability: XLParameterNullability = .required,
+        codingPath: [String] = ["parameter", "number"],
+        codingSite: XLValueCodingSite = .parameter
+    ) -> XLParameterSlot {
+        XLParameterSlot(
+            index: XLLogicalParameterIndex(index),
+            key: key,
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: type),
+            valueTypeName: "Diagnostic.\(type)",
+            nullability: nullability,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: codingSite,
+                path: XLValueCodingPath(codingPath)
+            )
+        )
+    }
+
+    func resultSlot(
+        index: Int,
+        identity: [String] = ["result", "value"],
+        codingSite: XLValueCodingSite = .result
+    ) throws -> XLStaticQueryResultSlot {
+        XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(index),
+            identity: try XLQuerySlotIdentity(path: identity),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: "Swift.Int",
+            nullability: .required,
+            codecIdentity: nil,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "integer"),
+            codingContext: XLValueCodingContext(
+                site: codingSite,
+                path: XLValueCodingPath(identity)
+            )
+        )
+    }
+}
+
+
+private func requireSendable<Value: Sendable>(_ value: Value) {
+    _ = value
+}


### PR DESCRIPTION
Closes #129

## Summary

- adds immutable, database-independent static query descriptors with explicit dialect, stable definition/query identities, parameter/result layout, cardinality, entities, storage, coding context, and renderable SQL metadata
- freezes a deterministic v1 canonical identity format using full length-framed bytes, NFC-normalized metadata, exact SQL bytes, and explicit definition collision/version checks
- adds GRDB preparation and execution for command, exactly-one, optional-one, and many cardinalities while retaining no connection-owned physical statement
- validates dialect, SQLite storage, full codec snapshots, binding packets, result shape/nullability/storage, and concurrent invocation isolation
- documents the identity and preparation contracts and exercises them from the committed Swift 5 downstream client

## Validation

- `swift test` — 480 tests, 0 failures
- `scripts/ci/check-strict-concurrency.sh` — clean
- `scripts/ci/check-first-party-warnings.sh` — clean
- `scripts/ci/check-core-contract-boundary.py` — package graph, database references, and isolated SwiftQLCore build pass
- `./make-docs.sh /private/tmp/swiftql-129-docs-20260717` — warnings-as-errors DocC build pass
- `scripts/ci/check-downstream-swift5-client.sh committed` — pass
- `git diff --check` — clean

## Scope

This establishes flat selected-result slots. Generated aggregate/property layout synthesis remains #40, and captured Swift-value inference remains #30.