### PR TITLE
Replace specialized BETWEEN builder logic with generic composition

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Move SQLite formatter and builder into separate file",
-  "issue_number": 34,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/34",
+  "task_name": "Replace specialised `between` method in XLBuilder with generic methods.",
+  "issue_number": 32,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/32",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#34 - Move SQLite formatter and builder into separate file",
+  "codex_session_title": "lukevanin/swiftql#32 - Replace specialised `between` method in XLBuilder with generic methods.",
   "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
   "codex_session_url": null,
-  "task_branch": "codex/34-move-sqlite-formatter-and-builder-into-separate-file",
-  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/34-move-sqlite-formatter-and-builder-into-separate-file"
+  "task_branch": "codex/32-replace-specialised-between-method-in-xlbuilder-with-generic-methods",
+  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/32-replace-specialised-between-method-in-xlbuilder-with-generic-methods"
 }

--- a/Sources/SwiftQL/SQLEncoder.swift
+++ b/Sources/SwiftQL/SQLEncoder.swift
@@ -454,6 +454,24 @@ extension XLBuilder {
             indexedBinding(index)
         }
     }
+
+    public mutating func between(
+        term: Builder,
+        minimum: Builder,
+        maximum: Builder
+    ) {
+        binaryOperator(
+            "BETWEEN",
+            left: term,
+            right: { context in
+                context.binaryOperator(
+                    "AND",
+                    left: minimum,
+                    right: maximum
+                )
+            }
+        )
+    }
     
     ///
     /// Convenience method used to add a sub-expression with leading and trailing paranthesis.

--- a/Sources/SwiftQL/SQLiteEncoding.swift
+++ b/Sources/SwiftQL/SQLiteEncoding.swift
@@ -510,19 +510,6 @@ public struct XLiteBuilder: XLBuilder {
         _entities.formUnion(rhsExpressionBuilder.entities())
     }
 
-    public mutating func between(term: (inout XLBuilder) -> Void, minimum: (inout XLBuilder) -> Void, maximum: (inout XLBuilder) -> Void) {
-        var termExpressionBuilder: XLBuilder = XLiteBuilder(formatter: formatter)
-        var minimumExpressionBuilder: XLBuilder = XLiteBuilder(formatter: formatter)
-        var maximumExpressionBuilder: XLBuilder = XLiteBuilder(formatter: formatter)
-        term(&termExpressionBuilder)
-        minimum(&minimumExpressionBuilder)
-        maximum(&maximumExpressionBuilder)
-        append(termExpressionBuilder.build() + " BETWEEN " + minimumExpressionBuilder.build() + " AND " + maximumExpressionBuilder.build())
-        _entities.formUnion(termExpressionBuilder.entities())
-        _entities.formUnion(minimumExpressionBuilder.entities())
-        _entities.formUnion(maximumExpressionBuilder.entities())
-    }
-
     public mutating func cast(type: String, expression: (inout XLBuilder) -> Void) {
         var expressionBuilder: XLBuilder = XLiteBuilder(formatter: formatter)
         expression(&expressionBuilder)

--- a/Tests/SQLTests/SQLDialectEncodingContractTests.swift
+++ b/Tests/SQLTests/SQLDialectEncodingContractTests.swift
@@ -143,6 +143,31 @@ final class SQLDialectEncodingContractTests: XCTestCase {
         )
     }
 
+    func testBuilderDefaultBetweenComposesGenericBinaryOperators() {
+        var builder: XLBuilder = XLiteBuilder(formatter: XLiteFormatter())
+
+        builder.between(
+            term: { context in
+                context.name("value")
+                context.entity("term")
+            },
+            minimum: { context in
+                context.integer(1)
+                context.entity("minimum")
+            },
+            maximum: { context in
+                context.integer(3)
+                context.entity("maximum")
+            }
+        )
+
+        XCTAssertEqual(builder.build(), "\"value\" BETWEEN 1 AND 3")
+        XCTAssertEqual(
+            builder.entities(),
+            ["term", "minimum", "maximum"]
+        )
+    }
+
     func testEncoderDerivesPlaceholderCapabilitiesFromRenderedSQL() {
         let encoder = XLiteEncoder(
             dialect: XLSQLiteDialect(version: XLDialectVersion(3, 46))


### PR DESCRIPTION
Closes #32

## Summary

- retains `XLBuilder.between(term:minimum:maximum:)` as a protocol requirement for witness-table dispatch and source compatibility
- supplies a backend-neutral default implementation composed from outer `BETWEEN` and nested `AND` `binaryOperator` calls
- removes the SQLite-specific `XLiteBuilder.between` implementation
- proves exact SQL and entity propagation through an `XLBuilder` existential
- reconciles with squash-merged #169; the issue-specific diff remains limited to the builder seam and focused regression test

## Boundaries

- no typed `BETWEEN` expression API (#31)
- no public signature or argument-label changes
- no parenthesis or SQL-token changes
- no unrelated SQLite builder cleanup

## Validation

- `SQLDialectEncodingContractTests` — 11 tests, 0 failures
- reconciled-head full `swift test` at `f9cef4c1` — 483 tests, 0 failures
- complete strict concurrency — clean
- first-party warning gate — clean
- direct downstream concrete `XLiteBuilder.between` source check — pass
- `git diff --check` — clean
- independent review — no P0–P2 findings