### PR TITLE
Add immutable query-capture tokens and invocation packets

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,9 +1,9 @@
 {
-  "task_name": "Infer immutable query bindings from Swift variables",
+  "task_name": "Add immutable query-capture tokens and invocation packets",
   "issue_number": 30,
   "issue_url": "https://github.com/lukevanin/swiftql/issues/30",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#30 - Infer immutable query bindings from Swift variables",
+  "codex_session_title": "lukevanin/swiftql#30 - Add immutable query-capture tokens and invocation packets",
   "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
   "codex_session_url": null,
   "task_branch": "codex/30-infer-immutable-query-bindings-from-swift-variables",

--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Replace specialised `between` method in XLBuilder with generic methods.",
-  "issue_number": 32,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/32",
+  "task_name": "Infer immutable query bindings from Swift variables",
+  "issue_number": 30,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/30",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#32 - Replace specialised `between` method in XLBuilder with generic methods.",
+  "codex_session_title": "lukevanin/swiftql#30 - Infer immutable query bindings from Swift variables",
   "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
   "codex_session_url": null,
-  "task_branch": "codex/32-replace-specialised-between-method-in-xlbuilder-with-generic-methods",
-  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/32-replace-specialised-between-method-in-xlbuilder-with-generic-methods"
+  "task_branch": "codex/30-infer-immutable-query-bindings-from-swift-variables",
+  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/30-infer-immutable-query-bindings-from-swift-variables"
 }

--- a/Sources/SwiftQL/GRDBStaticQuery.swift
+++ b/Sources/SwiftQL/GRDBStaticQuery.swift
@@ -144,6 +144,93 @@ private extension XLQueryCardinality {
 }
 
 
+/// A short-lived assembler for one immutable static-query invocation packet.
+///
+/// Builders are created only by ``GRDBPreparedStaticQuery/makeInvocationBindings(_:)``.
+/// They own a fresh packet and never mutate the prepared handle.
+public struct GRDBStaticQueryInvocationBuilder {
+
+    private let query: GRDBPreparedStaticQuery
+
+    private var packet: XLInvocationBindings<XLSQLiteValue>
+
+    fileprivate init(query: GRDBPreparedStaticQuery) {
+        self.query = query
+        self.packet = XLInvocationBindings(layout: query.parameterLayout)
+    }
+
+    /// Encodes and adds one required capture value.
+    public mutating func bind<Input, Literal>(
+        _ value: Input,
+        to capture: XLQueryCapture<Input, Literal, XLSQLiteDialect>
+    ) throws where Literal: XLLiteral {
+        let metadata = try query.validatedMetadata(for: capture)
+        try requireUnbound(metadata.slot)
+        let binding: XLInvocationBinding<XLSQLiteValue>
+        switch capture.encoding {
+        case .contextual:
+            binding = try query.preparedParameter(
+                Input.self,
+                identifiedBy: capture.identity
+            ).encode(value)
+        case .intrinsic(let encode):
+            binding = try XLInvocationBinding(
+                slot: metadata.slot,
+                value: encode(value)
+            )
+        }
+        packet = try packet.binding(binding)
+    }
+
+    /// Encodes and adds one nullable capture value. `nil` is a present SQL
+    /// `NULL` binding; it is never treated as an omitted argument.
+    public mutating func bind<Input, Wrapped>(
+        _ value: Input?,
+        to capture: XLQueryCapture<Input, Wrapped?, XLSQLiteDialect>
+    ) throws where Wrapped: XLLiteral {
+        let metadata = try query.validatedMetadata(for: capture)
+        try requireUnbound(metadata.slot)
+        let binding: XLInvocationBinding<XLSQLiteValue>
+        switch capture.encoding {
+        case .contextual:
+            binding = try query.preparedParameter(
+                Input.self,
+                identifiedBy: capture.identity
+            ).encodeOptional(value)
+        case .intrinsic(let encode):
+            guard let value else {
+                guard metadata.slot.nullability == .nullable else {
+                    throw XLInvocationBindingError.nullForRequiredParameter(
+                        slot: metadata.slot
+                    )
+                }
+                binding = try XLInvocationBinding(
+                    slot: metadata.slot,
+                    value: .null
+                )
+                packet = try packet.binding(binding)
+                return
+            }
+            binding = try XLInvocationBinding(
+                slot: metadata.slot,
+                value: encode(value)
+            )
+        }
+        packet = try packet.binding(binding)
+    }
+
+    fileprivate func completedPacket() throws -> XLInvocationBindings<XLSQLiteValue> {
+        try packet.validatingComplete()
+    }
+
+    private func requireUnbound(_ slot: XLParameterSlot) throws {
+        guard packet.binding(at: slot.index) == nil else {
+            throw XLInvocationBindingError.duplicateBinding(slot: slot)
+        }
+    }
+}
+
+
 /// A database-bound, concurrency-safe GRDB executor for one immutable static
 /// query descriptor.
 ///
@@ -178,6 +265,18 @@ public struct GRDBPreparedStaticQuery: Sendable {
 
     public var parameterLayout: XLParameterLayout {
         descriptor.statement.parameterLayout
+    }
+
+    /// Builds one fresh, immutable invocation packet from stable captures.
+    ///
+    /// The builder resolves contextual codecs only from this prepared handle's
+    /// snapshotted configuration. Values and packets are local to this call.
+    public func makeInvocationBindings(
+        _ build: (inout GRDBStaticQueryInvocationBuilder) throws -> Void
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        var builder = GRDBStaticQueryInvocationBuilder(query: self)
+        try build(&builder)
+        return try builder.completedPacket()
     }
 
     /// Resolves one typed parameter from the immutable database coding
@@ -263,6 +362,38 @@ public struct GRDBPreparedStaticQuery: Sendable {
             )
         }
         return codec
+    }
+
+    fileprivate func validatedMetadata<Input, Literal>(
+        for capture: XLQueryCapture<Input, Literal, XLSQLiteDialect>
+    ) throws -> XLStaticQueryParameterMetadata where Literal: XLLiteral {
+        guard capture.dialectIdentifier == dialect.descriptor.identity else {
+            throw XLQueryCaptureError.dialectMismatch(
+                identity: capture.identity,
+                expected: dialect.descriptor.identity,
+                actual: capture.dialectIdentifier
+            )
+        }
+        guard let metadata = descriptor.parameters.first(where: {
+            $0.identity == capture.identity
+        }) else {
+            throw GRDBStaticQueryError.parameterNotFound(
+                identity: descriptor.identity,
+                parameter: capture.identity
+            )
+        }
+        guard metadata.slot == capture.declaration.slot(at: metadata.slot.index),
+              metadata.storageIdentifier == capture.storageIdentifier else {
+            throw XLQueryCaptureError.descriptorMetadataMismatch(
+                query: descriptor.identity,
+                identity: capture.identity,
+                expectedSlot: metadata.slot,
+                expectedStorage: metadata.storageIdentifier,
+                actualDeclaration: capture.declaration,
+                actualStorage: capture.storageIdentifier
+            )
+        }
+        return metadata
     }
 
     /// Executes a descriptor declared with command cardinality.

--- a/Sources/SwiftQL/GRDBStaticQuery.swift
+++ b/Sources/SwiftQL/GRDBStaticQuery.swift
@@ -144,9 +144,59 @@ private extension XLQueryCardinality {
 }
 
 
+/// One immutable, per-call value assignment for a static query capture.
+///
+/// The argument temporarily retains its source value until all copies of the
+/// argument are released. Applying it is synchronous and copies only the
+/// encoded dialect value into a fresh packet. The prepared query never stores
+/// the argument or its source value.
+public struct GRDBStaticQueryArgument {
+
+    private let applyValue: (
+        inout GRDBStaticQueryInvocationBuilder
+    ) throws -> Void
+
+    fileprivate init(
+        applyValue: @escaping (
+            inout GRDBStaticQueryInvocationBuilder
+        ) throws -> Void
+    ) {
+        self.applyValue = applyValue
+    }
+
+    fileprivate func apply(
+        to builder: inout GRDBStaticQueryInvocationBuilder
+    ) throws {
+        try applyValue(&builder)
+    }
+}
+
+
+extension XLQueryCapture where Dialect == XLSQLiteDialect {
+
+    /// Pairs a required invocation value with this value-free capture.
+    public func argument(_ value: Input) -> GRDBStaticQueryArgument {
+        GRDBStaticQueryArgument { builder in
+            try builder.bind(value, to: self)
+        }
+    }
+
+    /// Pairs a nullable invocation value with an optional SQL capture.
+    /// `nil` remains a present SQL `NULL` argument.
+    public func argument<Wrapped>(
+        _ value: Input?
+    ) -> GRDBStaticQueryArgument
+    where Literal == Wrapped?, Wrapped: XLLiteral {
+        GRDBStaticQueryArgument { builder in
+            try builder.bind(value, to: self)
+        }
+    }
+}
+
+
 /// A short-lived assembler for one immutable static-query invocation packet.
 ///
