### PR TITLE
Compare coverage topology without requiring identical hit counters

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Replace specialised `between` method in XLBuilder with generic methods.",
-  "issue_number": 32,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/32",
+  "task_name": "Compare coverage source topology without requiring identical concurrent counters",
+  "issue_number": 208,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/208",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#32 - Replace specialised `between` method in XLBuilder with generic methods.",
+  "codex_session_title": "lukevanin/swiftql#208 - Compare coverage source topology without requiring identical concurrent counters",
   "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
   "codex_session_url": null,
-  "task_branch": "codex/32-replace-specialised-between-method-in-xlbuilder-with-generic-methods",
-  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/32-replace-specialised-between-method-in-xlbuilder-with-generic-methods"
+  "task_branch": "codex/208-compare-coverage-source-topology",
+  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/208-compare-coverage-source-topology"
 }

--- a/Coverage/README.md
+++ b/Coverage/README.md
@@ -16,8 +16,20 @@ platform and architecture; dependency graph; package-resolution digest; and
 exact coverage command in its retained artifact.
 
 Every coverage job performs two clean builds in independent SwiftPM scratch
-directories. The job fails if their normalized first-party source manifests
-differ.
+directories. The reproducibility identity requires the same source commit,
+clean-tree state, toolchain and dependency provenance, coverage command,
+filtering metadata, target membership, included and allowed-source manifests,
+and per-file, per-target, and overall static line/function/region counts.
+
+Covered and uncovered hit counters, their derived percentages, and the ranked
+largest-gap list are retained as diagnostic evidence but are not part of that
+identity. Concurrent tests can legitimately merge a different number of hits
+into two otherwise equivalent LLVM profiles. The gate records whether the
+complete dynamic reports matched, but it does not turn that observation into a
+percentage threshold or source-selection failure.
+`reproducibility.json` preserves `normalized_reports_match` as the exact-report
+equality observation, so it can be `false` while
+`reproducibility_identity_matches` remains `true` and the gate succeeds.
 
 ## Filtering contract
 
@@ -50,13 +62,22 @@ Run the fixture tests first:
 python3 scripts/ci/test-source-coverage-report.py
 ```
 
-Then run the real package tests with coverage into a clean output and scratch
-directory:
+Then run two real package-test captures with independent clean output and
+scratch directories and compare their reproducibility identities:
 
 ```bash
