### PR TITLE
Test QueryBuilder's documented missing-FROM failure

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Add immutable static query descriptors with stable identities",
-  "issue_number": 129,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/129",
+  "task_name": "Test QueryBuilder's documented missing-FROM failure",
+  "issue_number": 194,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/194",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#129 - Add immutable static query descriptors with stable identities",
+  "codex_session_title": "lukevanin/swiftql#194 - Test QueryBuilder's documented missing-FROM failure",
   "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
   "codex_session_url": null,
-  "task_branch": "codex/129-add-immutable-static-query-descriptors-with-stable-identities",
-  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/129-add-immutable-static-query-descriptors-with-stable-identities"
+  "task_branch": "codex/194-test-querybuilders-documented-missing-from-failure",
+  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/194-test-querybuilders-documented-missing-from-failure"
 }

--- a/Tests/SQLTests/Tests/XLQueryBuilderTests.swift
+++ b/Tests/SQLTests/Tests/XLQueryBuilderTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import GRDB
-import SwiftQL
+@testable import SwiftQL
 
     
 final class QueryBuilderTests: XCTestCase {
@@ -38,6 +38,31 @@ final class QueryBuilderTests: XCTestCase {
         let finalResult = try encoder.makeSQL(query.build()).sql
         
         XCTAssertEqual(finalResult, "SELECT `t0`.`id` AS `id`, `t0`.`name` AS `name` FROM `Company` AS `t0`")
+    }
+
+
+    func test_select_without_from_throws_missing_from_clause() throws {
+        let schema = XLSchema()
+        let company = schema.table(CompanyTable.self)
+        let query = QueryBuilder(select: company)
+
+        XCTAssertThrowsError(try query.build()) { error in
+            guard case .missingFromClause? =
+                error as? QueryBuilder<CompanyTable>.InternalError else {
+                return XCTFail(
+                    "Expected missing FROM clause, received \(error)"
+                )
+            }
+        }
+
+        let finalResult = try encoder.makeSQL(
+            query.from(company).build()
+        ).sql
+
+        XCTAssertEqual(
+            finalResult,
+            "SELECT `t0`.`id` AS `id`, `t0`.`name` AS `name` FROM `Company` AS `t0`"
+        )
     }
     
     


### PR DESCRIPTION
Closes #194

## Summary

- adds an exact regression assertion for `QueryBuilder<CompanyTable>.InternalError.missingFromClause`
- proves the same builder renders successfully once `.from(company)` is supplied
- keeps the change test-only and leaves production visibility and behavior unchanged

## Validation

- `swift test --filter QueryBuilderTests` — 14 tests, 0 failures
- `swift test` — 481 tests, 0 failures
- diagnostic LLVM coverage — `QueryBuilder.swift:241` execution count 1
- `git diff --check` — clean

The authoritative clean coverage evidence will come from this PR's pinned coverage job.