-/// Builders are created only by ``GRDBPreparedStaticQuery/makeInvocationBindings(_:)``.
+/// Builders are created only by `GRDBPreparedStaticQuery.makeInvocationBindings`.
 /// They own a fresh packet and never mutate the prepared handle.
 public struct GRDBStaticQueryInvocationBuilder {
 
@@ -277,6 +327,27 @@ public struct GRDBPreparedStaticQuery: Sendable {
         var builder = GRDBStaticQueryInvocationBuilder(query: self)
         try build(&builder)
         return try builder.completedPacket()
+    }
+
+    /// Builds one fresh packet from immutable per-call capture arguments.
+    public func makeInvocationBindings(
+        _ arguments: GRDBStaticQueryArgument...
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        try makeInvocationBindings(arguments: arguments)
+    }
+
+    /// Builds one fresh packet from a dynamically assembled argument list.
+    ///
+    /// Application order does not affect the completed packet: bindings are
+    /// canonicalized by the renderer-assigned logical parameter order.
+    public func makeInvocationBindings(
+        arguments: [GRDBStaticQueryArgument]
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        try makeInvocationBindings { builder in
+            for argument in arguments {
+                try argument.apply(to: &builder)
+            }
+        }
     }
 
     /// Resolves one typed parameter from the immutable database coding

--- a/Sources/SwiftQL/SQLInvocationBindings.swift
+++ b/Sources/SwiftQL/SQLInvocationBindings.swift
@@ -259,7 +259,7 @@ func _xlLegacyParameterDeclaration<Value>(
 }
 
 
-private protocol _XLOptionalLiteralType {
+protocol _XLOptionalLiteralType {
     static var wrappedType: Any.Type { get }
 }
 
@@ -271,7 +271,7 @@ extension Optional: _XLOptionalLiteralType {
 }
 
 
-private func sqliteStorageClass(
+func sqliteStorageClass(
     for type: Any.Type
 ) -> XLSQLiteStorageClass? {
     if let optional = type as? any _XLOptionalLiteralType.Type {
@@ -293,7 +293,7 @@ private func sqliteStorageClass(
 }
 
 
-private func legacyValueMetadata(
+func legacyValueMetadata(
     for type: Any.Type
 ) -> (identifier: XLValueTypeIdentifier, typeName: String, isOptional: Bool) {
     if let optional = type as? any _XLOptionalLiteralType.Type {

--- a/Sources/SwiftQL/SQLQueryCapture.swift
+++ b/Sources/SwiftQL/SQLQueryCapture.swift
@@ -30,6 +30,16 @@ public enum XLQueryCaptureError: Error, Equatable, Sendable, LocalizedError {
         expected: XLValueStorageIdentifier,
         actual: XLValueStorageIdentifier
     )
+    case codecSelectionFailed(
+        identity: XLQuerySlotIdentity,
+        valueType: String,
+        expectedDialect: XLDialectIdentifier,
+        expectedStorage: XLValueStorageIdentifier,
+        selection: XLQueryCodecSelection,
+        candidates: [XLValueCodecKey],
+        context: XLValueCodingContext,
+        detail: String
+    )
     case descriptorMetadataMismatch(
         query: XLQueryIdentity,
         identity: XLQuerySlotIdentity,
@@ -53,6 +63,29 @@ public enum XLQueryCaptureError: Error, Equatable, Sendable, LocalizedError {
             return "Query capture \(identity) expected dialect \(expected), but received \(actual)."
         case .storageMismatch(let identity, let expected, let actual):
             return "Query capture \(identity) requires storage \(expected), not \(actual)."
+        case .codecSelectionFailed(
+            let identity,
+            let valueType,
+            let expectedDialect,
+            let expectedStorage,
+            let selection,
+            let candidates,
+            let context,
+            let detail
+        ):
+            let selectionDescription: String
+            switch selection {
+            case .inferred:
+                selectionDescription = "inferred selection"
+            case .explicit(let key):
+                selectionDescription = "explicit codec \(key)"
+            case .query(let key):
+                selectionDescription = "query codec \(key)"
+            }
+            let candidateDescription = candidates.isEmpty
+                ? "no candidate codecs"
+                : "candidate codecs \(candidates.map(\.description).joined(separator: ", "))"
+            return "Query capture \(identity) could not select a codec for \(valueType) using storage \(expectedStorage) for expected dialect \(expectedDialect) at \(context). Selection: \(selectionDescription); \(candidateDescription). \(detail)"
         case .descriptorMetadataMismatch(
             let query,
             let identity,
@@ -323,19 +356,75 @@ extension XLValueCodingConfiguration {
             site: .parameter,
             path: XLValueCodingPath(identity.path)
         )
-        let codecIdentity = try codecIdentity(
-            for: inputType,
-            using: dialect,
-            context: codingContext,
-            requiringStorage: storage,
-            selection: selection
-        )
+        let codecIdentity: XLValueCodecIdentity
+        do {
+            codecIdentity = try self.codecIdentity(
+                for: inputType,
+                using: dialect,
+                context: codingContext,
+                requiringStorage: storage,
+                selection: selection
+            )
+        }
+        catch let error as XLQueryCodecSelectionError {
+            throw XLQueryCaptureError.codecSelectionFailed(
+                identity: identity,
+                valueType: String(reflecting: Input.self),
+                expectedDialect: dialect.descriptor.identity,
+                expectedStorage: storage,
+                selection: selection,
+                candidates: _xlQueryCaptureCodecCandidates(from: error),
+                context: codingContext,
+                detail: _xlQueryCaptureErrorDetail(error)
+            )
+        }
+        catch let error as XLValueCodecError {
+            throw XLQueryCaptureError.codecSelectionFailed(
+                identity: identity,
+                valueType: String(reflecting: Input.self),
+                expectedDialect: dialect.descriptor.identity,
+                expectedStorage: storage,
+                selection: selection,
+                candidates: _xlQueryCaptureCodecCandidates(from: error),
+                context: codingContext,
+                detail: _xlQueryCaptureErrorDetail(error)
+            )
+        }
         return try XLQueryCapture(
             identity: identity,
             dialectIdentifier: dialect.descriptor.identity,
             storageIdentifier: storage,
             codecIdentity: codecIdentity,
             context: codingContext
+        )
+    }
+
+    /// Declares a contextual SQLite capture whose literal type, nullability,
+    /// and storage contract are inferred from a typed SQL expression.
+    ///
+    /// The expression is only a declaration-time type witness. It is neither
+    /// rendered nor retained. Its associated `Literal` supplies SQL
+    /// nullability and SQLite storage; `selection` resolves matching codec
+    /// candidates.
+    ///
+    /// Use ``queryCapture(_:expressedAs:identifiedBy:using:context:selection:)``
+    /// when no representative expression is available.
+    public func queryCapture<Input, Literal>(
+        _ inputType: Input.Type,
+        matching _: any XLExpression<Literal>,
+        identifiedBy identity: XLQuerySlotIdentity,
+        using dialect: XLSQLiteDialect,
+        context: XLValueCodingContext? = nil,
+        selection: XLQueryCodecSelection = .inferred
+    ) throws -> XLQueryCapture<Input, Literal, XLSQLiteDialect>
+    where Literal: XLLiteral {
+        try queryCapture(
+            inputType,
+            expressedAs: Literal.self,
+            identifiedBy: identity,
+            using: dialect,
+            context: context,
+            selection: selection
         )
     }
 }
@@ -357,6 +446,26 @@ extension GRDBDatabase {
         try codingConfiguration.queryCapture(
             inputType,
             expressedAs: literalType,
+            identifiedBy: identity,
+            using: dialect,
+            context: context,
+            selection: selection
+        )
+    }
+
+    /// Declares a contextual capture using a typed SQL expression as the
+    /// source of literal type, nullability, and SQLite storage metadata.
+    public func queryCapture<Input, Literal>(
+        _ inputType: Input.Type,
+        matching expression: any XLExpression<Literal>,
+        identifiedBy identity: XLQuerySlotIdentity,
+        context: XLValueCodingContext? = nil,
+        selection: XLQueryCodecSelection = .inferred
+    ) throws -> XLQueryCapture<Input, Literal, XLSQLiteDialect>
+    where Literal: XLLiteral {
+        try codingConfiguration.queryCapture(
+            inputType,
+            matching: expression,
             identifiedBy: identity,
             using: dialect,
             context: context,
@@ -420,4 +529,55 @@ private func _xlAppendUInt64(_ value: UInt64, to bytes: inout [UInt8]) {
     for shift in stride(from: 56, through: 0, by: -8) {
         bytes.append(UInt8(truncatingIfNeeded: value >> UInt64(shift)))
     }
+}
+
+
+private func _xlQueryCaptureCodecCandidates(
+    from error: Error
+) -> [XLValueCodecKey] {
+    let candidates: [XLValueCodecKey]
+    if let error = error as? XLQueryCodecSelectionError {
+        switch error {
+        case .missingCodecForStorage:
+            candidates = []
+        case .ambiguousCodecForStorage(_, _, _, let candidates, _):
+            return _xlOrderedQueryCaptureCodecCandidates(candidates)
+        }
+    }
+    else if let error = error as? XLValueCodecError {
+        switch error {
+        case .unknownCodec(let key, _, _),
+             .storageMismatch(let key, _, _, _):
+            candidates = [key]
+        case .duplicateDefault(_, _, let keys, _),
+             .ambiguousCodec(_, _, let keys, _):
+            candidates = keys
+        default:
+            candidates = []
+        }
+    }
+    else {
+        candidates = []
+    }
+    return _xlOrderedQueryCaptureCodecCandidates(candidates)
+}
+
+
+private func _xlOrderedQueryCaptureCodecCandidates(
+    _ candidates: [XLValueCodecKey]
+) -> [XLValueCodecKey] {
+    candidates.sorted { lhs, rhs in
+        if lhs.id != rhs.id {
+            return lhs.id < rhs.id
+        }
+        return lhs.version < rhs.version
+    }
+}
+
+
+private func _xlQueryCaptureErrorDetail(_ error: Error) -> String {
+    if let description = (error as? LocalizedError)?.errorDescription {
+        return description
+    }
+    return String(describing: error)
 }

--- a/Sources/SwiftQL/SQLQueryCapture.swift
+++ b/Sources/SwiftQL/SQLQueryCapture.swift
@@ -1,0 +1,423 @@
+import Foundation
+
+
+/// Deterministic failures while declaring or using a value-free query capture.
+public enum XLQueryCaptureError: Error, Equatable, Sendable, LocalizedError {
+    case unsupportedLiteralStorage(
+        identity: XLQuerySlotIdentity,
+        literalType: String
+    )
+    case unsupportedIntrinsicValue(
+        identity: XLQuerySlotIdentity,
+        valueType: String,
+        literalType: String
+    )
+    case optionalInputType(
+        identity: XLQuerySlotIdentity,
+        valueType: String
+    )
+    case nonFiniteReal(
+        identity: XLQuerySlotIdentity,
+        value: String
+    )
+    case dialectMismatch(
+        identity: XLQuerySlotIdentity,
+        expected: XLDialectIdentifier,
+        actual: XLDialectIdentifier
+    )
+    case storageMismatch(
+        identity: XLQuerySlotIdentity,
+        expected: XLValueStorageIdentifier,
+        actual: XLValueStorageIdentifier
+    )
+    case descriptorMetadataMismatch(
+        query: XLQueryIdentity,
+        identity: XLQuerySlotIdentity,
+        expectedSlot: XLParameterSlot,
+        expectedStorage: XLValueStorageIdentifier,
+        actualDeclaration: XLParameterDeclaration,
+        actualStorage: XLValueStorageIdentifier
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedLiteralStorage(let identity, let literalType):
+            return "Query capture \(identity) uses \(literalType), whose SQLite storage representation is not statically known."
+        case .unsupportedIntrinsicValue(let identity, let valueType, let literalType):
+            return "Query capture \(identity) cannot intrinsically bind \(valueType) as \(literalType); select a contextual codec."
+        case .optionalInputType(let identity, let valueType):
+            return "Query capture \(identity) uses optional input type \(valueType); declare a nonoptional input and express SQL NULL through an optional literal capture."
+        case .nonFiniteReal(let identity, let value):
+            return "Query capture \(identity) cannot bind non-finite Double value \(value) because SQLite may normalize it to SQL NULL."
+        case .dialectMismatch(let identity, let expected, let actual):
+            return "Query capture \(identity) expected dialect \(expected), but received \(actual)."
+        case .storageMismatch(let identity, let expected, let actual):
+            return "Query capture \(identity) requires storage \(expected), not \(actual)."
+        case .descriptorMetadataMismatch(
+            let query,
+            let identity,
+            let expectedSlot,
+            let expectedStorage,
+            let actualDeclaration,
+            let actualStorage
+        ):
+            let expectedCodec = expectedSlot.codecIdentity?.key.description
+                ?? "intrinsic"
+            let actualCodec = actualDeclaration.codecIdentity?.key.description
+                ?? "intrinsic"
+            return "Static query \(query) expects capture \(identity) with codec \(expectedCodec) and storage \(expectedStorage), but the supplied capture declares codec \(actualCodec) and storage \(actualStorage)."
+        }
+    }
+}
+
+
+enum _XLQueryCaptureEncoding<Input, Dialect>: Sendable
+where Dialect: XLValueCodingDialect {
+    case contextual
+    case intrinsic(@Sendable (Input) throws -> Dialect.Value)
+}
+
+
+/// A stable, value-free bridge from a Swift input type to one immutable static
+/// query parameter.
+///
+/// The capture stores declaration metadata and, for intrinsic values, a
+/// stateless conversion function. It never retains an invocation value,
+/// database, registry, mutable argument table, or prepared statement.
+public struct XLQueryCapture<Input, Literal, Dialect>:
+    XLBindingReference,
+    Sendable
+where Literal: XLLiteral, Dialect: XLValueCodingDialect {
+
+    public typealias T = Literal
+
+    public let identity: XLQuerySlotIdentity
+
+    public let declaration: XLParameterDeclaration
+
+    public let storageIdentifier: XLValueStorageIdentifier
+
+    public let dialectIdentifier: XLDialectIdentifier
+
+    let encoding: _XLQueryCaptureEncoding<Input, Dialect>
+
+    /// Creates a pure contextual capture from durable codec metadata.
+    ///
+    /// This initializer performs no registry lookup. Dialect integrations
+    /// should validate `storageIdentifier` against `Literal` before calling it.
+    package init(
+        identity: XLQuerySlotIdentity,
+        dialectIdentifier: XLDialectIdentifier,
+        storageIdentifier: XLValueStorageIdentifier,
+        codecIdentity: XLValueCodecIdentity,
+        context: XLValueCodingContext? = nil
+    ) throws {
+        let expectedNullability = _xlLiteralNullability(Literal.self)
+        guard !(Input.self is any _XLOptionalLiteralType.Type) else {
+            throw XLQueryCaptureError.optionalInputType(
+                identity: identity,
+                valueType: String(reflecting: Input.self)
+            )
+        }
+        guard codecIdentity.dialectIdentifier == dialectIdentifier else {
+            throw XLQueryCaptureError.dialectMismatch(
+                identity: identity,
+                expected: dialectIdentifier,
+                actual: codecIdentity.dialectIdentifier
+            )
+        }
+        guard codecIdentity.storageIdentifier == storageIdentifier else {
+            throw XLQueryCaptureError.storageMismatch(
+                identity: identity,
+                expected: storageIdentifier,
+                actual: codecIdentity.storageIdentifier
+            )
+        }
+        let codingContext = context ?? XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(identity.path)
+        )
+        self.identity = identity
+        self.storageIdentifier = storageIdentifier
+        self.dialectIdentifier = dialectIdentifier
+        self.declaration = XLParameterDeclaration(
+            key: .named(_xlQueryCaptureBindingName(identity)),
+            valueTypeIdentifier: codecIdentity.valueTypeIdentifier,
+            valueTypeName: String(reflecting: Input.self),
+            nullability: expectedNullability,
+            codecIdentity: codecIdentity,
+            codingContext: codingContext
+        )
+        self.encoding = .contextual
+    }
+
+    init(
+        identity: XLQuerySlotIdentity,
+        dialectIdentifier: XLDialectIdentifier,
+        storageIdentifier: XLValueStorageIdentifier,
+        valueTypeIdentifier: XLValueTypeIdentifier,
+        nullability: XLParameterNullability,
+        context: XLValueCodingContext,
+        intrinsicEncoder: @escaping @Sendable (Input) throws -> Dialect.Value
+    ) {
+        self.identity = identity
+        self.storageIdentifier = storageIdentifier
+        self.dialectIdentifier = dialectIdentifier
+        self.declaration = XLParameterDeclaration(
+            key: .named(_xlQueryCaptureBindingName(identity)),
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: String(reflecting: Input.self),
+            nullability: nullability,
+            codecIdentity: nil,
+            codingContext: context
+        )
+        self.encoding = .intrinsic(intrinsicEncoder)
+    }
+
+    public func makeSQL(context: inout XLBuilder) {
+        Literal.wrapSQL(context: &context) { context in
+            context.parameter(declaration)
+        }
+    }
+
+    /// Returns the renderer-assigned metadata used to build a static query
+    /// descriptor. Repeated references to this capture resolve to one slot.
+    public func staticQueryParameter(
+        in encoding: XLEncoding
+    ) throws -> XLStaticQueryParameterMetadata {
+        if let error = encoding.parameterLayoutError {
+            throw error
+        }
+        guard encoding.dialectRequirement.identity == dialectIdentifier else {
+            throw XLQueryCaptureError.dialectMismatch(
+                identity: identity,
+                expected: dialectIdentifier,
+                actual: encoding.dialectRequirement.identity
+            )
+        }
+        let layout = encoding.parameterLayout
+        guard let slot = layout.slot(for: declaration.key) else {
+            throw XLInvocationBindingError.parameterDeclarationNotInLayout(
+                declaration: declaration
+            )
+        }
+        guard slot.declaration == declaration else {
+            throw XLInvocationBindingError.parameterMetadataMismatch(
+                expected: slot,
+                actual: declaration.slot(at: slot.index)
+            )
+        }
+        return XLStaticQueryParameterMetadata(
+            identity: identity,
+            slot: slot,
+            storageIdentifier: storageIdentifier
+        )
+    }
+}
+
+
+extension XLQueryCapture where Dialect == XLSQLiteDialect {
+
+    /// Creates a codec-free capture for SQLite's intrinsic Swift value types:
+    /// `Bool`, `Int`, `Double`, `String`, and `Data`.
+    public static func intrinsic(
+        identifiedBy identity: XLQuerySlotIdentity,
+        context: XLValueCodingContext? = nil
+    ) throws -> Self {
+        guard !(Input.self is any _XLOptionalLiteralType.Type) else {
+            throw XLQueryCaptureError.optionalInputType(
+                identity: identity,
+                valueType: String(reflecting: Input.self)
+            )
+        }
+        let literalStorage = try _xlRequiredSQLiteStorage(
+            for: Literal.self,
+            identity: identity
+        )
+        let inputStorage = sqliteStorageClass(for: Input.self)
+        let literalValueType = _xlUnwrappedLiteralType(Literal.self)
+        guard inputStorage == literalStorage,
+              literalValueType == Input.self else {
+            throw XLQueryCaptureError.unsupportedIntrinsicValue(
+                identity: identity,
+                valueType: String(reflecting: Input.self),
+                literalType: String(reflecting: Literal.self)
+            )
+        }
+        let metadata = legacyValueMetadata(for: Input.self)
+        let inputTypeName = String(reflecting: Input.self)
+        let literalTypeName = String(reflecting: Literal.self)
+        let codingContext = context ?? XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(identity.path)
+        )
+        let encoder: @Sendable (Input) throws -> XLSQLiteValue = { value in
+            if let value = value as? Bool {
+                return .integer(value ? 1 : 0)
+            }
+            if let value = value as? Int {
+                return .integer(Int64(value))
+            }
+            if let value = value as? Double {
+                guard value.isFinite else {
+                    throw XLQueryCaptureError.nonFiniteReal(
+                        identity: identity,
+                        value: String(describing: value)
+                    )
+                }
+                return .real(value)
+            }
+            if let value = value as? String {
+                return .text(value)
+            }
+            if let value = value as? Data {
+                return .blob(value)
+            }
+            throw XLQueryCaptureError.unsupportedIntrinsicValue(
+                identity: identity,
+                valueType: inputTypeName,
+                literalType: literalTypeName
+            )
+        }
+        return Self(
+            identity: identity,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: XLValueStorageIdentifier(
+                rawValue: literalStorage.rawValue
+            ),
+            valueTypeIdentifier: metadata.identifier,
+            nullability: _xlLiteralNullability(Literal.self),
+            context: codingContext,
+            intrinsicEncoder: encoder
+        )
+    }
+}
+
+
+extension XLValueCodingConfiguration {
+
+    /// Declares a contextual SQLite capture without requiring a live database.
+    /// The returned token retains only durable metadata from this immutable
+    /// configuration snapshot; it does not retain the configuration itself.
+    public func queryCapture<Input, Literal>(
+        _ inputType: Input.Type,
+        expressedAs literalType: Literal.Type,
+        identifiedBy identity: XLQuerySlotIdentity,
+        using dialect: XLSQLiteDialect,
+        context: XLValueCodingContext? = nil,
+        selection: XLQueryCodecSelection = .inferred
+    ) throws -> XLQueryCapture<Input, Literal, XLSQLiteDialect>
+    where Literal: XLLiteral {
+        guard !(Input.self is any _XLOptionalLiteralType.Type) else {
+            throw XLQueryCaptureError.optionalInputType(
+                identity: identity,
+                valueType: String(reflecting: Input.self)
+            )
+        }
+        let storageClass = try _xlRequiredSQLiteStorage(
+            for: literalType,
+            identity: identity
+        )
+        let storage = XLValueStorageIdentifier(rawValue: storageClass.rawValue)
+        let codingContext = context ?? XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(identity.path)
+        )
+        let codecIdentity = try codecIdentity(
+            for: inputType,
+            using: dialect,
+            context: codingContext,
+            requiringStorage: storage,
+            selection: selection
+        )
+        return try XLQueryCapture(
+            identity: identity,
+            dialectIdentifier: dialect.descriptor.identity,
+            storageIdentifier: storage,
+            codecIdentity: codecIdentity,
+            context: codingContext
+        )
+    }
+}
+
+
+extension GRDBDatabase {
+
+    /// Declares a contextual capture using this database's immutable coding
+    /// configuration. Selection is constrained by `Literal`'s SQLite storage
+    /// representation before a default or unique candidate can be inferred.
+    public func queryCapture<Input, Literal>(
+        _ inputType: Input.Type,
+        expressedAs literalType: Literal.Type,
+        identifiedBy identity: XLQuerySlotIdentity,
+        context: XLValueCodingContext? = nil,
+        selection: XLQueryCodecSelection = .inferred
+    ) throws -> XLQueryCapture<Input, Literal, XLSQLiteDialect>
+    where Literal: XLLiteral {
+        try codingConfiguration.queryCapture(
+            inputType,
+            expressedAs: literalType,
+            identifiedBy: identity,
+            using: dialect,
+            context: context,
+            selection: selection
+        )
+    }
+}
+
+
+private func _xlLiteralNullability(_ type: Any.Type) -> XLParameterNullability {
+    type is any _XLOptionalLiteralType.Type ? .nullable : .required
+}
+
+
+private func _xlUnwrappedLiteralType(_ type: Any.Type) -> Any.Type {
+    if let optional = type as? any _XLOptionalLiteralType.Type {
+        return optional.wrappedType
+    }
+    return type
+}
+
+
+private func _xlRequiredSQLiteStorage(
+    for type: Any.Type,
+    identity: XLQuerySlotIdentity
+) throws -> XLSQLiteStorageClass {
+    guard let storage = sqliteStorageClass(for: type) else {
+        throw XLQueryCaptureError.unsupportedLiteralStorage(
+            identity: identity,
+            literalType: String(reflecting: type)
+        )
+    }
+    return storage
+}
+
+
+private func _xlQueryCaptureBindingName(
+    _ identity: XLQuerySlotIdentity
+) -> String {
+    var bytes: [UInt8] = []
+    _xlAppendUInt64(UInt64(identity.path.count), to: &bytes)
+    for component in identity.path {
+        let canonical = Array(
+            component.precomposedStringWithCanonicalMapping.utf8
+        )
+        _xlAppendUInt64(UInt64(canonical.count), to: &bytes)
+        bytes.append(contentsOf: canonical)
+    }
+    let digits = Array("0123456789abcdef".utf8)
+    var encoded: [UInt8] = Array("__swiftql_capture_".utf8)
+    encoded.reserveCapacity(encoded.count + bytes.count * 2)
+    for byte in bytes {
+        encoded.append(digits[Int(byte >> 4)])
+        encoded.append(digits[Int(byte & 0x0f)])
+    }
+    return String(decoding: encoded, as: UTF8.self)
+}
+
+
+private func _xlAppendUInt64(_ value: UInt64, to bytes: inout [UInt8]) {
+    for shift in stride(from: 56, through: 0, by: -8) {
+        bytes.append(UInt8(truncatingIfNeeded: value >> UInt64(shift)))
+    }
+}

--- a/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
@@ -116,22 +116,37 @@ exactly one matching codec is required. Use `.explicit(codecKey)` or
 that storage class. This query-specific path never consults a legacy or
 process-global fallback.
 
+When a typed column or other `XLExpression` is available, use
+`queryCapture(_:matching:identifiedBy:)`. Its associated literal type supplies
+the SQL nullability and storage contract, so a `Date` matched to an expression
+of `String` selects only `TEXT` codecs. Keep the `expressedAs:` factory as the
+explicit fallback when declaration-time expression metadata is unavailable.
+Generated domain-property metadata beyond an expression's literal type belongs
+to the typed row-layout layer.
+
 `staticQueryParameter(in:)` validates the rendered dialect as well as the
 capture's complete parameter declaration. This is important for codec-free
 intrinsic captures, whose metadata otherwise has no codec dialect to verify.
 The token's stable binding name uses NFC-normalized, length-prefixed identity
 components; it does not use `hashValue` or a slash-joined path.
 
-After the descriptor is prepared, build a fresh packet by binding values to
-their captures. Contextual conversion is resolved from the prepared handle's
+After the descriptor is prepared, build a fresh packet from immutable per-call
+arguments such as `cutoffCapture.argument(cutoffDate)`, or use the builder
+closure for dynamic assembly. Arguments are intended for immediate packet
+construction. Applying one copies only its encoded dialect value into the
+packet; the reusable prepared handle stores neither arguments nor completed
+packets. Contextual conversion is resolved from the prepared handle's
 snapshotted configuration, not from whichever configuration happens to be
 current when the call runs.
 
-The nonoptional `bind` overload accepts required or nullable captures. Passing
-`nil` is available only for a capture whose SQL expression type is optional,
-such as `XLQueryCapture<String, String?, XLSQLiteDialect>`; `nil` becomes a
-present SQL `NULL`, never an omitted binding. The completed packet rejects
-missing, duplicate, foreign, or metadata-conflicting captures.
+The nonoptional `argument` and `bind` overloads accept required or nullable
+captures. Passing `nil` is available only for a capture whose SQL expression
+type is optional, such as
+`XLQueryCapture<String, String?, XLSQLiteDialect>`; `nil` becomes a present SQL
+`NULL`, never an omitted binding. The completed packet rejects missing,
+duplicate, foreign, or metadata-conflicting captures. Codec-selection failures
+retain the capture identity, expected dialect and storage, selection tier,
+ordered candidates, coding context, and the underlying deterministic detail.
 
 Collections do not expand into a runtime-dependent number of placeholders.
 Represent a collection as one dialect scalar through a contextual codec, such
@@ -220,12 +235,9 @@ let staticDatabase = try GRDBDatabase(
 let preparedCutoff = try staticDatabase.prepareInvocation(
     with: cutoffDescriptor
 )
-let cutoffBindings = try preparedCutoff.makeInvocationBindings {
-    try $0.bind(
-        Date(timeIntervalSince1970: 86_400),
-        to: cutoffParameter
-    )
-}
+let cutoffBindings = try preparedCutoff.makeInvocationBindings(
+    cutoffParameter.argument(Date(timeIntervalSince1970: 86_400))
+)
 let cutoffRow = try preparedCutoff.fetchExactlyOneValues(
     bindings: cutoffBindings
 )

--- a/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
@@ -40,13 +40,15 @@ let cutoffCodec = try staticDateCoding.resolvedCodec(
     using: staticQueryDialect,
     context: cutoffContext
 )
-let cutoffParameter = XLContextualBindingReference<
-    Date,
-    String,
-    XLSQLiteDialect
->(
-    key: .named("cutoffDate"),
-    codec: cutoffCodec
+let cutoffParameterIdentity = try XLQuerySlotIdentity(
+    path: ["invoice", "parameter", "cutoffDate"]
+)
+let cutoffParameter = try staticDateCoding.queryCapture(
+    Date.self,
+    expressedAs: String.self,
+    identifiedBy: cutoffParameterIdentity,
+    using: staticQueryDialect,
+    context: cutoffContext
 )
 
 let cutoffEncoding = try XLiteEncoder(dialect: staticQueryDialect)
@@ -54,15 +56,11 @@ let cutoffEncoding = try XLiteEncoder(dialect: staticQueryDialect)
 let cutoffStatement = try XLStaticStatementDefinition(
     validating: cutoffEncoding
 )
-let cutoffParameterIdentity = try XLQuerySlotIdentity(
-    path: ["invoice", "parameter", "cutoffDate"]
-)
 let selectedDateIdentity = try XLQuerySlotIdentity(
     path: ["invoice", "result", "cutoffDate"]
 )
 let cutoffMetadata = try cutoffParameter.staticQueryParameter(
-    identity: cutoffParameterIdentity,
-    in: cutoffStatement.parameterLayout
+    in: cutoffEncoding
 )
 let selectedDate = XLStaticQueryResultSlot(
     index: XLLogicalResultIndex(0),
@@ -92,6 +90,55 @@ let cutoffDescriptor = try XLStaticQueryDescriptor(
 The renderer owns placeholder discovery and logical parameter order. Parameter
 metadata must match the resulting `XLParameterLayout` exactly. Result indices
 are also zero-based, contiguous, and in SQL output-column order.
+
+### Capture Swift invocation values
+
+Use `XLQueryCapture` when a static query gets an immutable value from its Swift
+caller. A capture is a value-free declaration token: it stores a durable slot
+identity, expression nullability, dialect storage, and selected codec metadata,
+but never the caller's value or a database. Referencing the same capture more
+than once emits the same named placeholder and creates one logical binding in
+first-traversal order.
+
+The runtime DSL cannot distinguish a bare Swift variable from an inline SQL
+literal, so capture inference is explicit at this bridge today: put the
+`XLQueryCapture` in the expression and supply its value only when building the
+invocation packet. The syntax-aware query macro planned by issue #26 can
+generate these same stable tokens and packets for bare captured variables; it
+does not require a second runtime binding model.
+
+Intrinsic `Bool`, `Int`, finite `Double`, `String`, and `Data` inputs use
+`intrinsic(identifiedBy:)`. Contextual inputs use an immutable coding
+configuration or database factory. Contextual inference filters codecs by the
+SQL literal's storage first. A matching configuration default wins; otherwise
+exactly one matching codec is required. Use `.explicit(codecKey)` or
+`.query(codecKey)` when more than one codec represents the same Swift type in
+that storage class. This query-specific path never consults a legacy or
+process-global fallback.
+
+`staticQueryParameter(in:)` validates the rendered dialect as well as the
+capture's complete parameter declaration. This is important for codec-free
+intrinsic captures, whose metadata otherwise has no codec dialect to verify.
+The token's stable binding name uses NFC-normalized, length-prefixed identity
+components; it does not use `hashValue` or a slash-joined path.
+
+After the descriptor is prepared, build a fresh packet by binding values to
+their captures. Contextual conversion is resolved from the prepared handle's
+snapshotted configuration, not from whichever configuration happens to be
+current when the call runs.
+
+The nonoptional `bind` overload accepts required or nullable captures. Passing
+`nil` is available only for a capture whose SQL expression type is optional,
+such as `XLQueryCapture<String, String?, XLSQLiteDialect>`; `nil` becomes a
+present SQL `NULL`, never an omitted binding. The completed packet rejects
+missing, duplicate, foreign, or metadata-conflicting captures.
+
+Collections do not expand into a runtime-dependent number of placeholders.
+Represent a collection as one dialect scalar through a contextual codec, such
+as a JSON `TEXT` value consumed by SQLite's `json_each(?)`, or declare a fixed
+number of element captures in the query structure. Runtime identifiers are not
+bindable values: table, column, and ordering choices must remain in the static
+SwiftQL expression graph.
 
 Each selected property or direct output column is one flat `XLStaticQueryResultSlot`.
 A selection with three columns therefore declares
@@ -173,18 +220,12 @@ let staticDatabase = try GRDBDatabase(
 let preparedCutoff = try staticDatabase.prepareInvocation(
     with: cutoffDescriptor
 )
-let preparedCutoffParameter = try preparedCutoff.preparedParameter(
-    Date.self,
-    identifiedBy: cutoffParameterIdentity
-)
-let cutoffBindings = try XLInvocationBindings<XLSQLiteValue>(
-    layout: preparedCutoff.parameterLayout,
-    bindings: [
-        try preparedCutoffParameter.encode(
-            Date(timeIntervalSince1970: 86_400)
-        )
-    ]
-).validatingComplete()
+let cutoffBindings = try preparedCutoff.makeInvocationBindings {
+    try $0.bind(
+        Date(timeIntervalSince1970: 86_400),
+        to: cutoffParameter
+    )
+}
 let cutoffRow = try preparedCutoff.fetchExactlyOneValues(
     bindings: cutoffBindings
 )
@@ -208,11 +249,13 @@ operations fail if the exact selected codec is absent or incompatible in the
 prepared snapshot.
 
 Intrinsic `Bool`, `Int`, `Double`, `String`, and `Data` slots have no contextual
-codec identity. Build their packet bindings directly from `.integer`, `.real`,
-`.text`, or `.blob` `XLSQLiteValue` values and consume their result values in
-the same raw form. The prepared handle still enforces declared storage and
-nullability. `NULL` must be a present `.null` binding for a nullable slot;
-omitting a binding is an incomplete packet.
+codec identity. Prefer an `XLQueryCapture` and `makeInvocationBindings` for new
+static queries. The explicit packet API remains available and source-compatible:
+you can still build bindings directly from `.integer`, `.real`, `.text`, or
+`.blob` `XLSQLiteValue` values and consume result values in the same raw form.
+The prepared handle enforces declared storage and nullability either way.
+`NULL` must be a present `.null` binding for a nullable slot; omitting a binding
+is an incomplete packet.
 
 ### Cardinality
 

--- a/Sources/SwiftQLCore/ValueCodec.swift
+++ b/Sources/SwiftQLCore/ValueCodec.swift
@@ -191,6 +191,65 @@ public struct XLValueCodecSelection: Hashable, Sendable {
 }
 
 
+/// Query-declaration codec selection constrained by the SQL expression's
+/// stable storage representation.
+///
+/// Unlike ``XLValueCodecSelection``, inference never consults a legacy codec.
+/// A query may either request inference from its immutable configuration
+/// snapshot or select one codec explicitly at the declaration/query tier.
+public enum XLQueryCodecSelection: Hashable, Sendable {
+    case inferred
+    case explicit(XLValueCodecKey)
+    case query(XLValueCodecKey)
+}
+
+
+/// Storage-constrained inference failures for static query declarations.
+///
+/// This is separate from ``XLValueCodecError`` so query inference can add
+/// storage-specific diagnostics without changing that existing public enum.
+public enum XLQueryCodecSelectionError:
+    Error,
+    Equatable,
+    Sendable,
+    LocalizedError
+{
+    case missingCodecForStorage(
+        valueType: String,
+        dialect: XLDialectIdentifier,
+        storage: XLValueStorageIdentifier,
+        context: XLValueCodingContext
+    )
+    case ambiguousCodecForStorage(
+        valueType: String,
+        dialect: XLDialectIdentifier,
+        storage: XLValueStorageIdentifier,
+        candidates: [XLValueCodecKey],
+        context: XLValueCodingContext
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingCodecForStorage(
+            let valueType,
+            let dialect,
+            let storage,
+            let context
+        ):
+            return "No codec represents \(valueType) as \(storage) for \(dialect) at \(context)."
+        case .ambiguousCodecForStorage(
+            let valueType,
+            let dialect,
+            let storage,
+            let candidates,
+            let context
+        ):
+            return "Codecs \(candidates.map(\.description).joined(separator: ", ")) are ambiguous for \(valueType) as \(storage) for \(dialect) at \(context)."
+        }
+    }
+}
+
+
 /// Deterministic failures from codec registration, selection, and conversion.
 public enum XLValueCodecError: Error, Equatable, Sendable, LocalizedError {
     case duplicateCodec(key: XLValueCodecKey, context: XLValueCodingContext)
@@ -585,6 +644,24 @@ public struct XLValueCodingConfiguration: Sendable {
         ).identity
     }
 
+    /// Selects stable query codec metadata after constraining candidates to
+    /// the storage representation required by the SQL expression.
+    public func codecIdentity<Value, Dialect>(
+        for valueType: Value.Type,
+        using dialect: Dialect,
+        context: XLValueCodingContext,
+        requiringStorage storage: XLValueStorageIdentifier,
+        selection: XLQueryCodecSelection = .inferred
+    ) throws -> XLValueCodecIdentity where Dialect: XLValueCodingDialect {
+        try resolvedCodec(
+            for: valueType,
+            using: dialect,
+            context: context,
+            requiringStorage: storage,
+            selection: selection
+        ).identity
+    }
+
     /// Resolves one static coding slot against this immutable configuration.
     ///
     /// Retain the returned value on a query descriptor or prepared handle and
@@ -600,6 +677,34 @@ public struct XLValueCodingConfiguration: Sendable {
             valueType: valueType,
             dialect: dialect,
             context: context,
+            selection: selection
+        )
+        return XLResolvedValueCodec(
+            codec: codec,
+            dialect: dialect,
+            context: context
+        )
+    }
+
+    /// Resolves a query parameter codec after filtering by the SQL
+    /// expression's stable storage contract.
+    ///
+    /// This overload deliberately has no legacy fallback. For inference, a
+    /// matching configuration default wins; otherwise exactly one registered
+    /// codec for the runtime type, dialect, and storage is required.
+    public func resolvedCodec<Value, Dialect>(
+        for valueType: Value.Type,
+        using dialect: Dialect,
+        context: XLValueCodingContext,
+        requiringStorage storage: XLValueStorageIdentifier,
+        selection: XLQueryCodecSelection = .inferred
+    ) throws -> XLResolvedValueCodec<Value, Dialect>
+    where Dialect: XLValueCodingDialect {
+        let codec = try resolveQueryCodec(
+            valueType: valueType,
+            dialect: dialect,
+            context: context,
+            storage: storage,
             selection: selection
         )
         return XLResolvedValueCodec(
@@ -736,6 +841,85 @@ public struct XLValueCodingConfiguration: Sendable {
                 context: context
             )
         }
+    }
+
+    private func resolveQueryCodec<Value, Dialect>(
+        valueType: Value.Type,
+        dialect: Dialect,
+        context: XLValueCodingContext,
+        storage: XLValueStorageIdentifier,
+        selection: XLQueryCodecSelection
+    ) throws -> _XLAnyValueCodec where Dialect: XLValueCodingDialect {
+        let target = _XLValueCodecTarget(
+            valueType,
+            Dialect.self,
+            dialectIdentifier: dialect.descriptor.identity
+        )
+
+        let selected: _XLAnyValueCodec
+        switch selection {
+        case .explicit(let key):
+            selected = try resolve(
+                key,
+                source: .explicit,
+                target: target,
+                dialect: dialect,
+                context: context
+            )
+        case .query(let key):
+            selected = try resolve(
+                key,
+                source: .query,
+                target: target,
+                dialect: dialect,
+                context: context
+            )
+        case .inferred:
+            let candidates = registry.codecs.values
+                .filter {
+                    $0.runtimeTarget == target
+                        && $0.identity.storageIdentifier == storage
+                }
+                .sorted { lhs, rhs in
+                    _xlCodecKeyIsOrdered(lhs.identity.key, before: rhs.identity.key)
+                }
+            if let defaultKey = defaults[target],
+               let defaultCodec = registry.codecs[defaultKey],
+               defaultCodec.identity.storageIdentifier == storage {
+                selected = defaultCodec
+            }
+            else {
+                switch candidates.count {
+                case 1:
+                    selected = candidates[0]
+                case 0:
+                    throw XLQueryCodecSelectionError.missingCodecForStorage(
+                        valueType: String(reflecting: Value.self),
+                        dialect: dialect.descriptor.identity,
+                        storage: storage,
+                        context: context
+                    )
+                default:
+                    throw XLQueryCodecSelectionError.ambiguousCodecForStorage(
+                        valueType: String(reflecting: Value.self),
+                        dialect: dialect.descriptor.identity,
+                        storage: storage,
+                        candidates: candidates.map { $0.identity.key },
+                        context: context
+                    )
+                }
+            }
+        }
+
+        guard selected.identity.storageIdentifier == storage else {
+            throw XLValueCodecError.storageMismatch(
+                codec: selected.identity.key,
+                expected: selected.identity.storageIdentifier,
+                actual: storage,
+                context: context
+            )
+        }
+        return selected
     }
 
     private func resolve<Dialect>(

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1725,13 +1725,15 @@ extension XLDocumentationTests {
             using: staticQueryDialect,
             context: cutoffContext
         )
-        let cutoffParameter = XLContextualBindingReference<
-            Date,
-            String,
-            XLSQLiteDialect
-        >(
-            key: .named("cutoffDate"),
-            codec: cutoffCodec
+        let cutoffParameterIdentity = try XLQuerySlotIdentity(
+            path: ["invoice", "parameter", "cutoffDate"]
+        )
+        let cutoffParameter = try staticDateCoding.queryCapture(
+            Date.self,
+            expressedAs: String.self,
+            identifiedBy: cutoffParameterIdentity,
+            using: staticQueryDialect,
+            context: cutoffContext
         )
 
         let cutoffEncoding = try XLiteEncoder(dialect: staticQueryDialect)
@@ -1739,15 +1741,11 @@ extension XLDocumentationTests {
         let cutoffStatement = try XLStaticStatementDefinition(
             validating: cutoffEncoding
         )
-        let cutoffParameterIdentity = try XLQuerySlotIdentity(
-            path: ["invoice", "parameter", "cutoffDate"]
-        )
         let selectedDateIdentity = try XLQuerySlotIdentity(
             path: ["invoice", "result", "cutoffDate"]
         )
         let cutoffMetadata = try cutoffParameter.staticQueryParameter(
-            identity: cutoffParameterIdentity,
-            in: cutoffStatement.parameterLayout
+            in: cutoffEncoding
         )
         let selectedDate = XLStaticQueryResultSlot(
             index: XLLogicalResultIndex(0),
@@ -1773,7 +1771,10 @@ extension XLDocumentationTests {
             cardinality: .exactlyOne
         )
 
-        XCTAssertEqual(cutoffDescriptor.sql, "SELECT :cutoffDate")
+        guard case .named(let cutoffBindingName) = cutoffParameter.declaration.key else {
+            return XCTFail("Query captures must use stable named keys")
+        }
+        XCTAssertEqual(cutoffDescriptor.sql, "SELECT :\(cutoffBindingName)")
         XCTAssertEqual(cutoffDescriptor.parameters, [cutoffMetadata])
         XCTAssertEqual(cutoffDescriptor.results.slots, [selectedDate])
         let staticQueryRegistry = [
@@ -1823,6 +1824,10 @@ extension XLDocumentationTests {
         )
         let decodedCutoff = try cutoffResultCodec.decode(cutoffRow[0])
         XCTAssertEqual(decodedCutoff, expectedDate)
+        let capturedCutoffBindings = try preparedCutoff.makeInvocationBindings {
+            try $0.bind(expectedDate, to: cutoffParameter)
+        }
+        XCTAssertEqual(capturedCutoffBindings.bindings, cutoffBindings.bindings)
 
         let intrinsicParameter = XLNamedBindingReference<Int>(name: "value")
         let intrinsicEncoding = try XLiteEncoder(dialect: staticQueryDialect)

--- a/Tests/SQLTests/SQLQueryCaptureTests.swift
+++ b/Tests/SQLTests/SQLQueryCaptureTests.swift
@@ -1,0 +1,370 @@
+import Foundation
+import XCTest
+
+@testable import SwiftQL
+
+
+final class SQLQueryCaptureTests: XCTestCase {
+
+    private let encoder = XLiteEncoder(dialect: XLSQLiteDialect())
+
+    func testIntrinsicCaptureRendersOneStablePlaceholderAndNoValue() throws {
+        let identity = try XLQuerySlotIdentity(path: ["invoice", "customer/name"])
+        let capture = try XLQueryCapture<String, String, XLSQLiteDialect>
+            .intrinsic(identifiedBy: identity)
+
+        let encoding = try encoder.makeValidatedSQL(
+            sql { _ in Select(capture) }
+        )
+        let metadata = try capture.staticQueryParameter(in: encoding)
+
+        guard case .named(let bindingName) = capture.declaration.key else {
+            return XCTFail("Stable captures must use a named binding key")
+        }
+        XCTAssertEqual(encoding.sql, "SELECT :\(bindingName)")
+        XCTAssertEqual(
+            bindingName,
+            "__swiftql_capture_00000000000000020000000000000007696e766f696365000000000000000d637573746f6d65722f6e616d65"
+        )
+        XCTAssertEqual(encoding.parameterLayout.count, 1)
+        XCTAssertEqual(metadata.identity, identity)
+        XCTAssertEqual(metadata.slot.index, XLLogicalParameterIndex(0))
+        XCTAssertEqual(metadata.slot.codecIdentity, nil)
+        XCTAssertEqual(
+            metadata.storageIdentifier,
+            XLValueStorageIdentifier(rawValue: "text")
+        )
+    }
+
+    func testRepeatedCaptureSharesOneLogicalSlot() throws {
+        let capture = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["repeated"])
+        )
+        let probe = CaptureProbe { builder in
+            capture.makeSQL(context: &builder)
+            capture.makeSQL(context: &builder)
+            capture.makeSQL(context: &builder)
+        }
+
+        let encoding = try encoder.makeValidatedSQL(probe)
+
+        XCTAssertEqual(encoding.parameterLayout.count, 1)
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.index),
+            [XLLogicalParameterIndex(0)]
+        )
+    }
+
+    func testDistinctCaptureOrderIsFirstTraversalOrderNotIdentityOrder() throws {
+        let laterName = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["z"])
+        )
+        let earlierName = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["a"])
+        )
+        let probe = CaptureProbe { builder in
+            laterName.makeSQL(context: &builder)
+            earlierName.makeSQL(context: &builder)
+            laterName.makeSQL(context: &builder)
+        }
+
+        let encoding = try encoder.makeValidatedSQL(probe)
+
+        XCTAssertEqual(encoding.parameterLayout.count, 2)
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.key),
+            [laterName.declaration.key, earlierName.declaration.key]
+        )
+    }
+
+    func testLengthPrefixedIdentityKeyAvoidsJoinedPathCollisions() throws {
+        let slashComponent = try XLQueryCapture<Int, Int, XLSQLiteDialect>
+            .intrinsic(
+                identifiedBy: XLQuerySlotIdentity(path: ["a/b"])
+            )
+        let separateComponents = try XLQueryCapture<Int, Int, XLSQLiteDialect>
+            .intrinsic(
+                identifiedBy: XLQuerySlotIdentity(path: ["a", "b"])
+            )
+
+        XCTAssertNotEqual(
+            slashComponent.declaration.key,
+            separateComponents.declaration.key
+        )
+        let encoding = try encoder.makeValidatedSQL(
+            CaptureProbe { builder in
+                slashComponent.makeSQL(context: &builder)
+                separateComponents.makeSQL(context: &builder)
+            }
+        )
+        XCTAssertEqual(encoding.parameterLayout.count, 2)
+    }
+
+    func testCanonicalEquivalentIdentityComponentsProduceSameKey() throws {
+        let composed = try XLQueryCapture<String, String, XLSQLiteDialect>
+            .intrinsic(
+                identifiedBy: XLQuerySlotIdentity(path: ["caf\u{00e9}"])
+            )
+        let decomposed = try XLQueryCapture<String, String, XLSQLiteDialect>
+            .intrinsic(
+                identifiedBy: XLQuerySlotIdentity(path: ["cafe\u{0301}"])
+            )
+
+        XCTAssertEqual(composed.declaration.key, decomposed.declaration.key)
+    }
+
+    func testReservedLookingLegacyBindingCannotCoalesceWithCapture() throws {
+        let capture = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["reserved", "capture"])
+        )
+        guard case .named(let generatedName) = capture.declaration.key else {
+            return XCTFail("Capture key must be named")
+        }
+        let legacy = XLNamedBindingReference<Int>(name: XLName(generatedName))
+        let encoding = encoder.makeSQL(
+            CaptureProbe { builder in
+                capture.makeSQL(context: &builder)
+                legacy.makeSQL(context: &builder)
+            }
+        )
+
+        guard case .conflictingParameterIndex(_, let existing, let incoming)? =
+                encoding.parameterLayoutError else {
+            return XCTFail(
+                "Expected generated-name collision to fail closed, got \(String(describing: encoding.parameterLayoutError))"
+            )
+        }
+        XCTAssertEqual(existing.key, capture.declaration.key)
+        XCTAssertEqual(incoming.key, capture.declaration.key)
+    }
+
+    func testSameIdentityWithConflictingContextualCodecsFailsRendering() throws {
+        let firstCodec = captureTokenCodec(id: "tests.capture.first")
+        let secondCodec = captureTokenCodec(id: "tests.capture.second")
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry()
+                .registering(secondCodec)
+                .registering(firstCodec)
+        )
+        let identity = try XLQuerySlotIdentity(path: ["codec", "conflict"])
+        XCTAssertThrowsError(try configuration.queryCapture(
+            CaptureToken?.self,
+            expressedAs: String?.self,
+            identifiedBy: identity,
+            using: XLSQLiteDialect()
+        )) { error in
+            XCTAssertEqual(
+                error as? XLQueryCaptureError,
+                .optionalInputType(
+                    identity: identity,
+                    valueType: String(reflecting: CaptureToken?.self)
+                )
+            )
+        }
+        XCTAssertThrowsError(try configuration.queryCapture(
+            CaptureToken.self,
+            expressedAs: String.self,
+            identifiedBy: identity,
+            using: XLSQLiteDialect()
+        )) { error in
+            guard case .ambiguousCodecForStorage(_, _, _, let candidates, _) =
+                    error as? XLQueryCodecSelectionError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(
+                candidates,
+                [firstCodec.identity.key, secondCodec.identity.key]
+            )
+        }
+        let first = try configuration.queryCapture(
+            CaptureToken.self,
+            expressedAs: String.self,
+            identifiedBy: identity,
+            using: XLSQLiteDialect(),
+            selection: .explicit(firstCodec.identity.key)
+        )
+        let second = try configuration.queryCapture(
+            CaptureToken.self,
+            expressedAs: String.self,
+            identifiedBy: identity,
+            using: XLSQLiteDialect(),
+            selection: .query(secondCodec.identity.key)
+        )
+        let encoding = encoder.makeSQL(
+            CaptureProbe { builder in
+                first.makeSQL(context: &builder)
+                second.makeSQL(context: &builder)
+            }
+        )
+
+        guard case .conflictingParameterIndex(_, let existing, let incoming)? =
+                encoding.parameterLayoutError else {
+            return XCTFail(
+                "Expected codec conflict, got \(String(describing: encoding.parameterLayoutError))"
+            )
+        }
+        XCTAssertEqual(existing.codecIdentity, firstCodec.identity)
+        XCTAssertEqual(incoming.codecIdentity, secondCodec.identity)
+    }
+
+    func testSameIdentityWithConflictingStorageFailsRendering() throws {
+        let identity = try XLQuerySlotIdentity(path: ["conflict"])
+        let integer = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: identity
+        )
+        let text = try XLQueryCapture<String, String, XLSQLiteDialect>.intrinsic(
+            identifiedBy: identity
+        )
+        let encoding = encoder.makeSQL(
+            CaptureProbe { builder in
+                integer.makeSQL(context: &builder)
+                text.makeSQL(context: &builder)
+            }
+        )
+
+        guard case .conflictingParameterIndex(_, let existing, let incoming)? =
+                encoding.parameterLayoutError else {
+            return XCTFail(
+                "Expected a deterministic storage/type conflict, got \(String(describing: encoding.parameterLayoutError))"
+            )
+        }
+        XCTAssertEqual(existing.key, integer.declaration.key)
+        XCTAssertEqual(incoming.key, text.declaration.key)
+        XCTAssertThrowsError(try encoder.makeValidatedSQL(
+            CaptureProbe { builder in
+                integer.makeSQL(context: &builder)
+                text.makeSQL(context: &builder)
+            }
+        ))
+    }
+
+    func testOptionalLiteralDeclaresNullableSlot() throws {
+        let capture = try XLQueryCapture<String, String?, XLSQLiteDialect>
+            .intrinsic(
+                identifiedBy: XLQuerySlotIdentity(path: ["nullable"])
+            )
+        let encoding = try encoder.makeValidatedSQL(
+            sql { _ in Select(capture) }
+        )
+
+        XCTAssertEqual(
+            try capture.staticQueryParameter(in: encoding).slot.nullability,
+            .nullable
+        )
+    }
+
+    func testIntrinsicCaptureRejectsUnsupportedAndOptionalInputTypes() throws {
+        let identity = try XLQuerySlotIdentity(path: ["unsupported"])
+
+        XCTAssertThrowsError(
+            try XLQueryCapture<UnknownLiteral, UnknownLiteral, XLSQLiteDialect>
+                .intrinsic(identifiedBy: identity)
+        ) { error in
+            guard case .unsupportedLiteralStorage = error as? XLQueryCaptureError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertThrowsError(
+            try XLQueryCapture<String?, String?, XLSQLiteDialect>
+                .intrinsic(identifiedBy: identity)
+        ) { error in
+            XCTAssertEqual(
+                error as? XLQueryCaptureError,
+                .optionalInputType(
+                    identity: identity,
+                    valueType: String(reflecting: String?.self)
+                )
+            )
+        }
+    }
+
+    func testStaticMetadataRejectsForeignDialectEncoding() throws {
+        let capture = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["dialect"])
+        )
+        let sqliteEncoding = try encoder.makeValidatedSQL(
+            sql { _ in Select(capture) }
+        )
+        let foreign = XLEncoding(
+            sql: sqliteEncoding.sql,
+            entities: sqliteEncoding.entities,
+            dialectRequirement: XLDialectRequirement(
+                identity: XLDialectIdentifier(rawValue: "foreign")
+            ),
+            parameterLayout: sqliteEncoding.parameterLayout
+        )
+
+        XCTAssertThrowsError(try capture.staticQueryParameter(in: foreign)) {
+            error in
+            XCTAssertEqual(
+                error as? XLQueryCaptureError,
+                .dialectMismatch(
+                    identity: capture.identity,
+                    expected: XLSQLiteDialect.identity,
+                    actual: XLDialectIdentifier(rawValue: "foreign")
+                )
+            )
+        }
+    }
+}
+
+
+private struct CaptureProbe: XLEncodable {
+    let render: (inout XLBuilder) -> Void
+
+    func makeSQL(context: inout XLBuilder) {
+        render(&context)
+    }
+}
+
+
+private struct UnknownLiteral: XLExpression, XLLiteral {
+    typealias T = Self
+
+    static func sqlDefault() -> Self {
+        Self()
+    }
+
+    init() {}
+
+    init(reader: XLColumnReader, at index: Int) throws {
+        self.init()
+    }
+
+    func bind(context: inout XLBindingContext) {
+        context.bindNull()
+    }
+
+    func makeSQL(context: inout XLBuilder) {
+        context.null()
+    }
+}
+
+
+private struct CaptureToken {
+    let value: String
+}
+
+
+private func captureTokenCodec(
+    id: String
+) -> XLValueCodec<CaptureToken, XLSQLiteDialect> {
+    XLValueCodec(
+        key: XLValueCodecKey(id: id, version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "tests.CaptureToken"),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: XLValueStorageIdentifier(rawValue: "text"),
+        encode: { value, _, _ in .text(value.value) },
+        decode: { value, _, _ in
+            guard case .text(let value) = value else {
+                throw CaptureTokenError.invalidValue
+            }
+            return CaptureToken(value: value)
+        }
+    )
+}
+
+
+private enum CaptureTokenError: Error {
+    case invalidValue
+}