-SWIFTQL_COVERAGE_SCRATCH_PATH="${TMPDIR}/swiftql-coverage-build" \
-  scripts/ci/run-source-coverage.sh \
-  "${TMPDIR}/swiftql-coverage-report"
+coverage_root="$(mktemp -d "${TMPDIR:-/tmp}/swiftql-coverage.XXXXXX")"
+
+SWIFTQL_COVERAGE_SCRATCH_PATH="$coverage_root/build-1" \
+  scripts/ci/run-source-coverage.sh "$coverage_root/run-1"
+
+SWIFTQL_COVERAGE_SCRATCH_PATH="$coverage_root/build-2" \
+  scripts/ci/run-source-coverage.sh "$coverage_root/run-2"
+
+scripts/ci/verify-source-coverage-reproducibility.sh \
+  "$coverage_root/run-1" \
+  "$coverage_root/run-2" \
+  "$coverage_root/run-1/reproducibility.json"
 ```
 
 The output directory contains:
@@ -68,6 +89,11 @@ The output directory contains:
 - `allowed-uninstrumented-sources.txt`: explicit zero-region exceptions;
 - `summary.md`: the same concise target totals shown in the GitHub job summary;
 - toolchain, dependency, command, source-commit, and test-log provenance.
+
+After a successful comparison, the first output also contains
+`reproducibility.json` and a copy of the second run's manifest as
+`repeated-included-sources.txt`. Both run directories retain their complete raw
+JSON, LCOV, normalized report, summary, and test log.
 
 Use a new output directory for every run. The script refuses to overwrite a
 prior report and refuses to assign a commit to dirty source content. During

--- a/scripts/ci/test-source-coverage-report.py
+++ b/scripts/ci/test-source-coverage-report.py
@@ -18,6 +18,7 @@ SCRIPT = Path(__file__).with_name("source-coverage-report.py")
 VERIFY_SCRIPT = Path(__file__).with_name(
     "verify-source-coverage-reproducibility.sh"
 )
+RUN_SCRIPT = Path(__file__).with_name("run-source-coverage.sh")
 WORKFLOW = SCRIPT.parents[2] / ".github/workflows/swift.yml"
 INITIAL_BASELINE = (
     SCRIPT.parents[2]
@@ -102,23 +103,28 @@ class SourceCoverageReportTests(unittest.TestCase):
         path.write_text("func coveredFixture() {}\n", encoding="utf-8")
         return path
 
-    def write_config(self, allowed: Optional[List[str]] = None) -> None:
+    def write_config(
+        self,
+        allowed: Optional[List[str]] = None,
+        targets: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> None:
+        configured_targets = list(targets) if targets is not None else [
+            {
+                "name": "SQLMacros",
+                "source_root": "Sources/SQLMacros",
+                "allowed_uninstrumented_sources": [],
+            },
+            {
+                "name": "SwiftQL",
+                "source_root": "Sources/SwiftQL",
+                "allowed_uninstrumented_sources": allowed or [],
+            },
+        ]
         self.config.write_text(
             json.dumps(
                 {
                     "schema_version": 1,
-                    "targets": [
-                        {
-                            "name": "SQLMacros",
-                            "source_root": "Sources/SQLMacros",
-                            "allowed_uninstrumented_sources": [],
-                        },
-                        {
-                            "name": "SwiftQL",
-                            "source_root": "Sources/SwiftQL",
-                            "allowed_uninstrumented_sources": allowed or [],
-                        },
-                    ],
+                    "targets": configured_targets,
                 }
             ),
             encoding="utf-8",
@@ -194,6 +200,54 @@ class SourceCoverageReportTests(unittest.TestCase):
         if not expect_success and result.returncode == 0:
             self.fail("report unexpectedly succeeded")
         return result
+
+    def run_verifier(
+        self,
+        first_name: str,
+        second_name: str,
+        output_name: str = "reproducibility.json",
+    ) -> subprocess.CompletedProcess[str]:
+        first = self.root / first_name
+        second = self.root / second_name
+        return subprocess.run(
+            [str(VERIFY_SCRIPT), str(first), str(second), str(first / output_name)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def read_normalized_report(self, output_name: str) -> Dict[str, Any]:
+        return json.loads(
+            (self.root / output_name / "first-party-coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+    def write_normalized_report(
+        self, output_name: str, report: Dict[str, Any]
+    ) -> None:
+        (self.root / output_name / "first-party-coverage.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def replace_report_value(
+        self, output_name: str, path: Sequence[Any], value: Any
+    ) -> None:
+        report = self.read_normalized_report(output_name)
+        container: Any = report
+        for component in path[:-1]:
+            container = container[component]
+        container[path[-1]] = value
+        self.write_normalized_report(output_name, report)
+
+    def delete_report_value(self, output_name: str, path: Sequence[Any]) -> None:
+        report = self.read_normalized_report(output_name)
+        container: Any = report
+        for component in path[:-1]:
+            container = container[component]
+        del container[path[-1]]
+        self.write_normalized_report(output_name, report)
 
     def test_filters_dependencies_tests_generated_sources_and_benchmarks(self) -> None:
         outside_dependency = (
@@ -401,73 +455,334 @@ class SourceCoverageReportTests(unittest.TestCase):
         self.assertIn("untracked files inside target roots", result.stderr)
         self.assertIn("Sources/NewProductionTarget/New.swift", result.stderr)
 
-    def test_reproducibility_verifier_accepts_equal_and_rejects_different_sets(
-        self,
-    ) -> None:
+    def test_reproducibility_verifier_accepts_equal_reports(self) -> None:
         entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
         self.run_report(entries, "repro-first")
         self.run_report(entries, "repro-second")
-        first = self.root / "repro-first"
-        second = self.root / "repro-second"
-        success = subprocess.run(
-            [str(VERIFY_SCRIPT), str(first), str(second), str(first / "result.json")],
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+        success = self.run_verifier("repro-first", "repro-second")
         self.assertEqual(success.returncode, 0, success.stderr)
-        evidence = json.loads((first / "result.json").read_text(encoding="utf-8"))
+        evidence = json.loads(
+            (
+                self.root
+                / "repro-first/reproducibility.json"
+            ).read_text(encoding="utf-8")
+        )
         self.assertTrue(evidence["included_source_sets_match"])
+        self.assertTrue(evidence["reproducibility_identity_matches"])
         self.assertTrue(evidence["normalized_reports_match"])
-        different_manifest = (
-            "SQLMacros\tSources/SQLMacros/Macro.swift\n"
-            "SwiftQL\tSources/SwiftQL/Alternative.swift\n"
+        self.assertTrue(evidence["dynamic_coverage_metrics_match"])
+
+    def test_reproducibility_verifier_accepts_dynamic_counter_drift(self) -> None:
+        self.run_report(
+            [
+                file_entry(self.sql_macros, (8, 4), (4, 2)),
+                file_entry(self.swiftql, (10, 5), (2, 1)),
+            ],
+            "dynamic-first",
         )
-        (second / "included-sources.txt").write_text(
-            different_manifest, encoding="utf-8"
+        self.run_report(
+            [
+                file_entry(self.sql_macros, (8, 4), (4, 2)),
+                file_entry(self.swiftql, (10, 4), (2, 1)),
+            ],
+            "dynamic-second",
         )
-        second_report_path = second / "first-party-coverage.json"
-        second_report = json.loads(second_report_path.read_text(encoding="utf-8"))
-        second_report["filtering"]["included_sources_sha256"] = hashlib.sha256(
-            different_manifest.encode("utf-8")
-        ).hexdigest()
-        second_report_path.write_text(
-            json.dumps(second_report, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
+        self.assertNotEqual(
+            self.read_normalized_report("dynamic-first"),
+            self.read_normalized_report("dynamic-second"),
         )
-        failure = subprocess.run(
-            [str(VERIFY_SCRIPT), str(first), str(second), str(first / "failure.json")],
-            text=True,
+        self.assertNotEqual(
+            (self.root / "dynamic-first/summary.md").read_bytes(),
+            (self.root / "dynamic-second/summary.md").read_bytes(),
+        )
+        success = self.run_verifier("dynamic-first", "dynamic-second")
+        self.assertEqual(success.returncode, 0, success.stderr)
+        evidence = json.loads(
+            (
+                self.root
+                / "dynamic-first/reproducibility.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertTrue(evidence["reproducibility_identity_matches"])
+        self.assertFalse(evidence["normalized_reports_match"])
+        self.assertFalse(evidence["dynamic_coverage_metrics_match"])
+
+    def test_reproducibility_verifier_rejects_added_or_removed_source(self) -> None:
+        entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
+        self.run_report(entries, "source-first")
+        added = self.make_source("Sources/SwiftQL/Added.swift")
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.root),
+                "add",
+                "--",
+                "Sources/SwiftQL/Added.swift",
+            ],
+            check=True,
             capture_output=True,
-            check=False,
         )
+        self.run_report(entries + [file_entry(added)], "source-second")
+        failure = self.run_verifier("source-first", "source-second")
+        self.assertNotEqual(failure.returncode, 0)
+        self.assertIn("included source manifests differ", failure.stderr)
+        reverse_failure = self.run_verifier(
+            "source-second",
+            "source-first",
+            "removed-source.json",
+        )
+        self.assertNotEqual(reverse_failure.returncode, 0)
+        self.assertIn("included source manifests differ", reverse_failure.stderr)
+
+    def test_reproducibility_verifier_rejects_target_reassignment(self) -> None:
+        entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
+        self.run_report(entries, "target-first")
+        self.write_config(
+            targets=[
+                {
+                    "name": "SQLMacros",
+                    "source_root": "Sources/SwiftQL",
+                    "allowed_uninstrumented_sources": [],
+                },
+                {
+                    "name": "SwiftQL",
+                    "source_root": "Sources/SQLMacros",
+                    "allowed_uninstrumented_sources": [],
+                },
+            ]
+        )
+        self.run_report(entries, "target-second")
+        failure = self.run_verifier("target-first", "target-second")
         self.assertNotEqual(failure.returncode, 0)
         self.assertIn("included source manifests differ", failure.stderr)
 
-    def test_reproducibility_verifier_rejects_dirty_or_different_reports(self) -> None:
+    def test_reproducibility_verifier_rejects_manifest_report_disagreement(
+        self,
+    ) -> None:
+        allowed = self.make_source("Sources/SwiftQL/Allowed.swift")
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.root),
+                "add",
+                "--",
+                "Sources/SwiftQL/Allowed.swift",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        self.write_config(allowed=["Sources/SwiftQL/Allowed.swift"])
+        entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
+        output_names = ("manifest-first", "manifest-second")
+        for output_name in output_names:
+            self.run_report(entries, output_name)
+        originals = {
+            output_name: (
+                self.root / output_name / "first-party-coverage.json"
+            ).read_bytes()
+            for output_name in output_names
+        }
+        disagreements = {
+            "included": (
+                ("targets", "SwiftQL", "files", 0, "path"),
+                "Sources/SwiftQL/AQuery.swift",
+                "included-source manifest does not match report target topology",
+            ),
+            "allowed": (
+                (
+                    "targets",
+                    "SwiftQL",
+                    "allowed_uninstrumented_source_files",
+                    0,
+                ),
+                "Sources/SwiftQL/AlternativeAllowed.swift",
+                "allowed-source manifest does not match report target topology",
+            ),
+        }
+        for name, (path, value, message) in disagreements.items():
+            with self.subTest(name=name):
+                for output_name in output_names:
+                    (
+                        self.root / output_name / "first-party-coverage.json"
+                    ).write_bytes(originals[output_name])
+                    self.replace_report_value(output_name, path, value)
+                failure = self.run_verifier(
+                    "manifest-first",
+                    "manifest-second",
+                    f"failure-{name}-manifest.json",
+                )
+                self.assertNotEqual(failure.returncode, 0)
+                self.assertIn(message, failure.stderr)
+                self.assertNotIn("Traceback", failure.stderr)
+
+    def test_reproducibility_verifier_rejects_static_total_drift(self) -> None:
+        self.run_report(
+            [file_entry(self.sql_macros), file_entry(self.swiftql, (10, 5))],
+            "static-first",
+        )
+        self.run_report(
+            [file_entry(self.sql_macros), file_entry(self.swiftql, (11, 5))],
+            "static-second",
+        )
+        failure = self.run_verifier("static-first", "static-second")
+        self.assertNotEqual(failure.returncode, 0)
+        self.assertIn("reproducibility identities differ", failure.stderr)
+        self.assertIn("overall", failure.stderr)
+        self.assertIn("targets", failure.stderr)
+
+    def test_reproducibility_verifier_rejects_provenance_or_filtering_drift(
+        self,
+    ) -> None:
+        entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
+        self.run_report(entries, "provenance-first")
+        self.run_report(entries, "provenance-second")
+        original = (
+            self.root / "provenance-second/first-party-coverage.json"
+        ).read_bytes()
+        mutations = {
+            "source-commit": (
+                ("source_commit",),
+                "fedcba9876543210fedcba9876543210fedcba98",
+            ),
+            "toolchain": (("toolchain", "runner_image"), "different runner"),
+            "coverage-command": (
+                ("coverage_command",),
+                "swift test --enable-code-coverage --different",
+            ),
+            "package-resolution": (
+                ("package_resolved_sha256",),
+                "0" * 64,
+            ),
+            "filtering": (
+                ("filtering", "rule"),
+                "A different first-party filtering rule.",
+            ),
+        }
+        for name, (path, value) in mutations.items():
+            with self.subTest(name=name):
+                (
+                    self.root / "provenance-second/first-party-coverage.json"
+                ).write_bytes(original)
+                self.replace_report_value("provenance-second", path, value)
+                failure = self.run_verifier(
+                    "provenance-first",
+                    "provenance-second",
+                    f"failure-{name}.json",
+                )
+                self.assertNotEqual(failure.returncode, 0)
+                self.assertIn("reproducibility identities differ", failure.stderr)
+                self.assertNotIn("Traceback", failure.stderr)
+
+    def test_reproducibility_verifier_rejects_identically_malformed_schema(
+        self,
+    ) -> None:
+        entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
+        output_names = ("schema-first", "schema-second")
+        for output_name in output_names:
+            self.run_report(entries, output_name)
+        originals = {
+            output_name: (
+                self.root / output_name / "first-party-coverage.json"
+            ).read_bytes()
+            for output_name in output_names
+        }
+        missing_fields = {
+            "source-commit": ("source_commit",),
+            "toolchain-field": ("toolchain", "xcode"),
+            "raw-report-field": ("raw_llvm_report", "type"),
+            "filtering-field": ("filtering", "rule"),
+        }
+        for name, path in missing_fields.items():
+            with self.subTest(name=name):
+                for output_name in output_names:
+                    (
+                        self.root / output_name / "first-party-coverage.json"
+                    ).write_bytes(originals[output_name])
+                    self.delete_report_value(output_name, path)
+                failure = self.run_verifier(
+                    "schema-first",
+                    "schema-second",
+                    f"failure-{name}.json",
+                )
+                self.assertNotEqual(failure.returncode, 0)
+                self.assertIn("error: source coverage reproducibility", failure.stderr)
+                self.assertNotIn("Traceback", failure.stderr)
+
+    def test_reproducibility_verifier_rejects_malformed_nested_reports(
+        self,
+    ) -> None:
+        entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
+        self.run_report(entries, "malformed-first")
+        self.run_report(entries, "malformed-second")
+        original = (
+            self.root / "malformed-second/first-party-coverage.json"
+        ).read_bytes()
+        malformations = {
+            "targets-array": (("targets",), []),
+            "target-files-object": (("targets", "SwiftQL", "files"), {}),
+            "file-entry-string": (
+                ("targets", "SwiftQL", "files", 0),
+                "not a file report",
+            ),
+            "metric-count-string": (
+                ("targets", "SwiftQL", "files", 0, "lines", "count"),
+                "10",
+            ),
+            "overall-array": (("overall",), []),
+            "largest-gap-string": (("largest_uncovered_files", 0), "not a gap"),
+        }
+        for name, (path, value) in malformations.items():
+            with self.subTest(name=name):
+                (
+                    self.root / "malformed-second/first-party-coverage.json"
+                ).write_bytes(original)
+                self.replace_report_value("malformed-second", path, value)
+                failure = self.run_verifier(
+                    "malformed-first",
+                    "malformed-second",
+                    f"failure-{name}.json",
+                )
+                self.assertNotEqual(failure.returncode, 0)
+                self.assertIn("error: source coverage reproducibility", failure.stderr)
+                self.assertNotIn("Traceback", failure.stderr)
+
+    def test_reproducibility_verifier_rejects_dirty_reports(self) -> None:
         entries = [file_entry(self.sql_macros), file_entry(self.swiftql)]
         self.run_report(entries, "dirty-first")
         self.run_report(entries, "dirty-second")
-        first = self.root / "dirty-first"
-        second = self.root / "dirty-second"
-        second_report_path = second / "first-party-coverage.json"
-        second_report = json.loads(second_report_path.read_text(encoding="utf-8"))
-        second_report["source_tree_state"] = "dirty"
-        second_report_path.write_text(
-            json.dumps(second_report, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
+        self.replace_report_value(
+            "dirty-second", ("source_tree_state",), "dirty"
         )
-        failure = subprocess.run(
-            [str(VERIFY_SCRIPT), str(first), str(second), str(first / "failure.json")],
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+        failure = self.run_verifier("dirty-first", "dirty-second")
         self.assertNotEqual(failure.returncode, 0)
         self.assertIn("did not capture a clean tree", failure.stderr)
 
 
 class CoverageWorkflowTests(unittest.TestCase):
+    def test_coverage_artifact_retains_complete_raw_reports_for_both_runs(
+        self,
+    ) -> None:
+        run_script = RUN_SCRIPT.read_text(encoding="utf-8")
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            'cp "$raw_coverage_json" "$output_directory/llvm-coverage.json"',
+            run_script,
+        )
+        self.assertIn(
+            '> "$output_directory/llvm-coverage.lcov"',
+            run_script,
+        )
+        self.assertIn(
+            "${{ runner.temp }}/swiftql-coverage-run-1",
+            workflow,
+        )
+        self.assertIn(
+            "${{ runner.temp }}/swiftql-coverage-run-2",
+            workflow,
+        )
+
     def test_pull_request_capture_uses_durable_head_commit(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn(

--- a/scripts/ci/verify-source-coverage-reproducibility.py
+++ b/scripts/ci/verify-source-coverage-reproducibility.py
@@ -7,10 +7,64 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import shutil
 import sys
-from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+METRIC_NAMES = ("lines", "functions", "regions")
+METRIC_FIELDS = {"count", "covered", "uncovered", "percent"}
+REPORT_FIELDS = {
+    "schema_version",
+    "source_commit",
+    "source_tree_state",
+    "toolchain",
+    "coverage_command",
+    "package_resolved_sha256",
+    "raw_llvm_report",
+    "filtering",
+    "targets",
+    "overall",
+    "largest_uncovered_files",
+}
+TOOLCHAIN_FIELDS = {
+    "xcode",
+    "swift",
+    "sdk",
+    "llvm_cov",
+    "llvm_profdata",
+    "platform",
+    "architecture",
+    "runner_image",
+}
+RAW_REPORT_FIELDS = {"type", "version", "file_entries"}
+FILTERING_FIELDS = {
+    "rule",
+    "included_source_files",
+    "included_sources_sha256",
+    "allowed_uninstrumented_source_files",
+    "excluded_raw_file_entries",
+    "excluded_raw_file_entries_by_category",
+}
+FILTERING_CATEGORIES = {
+    "outside_repository",
+    "build_or_dependency",
+    "tests_or_fixtures",
+    "benchmarks",
+    "generated",
+    "other_repository_sources",
+}
+TARGET_FIELDS = {
+    "source_root",
+    "source_files",
+    "instrumented_source_files",
+    "allowed_uninstrumented_source_files",
+    "totals",
+    "files",
+}
+FILE_FIELDS = {"path", *METRIC_NAMES}
 
 
 class ReproducibilityError(RuntimeError):
@@ -43,28 +97,398 @@ def load_manifest(path: Path) -> Tuple[bytes, int, str]:
     return contents, len(lines), hashlib.sha256(contents).hexdigest()
 
 
+def require_mapping(value: Any, context: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise ReproducibilityError(f"{context} must be a JSON object")
+    return value
+
+
+def require_list(value: Any, context: str) -> List[Any]:
+    if not isinstance(value, list):
+        raise ReproducibilityError(f"{context} must be a JSON array")
+    return value
+
+
+def require_nonnegative_integer(value: Any, context: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ReproducibilityError(f"{context} must be a nonnegative integer")
+    return value
+
+
+def require_nonempty_string(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ReproducibilityError(f"{context} must be a non-empty string")
+    return value
+
+
+def require_exact_fields(
+    value: Mapping[str, Any], expected: Iterable[str], context: str
+) -> None:
+    expected_fields = set(expected)
+    actual_fields = set(value)
+    if actual_fields == expected_fields:
+        return
+    details = []
+    missing = sorted(expected_fields - actual_fields)
+    unexpected = sorted(actual_fields - expected_fields)
+    if missing:
+        details.append("missing " + ", ".join(missing))
+    if unexpected:
+        details.append("unexpected " + ", ".join(unexpected))
+    raise ReproducibilityError(f"{context} has invalid fields: {'; '.join(details)}")
+
+
+def require_sha256(value: Any, context: str) -> str:
+    digest = require_nonempty_string(value, context)
+    if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise ReproducibilityError(f"{context} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def require_source_path(value: Any, context: str, *, swift_file: bool) -> str:
+    source = require_nonempty_string(value, context)
+    path = PurePosixPath(source)
+    if (
+        path.is_absolute()
+        or source != path.as_posix()
+        or ".." in path.parts
+        or not source.startswith("Sources/")
+        or (swift_file and not source.endswith(".swift"))
+    ):
+        kind = "source file" if swift_file else "source root"
+        raise ReproducibilityError(
+            f"{context} must be a normalized repository-relative {kind} path"
+        )
+    return source
+
+
 def require_clean_report(report: Mapping[str, Any], path: Path) -> None:
+    require_exact_fields(report, REPORT_FIELDS, f"coverage report {path}")
     if report.get("schema_version") != 1:
         raise ReproducibilityError(f"unsupported report schema in {path}")
     if report.get("source_tree_state") != "clean":
         raise ReproducibilityError(f"coverage report did not capture a clean tree: {path}")
-    for field in (
-        "source_commit",
-        "coverage_command",
-        "package_resolved_sha256",
-        "toolchain",
-        "filtering",
-        "targets",
-        "overall",
+
+
+def require_sorted_unique_strings(value: Any, context: str) -> List[str]:
+    items = require_list(value, context)
+    if not all(isinstance(item, str) and item for item in items):
+        raise ReproducibilityError(f"{context} must contain non-empty strings")
+    if items != sorted(set(items)):
+        raise ReproducibilityError(f"{context} must be sorted and unique")
+    return items
+
+
+def static_metric_identity(value: Any, context: str) -> Mapping[str, int]:
+    metric = require_mapping(value, context)
+    if set(metric) != METRIC_FIELDS:
+        raise ReproducibilityError(
+            f"{context} must contain exactly count, covered, uncovered, and percent"
+        )
+    count = require_nonnegative_integer(metric["count"], f"{context}.count")
+    covered = require_nonnegative_integer(metric["covered"], f"{context}.covered")
+    uncovered = require_nonnegative_integer(
+        metric["uncovered"], f"{context}.uncovered"
+    )
+    percent = metric["percent"]
+    if not isinstance(percent, (int, float)) or isinstance(percent, bool):
+        raise ReproducibilityError(f"{context}.percent must be numeric")
+    if covered > count or uncovered != count - covered:
+        raise ReproducibilityError(f"{context} contains inconsistent counters")
+    expected_percent = 0.0 if count == 0 else round((covered * 100.0) / count, 2)
+    if percent != expected_percent:
+        raise ReproducibilityError(f"{context}.percent is inconsistent with counters")
+    return {"count": count}
+
+
+def static_metrics_identity(value: Any, context: str) -> Mapping[str, Any]:
+    metrics = require_mapping(value, context)
+    if set(metrics) != set(METRIC_NAMES):
+        raise ReproducibilityError(
+            f"{context} must contain exactly lines, functions, and regions"
+        )
+    return {
+        name: static_metric_identity(metrics[name], f"{context}.{name}")
+        for name in METRIC_NAMES
+    }
+
+
+def file_identity(value: Any, context: str) -> Mapping[str, Any]:
+    file_report = require_mapping(value, context)
+    require_exact_fields(file_report, FILE_FIELDS, context)
+    path = require_source_path(
+        file_report.get("path"), f"{context}.path", swift_file=True
+    )
+    return {
+        "path": path,
+        **{
+            name: static_metric_identity(file_report.get(name), f"{context}.{name}")
+            for name in METRIC_NAMES
+        },
+    }
+
+
+def target_identity(value: Any, context: str) -> Mapping[str, Any]:
+    target = require_mapping(value, context)
+    require_exact_fields(target, TARGET_FIELDS, context)
+    source_root = require_source_path(
+        target.get("source_root"), f"{context}.source_root", swift_file=False
+    )
+    source_files = require_nonnegative_integer(
+        target.get("source_files"), f"{context}.source_files"
+    )
+    instrumented_source_files = require_nonnegative_integer(
+        target.get("instrumented_source_files"),
+        f"{context}.instrumented_source_files",
+    )
+    allowed_values = require_sorted_unique_strings(
+        target.get("allowed_uninstrumented_source_files"),
+        f"{context}.allowed_uninstrumented_source_files",
+    )
+    allowed = [
+        require_source_path(
+            source,
+            f"{context}.allowed_uninstrumented_source_files[{index}]",
+            swift_file=True,
+        )
+        for index, source in enumerate(allowed_values)
+    ]
+    if instrumented_source_files + len(allowed) != source_files:
+        raise ReproducibilityError(
+            f"{context} source membership counts are inconsistent"
+        )
+    files = require_list(target.get("files"), f"{context}.files")
+    if len(files) != instrumented_source_files:
+        raise ReproducibilityError(
+            f"{context}.files does not match instrumented_source_files"
+        )
+    file_identities = [
+        file_identity(file_report, f"{context}.files[{index}]")
+        for index, file_report in enumerate(files)
+    ]
+    paths = [file_report["path"] for file_report in file_identities]
+    if paths != sorted(set(paths)):
+        raise ReproducibilityError(f"{context}.files must be sorted and unique by path")
+    for path in paths + allowed:
+        if not path.startswith(source_root + "/"):
+            raise ReproducibilityError(
+                f"{context} source is outside its source_root: {path}"
+            )
+    overlap = sorted(set(paths) & set(allowed))
+    if overlap:
+        raise ReproducibilityError(
+            f"{context} sources cannot be both instrumented and allowed: "
+            + ", ".join(overlap)
+        )
+    totals = static_metrics_identity(
+        target.get("totals"), f"{context}.totals"
+    )
+    for name in METRIC_NAMES:
+        file_total = sum(file_report[name]["count"] for file_report in file_identities)
+        if totals[name]["count"] != file_total:
+            raise ReproducibilityError(
+                f"{context}.totals.{name}.count does not match its files"
+            )
+    return {
+        "source_root": source_root,
+        "source_files": source_files,
+        "instrumented_source_files": instrumented_source_files,
+        "allowed_uninstrumented_source_files": allowed,
+        "totals": totals,
+        "files": file_identities,
+    }
+
+
+def toolchain_identity(value: Any, context: str) -> Mapping[str, str]:
+    toolchain = require_mapping(value, context)
+    require_exact_fields(toolchain, TOOLCHAIN_FIELDS, context)
+    return {
+        name: require_nonempty_string(toolchain.get(name), f"{context}.{name}")
+        for name in sorted(TOOLCHAIN_FIELDS)
+    }
+
+
+def raw_report_identity(value: Any, context: str) -> Mapping[str, Any]:
+    raw_report = require_mapping(value, context)
+    require_exact_fields(raw_report, RAW_REPORT_FIELDS, context)
+    if raw_report.get("type") != "llvm.coverage.json.export":
+        raise ReproducibilityError(
+            f"{context}.type must be llvm.coverage.json.export"
+        )
+    return {
+        "type": raw_report["type"],
+        "version": require_nonempty_string(
+            raw_report.get("version"), f"{context}.version"
+        ),
+        "file_entries": require_nonnegative_integer(
+            raw_report.get("file_entries"), f"{context}.file_entries"
+        ),
+    }
+
+
+def filtering_identity(value: Any, context: str) -> Mapping[str, Any]:
+    filtering = require_mapping(value, context)
+    require_exact_fields(filtering, FILTERING_FIELDS, context)
+    categories = require_mapping(
+        filtering.get("excluded_raw_file_entries_by_category"),
+        f"{context}.excluded_raw_file_entries_by_category",
+    )
+    unknown_categories = sorted(set(categories) - FILTERING_CATEGORIES)
+    if unknown_categories:
+        raise ReproducibilityError(
+            f"{context}.excluded_raw_file_entries_by_category has unknown categories: "
+            + ", ".join(unknown_categories)
+        )
+    category_counts = {
+        name: require_nonnegative_integer(
+            count,
+            f"{context}.excluded_raw_file_entries_by_category.{name}",
+        )
+        for name, count in categories.items()
+    }
+    excluded_entries = require_nonnegative_integer(
+        filtering.get("excluded_raw_file_entries"),
+        f"{context}.excluded_raw_file_entries",
+    )
+    if sum(category_counts.values()) != excluded_entries:
+        raise ReproducibilityError(
+            f"{context}.excluded_raw_file_entries does not match its categories"
+        )
+    return {
+        "rule": require_nonempty_string(filtering.get("rule"), f"{context}.rule"),
+        "included_source_files": require_nonnegative_integer(
+            filtering.get("included_source_files"),
+            f"{context}.included_source_files",
+        ),
+        "included_sources_sha256": require_sha256(
+            filtering.get("included_sources_sha256"),
+            f"{context}.included_sources_sha256",
+        ),
+        "allowed_uninstrumented_source_files": require_nonnegative_integer(
+            filtering.get("allowed_uninstrumented_source_files"),
+            f"{context}.allowed_uninstrumented_source_files",
+        ),
+        "excluded_raw_file_entries": excluded_entries,
+        "excluded_raw_file_entries_by_category": dict(sorted(category_counts.items())),
+    }
+
+
+def reproducibility_identity(
+    report: Mapping[str, Any], path: Path
+) -> Mapping[str, Any]:
+    source_commit = require_nonempty_string(
+        report.get("source_commit"), f"{path}: source_commit"
+    )
+    if re.fullmatch(r"[0-9a-f]{40}", source_commit) is None:
+        raise ReproducibilityError(
+            f"{path}: source_commit must be a full lowercase Git SHA"
+        )
+    coverage_command = require_nonempty_string(
+        report.get("coverage_command"), f"{path}: coverage_command"
+    )
+    package_resolved_sha256 = require_sha256(
+        report.get("package_resolved_sha256"),
+        f"{path}: package_resolved_sha256",
+    )
+    toolchain = toolchain_identity(report.get("toolchain"), f"{path}: toolchain")
+    raw_report = raw_report_identity(
+        report.get("raw_llvm_report"), f"{path}: raw_llvm_report"
+    )
+    filtering = filtering_identity(report.get("filtering"), f"{path}: filtering")
+    if raw_report["file_entries"] != (
+        filtering["included_source_files"]
+        + filtering["excluded_raw_file_entries"]
     ):
-        if field not in report:
-            raise ReproducibilityError(f"coverage report is missing {field}: {path}")
+        raise ReproducibilityError(
+            f"{path}: raw_llvm_report.file_entries does not match filtering counts"
+        )
+    targets = require_mapping(report.get("targets"), f"{path}: targets")
+    if not targets:
+        raise ReproducibilityError(f"{path}: targets must not be empty")
+    largest_uncovered_files = require_list(
+        report.get("largest_uncovered_files"),
+        f"{path}: largest_uncovered_files",
+    )
+    for index, file_report in enumerate(largest_uncovered_files):
+        file_identity(
+            file_report,
+            f"{path}: largest_uncovered_files[{index}]",
+        )
+    target_identities: Dict[str, Any] = {}
+    source_roots = set()
+    owned_sources = set()
+    for name, target in targets.items():
+        require_nonempty_string(name, f"{path}: target name")
+        target_report = target_identity(target, f"{path}: targets.{name}")
+        source_root = target_report["source_root"]
+        if source_root in source_roots:
+            raise ReproducibilityError(
+                f"{path}: duplicate target source_root: {source_root}"
+            )
+        source_roots.add(source_root)
+        target_sources = {
+            file_report["path"] for file_report in target_report["files"]
+        } | set(target_report["allowed_uninstrumented_source_files"])
+        duplicate_sources = sorted(owned_sources & target_sources)
+        if duplicate_sources:
+            raise ReproducibilityError(
+                f"{path}: sources belong to multiple targets: "
+                + ", ".join(duplicate_sources)
+            )
+        owned_sources.update(target_sources)
+        target_identities[name] = target_report
+
+    overall = static_metrics_identity(
+        report.get("overall"), f"{path}: overall"
+    )
+    for name in METRIC_NAMES:
+        target_total = sum(
+            target["totals"][name]["count"] for target in target_identities.values()
+        )
+        if overall[name]["count"] != target_total:
+            raise ReproducibilityError(
+                f"{path}: overall.{name}.count does not match its targets"
+            )
+    return {
+        "schema_version": 1,
+        "source_commit": source_commit,
+        "source_tree_state": "clean",
+        "toolchain": dict(toolchain),
+        "coverage_command": coverage_command,
+        "package_resolved_sha256": package_resolved_sha256,
+        "raw_llvm_report": dict(raw_report),
+        "filtering": dict(filtering),
+        "targets": target_identities,
+        "overall": overall,
+    }
 
 
-def verify_run(directory: Path) -> Tuple[Mapping[str, Any], bytes, bytes, int, str]:
+def canonical_manifests(identity: Mapping[str, Any]) -> Tuple[bytes, bytes]:
+    included_lines = []
+    allowed_lines = []
+    targets = identity["targets"]
+    for name in sorted(targets):
+        target = targets[name]
+        included_lines.extend(
+            f"{name}\t{file_report['path']}" for file_report in target["files"]
+        )
+        allowed_lines.extend(
+            f"{name}\t{source}"
+            for source in target["allowed_uninstrumented_source_files"]
+        )
+    included = "".join(line + "\n" for line in included_lines).encode("utf-8")
+    allowed = "".join(line + "\n" for line in allowed_lines).encode("utf-8")
+    return included, allowed
+
+
+def verify_run(
+    directory: Path,
+) -> Tuple[Mapping[str, Any], Mapping[str, Any], bytes, bytes, int, str]:
     report_path = directory / "first-party-coverage.json"
     report = load_json(report_path)
     require_clean_report(report, report_path)
+    identity = reproducibility_identity(report, report_path)
+    expected_included, expected_allowed = canonical_manifests(identity)
     included, source_count, source_sha256 = load_manifest(
         directory / "included-sources.txt"
     )
@@ -85,6 +509,11 @@ def verify_run(directory: Path) -> Tuple[Mapping[str, Any], bytes, bytes, int, s
         raise ReproducibilityError(
             f"included-source digest does not match manifest: {report_path}"
         )
+    if included != expected_included:
+        raise ReproducibilityError(
+            "included-source manifest does not match report target topology: "
+            f"{report_path}"
+        )
     try:
         allowed_lines = allowed.decode("utf-8").splitlines()
     except UnicodeDecodeError as error:
@@ -104,7 +533,12 @@ def verify_run(directory: Path) -> Tuple[Mapping[str, Any], bytes, bytes, int, s
         raise ReproducibilityError(
             f"allowed-source count does not match manifest: {report_path}"
         )
-    return report, included, allowed, source_count, source_sha256
+    if allowed != expected_allowed:
+        raise ReproducibilityError(
+            "allowed-source manifest does not match report target topology: "
+            f"{report_path}"
+        )
+    return report, identity, included, allowed, source_count, source_sha256
 
 
 def differing_top_level_keys(
@@ -120,8 +554,15 @@ def differing_top_level_keys(
 def run(first_directory: Path, second_directory: Path, output_json: Path) -> None:
     first = verify_run(first_directory)
     second = verify_run(second_directory)
-    first_report, first_included, first_allowed, source_count, source_sha256 = first
-    second_report, second_included, second_allowed, _, _ = second
+    (
+        first_report,
+        first_identity,
+        first_included,
+        first_allowed,
+        source_count,
+        source_sha256,
+    ) = first
+    second_report, second_identity, second_included, second_allowed, _, _ = second
 
     if first_included != second_included:
         raise ReproducibilityError("included source manifests differ between clean runs")
@@ -129,11 +570,13 @@ def run(first_directory: Path, second_directory: Path, output_json: Path) -> Non
         raise ReproducibilityError(
             "allowed-uninstrumented source manifests differ between clean runs"
         )
-    if first_report != second_report:
-        keys = ", ".join(differing_top_level_keys(first_report, second_report))
+    if first_identity != second_identity:
+        keys = ", ".join(differing_top_level_keys(first_identity, second_identity))
         raise ReproducibilityError(
-            f"normalized coverage reports differ between clean runs: {keys}"
+            f"coverage reproducibility identities differ between clean runs: {keys}"
         )
+
+    normalized_reports_match = first_report == second_report
 
     evidence: Dict[str, Any] = {
         "schema_version": 1,
@@ -145,7 +588,9 @@ def run(first_directory: Path, second_directory: Path, output_json: Path) -> Non
         "toolchain": first_report["toolchain"],
         "included_source_sets_match": True,
         "allowed_uninstrumented_source_sets_match": True,
-        "normalized_reports_match": True,
+        "reproducibility_identity_matches": True,
+        "normalized_reports_match": normalized_reports_match,
+        "dynamic_coverage_metrics_match": normalized_reports_match,
         "included_source_files": source_count,
         "included_sources_sha256": source_sha256,
     }


### PR DESCRIPTION
Closes #208

## Summary

- compares a schema-aware reproducibility identity that preserves source commit, clean-tree/toolchain/dependency provenance, coverage command, filtering, target/source topology, and per-file/target/overall static metric totals
- retains complete dynamic JSON/LCOV reports while excluding covered counters, percentages, and the derived largest-uncovered ranking from the gate identity
- reconstructs included and allowed-source manifests from target topology and rejects contradictory or malformed schema-v1 reports
- records both the new identity verdict and honest exact normalized-report equality
- documents why concurrent hit counters remain diagnostic evidence rather than a threshold

## Boundaries

- no percentage threshold
- no source-filtering or baseline change
- no workflow, raw-report, LCOV, or report-generator change
- complete artifacts for both runs remain retained

## Validation

- source coverage fixtures — 26 tests, 0 failures
- full `swift test` — 483 tests, 0 failures
- Python AST and shell syntax checks — clean
- `git diff --check` — clean
- independent review findings on manifest consistency, nested schema validation, and evidence-field semantics — addressed
- exact-head compatibility run `29623497662` — 9/9 successful
- exact-head documentation run `29623497727` — successful
- retained two-run evidence — `reproducibility_identity_matches=true`, `normalized_reports_match=false`, `dynamic_coverage_metrics_match=false`, 62 included sources