--- a/Tests/SQLTests/SQLQueryCaptureTests.swift
+++ b/Tests/SQLTests/SQLQueryCaptureTests.swift
@@ -167,10 +167,19 @@ final class SQLQueryCaptureTests: XCTestCase {
             identifiedBy: identity,
             using: XLSQLiteDialect()
         )) { error in
-            guard case .ambiguousCodecForStorage(_, _, _, let candidates, _) =
-                    error as? XLQueryCodecSelectionError else {
+            guard case .codecSelectionFailed(
+                let actualIdentity,
+                _,
+                _,
+                _,
+                .inferred,
+                let candidates,
+                _,
+                _
+            ) = error as? XLQueryCaptureError else {
                 return XCTFail("Unexpected error: \(error)")
             }
+            XCTAssertEqual(actualIdentity, identity)
             XCTAssertEqual(
                 candidates,
                 [firstCodec.identity.key, secondCodec.identity.key]
@@ -205,6 +214,140 @@ final class SQLQueryCaptureTests: XCTestCase {
         }
         XCTAssertEqual(existing.codecIdentity, firstCodec.identity)
         XCTAssertEqual(incoming.codecIdentity, secondCodec.identity)
+    }
+
+    func testExpressionMetadataInfersRequiredAndNullableCaptureStorage() throws {
+        let codec = captureTokenCodec(id: "tests.capture.expression")
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(codec)
+        )
+        let requiredIdentity = try XLQuerySlotIdentity(
+            path: ["expression", "required"]
+        )
+        let nullableIdentity = try XLQuerySlotIdentity(
+            path: ["expression", "nullable"]
+        )
+
+        let required = try configuration.queryCapture(
+            CaptureToken.self,
+            matching: CaptureTypedExpression<String>(),
+            identifiedBy: requiredIdentity,
+            using: XLSQLiteDialect()
+        )
+        let nullable = try configuration.queryCapture(
+            CaptureToken.self,
+            matching: CaptureTypedExpression<String?>(),
+            identifiedBy: nullableIdentity,
+            using: XLSQLiteDialect()
+        )
+
+        XCTAssertEqual(required.declaration.nullability, .required)
+        XCTAssertEqual(nullable.declaration.nullability, .nullable)
+        XCTAssertEqual(required.storageIdentifier, codec.identity.storageIdentifier)
+        XCTAssertEqual(nullable.storageIdentifier, codec.identity.storageIdentifier)
+        XCTAssertEqual(required.declaration.codecIdentity, codec.identity)
+        XCTAssertEqual(nullable.declaration.codecIdentity, codec.identity)
+    }
+
+    func testCodecSelectionFailuresRetainCaptureSpecificMetadata() throws {
+        let identity = try XLQuerySlotIdentity(
+            path: ["diagnostic", "captured-value"]
+        )
+        let context = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(["custom", "context"])
+        )
+        let first = captureTokenCodec(id: "tests.capture.z-second")
+        let second = captureTokenCodec(id: "tests.capture.a-first")
+        let expectedText = XLValueStorageIdentifier(rawValue: "text")
+
+        func assertFailure(
+            _ error: Error,
+            expectedStorage: XLValueStorageIdentifier,
+            selection: XLQueryCodecSelection,
+            candidates: [XLValueCodecKey]
+        ) {
+            guard case .codecSelectionFailed(
+                let actualIdentity,
+                let valueType,
+                let expectedDialect,
+                let actualStorage,
+                let actualSelection,
+                let actualCandidates,
+                let actualContext,
+                let detail
+            ) = error as? XLQueryCaptureError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(actualIdentity, identity)
+            XCTAssertEqual(valueType, String(reflecting: CaptureToken.self))
+            XCTAssertEqual(expectedDialect, XLSQLiteDialect.identity)
+            XCTAssertEqual(actualStorage, expectedStorage)
+            XCTAssertEqual(actualSelection, selection)
+            XCTAssertEqual(actualCandidates, candidates)
+            XCTAssertEqual(actualContext, context)
+            XCTAssertFalse(detail.isEmpty)
+            let description = (error as? LocalizedError)?.errorDescription ?? ""
+            XCTAssertTrue(description.contains(identity.description))
+            XCTAssertTrue(description.contains(expectedDialect.description))
+            XCTAssertTrue(description.contains(expectedStorage.description))
+            XCTAssertTrue(description.contains(context.description))
+        }
+
+        let empty = try XLValueCodingConfiguration()
+        XCTAssertThrowsError(try empty.queryCapture(
+            CaptureToken.self,
+            expressedAs: String.self,
+            identifiedBy: identity,
+            using: XLSQLiteDialect(),
+            context: context
+        )) { error in
+            assertFailure(
+                error,
+                expectedStorage: expectedText,
+                selection: .inferred,
+                candidates: []
+            )
+        }
+
+        let ambiguous = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry()
+                .registering(first)
+                .registering(second)
+        )
+        XCTAssertThrowsError(try ambiguous.queryCapture(
+            CaptureToken.self,
+            expressedAs: String.self,
+            identifiedBy: identity,
+            using: XLSQLiteDialect(),
+            context: context
+        )) { error in
+            assertFailure(
+                error,
+                expectedStorage: expectedText,
+                selection: .inferred,
+                candidates: [second.identity.key, first.identity.key]
+            )
+        }
+
+        let explicit = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(first)
+        )
+        XCTAssertThrowsError(try explicit.queryCapture(
+            CaptureToken.self,
+            expressedAs: Int.self,
+            identifiedBy: identity,
+            using: XLSQLiteDialect(),
+            context: context,
+            selection: .explicit(first.identity.key)
+        )) { error in
+            assertFailure(
+                error,
+                expectedStorage: XLValueStorageIdentifier(rawValue: "integer"),
+                selection: .explicit(first.identity.key),
+                candidates: [first.identity.key]
+            )
+        }
     }
 
     func testSameIdentityWithConflictingStorageFailsRendering() throws {
@@ -314,6 +457,16 @@ private struct CaptureProbe: XLEncodable {
 
     func makeSQL(context: inout XLBuilder) {
         render(&context)
+    }
+}
+
+
+private struct CaptureTypedExpression<Literal>: XLExpression
+where Literal: XLLiteral {
+    typealias T = Literal
+
+    func makeSQL(context: inout XLBuilder) {
+        context.null()
     }
 }
 

--- a/Tests/SwiftQLCodecIntegrationTests/QueryCaptureGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/QueryCaptureGRDBTests.swift
@@ -5,6 +5,12 @@ import XCTest
 @testable import SwiftQL
 
 
+@SQLTable(name: "QueryCaptureDateRecord")
+private struct QueryCaptureDateRecord: Equatable {
+    let storedDate: String
+}
+
+
 final class QueryCaptureGRDBTests: XCTestCase {
 
     func testIntrinsicValuesAndNullRoundTripWithoutInterpolation() throws {
@@ -123,9 +129,9 @@ final class QueryCaptureGRDBTests: XCTestCase {
         let preparedRepeated = try fixture.database.prepareInvocation(
             with: repeatedDescriptor
         )
-        let repeatedPacket = try preparedRepeated.makeInvocationBindings {
-            try $0.bind("same", to: repeated)
-        }
+        let repeatedPacket = try preparedRepeated.makeInvocationBindings(
+            repeated.argument("same")
+        )
         XCTAssertEqual(repeatedPacket.bindingCount, 1)
         XCTAssertEqual(preparedRepeated.parameterLayout.count, 1)
         XCTAssertEqual(
@@ -157,12 +163,14 @@ final class QueryCaptureGRDBTests: XCTestCase {
         let preparedDistinct = try fixture.database.prepareInvocation(
             with: distinctDescriptor
         )
-        let distinctPacket = try preparedDistinct.makeInvocationBindings {
-            // Supply out of order; the immutable packet canonicalizes by the
-            // renderer's first-use logical order.
-            try $0.bind(7, to: second)
-            try $0.bind(7, to: first)
-        }
+        let distinctPacket = try preparedDistinct.makeInvocationBindings(
+            arguments: [
+                // Supply out of order; the immutable packet canonicalizes by
+                // the renderer's first-use logical order.
+                second.argument(7),
+                first.argument(7),
+            ]
+        )
         XCTAssertEqual(distinctPacket.bindingCount, 2)
         XCTAssertEqual(
             distinctPacket.bindings.map(\.slot.key),
@@ -261,6 +269,77 @@ final class QueryCaptureGRDBTests: XCTestCase {
         // A collection remains one scalar logical parameter. Runtime size does
         // not alter SQL text, placeholder count, or static query identity.
         XCTAssertEqual(prepared.parameterLayout.count, 3)
+    }
+
+    func testTypedColumnCaptureExecutesWithFreshImmutableArguments() throws {
+        let codecs = makeContextualCodecs()
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry()
+                .registering(codecs.dateInteger)
+                .registering(codecs.dateText)
+        )
+        let fixture = try makeQueryCaptureDatabase(configuration: configuration)
+        defer { fixture.tearDown() }
+        let firstDate = Date(timeIntervalSince1970: 1_700_000_111)
+        let secondDate = Date(timeIntervalSince1970: 1_700_000_222)
+        try fixture.database.databasePool.write { database in
+            try database.execute(
+                sql: "CREATE TABLE QueryCaptureDateRecord (storedDate TEXT NOT NULL)"
+            )
+            try database.execute(
+                sql: "INSERT INTO QueryCaptureDateRecord (storedDate) VALUES (?), (?)",
+                arguments: [
+                    String(firstDate.timeIntervalSince1970),
+                    String(secondDate.timeIntervalSince1970),
+                ]
+            )
+        }
+
+        let schema = XLSchema()
+        let record = schema.table(QueryCaptureDateRecord.self)
+        let capture = try fixture.database.queryCapture(
+            Date.self,
+            matching: record.storedDate,
+            identifiedBy: XLQuerySlotIdentity(
+                path: ["typed-column", "stored-date"]
+            )
+        )
+        let expression = select(record.storedDate)
+            .from(record)
+            .where(record.storedDate == capture)
+        let encoding = try XLiteEncoder(dialect: XLSQLiteDialect())
+            .makeValidatedSQL(expression)
+        let queryDescriptor = try descriptor(
+            definition: ["tests", "query-capture", "typed-column"],
+            encoding: encoding,
+            parameters: [capture.staticQueryParameter(in: encoding)],
+            resultStorage: [.text]
+        )
+        let prepared = try fixture.database.prepareInvocation(
+            with: queryDescriptor
+        )
+        let stableIdentity = prepared.identity
+
+        let firstPacket = try prepared.makeInvocationBindings(
+            capture.argument(firstDate)
+        )
+        XCTAssertEqual(
+            try prepared.fetchExactlyOneValues(bindings: firstPacket),
+            [.text(String(firstDate.timeIntervalSince1970))]
+        )
+        let secondPacket = try prepared.makeInvocationBindings(
+            capture.argument(secondDate)
+        )
+        XCTAssertEqual(
+            try prepared.fetchExactlyOneValues(bindings: secondPacket),
+            [.text(String(secondDate.timeIntervalSince1970))]
+        )
+
+        XCTAssertEqual(prepared.identity, stableIdentity)
+        XCTAssertEqual(prepared.parameterLayout.count, 1)
+        XCTAssertEqual(capture.storageIdentifier.rawValue, "text")
+        XCTAssertEqual(capture.declaration.codecIdentity, codecs.dateText.identity)
+        XCTAssertNotEqual(firstPacket.bindings[0].value, secondPacket.bindings[0].value)
     }
 
     func testBuilderReportsMissingDuplicateAndForeignCaptures() throws {
@@ -370,9 +449,9 @@ final class QueryCaptureGRDBTests: XCTestCase {
         ) { group in
             for value in 0 ..< 32 {
                 group.addTask {
-                    let packet = try prepared.makeInvocationBindings {
-                        try $0.bind(value, to: capture)
-                    }
+                    let packet = try prepared.makeInvocationBindings(
+                        capture.argument(value)
+                    )
                     guard packet.bindingCount == 1,
                           case .integer(let result) = try prepared
                             .fetchExactlyOneValues(bindings: packet)[0] else {
@@ -522,9 +601,7 @@ private func executeScalar<Input, Literal>(
         database: database,
         definition: definition
     )
-    let packet = try prepared.makeInvocationBindings {
-        try $0.bind(value, to: capture)
-    }
+    let packet = try prepared.makeInvocationBindings(capture.argument(value))
     XCTAssertEqual(packet.bindingCount, 1)
     return try prepared.fetchExactlyOneValues(bindings: packet)[0]
 }
@@ -541,9 +618,7 @@ private func executeNullableScalar<Input, Wrapped>(
         database: database,
         definition: definition
     )
-    let packet = try prepared.makeInvocationBindings {
-        try $0.bind(value, to: capture)
-    }
+    let packet = try prepared.makeInvocationBindings(capture.argument(value))
     return try prepared.fetchExactlyOneValues(bindings: packet)[0]
 }
 

--- a/Tests/SwiftQLCodecIntegrationTests/QueryCaptureGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/QueryCaptureGRDBTests.swift
@@ -1,0 +1,800 @@
+import Foundation
+import GRDB
+import XCTest
+
+@testable import SwiftQL
+
+
+final class QueryCaptureGRDBTests: XCTestCase {
+
+    func testIntrinsicValuesAndNullRoundTripWithoutInterpolation() throws {
+        let fixture = try makeQueryCaptureDatabase()
+        defer { fixture.tearDown() }
+        try fixture.database.databasePool.write { database in
+            try database.execute(sql: "CREATE TABLE injection_guard (id INTEGER)")
+        }
+
+        let dangerous = "x'); DROP TABLE injection_guard; -- \"quoted\""
+        let text = try XLQueryCapture<String, String, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["intrinsic", "text"])
+        )
+        XCTAssertEqual(
+            try executeScalar(
+                dangerous,
+                capture: text,
+                database: fixture.database,
+                definition: ["tests", "query-capture", "text"]
+            ),
+            .text(dangerous)
+        )
+        let tableCount = try fixture.database.databasePool.read { database in
+            try Int.fetchOne(
+                database,
+                sql: "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'injection_guard'"
+            )
+        }
+        XCTAssertEqual(tableCount, 1)
+
+        let nullable = try XLQueryCapture<String, String?, XLSQLiteDialect>
+            .intrinsic(
+                identifiedBy: XLQuerySlotIdentity(path: ["intrinsic", "null"])
+            )
+        XCTAssertEqual(
+            try executeNullableScalar(
+                nil,
+                capture: nullable,
+                database: fixture.database,
+                definition: ["tests", "query-capture", "null"]
+            ),
+            .null
+        )
+
+        let blob = try XLQueryCapture<Data, Data, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["intrinsic", "blob"])
+        )
+        let blobValue = Data([0x00, 0x27, 0xff, 0x3b])
+        XCTAssertEqual(
+            try executeScalar(
+                blobValue,
+                capture: blob,
+                database: fixture.database,
+                definition: ["tests", "query-capture", "blob"]
+            ),
+            .blob(blobValue)
+        )
+
+        let boolean = try XLQueryCapture<Bool, Bool, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["intrinsic", "bool"])
+        )
+        XCTAssertEqual(
+            try executeScalar(
+                true,
+                capture: boolean,
+                database: fixture.database,
+                definition: ["tests", "query-capture", "bool"]
+            ),
+            .integer(1)
+        )
+        let integer = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["intrinsic", "int"])
+        )
+        XCTAssertEqual(
+            try executeScalar(
+                Int.max,
+                capture: integer,
+                database: fixture.database,
+                definition: ["tests", "query-capture", "int"]
+            ),
+            .integer(Int64.max)
+        )
+        let real = try XLQueryCapture<Double, Double, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["intrinsic", "real"])
+        )
+        XCTAssertEqual(
+            try executeScalar(
+                1234.5,
+                capture: real,
+                database: fixture.database,
+                definition: ["tests", "query-capture", "real"]
+            ),
+            .real(1234.5)
+        )
+    }
+
+    func testRepeatedAndDistinctCapturesPreserveLogicalCountAndOrder() throws {
+        let fixture = try makeQueryCaptureDatabase()
+        defer { fixture.tearDown() }
+        let repeated = try XLQueryCapture<String, String, XLSQLiteDialect>
+            .intrinsic(
+                identifiedBy: XLQuerySlotIdentity(path: ["repeat", "value"])
+            )
+        let repeatedEncoding = try customEncoding(
+            sql: "SELECT :\(try namedKey(repeated)) = :\(try namedKey(repeated))"
+        ) { builder in
+            repeated.makeSQL(context: &builder)
+            repeated.makeSQL(context: &builder)
+        }
+        let repeatedDescriptor = try descriptor(
+            definition: ["tests", "query-capture", "repeated"],
+            encoding: repeatedEncoding,
+            parameters: [repeated.staticQueryParameter(in: repeatedEncoding)],
+            resultStorage: [.integer]
+        )
+        let preparedRepeated = try fixture.database.prepareInvocation(
+            with: repeatedDescriptor
+        )
+        let repeatedPacket = try preparedRepeated.makeInvocationBindings {
+            try $0.bind("same", to: repeated)
+        }
+        XCTAssertEqual(repeatedPacket.bindingCount, 1)
+        XCTAssertEqual(preparedRepeated.parameterLayout.count, 1)
+        XCTAssertEqual(
+            try preparedRepeated.fetchExactlyOneValues(bindings: repeatedPacket),
+            [.integer(1)]
+        )
+
+        let first = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["distinct", "first"])
+        )
+        let second = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["distinct", "second"])
+        )
+        let distinctEncoding = try customEncoding(
+            sql: "SELECT :\(try namedKey(first)), :\(try namedKey(second))"
+        ) { builder in
+            first.makeSQL(context: &builder)
+            second.makeSQL(context: &builder)
+        }
+        let distinctDescriptor = try descriptor(
+            definition: ["tests", "query-capture", "distinct"],
+            encoding: distinctEncoding,
+            parameters: [
+                first.staticQueryParameter(in: distinctEncoding),
+                second.staticQueryParameter(in: distinctEncoding),
+            ],
+            resultStorage: [.integer, .integer]
+        )
+        let preparedDistinct = try fixture.database.prepareInvocation(
+            with: distinctDescriptor
+        )
+        let distinctPacket = try preparedDistinct.makeInvocationBindings {
+            // Supply out of order; the immutable packet canonicalizes by the
+            // renderer's first-use logical order.
+            try $0.bind(7, to: second)
+            try $0.bind(7, to: first)
+        }
+        XCTAssertEqual(distinctPacket.bindingCount, 2)
+        XCTAssertEqual(
+            distinctPacket.bindings.map(\.slot.key),
+            [first.declaration.key, second.declaration.key]
+        )
+        XCTAssertEqual(
+            try preparedDistinct.fetchExactlyOneValues(bindings: distinctPacket),
+            [.integer(7), .integer(7)]
+        )
+    }
+
+    func testContextualDateUUIDAndCollectionUseStorageConstrainedCodecs() throws {
+        let codecs = makeContextualCodecs()
+        let registry = try XLValueCodecRegistry()
+            .registering(codecs.dateInteger)
+            .registering(codecs.dateText)
+            .registering(codecs.uuidText)
+            .registering(codecs.uuidArrayJSON)
+        let configuration = try XLValueCodingConfiguration(registry: registry)
+        let fixture = try makeQueryCaptureDatabase(configuration: configuration)
+        defer { fixture.tearDown() }
+
+        // Date has two registered representations and no default. The String
+        // SQL expression constrains inference to the unique TEXT codec.
+        let date = try fixture.database.queryCapture(
+            Date.self,
+            expressedAs: String.self,
+            identifiedBy: XLQuerySlotIdentity(path: ["contextual", "date"])
+        )
+        let uuid = try fixture.database.queryCapture(
+            UUID.self,
+            expressedAs: String.self,
+            identifiedBy: XLQuerySlotIdentity(path: ["contextual", "uuid"])
+        )
+        let collection = try fixture.database.queryCapture(
+            [UUID].self,
+            expressedAs: String.self,
+            identifiedBy: XLQuerySlotIdentity(path: ["contextual", "uuids"])
+        )
+        XCTAssertEqual(date.declaration.codecIdentity?.key, codecs.dateText.identity.key)
+
+        let encoding = try customEncoding(
+            sql: "SELECT :\(try namedKey(date)), :\(try namedKey(uuid)), value FROM json_each(:\(try namedKey(collection)))"
+        ) { builder in
+            date.makeSQL(context: &builder)
+            uuid.makeSQL(context: &builder)
+            collection.makeSQL(context: &builder)
+        }
+        let descriptor = try descriptor(
+            definition: ["tests", "query-capture", "contextual-collection"],
+            encoding: encoding,
+            parameters: [
+                date.staticQueryParameter(in: encoding),
+                uuid.staticQueryParameter(in: encoding),
+                collection.staticQueryParameter(in: encoding),
+            ],
+            resultStorage: [.text, .text, .text],
+            cardinality: .many
+        )
+        let prepared = try fixture.database.prepareInvocation(with: descriptor)
+        let expectedDate = Date(timeIntervalSince1970: 1_700_000_123)
+        let expectedUUID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+        let values = [
+            UUID(uuidString: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")!,
+            UUID(uuidString: "01234567-89ab-cdef-0123-456789abcdef")!,
+        ]
+        let packet = try prepared.makeInvocationBindings {
+            try $0.bind(values, to: collection)
+            try $0.bind(expectedUUID, to: uuid)
+            try $0.bind(expectedDate, to: date)
+        }
+
+        XCTAssertEqual(packet.bindingCount, 3)
+        XCTAssertEqual(
+            packet.bindings.map { $0.slot.codecIdentity?.key },
+            [
+                codecs.dateText.identity.key,
+                codecs.uuidText.identity.key,
+                codecs.uuidArrayJSON.identity.key,
+            ]
+        )
+        let rows = try prepared.fetchAllValues(bindings: packet)
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows.map { $0[0] }, Array(
+            repeating: .text(String(expectedDate.timeIntervalSince1970)),
+            count: 2
+        ))
+        XCTAssertEqual(rows.map { $0[1] }, Array(
+            repeating: .text(expectedUUID.uuidString.lowercased()),
+            count: 2
+        ))
+        XCTAssertEqual(
+            rows.map { $0[2] },
+            values.map { .text($0.uuidString.lowercased()) }
+        )
+        // A collection remains one scalar logical parameter. Runtime size does
+        // not alter SQL text, placeholder count, or static query identity.
+        XCTAssertEqual(prepared.parameterLayout.count, 3)
+    }
+
+    func testBuilderReportsMissingDuplicateAndForeignCaptures() throws {
+        let fixture = try makeQueryCaptureDatabase()
+        defer { fixture.tearDown() }
+        let capture = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["diagnostic", "value"])
+        )
+        let prepared = try prepareScalar(
+            capture: capture,
+            database: fixture.database,
+            definition: ["tests", "query-capture", "diagnostics"]
+        )
+
+        XCTAssertThrowsError(try prepared.makeInvocationBindings { _ in }) {
+            error in
+            guard case .missingBindings(let slots) =
+                    error as? XLInvocationBindingError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(slots.map(\.key), [capture.declaration.key])
+        }
+        XCTAssertThrowsError(try prepared.makeInvocationBindings {
+            try $0.bind(1, to: capture)
+            try $0.bind(2, to: capture)
+        }) { error in
+            guard case .duplicateBinding(let slot) =
+                    error as? XLInvocationBindingError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(slot.key, capture.declaration.key)
+        }
+
+        let missing = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["diagnostic", "missing"])
+        )
+        XCTAssertThrowsError(try prepared.makeInvocationBindings {
+            try $0.bind(1, to: missing)
+        }) { error in
+            guard case .parameterNotFound(_, let identity) =
+                    error as? GRDBStaticQueryError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(identity, missing.identity)
+        }
+
+        let conflicting = try XLQueryCapture<String, String, XLSQLiteDialect>
+            .intrinsic(identifiedBy: capture.identity)
+        XCTAssertThrowsError(try prepared.makeInvocationBindings {
+            try $0.bind("wrong", to: conflicting)
+        }) { error in
+            XCTAssertEqual(
+                error as? XLQueryCaptureError,
+                .descriptorMetadataMismatch(
+                    query: prepared.identity,
+                    identity: capture.identity,
+                    expectedSlot: prepared.parameterLayout.slots[0],
+                    expectedStorage: capture.storageIdentifier,
+                    actualDeclaration: conflicting.declaration,
+                    actualStorage: conflicting.storageIdentifier
+                )
+            )
+        }
+    }
+
+    func testIntrinsicDoubleRejectsValuesSQLiteWouldNormalizeToNull() throws {
+        let fixture = try makeQueryCaptureDatabase()
+        defer { fixture.tearDown() }
+        let capture = try XLQueryCapture<Double, Double, XLSQLiteDialect>
+            .intrinsic(
+                identifiedBy: XLQuerySlotIdentity(path: ["diagnostic", "real"])
+            )
+        let prepared = try prepareScalar(
+            capture: capture,
+            database: fixture.database,
+            definition: ["tests", "query-capture", "non-finite"]
+        )
+
+        for value in [Double.nan, .infinity, -.infinity] {
+            XCTAssertThrowsError(try prepared.makeInvocationBindings {
+                try $0.bind(value, to: capture)
+            }) { error in
+                guard case .nonFiniteReal(let identity, _) =
+                        error as? XLQueryCaptureError else {
+                    return XCTFail("Unexpected error: \(error)")
+                }
+                XCTAssertEqual(identity, capture.identity)
+            }
+        }
+    }
+
+    func testPreparedCaptureBuildsFreshPacketsConcurrently() async throws {
+        let fixture = try makeQueryCaptureDatabase()
+        defer { fixture.tearDown() }
+        let capture = try XLQueryCapture<Int, Int, XLSQLiteDialect>.intrinsic(
+            identifiedBy: XLQuerySlotIdentity(path: ["concurrent", "value"])
+        )
+        let prepared = try prepareScalar(
+            capture: capture,
+            database: fixture.database,
+            definition: ["tests", "query-capture", "concurrent"]
+        )
+
+        let results = try await withThrowingTaskGroup(
+            of: Int64.self,
+            returning: [Int64].self
+        ) { group in
+            for value in 0 ..< 32 {
+                group.addTask {
+                    let packet = try prepared.makeInvocationBindings {
+                        try $0.bind(value, to: capture)
+                    }
+                    guard packet.bindingCount == 1,
+                          case .integer(let result) = try prepared
+                            .fetchExactlyOneValues(bindings: packet)[0] else {
+                        throw QueryCaptureFixtureError.invalidValue
+                    }
+                    return result
+                }
+            }
+            var values: [Int64] = []
+            for try await value in group {
+                values.append(value)
+            }
+            return values.sorted()
+        }
+        XCTAssertEqual(results, (0 ..< 32).map(Int64.init))
+    }
+
+    func testInvocationUsesPreparedCodecSnapshotNotCaptureFactoryCodec() throws {
+        let factoryProbe = QueryCaptureEncodingProbe()
+        let preparedProbe = QueryCaptureEncodingProbe()
+        let factoryCodec = snapshotTokenCodec(probe: factoryProbe)
+        let preparedCodec = snapshotTokenCodec(probe: preparedProbe)
+        XCTAssertEqual(factoryCodec.identity, preparedCodec.identity)
+        let factoryConfiguration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(factoryCodec)
+        )
+        let preparedConfiguration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(preparedCodec)
+        )
+        let capture = try factoryConfiguration.queryCapture(
+            SnapshotToken.self,
+            expressedAs: String.self,
+            identifiedBy: XLQuerySlotIdentity(path: ["snapshot", "token"]),
+            using: XLSQLiteDialect()
+        )
+        let queryDescriptor = try scalarDescriptor(
+            capture: capture,
+            definition: ["tests", "query-capture", "prepared-snapshot"]
+        )
+        let preparedFixture = try makeQueryCaptureDatabase(
+            configuration: preparedConfiguration
+        )
+        defer { preparedFixture.tearDown() }
+        let prepared = try preparedFixture.database.prepareInvocation(
+            with: queryDescriptor
+        )
+
+        let packet = try prepared.makeInvocationBindings {
+            try $0.bind(SnapshotToken(value: "prepared"), to: capture)
+        }
+        XCTAssertEqual(packet.bindings.map(\.value), [.text("prepared")])
+        XCTAssertEqual(factoryProbe.count, 0)
+        XCTAssertEqual(preparedProbe.count, 1)
+        XCTAssertThrowsError(try prepared.makeInvocationBindings {
+            try $0.bind(SnapshotToken(value: "first"), to: capture)
+            try $0.bind(SnapshotToken(value: "duplicate"), to: capture)
+        }) { error in
+            guard case .duplicateBinding = error as? XLInvocationBindingError else {
+                return XCTFail("Unexpected duplicate error: \(error)")
+            }
+        }
+        XCTAssertEqual(
+            preparedProbe.count,
+            2,
+            "Duplicate preflight must not invoke contextual codec logic"
+        )
+
+        let missingFixture = try makeQueryCaptureDatabase()
+        defer { missingFixture.tearDown() }
+        XCTAssertThrowsError(try missingFixture.database.prepareInvocation(
+            with: queryDescriptor
+        )) { error in
+            guard case .preparedCodecUnavailable =
+                    error as? XLInvocationBindingError else {
+                return XCTFail("Unexpected missing-codec error: \(error)")
+            }
+        }
+
+        let mismatchedCodec = snapshotTokenCodec(
+            probe: QueryCaptureEncodingProbe(),
+            valueTypeIdentifier: "tests.SnapshotToken.changed"
+        )
+        let mismatchedConfiguration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(mismatchedCodec)
+        )
+        let mismatchedFixture = try makeQueryCaptureDatabase(
+            configuration: mismatchedConfiguration
+        )
+        defer { mismatchedFixture.tearDown() }
+        XCTAssertThrowsError(try mismatchedFixture.database.prepareInvocation(
+            with: queryDescriptor
+        )) { error in
+            guard case .preparedCodecIdentityMismatch =
+                    error as? XLInvocationBindingError else {
+                return XCTFail("Unexpected mismatched-codec error: \(error)")
+            }
+        }
+    }
+}
+
+
+private enum QueryCaptureFixtureError: Error {
+    case invalidValue
+}
+
+
+private struct QueryCaptureDatabaseFixture {
+    let directory: URL
+    let database: GRDBDatabase
+
+    func tearDown() {
+        try? database.databasePool.close()
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+
+private func makeQueryCaptureDatabase(
+    configuration: XLValueCodingConfiguration? = nil
+) throws -> QueryCaptureDatabaseFixture {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("swiftql-query-capture-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+        at: directory,
+        withIntermediateDirectories: false
+    )
+    let database = try GRDBDatabase(
+        databasePool: DatabasePool(
+            path: directory.appendingPathComponent("database.sqlite").path
+        ),
+        codingConfiguration: try configuration ?? XLValueCodingConfiguration(),
+        formatter: XLiteFormatter(),
+        logger: nil
+    )
+    return QueryCaptureDatabaseFixture(directory: directory, database: database)
+}
+
+
+private func executeScalar<Input, Literal>(
+    _ value: Input,
+    capture: XLQueryCapture<Input, Literal, XLSQLiteDialect>,
+    database: GRDBDatabase,
+    definition: [String]
+) throws -> XLSQLiteValue where Literal: XLLiteral {
+    let prepared = try prepareScalar(
+        capture: capture,
+        database: database,
+        definition: definition
+    )
+    let packet = try prepared.makeInvocationBindings {
+        try $0.bind(value, to: capture)
+    }
+    XCTAssertEqual(packet.bindingCount, 1)
+    return try prepared.fetchExactlyOneValues(bindings: packet)[0]
+}
+
+
+private func executeNullableScalar<Input, Wrapped>(
+    _ value: Input?,
+    capture: XLQueryCapture<Input, Wrapped?, XLSQLiteDialect>,
+    database: GRDBDatabase,
+    definition: [String]
+) throws -> XLSQLiteValue where Wrapped: XLLiteral {
+    let prepared = try prepareScalar(
+        capture: capture,
+        database: database,
+        definition: definition
+    )
+    let packet = try prepared.makeInvocationBindings {
+        try $0.bind(value, to: capture)
+    }
+    return try prepared.fetchExactlyOneValues(bindings: packet)[0]
+}
+
+
+private func prepareScalar<Input, Literal>(
+    capture: XLQueryCapture<Input, Literal, XLSQLiteDialect>,
+    database: GRDBDatabase,
+    definition: [String]
+) throws -> GRDBPreparedStaticQuery where Literal: XLLiteral {
+    try database.prepareInvocation(
+        with: scalarDescriptor(capture: capture, definition: definition)
+    )
+}
+
+
+private func scalarDescriptor<Input, Literal>(
+    capture: XLQueryCapture<Input, Literal, XLSQLiteDialect>,
+    definition: [String]
+) throws -> XLStaticQueryDescriptor where Literal: XLLiteral {
+    let encoding = try customEncoding(
+        sql: "SELECT :\(try namedKey(capture))"
+    ) { builder in
+        capture.makeSQL(context: &builder)
+    }
+    let queryDescriptor = try descriptor(
+        definition: definition,
+        encoding: encoding,
+        parameters: [capture.staticQueryParameter(in: encoding)],
+        resultStorage: [XLSQLiteStorageClass(
+            rawValue: capture.storageIdentifier.rawValue
+        )!],
+        resultNullability: [capture.declaration.nullability]
+    )
+    return queryDescriptor
+}
+
+
+private func descriptor(
+    definition: [String],
+    encoding: XLEncoding,
+    parameters: [XLStaticQueryParameterMetadata],
+    resultStorage: [XLSQLiteStorageClass],
+    resultNullability: [XLParameterNullability]? = nil,
+    cardinality: XLQueryCardinality = .exactlyOne
+) throws -> XLStaticQueryDescriptor {
+    let nullability = resultNullability
+        ?? Array(repeating: .required, count: resultStorage.count)
+    let results = try XLStaticQueryResultMetadata(slots: zip(
+        resultStorage,
+        nullability
+    ).enumerated().map { index, pair in
+        XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(index),
+            identity: try XLQuerySlotIdentity(
+                path: definition + ["result", String(index)]
+            ),
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: "tests.query-capture.result.\(pair.0.rawValue)"
+            ),
+            valueTypeName: pair.0.rawValue,
+            nullability: pair.1,
+            codecIdentity: nil,
+            storageIdentifier: XLValueStorageIdentifier(
+                rawValue: pair.0.rawValue
+            ),
+            codingContext: XLValueCodingContext(
+                site: .result,
+                path: XLValueCodingPath(definition + ["result", String(index)])
+            )
+        )
+    })
+    return try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: definition,
+            version: 1
+        ),
+        statement: XLStaticStatementDefinition(validating: encoding),
+        parameters: parameters,
+        results: results,
+        cardinality: cardinality
+    )
+}
+
+
+private func customEncoding(
+    sql: String,
+    render: @escaping (inout XLBuilder) -> Void
+) throws -> XLEncoding {
+    let rendered = try XLiteEncoder(dialect: XLSQLiteDialect())
+        .makeValidatedSQL(QueryCaptureLayoutProbe(render: render))
+    return XLEncoding(
+        sql: sql,
+        entities: [],
+        dialectRequirement: rendered.dialectRequirement,
+        parameterLayout: rendered.parameterLayout,
+        parameterLayoutError: rendered.parameterLayoutError
+    )
+}
+
+
+private struct QueryCaptureLayoutProbe: XLEncodable {
+    let render: (inout XLBuilder) -> Void
+
+    func makeSQL(context: inout XLBuilder) {
+        render(&context)
+    }
+}
+
+
+private func namedKey<Input, Literal>(
+    _ capture: XLQueryCapture<Input, Literal, XLSQLiteDialect>
+) throws -> String where Literal: XLLiteral {
+    guard case .named(let name) = capture.declaration.key else {
+        throw QueryCaptureFixtureError.invalidValue
+    }
+    return name
+}
+
+
+private func makeContextualCodecs() -> (
+    dateText: XLValueCodec<Date, XLSQLiteDialect>,
+    dateInteger: XLValueCodec<Date, XLSQLiteDialect>,
+    uuidText: XLValueCodec<UUID, XLSQLiteDialect>,
+    uuidArrayJSON: XLValueCodec<[UUID], XLSQLiteDialect>
+) {
+    let text = XLValueStorageIdentifier(rawValue: "text")
+    let dateType = XLValueTypeIdentifier(rawValue: "foundation.Date")
+    let dateText = XLValueCodec<Date, XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.query-capture.date-text", version: 1),
+        valueTypeIdentifier: dateType,
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: text,
+        encode: { value, _, _ in
+            .text(String(value.timeIntervalSince1970))
+        },
+        decode: { value, _, _ in
+            guard case .text(let value) = value,
+                  let seconds = TimeInterval(value) else {
+                throw QueryCaptureFixtureError.invalidValue
+            }
+            return Date(timeIntervalSince1970: seconds)
+        }
+    )
+    let dateInteger = XLValueCodec<Date, XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.query-capture.date-integer", version: 1),
+        valueTypeIdentifier: dateType,
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: XLValueStorageIdentifier(rawValue: "integer"),
+        encode: { value, _, _ in .integer(Int64(value.timeIntervalSince1970)) },
+        decode: { value, _, _ in
+            guard case .integer(let seconds) = value else {
+                throw QueryCaptureFixtureError.invalidValue
+            }
+            return Date(timeIntervalSince1970: TimeInterval(seconds))
+        }
+    )
+    let uuidText = XLValueCodec<UUID, XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.query-capture.uuid-text", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "foundation.UUID"),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: text,
+        encode: { value, _, _ in .text(value.uuidString.lowercased()) },
+        decode: { value, _, _ in
+            guard case .text(let value) = value,
+                  let uuid = UUID(uuidString: value) else {
+                throw QueryCaptureFixtureError.invalidValue
+            }
+            return uuid
+        }
+    )
+    let uuidArrayJSON = XLValueCodec<[UUID], XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.query-capture.uuid-json", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(
+            rawValue: "foundation.UUID-array"
+        ),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: text,
+        encode: { values, _, _ in
+            let data = try JSONSerialization.data(
+                withJSONObject: values.map { $0.uuidString.lowercased() }
+            )
+            guard let json = String(data: data, encoding: .utf8) else {
+                throw QueryCaptureFixtureError.invalidValue
+            }
+            return .text(json)
+        },
+        decode: { value, _, _ in
+            guard case .text(let json) = value,
+                  let data = json.data(using: .utf8),
+                  let strings = try JSONSerialization.jsonObject(with: data)
+                    as? [String] else {
+                throw QueryCaptureFixtureError.invalidValue
+            }
+            return try strings.map {
+                guard let value = UUID(uuidString: $0) else {
+                    throw QueryCaptureFixtureError.invalidValue
+                }
+                return value
+            }
+        }
+    )
+    return (dateText, dateInteger, uuidText, uuidArrayJSON)
+}
+
+
+private struct SnapshotToken {
+    let value: String
+}
+
+
+private final class QueryCaptureEncodingProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func record() {
+        lock.lock()
+        storage += 1
+        lock.unlock()
+    }
+}
+
+
+private func snapshotTokenCodec(
+    probe: QueryCaptureEncodingProbe,
+    valueTypeIdentifier: String = "tests.SnapshotToken"
+) -> XLValueCodec<SnapshotToken, XLSQLiteDialect> {
+    XLValueCodec(
+        key: XLValueCodecKey(
+            id: "tests.query-capture.snapshot-token",
+            version: 1
+        ),
+        valueTypeIdentifier: XLValueTypeIdentifier(
+            rawValue: valueTypeIdentifier
+        ),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: XLValueStorageIdentifier(rawValue: "text"),
+        encode: { value, _, _ in
+            probe.record()
+            return .text(value.value)
+        },
+        decode: { value, _, _ in
+            guard case .text(let value) = value else {
+                throw QueryCaptureFixtureError.invalidValue
+            }
+            return SnapshotToken(value: value)
+        }
+    )
+}

--- a/Tests/SwiftQLCoreTests/ValueCodecContractTests.swift
+++ b/Tests/SwiftQLCoreTests/ValueCodecContractTests.swift
@@ -175,6 +175,131 @@ final class ValueCodecContractTests: XCTestCase {
         )
     }
 
+    func testQueryInferenceFiltersByStorageBeforeApplyingDefaults() throws {
+        let text = makeMarkerCodec("query-text-default")
+        let integer = makeCodec(
+            key: key("query-integer"),
+            storage: .integer,
+            encode: { .integer($0.rawValue) },
+            decode: { value in
+                guard case .integer(let rawValue) = value else {
+                    throw CodecTestFailure.invalidValue
+                }
+                return CodecToken(rawValue: rawValue)
+            }
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try register([text, integer]),
+            defaultCodecKeys: [text.identity.key]
+        )
+
+        let resolved = try configuration.resolvedCodec(
+            for: CodecToken.self,
+            using: dialect,
+            context: parameterContext,
+            requiringStorage: storageIdentifier(.integer)
+        )
+
+        XCTAssertEqual(resolved.identity, integer.identity)
+        XCTAssertEqual(
+            try resolved.encode(CodecToken(rawValue: 42)),
+            .integer(42)
+        )
+        // The existing selection API remains default-driven and unchanged.
+        XCTAssertEqual(
+            try configuration.encode(
+                CodecToken(rawValue: 42),
+                using: dialect,
+                context: parameterContext
+            ),
+            .text("query-text-default")
+        )
+
+        let alternateText = makeMarkerCodec("query-text-alternate")
+        let ambiguousTextConfiguration = try XLValueCodingConfiguration(
+            registry: try register([alternateText, integer, text]),
+            defaultCodecKeys: [text.identity.key]
+        )
+        XCTAssertEqual(
+            try ambiguousTextConfiguration.resolvedCodec(
+                for: CodecToken.self,
+                using: dialect,
+                context: parameterContext,
+                requiringStorage: storageIdentifier(.text)
+            ).identity,
+            text.identity,
+            "A storage-matching default must disambiguate matching candidates"
+        )
+    }
+
+    func testQuerySelectionReportsStorageConstrainedMissingAndAmbiguity() throws {
+        let textA = makeMarkerCodec("query-a")
+        let textB = makeMarkerCodec("query-b")
+        let configuration = try XLValueCodingConfiguration(
+            registry: try register([textB, textA])
+        )
+
+        assertQueryCodecSelectionError(
+            try configuration.resolvedCodec(
+                for: CodecToken.self,
+                using: dialect,
+                context: parameterContext,
+                requiringStorage: storageIdentifier(.integer)
+            ),
+            equals: .missingCodecForStorage(
+                valueType: String(reflecting: CodecToken.self),
+                dialect: CodecTestDialect.identity,
+                storage: storageIdentifier(.integer),
+                context: parameterContext
+            )
+        )
+        assertQueryCodecSelectionError(
+            try configuration.resolvedCodec(
+                for: CodecToken.self,
+                using: dialect,
+                context: parameterContext,
+                requiringStorage: storageIdentifier(.text)
+            ),
+            equals: .ambiguousCodecForStorage(
+                valueType: String(reflecting: CodecToken.self),
+                dialect: CodecTestDialect.identity,
+                storage: storageIdentifier(.text),
+                candidates: [textA.identity.key, textB.identity.key].sorted(
+                    by: codecKeyOrder
+                ),
+                context: parameterContext
+            )
+        )
+    }
+
+    func testExplicitQuerySelectionFailsOnStorageConflict() throws {
+        let text = makeMarkerCodec("query-explicit-text")
+        let configuration = try XLValueCodingConfiguration(
+            registry: try register([text])
+        )
+
+        for selection in [
+            XLQueryCodecSelection.explicit(text.identity.key),
+            XLQueryCodecSelection.query(text.identity.key),
+        ] {
+            assertCodecError(
+                try configuration.resolvedCodec(
+                    for: CodecToken.self,
+                    using: dialect,
+                    context: parameterContext,
+                    requiringStorage: storageIdentifier(.integer),
+                    selection: selection
+                ),
+                equals: .storageMismatch(
+                    codec: text.identity.key,
+                    expected: storageIdentifier(.text),
+                    actual: storageIdentifier(.integer),
+                    context: parameterContext
+                )
+            )
+        }
+    }
+
     func testOptionalNullResolvesSelectionButBypassesNonoptionalClosures() throws {
         let codec = XLValueCodec<CodecToken, CodecTestDialect>(
             key: key("null-bypass"),
@@ -726,6 +851,27 @@ final class ValueCodecContractTests: XCTestCase {
         XCTAssertThrowsError(try expression(), file: file, line: line) { error in
             XCTAssertEqual(error as? XLValueCodecError, expected, file: file, line: line)
             XCTAssertFalse(error.localizedDescription.isEmpty, file: file, line: line)
+        }
+    }
+
+    private func assertQueryCodecSelectionError<T>(
+        _ expression: @autoclosure () throws -> T,
+        equals expected: XLQueryCodecSelectionError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try expression(), file: file, line: line) { error in
+            XCTAssertEqual(
+                error as? XLQueryCodecSelectionError,
+                expected,
+                file: file,
+                line: line
+            )
+            XCTAssertFalse(
+                error.localizedDescription.isEmpty,
+                file: file,
+                line: line
+            )
         }
     }
 }


### PR DESCRIPTION
Closes #30

## Summary

- add value-free typed `XLQueryCapture` tokens with collision-free stable identities, one logical placeholder, and deterministic traversal order
- add storage-constrained contextual codec selection that never falls back to legacy or process-global configuration
- infer literal type, nullability, SQLite storage, and codec candidates from typed `XLExpression` witnesses via `queryCapture(...matching:)`
- build fresh immutable invocation packets through prepared-query snapshots using either the existing builder or additive `capture.argument(value)` conveniences
- support intrinsic values, nullable captures, contextual Date/UUID codecs, scalar-encoded collections, repeated references, and concurrent invocations
- return structured identity-rich diagnostics for missing, ambiguous, selected, dialect, storage, duplicate, foreign, and metadata-conflicting captures
- document the source-compatible runtime seam for #18/#26 and the generated metadata handoff to #40

## Design boundary

Swift’s runtime expression DSL receives already-evaluated values and cannot distinguish a bare local variable from an inline literal. This PR implements the immutable runtime binding foundation. Syntax-aware lowering remains #26’s responsibility and must generate these capture tokens and invocation arguments rather than parallel parameter machinery.

## Validation

- `swift test`: 523 tests passed
- focused query-capture suites: 21 tests passed
- real SQLite typed-column predicate: two fresh Date packets, stable query identity, distinct results
- static-query documentation test: passed
- first-party warnings-as-errors gate: clean
- complete strict-concurrency gate: clean
- downstream Swift 5 language-mode client: passed
- SwiftQLCore GRDB-free boundary: passed
- bitwise type-safety compile fixture: passed
- full DocC build/inspection: passed
- source-coverage report fixtures: 26 tests passed
- release workflow fixtures: passed
- `git diff --check`: clean