### PR TITLE
Remove sqlDefault() requirements through static result descriptors

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Add immutable query-capture tokens and invocation packets",
-  "issue_number": 30,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/30",
+  "task_name": "Remove sqlDefault() requirements through static result descriptors",
+  "issue_number": 40,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/40",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#30 - Add immutable query-capture tokens and invocation packets",
+  "codex_session_title": "lukevanin/swiftql#40 - Remove sqlDefault() requirements through static result descriptors",
   "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
   "codex_session_url": null,
-  "task_branch": "codex/30-infer-immutable-query-bindings-from-swift-variables",
-  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/30-infer-immutable-query-bindings-from-swift-variables"
+  "task_branch": "codex/40-remove-sqldefault-requirements-through-static-result-descriptors",
+  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/40-remove-sqldefault-requirements-through-static-result-descriptors"
 }

--- a/Sources/SQLMacros/MetaBuilder.swift
+++ b/Sources/SQLMacros/MetaBuilder.swift
@@ -70,6 +70,26 @@ internal struct MetaProperty {
 }
 
 
+private struct GeneratedIdentifierAllocator {
+    private var used: Set<String>
+
+    init(used: Set<String>) {
+        self.used = used
+    }
+
+    mutating func allocate(_ base: String) -> String {
+        var candidate = base
+        var suffix = 0
+        while used.contains(candidate) {
+            suffix += 1
+            candidate = "\(base)_\(suffix)"
+        }
+        used.insert(candidate)
+        return candidate
+    }
+}
+
+
 // Removal of the legacy anonymous-result surface is tracked by
 // https://github.com/lukevanin/swiftql/issues/90.
 
@@ -120,6 +140,35 @@ internal struct MetaBuilder {
 
     /// Mutable properties defined on the struct.
     let mutableProperties: [MetaProperty]
+
+    /// Identifiers that generated method generics and locals must not shadow.
+    ///
+    /// Property types are included because a generated generic named like a
+    /// concrete type would silently change the meaning of that type inside the
+    /// generated signature. The nominal name is included because a generated
+    /// local can otherwise shadow a return type with the same spelling.
+    private var generatedIdentifierReservations: Set<String> {
+        var identifiers: Set<String> = [structName]
+        if let clause = declaration.genericParameterClause {
+            identifiers.formUnion(clause.parameters.map { $0.name.text })
+        }
+        for property in properties {
+            identifiers.insert(property.alias)
+            identifiers.formUnion(Self.identifiers(in: property.type))
+            identifiers.formUnion(Self.identifiers(in: property.qualifiedType))
+        }
+        return identifiers
+    }
+
+    private static func identifiers(in source: String) -> Set<String> {
+        Set(
+            source.split { character in
+                character != "_"
+                    && !character.isLetter
+                    && !character.isNumber
+            }.map(String.init)
+        )
+    }
 
     ///
     /// Convenience initializer used to initialise the builder with a `DeclGroupSyntax`.
@@ -522,6 +571,77 @@ internal struct MetaBuilder {
         }
         return context.build()
     }
+
+    // Generate the static layout factory as a nominal member for the same
+    // Swift 5.9 cross-file lookup reason as `columns(...)`. The caller supplies
+    // one immutable typed field per property, allowing each use to select its
+    // own expression and codec without constructing the model or SQLReader.
+    func makeStaticRowLayoutFunction() -> String {
+        var context = SwiftSyntaxBuilder()
+        var allocator = GeneratedIdentifierAllocator(
+            used: generatedIdentifierReservations
+        )
+        let dialect = allocator.allocate("_SwiftQLStaticDialect")
+        let positionedFields = properties.indices.map { index in
+            allocator.allocate("_swiftQLStaticField\(index)")
+        }
+        let reader = allocator.allocate("_swiftQLStaticReader")
+        let row = allocator.allocate("_swiftQLStaticRow")
+
+        var parameters = ["using _: \(dialect).Type"]
+        for property in properties {
+            parameters.append(
+                "\(property.name): some SwiftQL.XLStaticSelectFieldProtocol<\(property.qualifiedType), \(dialect)>"
+            )
+        }
+
+        context.block(
+            "public static func staticRowLayout<\(dialect)>(\(parameters.joined(separator: ", "))) throws -> SwiftQL.XLStaticRowLayout<Self, \(dialect)> where \(dialect): SwiftQL.XLValueCodingDialect"
+        ) { context in
+            for (index, property) in properties.enumerated() {
+                context.line(
+                    "let \(positionedFields[index]) = \(property.name).positioned(at: \(index), alias: \(quoted(property.alias)))"
+                )
+            }
+
+            context.block("return try SwiftQL.XLStaticRowLayout", opening: "(", closing: ")") { context in
+                context.block("fields: [", opening: "", closing: "],") { context in
+                    for field in positionedFields {
+                        context.line("try \(field).erased(),")
+                    }
+                }
+                context.block(
+                    "decode: { \(reader) in",
+                    opening: "",
+                    closing: "},"
+                ) { context in
+                    context.declaration("Self") { context in
+                        for (index, property) in properties.enumerated() {
+                            context.item { context in
+                                context.line(
+                                    "\(property.name): try \(positionedFields[index]).read(from: \(reader))"
+                                )
+                            }
+                        }
+                    }
+                }
+                context.block(
+                    "encode: { \(row) in",
+                    opening: "",
+                    closing: "}"
+                ) { context in
+                    context.block("[", opening: "", closing: "]") { context in
+                        for (index, property) in properties.enumerated() {
+                            context.line(
+                                "try \(positionedFields[index]).encode(\(row).\(property.name)),"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        return context.build()
+    }
     
     // Build table meta data, used to select from concrete tables and views which are defined by the database schema.
     func makeMetaTableExtension() -> String {
@@ -542,11 +662,14 @@ internal struct MetaBuilder {
                 for property in properties {
                     parameters.append(property.name + ": " + property.makeInstance(kind: .reference, dependency: "dependency"))
                 }
-                context.block("MetaResult(" + parameters.joined(separator: ", ") + ")") { context in
+                context.block(
+                    "MetaResult(" + parameters.joined(separator: ", ") + ")",
+                    opening: properties.isEmpty ? " { _ in" : " {"
+                ) { context in
                     context.declaration("\(structName)") { context in
                         for property in properties {
                             context.item { context in
-                                context.line("\(property.name): try $0.column(\(property.makeInstance(kind: .reference, dependency: "dependency")), alias: \(quoted(property.alias)))")
+                                context.line("\(property.name): try $0.staticColumn(\(property.makeInstance(kind: .reference, dependency: "dependency")), alias: \(quoted(property.alias)))")
                             }
                         }
                     }
@@ -560,11 +683,14 @@ internal struct MetaBuilder {
                 for property in properties {
                     parameters.append(property.name + ": " + property.makeInstance(kind: .reference, dependency: "dependency"))
                 }
-                context.block("MetaNamedResult(" + parameters.joined(separator: ", ") + ")") { context in
+                context.block(
+                    "MetaNamedResult(" + parameters.joined(separator: ", ") + ")",
+                    opening: properties.isEmpty ? " { _ in" : " {"
+                ) { context in
                     context.declaration("\(structName)") { context in
                         for property in properties {
                             context.item { context in
-                                context.line("\(property.name): try $0.column(\(property.makeInstance(kind: .reference, dependency: "dependency")), alias: \(quoted(property.alias)))")
+                                context.line("\(property.name): try $0.staticColumn(\(property.makeInstance(kind: .reference, dependency: "dependency")), alias: \(quoted(property.alias)))")
                             }
                         }
                     }
@@ -578,11 +704,14 @@ internal struct MetaBuilder {
                 for property in optionalProperties {
                     parameters.append(property.name + ": " + property.makeInstance(kind: .reference, dependency: "dependency"))
                 }
-                context.block("return MetaNullableResult(" + parameters.joined(separator: ", ") + ")") { context in
+                context.block(
+                    "return MetaNullableResult(" + parameters.joined(separator: ", ") + ")",
+                    opening: optionalProperties.isEmpty ? " { _ in" : " {"
+                ) { context in
                     context.declaration("Nullable") { context in
                         for property in optionalProperties {
                             context.item { context in
-                                context.line("\(property.name): try $0.column(\(property.makeInstance(kind: .reference, dependency: "dependency")), alias: \(quoted(property.alias)))")
+                                context.line("\(property.name): try $0.staticColumn(\(property.makeInstance(kind: .reference, dependency: "dependency")), alias: \(quoted(property.alias)))")
                             }
                         }
                     }
@@ -596,11 +725,14 @@ internal struct MetaBuilder {
                 for property in optionalProperties {
                     parameters.append(property.name + ": " + property.makeInstance(kind: .reference, dependency: "dependency"))
                 }
-                context.block("return MetaNullableNamedResult(" + parameters.joined(separator: ", ") + ")") { context in
+                context.block(
+                    "return MetaNullableNamedResult(" + parameters.joined(separator: ", ") + ")",
+                    opening: optionalProperties.isEmpty ? " { _ in" : " {"
+                ) { context in
                     context.declaration("Nullable") { context in
                         for property in optionalProperties {
                             context.item { context in
-                                context.line("\(property.name): try $0.column(\(property.makeInstance(kind: .reference, dependency: "dependency")), alias: \(quoted(property.alias)))")
+                                context.line("\(property.name): try $0.staticColumn(\(property.makeInstance(kind: .reference, dependency: "dependency")), alias: \(quoted(property.alias)))")
                             }
                         }
                     }
@@ -665,7 +797,7 @@ internal struct MetaBuilder {
             // Instance parameter.
             context.block("public init(_ instance: \(structName))") { context in
                 for property in properties {
-                    context.line("\(property.name) = XLTypeAffinityExpression<\(property.qualifiedType)>(expression: instance.\(property.name))")
+                    context.line("\(property.name) = SwiftQL._xlLegacyValueExpression(instance.\(property.name))")
                 }
             }
             
@@ -788,10 +920,10 @@ internal struct MetaBuilder {
                     for property in mutableProperties {
                         context.block("if let value = \(property.name)") { context in
                             if property.optional {
-                                context.line("output.\(property.name) = XLTypeAffinityExpression<\(property.qualifiedType)>(expression: value.toNullable())")
+                                context.line("output.\(property.name) = SwiftQL._xlLegacyValueExpression(value).toNullable()")
                             }
                             else {
-                                context.line("output.\(property.name) = XLTypeAffinityExpression<\(property.qualifiedType)>(expression: value)")
+                                context.line("output.\(property.name) = SwiftQL._xlLegacyValueExpression(value)")
                             }
                         }
                     }
@@ -994,6 +1126,10 @@ internal struct MetaBuilder {
         }
 
         // Reader
+        var readerAllocator = GeneratedIdentifierAllocator(
+            used: generatedIdentifierReservations
+        )
+        let rowReader = readerAllocator.allocate("_swiftQLRowReader")
         context.block("public struct SQLReader: XLRowReadable") { context in
 
             context.line("public typealias Row = \(structName)")
@@ -1012,11 +1148,11 @@ internal struct MetaBuilder {
                 }
             }
 
-            context.block("public func readRow(reader: XLRowReader) throws -> \(structName)") { context in
+            context.block("public func readRow(reader \(rowReader): XLRowReader) throws -> \(structName)") { context in
                 context.declaration("\(structName)") { context in
                     for property in properties {
                         context.item { context in
-                            context.line("\(property.name): try reader.column(\(property.name), alias: \(quoted(property.alias)))")
+                            context.line("\(property.name): try \(rowReader).staticColumn(\(property.name), alias: \(quoted(property.alias)))")
                         }
                     }
                 }
@@ -1058,11 +1194,14 @@ internal struct MetaBuilder {
             for property in anonymousProperties {
                 parameters.append(property.name + ": " + property.makeInstance(kind: columnKind, dependency: "dependency"))
             }
-            context.block("return MetaResult(" + parameters.joined(separator: ", ") + ")") { context in
+            context.block(
+                "return MetaResult(" + parameters.joined(separator: ", ") + ")",
+                opening: anonymousProperties.isEmpty ? " { _ in" : " {"
+            ) { context in
                 context.declaration("\(structName)") { context in
                     for property in anonymousProperties {
                         context.item { context in
-                            context.line("\(property.name): try $0.column(\(property.makeInstance(kind: .result, dependency: "dependency")), alias: \(quoted(property.alias)))")
+                            context.line("\(property.name): try $0.staticColumn(\(property.makeInstance(kind: .result, dependency: "dependency")), alias: \(quoted(property.alias)))")
                         }
                     }
                 }
@@ -1076,11 +1215,14 @@ internal struct MetaBuilder {
             for property in anonymousProperties {
                 parameters.append(property.name + ": " + property.makeInstance(kind: columnKind, dependency: "dependency"))
             }
-            context.block("return MetaNamedResult(" + parameters.joined(separator: ", ") + ")") { context in
+            context.block(
+                "return MetaNamedResult(" + parameters.joined(separator: ", ") + ")",
+                opening: anonymousProperties.isEmpty ? " { _ in" : " {"
+            ) { context in
                 context.declaration("\(structName)") { context in
                     for property in anonymousProperties {
                         context.item { context in
-                            context.line("\(property.name): try $0.column(\(property.makeInstance(kind: .result, dependency: "dependency")), alias: \(quoted(property.alias)))")
+                            context.line("\(property.name): try $0.staticColumn(\(property.makeInstance(kind: .result, dependency: "dependency")), alias: \(quoted(property.alias)))")
                         }
                     }
                 }
@@ -1094,11 +1236,14 @@ internal struct MetaBuilder {
             for property in anonymousOptionalProperties {
                 parameters.append(property.name + ": " + property.makeInstance(kind: columnKind, dependency: "dependency"))
             }
-            context.block("return MetaNullableResult(" + parameters.joined(separator: ", ") + ")") { context in
+            context.block(
+                "return MetaNullableResult(" + parameters.joined(separator: ", ") + ")",
+                opening: anonymousOptionalProperties.isEmpty ? " { _ in" : " {"
+            ) { context in
                 context.declaration("Nullable") { context in
                     for property in anonymousOptionalProperties {
                         context.item { context in
-                            context.line("\(property.name): try $0.column(\(property.makeInstance(kind: .result, dependency: "dependency")), alias: \(quoted(property.alias)))")
+                            context.line("\(property.name): try $0.staticColumn(\(property.makeInstance(kind: .result, dependency: "dependency")), alias: \(quoted(property.alias)))")
                         }
                     }
                 }
@@ -1112,11 +1257,14 @@ internal struct MetaBuilder {
             for property in anonymousOptionalProperties {
                 parameters.append(property.name + ": " + property.makeInstance(kind: columnKind, dependency: "dependency"))
             }
-            context.block("return MetaNullableNamedResult(" + parameters.joined(separator: ", ") + ")") { context in
+            context.block(
+                "return MetaNullableNamedResult(" + parameters.joined(separator: ", ") + ")",
+                opening: anonymousOptionalProperties.isEmpty ? " { _ in" : " {"
+            ) { context in
                 context.declaration("Nullable") { context in
                     for property in anonymousOptionalProperties {
                         context.item { context in
-                            context.line("\(property.name): try $0.column(\(property.makeInstance(kind: .result, dependency: "dependency")), alias: \(quoted(property.alias)))")
+                            context.line("\(property.name): try $0.staticColumn(\(property.makeInstance(kind: .result, dependency: "dependency")), alias: \(quoted(property.alias)))")
                         }
                     }
                 }

--- a/Sources/SQLMacros/SQLMacro.swift
+++ b/Sources/SQLMacros/SQLMacro.swift
@@ -67,6 +67,7 @@ extension SQLTableMacro: MemberMacro {
         return [
             DeclSyntax(stringLiteral: builder.makeMemberwizeInitializer()),
             DeclSyntax(stringLiteral: builder.makeColumnsFunction()),
+            DeclSyntax(stringLiteral: builder.makeStaticRowLayoutFunction()),
         ]
     }
 }
@@ -120,6 +121,7 @@ extension SQLResultMacro: MemberMacro {
         return [
             DeclSyntax(stringLiteral: builder.makeMemberwizeInitializer()),
             DeclSyntax(stringLiteral: builder.makeColumnsFunction()),
+            DeclSyntax(stringLiteral: builder.makeStaticRowLayoutFunction()),
         ]
     }
 }

--- a/Sources/SwiftQL/GRDBStaticQuery.swift
+++ b/Sources/SwiftQL/GRDBStaticQuery.swift
@@ -630,3 +630,101 @@ public struct GRDBPreparedStaticQuery: Sendable {
         }
     }
 }
+
+
+/// A GRDB prepared handle that decodes through a generated static row layout.
+///
+/// The driver-specific wrapper is intentionally separate from
+/// ``XLTypedStaticQueryDescriptor`` so the descriptor and layout APIs remain
+/// free of GRDB types.
+public struct GRDBPreparedTypedStaticQuery<Row> {
+
+    public let definition: XLTypedStaticQueryDescriptor<
+        Row,
+        XLSQLiteDialect
+    >
+
+    private let query: GRDBPreparedStaticQuery
+
+    init(
+        definition: XLTypedStaticQueryDescriptor<Row, XLSQLiteDialect>,
+        query: GRDBPreparedStaticQuery
+    ) {
+        self.definition = definition
+        self.query = query
+    }
+
+    public var descriptor: XLStaticQueryDescriptor {
+        definition.descriptor
+    }
+
+    public var identity: XLQueryIdentity {
+        query.identity
+    }
+
+    public var parameterLayout: XLParameterLayout {
+        query.parameterLayout
+    }
+
+    public func makeInvocationBindings(
+        _ build: (inout GRDBStaticQueryInvocationBuilder) throws -> Void
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        try query.makeInvocationBindings(build)
+    }
+
+    public func makeInvocationBindings(
+        _ arguments: GRDBStaticQueryArgument...
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        try query.makeInvocationBindings(arguments: arguments)
+    }
+
+    public func makeInvocationBindings(
+        arguments: [GRDBStaticQueryArgument]
+    ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        try query.makeInvocationBindings(arguments: arguments)
+    }
+
+    public func fetchExactlyOne(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> Row {
+        try definition.layout.decode(
+            query.fetchExactlyOneValues(bindings: bindings)
+        )
+    }
+
+    public func fetchZeroOrOne(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> Row? {
+        guard let values = try query.fetchZeroOrOneValues(bindings: bindings)
+        else {
+            return nil
+        }
+        return try definition.layout.decode(values)
+    }
+
+    public func fetchAll(
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [Row] {
+        try query.fetchAllValues(bindings: bindings).map(
+            definition.layout.decode
+        )
+    }
+}
+
+
+extension GRDBDatabase {
+
+    /// Prepares a typed static query only after its generated row layout has
+    /// been proven equal to the descriptor's complete result metadata.
+    public func prepareInvocation<Row>(
+        with definition: XLTypedStaticQueryDescriptor<
+            Row,
+            XLSQLiteDialect
+        >
+    ) throws -> GRDBPreparedTypedStaticQuery<Row> {
+        GRDBPreparedTypedStaticQuery(
+            definition: definition,
+            query: try prepareInvocation(with: definition.descriptor)
+        )
+    }
+}

--- a/Sources/SwiftQL/SQLExpression.swift
+++ b/Sources/SwiftQL/SQLExpression.swift
@@ -31,7 +31,11 @@ extension XLExpression {
     /// Automatically unwraps the expression.
     ///
     public func writeSQL(context: inout XLBuilder) {
-        (T.self as! XLEncodable.Type).unwrapSQL(context: &context, builder: makeSQL)
+        guard let encodableType = T.self as? any XLEncodable.Type else {
+            makeSQL(context: &context)
+            return
+        }
+        encodableType.unwrapSQL(context: &context, builder: makeSQL)
     }
 }
 
@@ -66,8 +70,9 @@ public protocol XLBindable {
 ///
 /// A value stored in the database.
 ///
-/// Custom types must implement an initializer to read an intrinsic value from the database, and provide an
-/// appropriate default placeholder value.
+/// Custom types must implement an initializer to read an intrinsic value from
+/// the database. A default placeholder is needed only when the type is decoded
+/// through the legacy result-introspection path.
 ///
 /// Custom types may optionally implement a wrapper to transform values in SQL expressions.
 ///
@@ -79,7 +84,13 @@ public protocol XLLiteral: XLBindable {
     typealias MakeExpression = (inout XLBuilder) -> Void
     
     ///
-    /// - Returns: Any valid instance of the implementation. The default value is used internally by SwiftQL when creating prepared statements.
+    /// Returns a placeholder for legacy `SQLReader` result introspection.
+    ///
+    /// Generated static row layouts never call this method. New literal types
+    /// that decode exclusively through a static layout can rely on the default
+    /// implementation, which stops with a migration diagnostic if a legacy
+    /// introspection path reaches it. Existing v1 types should keep an explicit
+    /// implementation while they still use legacy result construction.
     ///
     static func sqlDefault() -> Self
     
@@ -105,6 +116,16 @@ public protocol XLLiteral: XLBindable {
 }
 
 extension XLLiteral {
+    public static func sqlDefault() -> Self {
+        let typeName = String(reflecting: Self.self)
+        preconditionFailure(
+            "\(typeName) does not provide a legacy sqlDefault() placeholder. "
+                + "Legacy SQLReader result introspection requires an explicit "
+                + "placeholder; construct this result through the macro-generated "
+                + "staticRowLayout(using:...) path instead."
+        )
+    }
+
     public static func wrapSQL(context: inout XLBuilder, builder: MakeExpression) {
         builder(&context)
     }
@@ -131,7 +152,7 @@ public protocol XLComparable: XLEquatable {
 ///
 /// Expression that refers to a table column.
 ///
-public struct XLColumnReference<T>: XLExpression where T: XLLiteral {
+public struct XLColumnReference<T>: XLExpression {
     
     public var alias: XLName
     
@@ -143,7 +164,11 @@ public struct XLColumnReference<T>: XLExpression where T: XLLiteral {
     }
     
     public func makeSQL(context: inout XLBuilder) {
-        T.wrapSQL(context: &context) { context in
+        guard let literalType = T.self as? any XLLiteral.Type else {
+            context.qualifiedName(dependency.qualifiedName(forColumn: alias))
+            return
+        }
+        literalType.wrapSQL(context: &context) { context in
             context.qualifiedName(dependency.qualifiedName(forColumn: alias))
         }
     }    
@@ -153,7 +178,7 @@ public struct XLColumnReference<T>: XLExpression where T: XLLiteral {
 ///
 /// Expression that refers to a column in a result, such as the list of columns in a select statement.
 ///
-public struct XLColumnResult<T>: XLExpression where T: XLLiteral {
+public struct XLColumnResult<T>: XLExpression {
     
     public var alias: XLName
     
@@ -167,6 +192,73 @@ public struct XLColumnResult<T>: XLExpression where T: XLLiteral {
     public func makeSQL(context: inout XLBuilder) {
         context.qualifiedName(dependency.qualifiedName(forColumn: alias))
     }
+}
+
+
+/// An expression whose logical result type can be replaced by an explicit
+/// storage carrier for static contextual coding.
+///
+/// Column references opt in so a contextual `Date -> String`, for example,
+/// renders the bare SQL column as `String` storage even if another module has
+/// supplied a retroactive legacy `Date: XLLiteral` wrapper.
+public protocol XLStaticStorageRetypableExpression {
+    func staticStorageExpression<Storage>(
+        as storageType: Storage.Type
+    ) -> any XLExpression<Storage>
+}
+
+
+extension XLColumnReference: XLStaticStorageRetypableExpression {
+    public func staticStorageExpression<Storage>(
+        as _: Storage.Type
+    ) -> any XLExpression<Storage> {
+        XLColumnReference<Storage>(dependency: dependency, as: alias)
+    }
+}
+
+
+extension XLColumnResult: XLStaticStorageRetypableExpression {
+    public func staticStorageExpression<Storage>(
+        as _: Storage.Type
+    ) -> any XLExpression<Storage> {
+        XLColumnResult<Storage>(dependency: dependency, as: alias)
+    }
+}
+
+
+/// Source-compatibility bridge used by macro-generated v1 insert/update
+/// helpers after column declarations became unconstrained.
+///
+/// Contextual-only values can now appear in generated table metadata, but
+/// they must use a static row layout for encoding. Existing `XLLiteral` /
+/// `XLExpression` values retain their original rendering behavior through
+/// this wrapper.
+public struct XLLegacyDynamicValueExpression<Value>: XLExpression {
+    public typealias T = Value
+
+    private let value: Value
+
+    public init(_ value: Value) {
+        self.value = value
+    }
+
+    public func makeSQL(context: inout XLBuilder) {
+        guard let expression = value as? any XLEncodable else {
+            preconditionFailure(
+                "\(String(reflecting: Value.self)) is a contextual-only SQL value. Encode it through XLStaticRowLayout instead of the v1 MetaInsert/MetaUpdate path."
+            )
+        }
+        expression.makeSQL(context: &context)
+    }
+}
+
+
+/// Creates the dynamic v1 expression bridge used by generated compatibility
+/// APIs. New contextual code should use ``XLStaticSelectField`` instead.
+public func _xlLegacyValueExpression<Value>(
+    _ value: Value
+) -> XLLegacyDynamicValueExpression<Value> {
+    XLLegacyDynamicValueExpression(value)
 }
 
 
@@ -253,8 +345,10 @@ public struct XLFunction<T>: XLExpression where T: XLLiteral {
 /// To use an enum for a column the enum must adhere to the following conditions:
 /// - Use a supported intrinsic type for the `RawValue`.
 /// - Conform to the `XLEnum` protocol and declare `T` as `Self`.
-/// - Implement `sqlDefault()` and return any valid enum value. SwiftQL uses this value only as a
-///   construction and introspection placeholder; it is never a fallback for database decoding.
+/// - When using legacy `SQLReader` result introspection, implement
+///   `sqlDefault()` and return any valid enum value. Static row layouts do not
+///   require or call that placeholder, and it is never a fallback for database
+///   decoding.
 ///
 /// The `XLEnum` protocol provides default implementations for most of the required methods which can
 /// be overridden as required. Reading an unknown stored raw value throws ``XLColumnReadError``.

--- a/Sources/SwiftQL/SQLMeta.swift
+++ b/Sources/SwiftQL/SQLMeta.swift
@@ -174,7 +174,106 @@ public protocol XLRowReader: AnyObject {
     /// Columns are read sequentially in order starting at the first column in the result set. This method
     /// should be called multiple times, to read each column in sequence.
     ///
-    func column<T>(_ expression: any XLExpression<T>, alias: XLName) throws -> T where T: XLLiteral
+    func column<T>(
+        _ expression: any XLExpression<T>,
+        alias: XLName
+    ) throws -> T where T: XLLiteral
+
+    /// Reads a value through the static-row compatibility seam.
+    ///
+    /// The default implementation preserves existing `XLRowReader`
+    /// conformances by reopening legacy `XLLiteral` types through `column`.
+    /// Contextual-only types fail with a structured migration diagnostic;
+    /// generated static layouts decode those types from `dialectValue`
+    /// instead.
+    func staticColumn<T>(
+        _ expression: any XLExpression<T>,
+        alias: XLName
+    ) throws -> T
+
+    /// Reads one raw dialect value for a statically described row field.
+    ///
+    /// Legacy row readers may rely on the default implementation. Database
+    /// adapters that support static layouts expose raw values through
+    /// ``XLStaticColumnReader`` instead of fabricating a Swift placeholder.
+    func dialectValue<Dialect>(
+        at index: Int,
+        using dialect: Dialect
+    ) throws -> Dialect.Value where Dialect: XLValueCodingDialect
+}
+
+
+extension XLRowReader {
+    public func staticColumn<T>(
+        _ expression: any XLExpression<T>,
+        alias: XLName
+    ) throws -> T {
+        guard let literalType = T.self as? any XLLiteral.Type else {
+            throw XLStaticRowReadError.staticLayoutRequired(
+                valueType: String(reflecting: T.self),
+                alias: alias.rawValue
+            )
+        }
+        return try _xlReadLegacyStaticColumn(
+            literalType,
+            expression: expression,
+            alias: alias,
+            reader: self
+        )
+    }
+
+    public func dialectValue<Dialect>(
+        at index: Int,
+        using dialect: Dialect
+    ) throws -> Dialect.Value where Dialect: XLValueCodingDialect {
+        throw XLStaticRowReadError.rawDialectValuesUnavailable(
+            index: index,
+            dialect: dialect.descriptor.identity,
+            readerType: String(reflecting: type(of: self))
+        )
+    }
+}
+
+
+/// A column transport that can expose the dialect-owned value required by a
+/// static row layout.
+public protocol XLStaticColumnReader: XLColumnReader {
+    func dialectValue<Dialect>(
+        at index: Int,
+        using dialect: Dialect
+    ) throws -> Dialect.Value where Dialect: XLValueCodingDialect
+}
+
+
+/// Failures at the static row-reading compatibility boundary.
+public enum XLStaticRowReadError:
+    Error,
+    Equatable,
+    Sendable,
+    LocalizedError
+{
+    case staticLayoutRequired(valueType: String, alias: String)
+    case rawDialectValuesUnavailable(
+        index: Int,
+        dialect: XLDialectIdentifier,
+        readerType: String
+    )
+    case dialectValueTypeMismatch(
+        index: Int,
+        expected: String,
+        actual: String
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .staticLayoutRequired(let valueType, let alias):
+            return "Property/result slot '\(alias)' has contextual Swift type \(valueType); construct it through a static row layout instead of the legacy SQLReader/sqlDefault path."
+        case .rawDialectValuesUnavailable(let index, let dialect, let readerType):
+            return "Static result slot at index \(index) requires a raw \(dialect) value, but row reader \(readerType) does not expose dialect values."
+        case .dialectValueTypeMismatch(let index, let expected, let actual):
+            return "Static result slot at index \(index) expected raw value type \(expected), but the column transport exposes \(actual)."
+        }
+    }
 }
 
 
@@ -186,7 +285,10 @@ final class XLColumnsDefinitionRowReader: XLRowReader, XLEncodable {
     private var expressions: [any XLEncodable] = []
     private var names: [XLName] = []
     
-    func column<T>(_ expression: any XLExpression<T>, alias: XLName) -> T where T: XLLiteral {
+    func column<T>(
+        _ expression: any XLExpression<T>,
+        alias: XLName
+    ) -> T where T: XLLiteral {
         names.append(alias)
         if expression is any XLQueryStatement {
             expressions.append(XLParenthesis<T>(expression: expression))
@@ -233,7 +335,10 @@ final class XLColumnValuesRowReader<Output>: XLRowReader {
     ///
     /// Reads the value of the current column from the row, then advances the state to the next column.
     ///
-    func column<T>(_ expression: any XLExpression<T>, alias: XLName) throws -> T where T: XLLiteral {
+    func column<T>(
+        _ expression: any XLExpression<T>,
+        alias: XLName
+    ) throws -> T where T: XLLiteral {
         try readValue()
     }
 
@@ -244,6 +349,41 @@ final class XLColumnValuesRowReader<Output>: XLRowReader {
         return try T.init(reader: reader, at: count)
     }
 
+    func dialectValue<Dialect>(
+        at index: Int,
+        using dialect: Dialect
+    ) throws -> Dialect.Value where Dialect: XLValueCodingDialect {
+        guard let staticReader = reader as? any XLStaticColumnReader else {
+            throw XLStaticRowReadError.rawDialectValuesUnavailable(
+                index: index,
+                dialect: dialect.descriptor.identity,
+                readerType: String(reflecting: type(of: reader as Any))
+            )
+        }
+        return try staticReader.dialectValue(at: index, using: dialect)
+    }
+
+}
+
+
+private func _xlReadLegacyStaticColumn<Literal, Value>(
+    _ literalType: Literal.Type,
+    expression: any XLExpression<Value>,
+    alias: XLName,
+    reader: any XLRowReader
+) throws -> Value where Literal: XLLiteral {
+    guard let retyped = expression as? any XLExpression<Literal> else {
+        preconditionFailure(
+            "Reopened literal expression type \(String(reflecting: Literal.self)) does not match \(String(reflecting: Value.self))."
+        )
+    }
+    let literal = try reader.column(retyped, alias: alias)
+    guard let value = literal as? Value else {
+        preconditionFailure(
+            "Reopened literal type \(String(reflecting: Literal.self)) does not match \(String(reflecting: Value.self))."
+        )
+    }
+    return value
 }
 
 

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -30,6 +30,17 @@ public struct Select<Row>: XLEncodable, XLRowReadable {
     private let fields: any XLEncodable
     
     private let row: (XLRowReader) throws -> Row
+
+    /// Builds a select directly from immutable static projection metadata.
+    ///
+    /// This more-specific overload deliberately does not call `readRow` while
+    /// constructing the statement. Generated model initializers and
+    /// contextual codecs run only when a returned database row is decoded.
+    public init<T>(_ layout: T)
+    where T: XLStaticRowReadable, T.Row == Row {
+        self.fields = layout
+        self.row = layout.readRow
+    }
     
     public init<T>(_ meta: T) where T: XLRowReadable, T.Row == Row {
         let reader = XLColumnsDefinitionRowReader()

--- a/Sources/SwiftQL/SQLStaticRowLayout.swift
+++ b/Sources/SwiftQL/SQLStaticRowLayout.swift
@@ -1,0 +1,710 @@
+import Foundation
+
+
+/// Failures while positioning, encoding, or decoding an operational static
+/// row layout.
+public enum XLStaticRowLayoutError:
+    Error,
+    Equatable,
+    Sendable,
+    LocalizedError
+{
+    case fieldNotPositioned(identity: XLQuerySlotIdentity)
+    case unsupportedSQLiteStorage(
+        identity: XLQuerySlotIdentity,
+        storageType: String
+    )
+    case expressionStorageTypeMismatch(
+        identity: XLQuerySlotIdentity,
+        expectedStorageType: String,
+        expressionType: String
+    )
+    case valueCountMismatch(expected: Int, actual: Int)
+    case nullForRequiredField(field: XLStaticRowField)
+    case storageMismatch(
+        field: XLStaticRowField,
+        actual: XLValueStorageIdentifier
+    )
+    case descriptorResultsMismatch(
+        expected: XLStaticQueryResultMetadata,
+        actual: XLStaticQueryResultMetadata
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .fieldNotPositioned(let identity):
+            return "Static result slot \(identity) must be positioned by its generated row-layout factory before use."
+        case .unsupportedSQLiteStorage(let identity, let storageType):
+            return "Static result slot \(identity) uses storage carrier \(storageType), whose SQLite storage class is not statically known."
+        case .expressionStorageTypeMismatch(
+            let identity,
+            let expectedStorageType,
+            let expressionType
+        ):
+            return "Static result slot \(identity) requires an expression typed as storage carrier \(expectedStorageType), but received \(expressionType)."
+        case .valueCountMismatch(let expected, let actual):
+            return "Static row layout expected \(expected) values, but received \(actual)."
+        case .nullForRequiredField(let field):
+            return "Static row property/result slot '\(field.alias)' (\(field.result.identity), codec \(Self.codecDescription(field))) received SQL NULL but is required."
+        case .storageMismatch(let field, let actual):
+            return "Static row property/result slot '\(field.alias)' (\(field.result.identity), codec \(Self.codecDescription(field))) requires storage \(field.result.storageIdentifier), not \(actual)."
+        case .descriptorResultsMismatch(let expected, let actual):
+            return Self.descriptorResultsMismatchDescription(
+                expected: expected,
+                actual: actual
+            )
+        }
+    }
+
+    private static func codecDescription(_ field: XLStaticRowField) -> String {
+        field.result.codecIdentity?.key.description ?? "intrinsic/none"
+    }
+
+    private static func descriptorResultsMismatchDescription(
+        expected: XLStaticQueryResultMetadata,
+        actual: XLStaticQueryResultMetadata
+    ) -> String {
+        let sharedCount = min(expected.slots.count, actual.slots.count)
+        for position in 0..<sharedCount {
+            let expectedSlot = expected.slots[position]
+            let actualSlot = actual.slots[position]
+            guard expectedSlot != actualSlot else {
+                continue
+            }
+            return descriptorResultsMismatchDescription(
+                position: position,
+                expected: expectedSlot,
+                actual: actualSlot,
+                expectedCount: expected.slots.count,
+                actualCount: actual.slots.count
+            )
+        }
+
+        if expected.slots.count > sharedCount {
+            return descriptorResultsMismatchDescription(
+                position: sharedCount,
+                expected: expected.slots[sharedCount],
+                actual: nil,
+                expectedCount: expected.slots.count,
+                actualCount: actual.slots.count
+            )
+        }
+        if actual.slots.count > sharedCount {
+            return descriptorResultsMismatchDescription(
+                position: sharedCount,
+                expected: nil,
+                actual: actual.slots[sharedCount],
+                expectedCount: expected.slots.count,
+                actualCount: actual.slots.count
+            )
+        }
+
+        return "Typed static query result metadata does not match its row layout, but no differing result slot could be identified."
+    }
+
+    private static func descriptorResultsMismatchDescription(
+        position: Int,
+        expected: XLStaticQueryResultSlot?,
+        actual: XLStaticQueryResultSlot?,
+        expectedCount: Int,
+        actualCount: Int
+    ) -> String {
+        [
+            "Typed static query result metadata does not match its row layout.",
+            "First differing result position \(position):",
+            "expected descriptor slot \(slotDescription(expected));",
+            "actual layout slot \(slotDescription(actual)).",
+            "Result counts: expected \(expectedCount), actual \(actualCount).",
+        ].joined(separator: " ")
+    }
+
+    private static func slotDescription(
+        _ slot: XLStaticQueryResultSlot?
+    ) -> String {
+        guard let slot else {
+            return "<missing>"
+        }
+        let codec: String
+        if let identity = slot.codecIdentity {
+            codec = "\(identity.key.description) { " + [
+                "value type: \(identity.valueTypeIdentifier)",
+                "dialect: \(identity.dialectIdentifier)",
+                "storage: \(identity.storageIdentifier)",
+            ].joined(separator: ", ") + " }"
+        }
+        else {
+            codec = "intrinsic/none"
+        }
+        return "{ " + [
+            "index: \(slot.index)",
+            "identity: \(slot.identity)",
+            "type: \(slot.valueTypeName) [\(slot.valueTypeIdentifier)]",
+            "nullability: \(slot.nullability.rawValue)",
+            "codec: \(codec)",
+            "storage: \(slot.storageIdentifier)",
+            "coding context: \(slot.codingContext.site.rawValue):\(slot.codingContext.path)",
+        ].joined(separator: ", ") + " }"
+    }
+}
+
+
+/// One typed projected expression and its immutable result-codec behavior.
+///
+/// A field created by a value-coding configuration is value-free. It retains
+/// an expression, stable descriptor metadata, and stateless conversion
+/// closures, but never a model instance, database, SQL reader, or invocation
+/// value. Generated row-layout factories assign its declaration position and
+/// SQL alias.
+public protocol XLStaticSelectFieldProtocol<FieldValue, FieldDialect> {
+    associatedtype FieldValue
+    associatedtype FieldDialect: XLValueCodingDialect
+
+    func positioned(at index: Int, alias: String) -> Self
+    func erased() throws -> XLAnyStaticSelectField<FieldDialect>
+    func read(from reader: XLRowReader) throws -> FieldValue
+    func encode(_ value: FieldValue) throws -> FieldDialect.Value
+}
+
+
+/// One storage-typed projected expression and its immutable result-codec
+/// behavior. The concrete `Storage` parameter remains available to callers
+/// even though generated row-layout factories accept the protocol abstraction.
+public struct XLStaticSelectField<Value, Storage, Dialect>
+where Storage: XLLiteral, Dialect: XLValueCodingDialect {
+
+    /// The selected SQL expression retyped to this field's intrinsic storage
+    /// carrier. Callers can pass it directly to storage-inferred APIs such as
+    /// `queryCapture(_:matching:identifiedBy:selection:)`.
+    public let expression: any XLExpression<Storage>
+
+    /// The durable storage contract shared by result and parameter metadata.
+    public let storageIdentifier: XLValueStorageIdentifier
+
+    /// The codec selector retained when this field was declared.
+    public let codecSelection: XLQueryCodecSelection
+
+    /// The exact codec selected for this field, or `nil` for intrinsic fields.
+    public let selectedCodecIdentity: XLValueCodecIdentity?
+
+    private let identity: XLQuerySlotIdentity
+    private let valueTypeIdentifier: XLValueTypeIdentifier
+    private let valueTypeName: String
+    private let nullability: XLParameterNullability
+    private let codingContext: XLValueCodingContext
+    private let dialect: Dialect
+    private let decodeValue: (Dialect.Value) throws -> Value
+    private let encodeValue: (Value) throws -> Dialect.Value
+    private let field: XLStaticRowField?
+
+    init(
+        expression: any XLExpression<Storage>,
+        identity: XLQuerySlotIdentity,
+        valueTypeIdentifier: XLValueTypeIdentifier,
+        valueTypeName: String,
+        nullability: XLParameterNullability,
+        codecIdentity: XLValueCodecIdentity?,
+        codecSelection: XLQueryCodecSelection,
+        storageIdentifier: XLValueStorageIdentifier,
+        codingContext: XLValueCodingContext,
+        dialect: Dialect,
+        decode: @escaping (Dialect.Value) throws -> Value,
+        encode: @escaping (Value) throws -> Dialect.Value,
+        field: XLStaticRowField? = nil
+    ) {
+        self.expression = expression
+        self.identity = identity
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.valueTypeName = valueTypeName
+        self.nullability = nullability
+        self.selectedCodecIdentity = codecIdentity
+        self.codecSelection = codecSelection
+        self.storageIdentifier = storageIdentifier
+        self.codingContext = codingContext
+        self.dialect = dialect
+        self.decodeValue = decode
+        self.encodeValue = encode
+        self.field = field
+    }
+
+    /// Assigns the generated declaration position and SQL result alias.
+    public func positioned(at index: Int, alias: String) -> Self {
+        let result = XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(index),
+            identity: identity,
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codecIdentity: selectedCodecIdentity,
+            storageIdentifier: storageIdentifier,
+            codingContext: codingContext
+        )
+        return Self(
+            expression: expression,
+            identity: identity,
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codecIdentity: selectedCodecIdentity,
+            codecSelection: codecSelection,
+            storageIdentifier: storageIdentifier,
+            codingContext: codingContext,
+            dialect: dialect,
+            decode: decodeValue,
+            encode: encodeValue,
+            field: XLStaticRowField(alias: alias, result: result)
+        )
+    }
+
+    /// Type-erases this positioned field for storage in a heterogeneous row
+    /// layout.
+    public func erased() throws -> XLAnyStaticSelectField<Dialect> {
+        guard let field else {
+            throw XLStaticRowLayoutError.fieldNotPositioned(
+                identity: identity
+            )
+        }
+        return XLAnyStaticSelectField(
+            expression: expression,
+            metadata: field,
+            validate: { value in
+                try validate(value, field: field)
+            }
+        )
+    }
+
+    /// Decodes this field from its generated logical result index.
+    public func read(from reader: XLRowReader) throws -> Value {
+        guard let field else {
+            throw XLStaticRowLayoutError.fieldNotPositioned(
+                identity: identity
+            )
+        }
+        let value = try reader.dialectValue(
+            at: field.result.index.rawValue,
+            using: dialect
+        )
+        try validate(value, field: field)
+        return try decodeValue(value)
+    }
+
+    /// Encodes one property value with the field's selected codec.
+    public func encode(_ value: Value) throws -> Dialect.Value {
+        guard let field else {
+            throw XLStaticRowLayoutError.fieldNotPositioned(
+                identity: identity
+            )
+        }
+        let encoded = try encodeValue(value)
+        try validate(encoded, field: field)
+        return encoded
+    }
+
+    private func validate(
+        _ value: Dialect.Value,
+        field: XLStaticRowField
+    ) throws {
+        if dialect.isNull(value) {
+            guard field.result.nullability == .nullable else {
+                throw XLStaticRowLayoutError.nullForRequiredField(field: field)
+            }
+            return
+        }
+        let actual = dialect.stableStorageIdentifier(for: value)
+        guard actual == field.result.storageIdentifier else {
+            throw XLStaticRowLayoutError.storageMismatch(
+                field: field,
+                actual: actual
+            )
+        }
+    }
+}
+
+
+extension XLStaticSelectField: XLStaticSelectFieldProtocol {
+    public typealias FieldValue = Value
+    public typealias FieldDialect = Dialect
+}
+
+
+/// The expression-bearing, type-erased half of one static row field.
+///
+/// Its public metadata is driver-neutral. The retained expression is used only
+/// for SQL rendering and introduces no GRDB dependency into descriptor APIs.
+public struct XLAnyStaticSelectField<Dialect>
+where Dialect: XLValueCodingDialect {
+    public let metadata: XLStaticRowField
+    fileprivate let expression: any XLEncodable
+    fileprivate let validateValue: (Dialect.Value) throws -> Void
+
+    fileprivate init(
+        expression: any XLEncodable,
+        metadata: XLStaticRowField,
+        validate: @escaping (Dialect.Value) throws -> Void
+    ) {
+        self.expression = expression
+        self.metadata = metadata
+        self.validateValue = validate
+    }
+}
+
+
+/// A row reader whose projection is available structurally without executing
+/// its decoding closure.
+public protocol XLStaticRowReadable<Row>: XLRowReadable, XLEncodable {
+    associatedtype Row
+    var metadata: XLStaticRowMetadata { get }
+}
+
+
+/// An operational typed row layout paired with driver-neutral structural
+/// metadata.
+///
+/// Construction validates only immutable field metadata. The model
+/// initializer in `decode` runs exclusively when a database row is decoded;
+/// it is never called while building a `Select` or static query descriptor.
+public struct XLStaticRowLayout<Row, Dialect>:
+    XLStaticRowReadable
+where Dialect: XLValueCodingDialect {
+
+    public let metadata: XLStaticRowMetadata
+
+    private let fields: [XLAnyStaticSelectField<Dialect>]
+    private let decodeRow: (XLRowReader) throws -> Row
+    private let encodeRow: (Row) throws -> [Dialect.Value]
+
+    public init(
+        fields: [XLAnyStaticSelectField<Dialect>],
+        decode: @escaping (XLRowReader) throws -> Row,
+        encode: @escaping (Row) throws -> [Dialect.Value]
+    ) throws {
+        self.metadata = try XLStaticRowMetadata(
+            fields: fields.map(\.metadata)
+        )
+        self.fields = fields
+        self.decodeRow = decode
+        self.encodeRow = encode
+    }
+
+    public func makeSQL(context: inout XLBuilder) {
+        context.list(separator: ", ") { list in
+            for field in fields {
+                list.listItem { builder in
+                    builder.alias(
+                        XLName(field.metadata.alias),
+                        expression: { expressionBuilder in
+                            if field.expression is any XLQueryStatement {
+                                expressionBuilder.parenthesis(
+                                    contents: field.expression.makeSQL
+                                )
+                            }
+                            else {
+                                field.expression.makeSQL(
+                                    context: &expressionBuilder
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    public func readRow(reader: XLRowReader) throws -> Row {
+        try decodeRow(reader)
+    }
+
+    /// Decodes one complete ordered row of dialect values.
+    public func decode(_ values: [Dialect.Value]) throws -> Row {
+        guard values.count == metadata.fields.count else {
+            throw XLStaticRowLayoutError.valueCountMismatch(
+                expected: metadata.fields.count,
+                actual: values.count
+            )
+        }
+        try validate(values)
+        let reader = _XLStaticDialectValuesRowReader(
+            values: values,
+            dialect: Dialect.self
+        )
+        return try decodeRow(reader)
+    }
+
+    /// Encodes every property in declaration order using the exact codecs
+    /// retained by this layout.
+    public func encode(_ row: Row) throws -> [Dialect.Value] {
+        let values = try encodeRow(row)
+        guard values.count == metadata.fields.count else {
+            throw XLStaticRowLayoutError.valueCountMismatch(
+                expected: metadata.fields.count,
+                actual: values.count
+            )
+        }
+        try validate(values)
+        return values
+    }
+
+    private func validate(_ values: [Dialect.Value]) throws {
+        for (field, value) in zip(fields, values) {
+            try field.validateValue(value)
+        }
+    }
+}
+
+
+/// A typed static descriptor whose operational row layout is proven to match
+/// the structural result contract used by stable query identity.
+///
+/// This API is database-driver independent and contains no GRDB types.
+public struct XLTypedStaticQueryDescriptor<Row, Dialect>
+where Dialect: XLValueCodingDialect {
+    public let descriptor: XLStaticQueryDescriptor
+    public let layout: XLStaticRowLayout<Row, Dialect>
+
+    public init(
+        descriptor: XLStaticQueryDescriptor,
+        layout: XLStaticRowLayout<Row, Dialect>
+    ) throws {
+        guard descriptor.results == layout.metadata.results else {
+            throw XLStaticRowLayoutError.descriptorResultsMismatch(
+                expected: descriptor.results,
+                actual: layout.metadata.results
+            )
+        }
+        self.descriptor = descriptor
+        self.layout = layout
+    }
+}
+
+
+extension XLValueCodingConfiguration {
+
+    /// Creates a required contextual SQLite result field. `Storage` is a type
+    /// witness for the selected SQL expression's intrinsic storage carrier;
+    /// no value or `sqlDefault()` call is required.
+    public func staticResultField<Value, Storage>(
+        _ valueType: Value.Type,
+        selecting expression: any XLEncodable,
+        storedAs storageType: Storage.Type,
+        identifiedBy identity: XLQuerySlotIdentity,
+        using dialect: XLSQLiteDialect,
+        context: XLValueCodingContext? = nil,
+        selection: XLQueryCodecSelection = .inferred
+    ) throws -> XLStaticSelectField<Value, Storage, XLSQLiteDialect>
+    where Storage: XLLiteral {
+        let storage = try _xlStaticSQLiteStorage(
+            storageType,
+            identity: identity
+        )
+        let codingContext = context ?? XLValueCodingContext(
+            site: .property,
+            path: XLValueCodingPath(identity.path)
+        )
+        let codec = try resolvedCodec(
+            for: valueType,
+            using: dialect,
+            context: codingContext,
+            requiringStorage: storage,
+            selection: selection
+        )
+        let storageExpression = try _xlStaticStorageExpression(
+            expression,
+            as: storageType,
+            identity: identity
+        )
+        return XLStaticSelectField(
+            expression: storageExpression,
+            identity: identity,
+            valueTypeIdentifier: codec.identity.valueTypeIdentifier,
+            valueTypeName: String(reflecting: Value.self),
+            nullability: .required,
+            codecIdentity: codec.identity,
+            codecSelection: selection,
+            storageIdentifier: storage,
+            codingContext: codingContext,
+            dialect: dialect,
+            decode: codec.decode,
+            encode: codec.encode
+        )
+    }
+
+    /// Creates a nullable contextual SQLite result field. Optionality belongs
+    /// to the field contract; the same nonoptional codec is reused for present
+    /// values while SQL `NULL` maps to and from `nil`.
+    public func staticResultField<Value, Storage>(
+        _ valueType: Value?.Type,
+        selecting expression: any XLEncodable,
+        storedAs storageType: Storage?.Type,
+        identifiedBy identity: XLQuerySlotIdentity,
+        using dialect: XLSQLiteDialect,
+        context: XLValueCodingContext? = nil,
+        selection: XLQueryCodecSelection = .inferred
+    ) throws -> XLStaticSelectField<Value?, Storage?, XLSQLiteDialect>
+    where Storage: XLLiteral {
+        let storage = try _xlStaticSQLiteStorage(
+            Storage.self,
+            identity: identity
+        )
+        let codingContext = context ?? XLValueCodingContext(
+            site: .property,
+            path: XLValueCodingPath(identity.path)
+        )
+        let codec = try resolvedCodec(
+            for: Value.self,
+            using: dialect,
+            context: codingContext,
+            requiringStorage: storage,
+            selection: selection
+        )
+        let storageExpression = try _xlStaticStorageExpression(
+            expression,
+            as: storageType,
+            identity: identity
+        )
+        return XLStaticSelectField(
+            expression: storageExpression,
+            identity: identity,
+            valueTypeIdentifier: codec.identity.valueTypeIdentifier,
+            valueTypeName: String(reflecting: Value?.self),
+            nullability: .nullable,
+            codecIdentity: codec.identity,
+            codecSelection: selection,
+            storageIdentifier: storage,
+            codingContext: codingContext,
+            dialect: dialect,
+            decode: codec.decodeOptional,
+            encode: codec.encodeOptional
+        )
+    }
+}
+
+
+extension XLStaticSelectField
+where Dialect == XLSQLiteDialect, Value: XLLiteral, Storage == Value {
+
+    /// Creates a codec-free field for an intrinsic v1 literal whose SQLite
+    /// storage class is statically known. This never calls `sqlDefault()`.
+    public static func intrinsic(
+        selecting expression: any XLExpression<Value>,
+        identifiedBy identity: XLQuerySlotIdentity,
+        using dialect: XLSQLiteDialect = XLSQLiteDialect(),
+        context: XLValueCodingContext? = nil
+    ) throws -> Self {
+        let storage = try _xlStaticSQLiteStorage(
+            Value.self,
+            identity: identity
+        )
+        let metadata = legacyValueMetadata(for: Value.self)
+        let codingContext = context ?? XLValueCodingContext(
+            site: .property,
+            path: XLValueCodingPath(identity.path)
+        )
+        return Self(
+            expression: expression,
+            identity: identity,
+            valueTypeIdentifier: metadata.identifier,
+            valueTypeName: metadata.typeName,
+            nullability: metadata.isOptional ? .nullable : .required,
+            codecIdentity: nil,
+            codecSelection: .inferred,
+            storageIdentifier: storage,
+            codingContext: codingContext,
+            dialect: dialect,
+            decode: { value in
+                try Value(
+                    reader: XLSQLiteValueReader(values: [value]),
+                    at: 0
+                )
+            },
+            encode: { value in
+                var context: any XLBindingContext = _XLStaticLiteralBindingContext()
+                value.bind(context: &context)
+                return (context as! _XLStaticLiteralBindingContext).value
+            }
+        )
+    }
+}
+
+
+private final class _XLStaticDialectValuesRowReader<Dialect>: XLRowReader
+where Dialect: XLValueCodingDialect {
+    let values: [Dialect.Value]
+
+    init(values: [Dialect.Value], dialect _: Dialect.Type) {
+        self.values = values
+    }
+
+    func column<Value>(
+        _ expression: any XLExpression<Value>,
+        alias: XLName
+    ) throws -> Value where Value: XLLiteral {
+        throw XLStaticRowReadError.staticLayoutRequired(
+            valueType: String(reflecting: Value.self),
+            alias: alias.rawValue
+        )
+    }
+
+    func dialectValue<RequestedDialect>(
+        at index: Int,
+        using _: RequestedDialect
+    ) throws -> RequestedDialect.Value
+    where RequestedDialect: XLValueCodingDialect {
+        guard values.indices.contains(index) else {
+            throw XLStaticRowLayoutError.valueCountMismatch(
+                expected: index + 1,
+                actual: values.count
+            )
+        }
+        guard let value = values[index] as? RequestedDialect.Value else {
+            throw XLStaticRowReadError.dialectValueTypeMismatch(
+                index: index,
+                expected: String(reflecting: RequestedDialect.Value.self),
+                actual: String(reflecting: Dialect.Value.self)
+            )
+        }
+        return value
+    }
+}
+
+
+private struct _XLStaticLiteralBindingContext: XLBindingContext {
+    var value: XLSQLiteValue = .null
+
+    mutating func bindNull() { value = .null }
+    mutating func bindInteger(value: Int) { self.value = .integer(Int64(value)) }
+    mutating func bindReal(value: Double) { self.value = .real(value) }
+    mutating func bindText(value: String) { self.value = .text(value) }
+    mutating func bindBlob(value: Data) { self.value = .blob(value) }
+}
+
+
+private func _xlStaticSQLiteStorage(
+    _ type: Any.Type,
+    identity: XLQuerySlotIdentity
+) throws -> XLValueStorageIdentifier {
+    guard let storage = sqliteStorageClass(for: type) else {
+        throw XLStaticRowLayoutError.unsupportedSQLiteStorage(
+            identity: identity,
+            storageType: String(reflecting: type)
+        )
+    }
+    return XLValueStorageIdentifier(rawValue: storage.rawValue)
+}
+
+
+private func _xlStaticStorageExpression<Storage>(
+    _ expression: any XLEncodable,
+    as storageType: Storage.Type,
+    identity: XLQuerySlotIdentity
+) throws -> any XLExpression<Storage> {
+    if let retypable = expression as? any XLStaticStorageRetypableExpression {
+        return retypable.staticStorageExpression(as: storageType)
+    }
+    guard let typed = expression as? any XLExpression<Storage> else {
+        throw XLStaticRowLayoutError.expressionStorageTypeMismatch(
+            identity: identity,
+            expectedStorageType: String(reflecting: Storage.self),
+            expressionType: String(reflecting: type(of: expression))
+        )
+    }
+    return typed
+}

--- a/Sources/SwiftQL/SQLiteValueReader.swift
+++ b/Sources/SwiftQL/SQLiteValueReader.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Reads legacy SwiftQL literals from SQLite dialect values without depending
 /// on a database-driver transport.
-public struct XLSQLiteValueReader: XLColumnReader {
+public struct XLSQLiteValueReader: XLStaticColumnReader {
 
     public let values: [XLSQLiteValue]
 
@@ -91,6 +91,21 @@ public struct XLSQLiteValueReader: XLColumnReader {
         case .integer, .real:
             throw typeMismatch(value, at: index, expectedType: "Data")
         }
+    }
+
+    public func dialectValue<Dialect>(
+        at index: Int,
+        using _: Dialect
+    ) throws -> Dialect.Value where Dialect: XLValueCodingDialect {
+        let value = try value(at: index, expectedType: String(reflecting: Dialect.Value.self))
+        guard let typed = value as? Dialect.Value else {
+            throw XLStaticRowReadError.dialectValueTypeMismatch(
+                index: index,
+                expected: String(reflecting: Dialect.Value.self),
+                actual: String(reflecting: XLSQLiteValue.self)
+            )
+        }
+        return typed
     }
 
     private func value(at index: Int, expectedType: String?) throws -> XLSQLiteValue {

--- a/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
@@ -10,8 +10,10 @@ type has more than one valid database representation. A codec pairs throwing
 encode and decode closures with stable type, dialect, storage, name, and version
 metadata. It does not require a property wrapper or a retroactive conformance.
 
-The older `XLCustomType` literal path remains source compatible. It is described
-after the contextual API so existing applications can migrate deliberately
+The older `XLCustomType` literal path remains source compatible. Existing types
+can keep an explicit legacy introspection placeholder, while new types that use
+generated static row layouts do not need to invent one. The compatibility path
+is described after the contextual API so applications can migrate deliberately
 without silently changing persisted representations.
 
 ## Contextual value codecs
@@ -281,6 +283,13 @@ adopt these marker protocols to opt into operators:
 - `XLEquatable`: Enables equality expressions such as `==` and `!=`.
 - `XLComparable`: Refines `XLEquatable` and also enables `<`, `>`, `<=`, and `>=`.
 
+`XLLiteral` retains the `sqlDefault()` requirement so existing implementations
+remain protocol witnesses. Its default implementation stops with a migration
+diagnostic if legacy `SQLReader` introspection reaches a type that did not
+provide a placeholder. Override it only while the type still uses that legacy
+result path. A generated static row layout decodes from raw dialect values and
+never calls `sqlDefault()`.
+
 Legacy custom types are stored in the SQL database as one of the native
 representations used by SQLite: `Int`, `Double`, `String`, or `Data`. Custom 
 types need to implement support to convert to and from one of these native 
@@ -340,7 +349,7 @@ struct MyUUID: XLCustomType, XLComparable, Equatable, Sendable {
         context.text(wrappedValue.uuidString)
     }
 
-    // 6. Provide a default value.
+    // 6. Opt into legacy SQLReader result introspection.
     public static func sqlDefault() -> MyUUID {
         MyUUID(UUID(uuidString: "00000000-0000-0000-0000-000000000000")!)
     }
@@ -375,10 +384,20 @@ a `Text` value, we can bind the string representation.
 5. Implement the `makeSQL` method. This method is used to encode our custom type
 when it is used as a literal value in an expression. 
 
-6. Implement `sqlDefault`. SwiftQL uses this placeholder while it determines a
-result type's column expressions. The only requirement is to return a valid
-instance of the custom type; the placeholder value is not read from or written
-to the database.
+6. This example continues to use the legacy query/result APIs, so it overrides
+`sqlDefault`. SwiftQL uses the placeholder while it determines that result
+type's column expressions. The placeholder is not read from or written to the
+database. A type used only through a generated static row layout omits this
+override instead of inventing a semantically fake value.
+
+Steps 2 through 5 define the literal behavior; step 6 opts into legacy result
+introspection. New domain values can instead remain plain Swift structs, enums,
+`Date`, or `UUID` values, or retain `XLCustomType` expression behavior without a
+placeholder: register an `XLValueCodec`, create each projected field with
+`staticResultField`, and pass those fields to the macro-generated
+`staticRowLayout(using:...)` factory. That path constructs result metadata and
+renders projections without calling a model initializer, `SQLReader`, or
+`sqlDefault()`.
 
 This conformance allows `MyUUID` to be used in SQL expressions, such as a column
 in a table or a condition in a `WHERE` clause:
@@ -555,6 +574,12 @@ safe to share between tasks; the original v1 literal path remains unchanged for
 older types. This is a compatibility bridge, not permission to change storage
 implicitly: declare the actual v1 storage class, test existing rows, and retain
 the old representation until a deliberate migration has completed.
+
+The adapter calls the literal's existing `bind(context:)` and
+`init(reader:at:)` implementations; it does not call `sqlDefault()`. A new
+`XLCustomType` can therefore omit an explicit placeholder when all of its result
+decoding uses generated static layouts. Keep an explicit placeholder on older
+types for as long as legacy result introspection remains in use.
 
 <!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
 ```swift

--- a/Sources/SwiftQL/SwiftQL.docc/Enums.md
+++ b/Sources/SwiftQL/SwiftQL.docc/Enums.md
@@ -12,13 +12,21 @@ A conforming enum must:
 
 - use a supported intrinsic raw type such as `Int`, `Double`, or `String`;
 - conform to ``XLEnum`` and declare its ``XLExpression/T`` associated type as
-  `Self`; and
-- implement ``XLLiteral/sqlDefault()`` by returning any valid case.
+  `Self`.
 
-The `sqlDefault()` value is a construction and introspection placeholder.
-SwiftQL uses it while determining the typed columns of a statement. It is not a
-database default, is not written by that introspection, and is never used to
-recover from a decoding error.
+An explicit `sqlDefault()` value is needed only for legacy `SQLReader` result
+introspection. `XLLiteral` provides a default implementation that stops with a
+migration diagnostic if that legacy path reaches an enum without a placeholder.
+Generated static row layouts do not call it, and it is never used to recover
+from a decoding error.
+
+A plain Swift enum, or an `XLEnum` that retains v1 expression and operator
+behavior, does not need to declare `sqlDefault()` when it is encoded by an
+`XLValueCodec` and selected through a generated static row layout. Supply an
+intrinsic storage carrier such as `String.self` or `Int.self` to
+`staticResultField`; the layout retains that codec and decodes the enum only
+when SQLite returns a row. Override `sqlDefault()` only while the enum also uses
+legacy result introspection.
 
 ## Define integer- and string-backed enums
 
@@ -34,6 +42,7 @@ enum JobPriority: Int, XLEnum {
     case low = 0
     case high = 1
 
+    // The examples below use the legacy result path.
     static func sqlDefault() -> JobPriority {
         .low
     }
@@ -45,6 +54,7 @@ enum JobState: String, XLEnum {
     case queued
     case running
 
+    // The examples below use the legacy result path.
     static func sqlDefault() -> JobState {
         .queued
     }

--- a/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
@@ -12,10 +12,15 @@ physical statement, codec registry, or invocation value. You can therefore
 construct and register descriptors before opening a database, then prepare the
 same descriptor against a compatible database when it is needed.
 
-Static descriptors complement ordinary SwiftQL requests. Use a request when
-you want the existing typed row-reader facade. Use a descriptor when you need a
-durable query identity, an immutable cross-task prepared handle, an explicit
-result contract, or a registry of query definitions.
+Static descriptors complement ordinary SwiftQL requests. Existing v1 requests
+remain source compatible. Use a generated static row layout when a model has
+contextual-codec properties that do not conform to `XLLiteral`, or whenever
+query construction must not execute a model initializer, `SQLReader`, or
+`sqlDefault()`. Pair that layout with a descriptor when you also need a durable
+query identity, an explicit result contract, typed fetch operations, or a
+registry of query definitions. The raw `GRDBPreparedStaticQuery` handle is
+`Sendable`; the closure-backed typed row layout and its prepared wrapper are
+currently task-local.
 
 ## Construct a descriptor
 
@@ -157,10 +162,55 @@ SwiftQL expression graph.
 
 Each selected property or direct output column is one flat `XLStaticQueryResultSlot`.
 A selection with three columns therefore declares
-three slots, even when a typed request would decode those columns into one
-Swift value. Automatic synthesis of aggregate or nested property/result graphs
-is owned by issue #40; static descriptors currently describe the flat values
-that cross the driver boundary.
+three slots, even when those columns decode into one Swift row. Generated
+`staticRowLayout(using:...)` factories position those slots in declaration
+order and retain the corresponding typed encode/decode behavior.
+
+## Generate a typed row layout
+
+`@SQLTable` and `@SQLResult` generate a nominal
+`staticRowLayout(using:...)` factory alongside the existing `columns(...)`
+factory. Supply one `XLStaticSelectField` for each property. Intrinsic v1
+literals can use `XLStaticSelectField.intrinsic`; contextual values use
+`XLValueCodingConfiguration.staticResultField`, with an explicit intrinsic
+storage carrier such as `String.self` and a codec selection when needed.
+
+The public field type is
+`XLStaticSelectField<Value, Storage, Dialect>`. It retains a storage-typed
+`expression`, `storageIdentifier`, `codecSelection`, and the resolved
+`selectedCodecIdentity`. This makes the result-to-parameter handoff explicit:
+pass `field.expression` to `queryCapture(_:matching:identifiedBy:)` and reuse
+`field.codecSelection`. The resulting capture must have the same storage and
+selected codec identity as the field. Generated layout factories accept each
+concrete field through a primary-associated-type protocol, so every property
+keeps its independently inferred `Storage` without synthesized generic names
+that can shadow model generics.
+
+The factory assigns declaration indices and SQL aliases, validates them through
+`XLStaticRowMetadata`, and returns `XLStaticRowLayout`. Constructing that layout
+or `Select(layout)` only inspects immutable metadata and expressions. The
+generated model initializer and codec decode closures run only when a row is
+actually decoded. Empty rows follow the same rule: `Self()` appears inside the
+decode closure, not in layout construction.
+
+Optionality belongs to the generated field, not to its codec. A `Date?`
+property therefore uses the same selected `Date` codec as a required `Date`,
+while the layout maps SQL `NULL` to and from `nil`. Two properties of the same
+Swift type can select different codec keys; their projection metadata,
+layout-based encoding, and decoding remain distinct.
+
+`XLTypedStaticQueryDescriptor` pairs the operational layout with an existing
+structural descriptor and requires exact equality between
+`descriptor.results` and `layout.metadata.results`. The type contains no GRDB
+API. Preparing it through `GRDBDatabase` returns a
+`GRDBPreparedTypedStaticQuery`, whose typed fetch operations decode raw SQLite
+rows through the retained layout.
+
+The existing `XLResult`, `SQLReader`, `columns(...)`, table, union, and common
+table APIs remain the v1 compatibility path. Their `XLLiteral` behavior,
+including `wrapSQL`, is unchanged. Contextual-only properties compile in
+generated metadata, but must use a static layout for value encoding and row
+decoding instead of the v1 `MetaInsert`/`MetaUpdate` and introspection path.
 
 ## Stable identity
 
@@ -214,10 +264,11 @@ prepared.
 ## Prepare and invoke
 
 Preparing binds the database-independent descriptor to one `GRDBDatabase` and
-returns a `Sendable` `GRDBPreparedStaticQuery`. Preparation validates dialect
-requirements and every contextual codec against the database's immutable coding
-configuration. The handle retains that exact configuration snapshot; it never
-consults process-global mutable state and does not own a connection-bound
+returns a `Sendable` `GRDBPreparedStaticQuery`. Preparing a matching typed
+descriptor instead returns `GRDBPreparedTypedStaticQuery`. Preparation validates
+dialect requirements and every contextual codec against the database's immutable
+coding configuration. The handle retains that exact configuration snapshot; it
+never consults process-global mutable state and does not own a connection-bound
 SQLite statement.
 
 Create a fresh `XLInvocationBindings` packet for every call. The packet owns

--- a/Sources/SwiftQLCore/SQLStaticQueryDescriptor.swift
+++ b/Sources/SwiftQLCore/SQLStaticQueryDescriptor.swift
@@ -266,8 +266,8 @@ public struct XLLogicalResultIndex:
 /// Static metadata for one value in a returned row.
 ///
 /// Each selected property or direct output column is represented by one flat
-/// result slot. Static aggregate/property graph synthesis remains deferred to
-/// issue #40.
+/// result slot. Generated static row metadata composes these slots without
+/// changing their frozen query-identity representation.
 public struct XLStaticQueryResultSlot: Hashable, Sendable {
 
     public let index: XLLogicalResultIndex
@@ -411,6 +411,127 @@ public struct XLStaticQueryResultMetadata: Hashable, Sendable {
         for identity: XLQuerySlotIdentity
     ) -> XLStaticQueryResultSlot? {
         slots.first { $0.identity == identity }
+    }
+}
+
+
+/// Structural metadata for one property in a statically described row.
+///
+/// The field carries no expression, database value, or executable closure. It
+/// is safe to retain in generated descriptors and can be inspected without
+/// constructing the model that ultimately receives the value.
+public struct XLStaticRowField: Hashable, Sendable {
+
+    /// The SQL result alias generated for the property.
+    public let alias: String
+
+    /// The complete static result-slot contract for the property.
+    public let result: XLStaticQueryResultSlot
+
+    public init(alias: String, result: XLStaticQueryResultSlot) {
+        self.alias = alias
+        self.result = result
+    }
+}
+
+
+/// An immutable, declaration-ordered structural description of a Swift row.
+///
+/// Validation deliberately happens before any operational row layout is
+/// retained. Result-slot validation is delegated to
+/// ``XLStaticQueryResultMetadata`` so a row and a static query share exactly
+/// the same index, identity, nullability, value-type, codec, and storage
+/// invariants.
+public struct XLStaticRowMetadata: Hashable, Sendable {
+
+    public static let empty = Self(
+        canonicalFields: [],
+        results: .empty
+    )
+
+    /// Fields in declaration and projection order.
+    public let fields: [XLStaticRowField]
+
+    /// Canonical result metadata for the same fields.
+    public let results: XLStaticQueryResultMetadata
+
+    public init(fields: [XLStaticRowField]) throws {
+        var aliases: [String: XLStaticRowField] = [:]
+
+        for (offset, field) in fields.enumerated() {
+            let expected = XLLogicalResultIndex(offset)
+            guard field.result.index == expected else {
+                throw XLStaticRowMetadataError.fieldPositionMismatch(
+                    field: field,
+                    expected: expected
+                )
+            }
+
+            let canonicalAlias = field.alias
+                .precomposedStringWithCanonicalMapping
+                .lowercased()
+            guard !canonicalAlias.isEmpty else {
+                throw XLStaticRowMetadataError.emptyFieldAlias(field: field)
+            }
+            if let existing = aliases[canonicalAlias] {
+                throw XLStaticRowMetadataError.duplicateFieldAlias(
+                    alias: field.alias,
+                    existing: existing,
+                    incoming: field
+                )
+            }
+            aliases[canonicalAlias] = field
+        }
+
+        self.fields = fields
+        self.results = try XLStaticQueryResultMetadata(
+            slots: fields.map(\.result)
+        )
+    }
+
+    private init(
+        canonicalFields: [XLStaticRowField],
+        results: XLStaticQueryResultMetadata
+    ) {
+        self.fields = canonicalFields
+        self.results = results
+    }
+}
+
+
+/// Deterministic row-layout validation failures.
+public enum XLStaticRowMetadataError:
+    Error,
+    Equatable,
+    Sendable,
+    LocalizedError
+{
+    case fieldPositionMismatch(
+        field: XLStaticRowField,
+        expected: XLLogicalResultIndex
+    )
+    case emptyFieldAlias(field: XLStaticRowField)
+    case duplicateFieldAlias(
+        alias: String,
+        existing: XLStaticRowField,
+        incoming: XLStaticRowField
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .fieldPositionMismatch(let field, let expected):
+            return "Static row property '\(field.alias)' (result slot \(field.result.identity), codec \(Self.codecDescription(field.result))) is at index \(field.result.index); expected declaration position \(expected)."
+        case .emptyFieldAlias(let field):
+            return "Static row result slot \(field.result.identity) (codec \(Self.codecDescription(field.result))) requires a nonempty property/result alias."
+        case .duplicateFieldAlias(let alias, let existing, let incoming):
+            return "Static row property/result alias '\(alias)' is declared by both result slot \(existing.result.identity) (codec \(Self.codecDescription(existing.result))) and result slot \(incoming.result.identity) (codec \(Self.codecDescription(incoming.result)))."
+        }
+    }
+
+    private static func codecDescription(
+        _ result: XLStaticQueryResultSlot
+    ) -> String {
+        result.codecIdentity?.key.description ?? "intrinsic/none"
     }
 }
 

--- a/Tests/SQLMacrosTests/SQLTests.swift
+++ b/Tests/SQLMacrosTests/SQLTests.swift
@@ -65,7 +65,7 @@ private struct SQLResultColumnsMemberMacro: MemberMacro {
                 of: node,
                 providingMembersOf: declaration,
                 in: context
-            ).dropFirst()
+            ).dropFirst().prefix(1)
         )
     }
 }
@@ -828,6 +828,142 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains(").readRow"))
     }
 
+    func test_staticRowLayoutGenerationCoversTypedOptionalQualifiedGenericAndBacktickedFields() throws {
+        let builder = try makeBuilder(
+            """
+            @SQLResult
+            struct Projection<Element> {
+                let `switch`: Swift.Optional<Element>
+                let values: Array<Element>
+            }
+            """
+        )
+        let source = builder.makeStaticRowLayoutFunction()
+
+        XCTAssertFalse(Parser.parse(source: source).hasError)
+        XCTAssertTrue(source.contains("public static func staticRowLayout<_SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("some SwiftQL.XLStaticSelectFieldProtocol<Element?, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("some SwiftQL.XLStaticSelectFieldProtocol<Array<Element>, _SwiftQLStaticDialect>"))
+        XCTAssertFalse(source.contains("_SwiftQLStaticStorage"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = `switch`.positioned(at: 0, alias: \"switch\")"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField1 = values.positioned(at: 1, alias: \"values\")"))
+        XCTAssertTrue(source.contains("try _swiftQLStaticField0.read(from: _swiftQLStaticReader)"))
+        XCTAssertTrue(source.contains("try _swiftQLStaticField1.encode(_swiftQLStaticRow.values)"))
+        XCTAssertTrue(source.contains("try _swiftQLStaticField0.erased()"))
+    }
+
+    func test_staticRowLayoutGenerationAvoidsReaderAndRowPropertyCollisions() throws {
+        let builder = try makeBuilder(
+            """
+            @SQLResult
+            struct Projection {
+                let reader: String
+                let row: Int
+            }
+            """
+        )
+        let source = builder.makeStaticRowLayoutFunction()
+        let metaSource = builder.makeMetaResultExtension(table: false)
+
+        XCTAssertFalse(Parser.parse(source: source).hasError)
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = reader.positioned"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField1 = row.positioned"))
+        XCTAssertTrue(source.contains("decode: { _swiftQLStaticReader in"))
+        XCTAssertTrue(source.contains("reader: try _swiftQLStaticField0.read(from: _swiftQLStaticReader)"))
+        XCTAssertTrue(source.contains("encode: { _swiftQLStaticRow in"))
+        XCTAssertTrue(source.contains("try _swiftQLStaticField1.encode(_swiftQLStaticRow.row)"))
+        XCTAssertFalse(source.contains("decode: { reader in"))
+        XCTAssertFalse(source.contains("encode: { row in"))
+        XCTAssertTrue(metaSource.contains("readRow(reader _swiftQLRowReader: XLRowReader)"))
+        XCTAssertTrue(metaSource.contains("reader: try _swiftQLRowReader.staticColumn(reader"))
+        XCTAssertTrue(metaSource.contains("row: try _swiftQLRowReader.staticColumn(row"))
+    }
+
+    func test_staticRowLayoutGenerationAllocatesCollisionFreeIdentifiers() throws {
+        let builder = try makeBuilder(
+            """
+            @SQLResult
+            struct Projection<
+                Dialect,
+                _SwiftQLStaticDialect,
+                _SwiftQLStaticStorage0
+            > {
+                let dialect: Dialect
+                let staticDialect: _SwiftQLStaticDialect
+                let storage: _SwiftQLStaticStorage0
+                let _swiftQLStaticField0: String
+                let _swiftQLStaticReader: String
+                let _swiftQLStaticRow: String
+            }
+            """
+        )
+        let source = builder.makeStaticRowLayoutFunction()
+
+        XCTAssertFalse(Parser.parse(source: source).hasError)
+        XCTAssertTrue(source.contains("staticRowLayout<_SwiftQLStaticDialect_1>"))
+        XCTAssertTrue(source.contains("XLStaticSelectFieldProtocol<Dialect, _SwiftQLStaticDialect_1>"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0_1 = dialect.positioned"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField3 = _swiftQLStaticField0.positioned"))
+        XCTAssertTrue(source.contains("decode: { _swiftQLStaticReader_1 in"))
+        XCTAssertTrue(source.contains("encode: { _swiftQLStaticRow_1 in"))
+        XCTAssertFalse(source.contains("staticRowLayout<Dialect>"))
+    }
+
+    func test_generatedAllocatorsReserveNominalAndPropertyTypeIdentifiers() throws {
+        let builder = try makeBuilder(
+            """
+            @SQLResult
+            struct _swiftQLRowReader {
+                let direct: _SwiftQLStaticDialect
+                let nested: Box<Array<_SwiftQLStaticDialect?>>
+            }
+            """
+        )
+        let staticSource = builder.makeStaticRowLayoutFunction()
+        let metaSource = builder.makeMetaResultExtension(table: false)
+
+        XCTAssertFalse(Parser.parse(source: staticSource).hasError)
+        XCTAssertTrue(
+            staticSource.contains(
+                "staticRowLayout<_SwiftQLStaticDialect_1>"
+            )
+        )
+        XCTAssertTrue(
+            staticSource.contains(
+                "XLStaticSelectFieldProtocol<_SwiftQLStaticDialect, _SwiftQLStaticDialect_1>"
+            )
+        )
+        XCTAssertTrue(
+            staticSource.contains(
+                "XLStaticSelectFieldProtocol<Box<Array<_SwiftQLStaticDialect?>>, _SwiftQLStaticDialect_1>"
+            )
+        )
+        XCTAssertTrue(
+            metaSource.contains(
+                "readRow(reader _swiftQLRowReader_1: XLRowReader) throws -> _swiftQLRowReader"
+            )
+        )
+    }
+
+    func test_emptyStaticRowLayoutGenerationDefersInitializerToDecodeClosure() throws {
+        let builder = try makeBuilder(
+            """
+            @SQLResult
+            struct EmptyProjection {
+            }
+            """
+        )
+        let source = builder.makeStaticRowLayoutFunction()
+
+        XCTAssertFalse(Parser.parse(source: source).hasError)
+        XCTAssertTrue(source.contains("fields: ["))
+        XCTAssertTrue(source.contains("decode: { _swiftQLStaticReader in"))
+        XCTAssertTrue(source.contains("Self"))
+        XCTAssertTrue(source.contains("encode: { _swiftQLStaticRow in"))
+        XCTAssertFalse(source.contains("sqlDefault"))
+        XCTAssertFalse(source.contains("SQLReader"))
+    }
+
     func test_immutableTableUpdateRequestAvoidsUnusedTemporaries() throws {
         let builder = try makeBuilder(
             """
@@ -861,6 +997,6 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains("var output = entity"))
         XCTAssertTrue(source.contains("output.id = value"))
         XCTAssertTrue(source.contains("var output = MetaUpdate()"))
-        XCTAssertTrue(source.contains("output.id = XLTypeAffinityExpression<Int>(expression: value)"))
+        XCTAssertTrue(source.contains("output.id = SwiftQL._xlLegacyValueExpression(value)"))
     }
 }

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -183,7 +183,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         for semanticPhrase in [
             "construct and register descriptors before opening a database",
             "one flat `XLStaticQueryResultSlot`",
-            "owned by issue #40",
+            "`staticRowLayout(using:...)` factories",
             "Exact rendered SQL bytes",
             "deliberately excludes invocation values",
             "Metadata strings that participate in identity use Unicode NFC normalization",

--- a/Tests/SQLTests/SQLRequestCompatibilityTests.swift
+++ b/Tests/SQLTests/SQLRequestCompatibilityTests.swift
@@ -7,6 +7,38 @@ import XCTest
 
 final class SQLRequestCompatibilityTests: XCTestCase {
 
+    func testLegacyRowReaderConformerKeepsOriginalColumnRequirement() throws {
+        let reader = LegacyManualRowReader()
+
+        let value: Int = try reader.staticColumn(42, alias: "value")
+
+        XCTAssertEqual(value, Int.sqlDefault())
+        XCTAssertEqual(reader.readCount, 1)
+        XCTAssertThrowsError(
+            try reader.staticColumn(
+                LegacyContextOnlyExpression(),
+                alias: "contextual"
+            ) as LegacyContextOnlyValue
+        ) { error in
+            guard case .staticLayoutRequired(let valueType, let alias) =
+                    error as? XLStaticRowReadError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(valueType.contains("LegacyContextOnlyValue"))
+            XCTAssertEqual(alias, "contextual")
+        }
+        XCTAssertEqual(reader.readCount, 1)
+    }
+
+    func testStaticColumnBridgePreservesQueryStatementParenthesization() {
+        let statement = Select(LegacyQueryStatementProjection())
+        let encoding = XLiteEncoder(dialect: XLSQLiteDialect()).makeSQL(
+            statement
+        )
+
+        XCTAssertEqual(encoding.sql, "SELECT (SELECT 1) AS \"value\"")
+    }
+
     func testLegacyReadConformerUsesDefaultPacketRequirements() throws {
         var request = LegacyReadRequest(rows: [82])
         let parameter = XLNamedBindingReference<Int>(name: "value")
@@ -116,6 +148,58 @@ final class SQLRequestCompatibilityTests: XCTestCase {
         request.set(parameter, "direct legacy binding")
 
         XCTAssertEqual(try request.fetchOne(), "direct legacy binding")
+    }
+}
+
+
+private final class LegacyManualRowReader: XLRowReader {
+    private(set) var readCount = 0
+
+    func column<T>(
+        _ expression: any XLExpression<T>,
+        alias: XLName
+    ) -> T where T: XLLiteral {
+        readCount += 1
+        return T.sqlDefault()
+    }
+}
+
+
+private struct LegacyContextOnlyValue {}
+
+
+private struct LegacyContextOnlyExpression: XLExpression {
+    typealias T = LegacyContextOnlyValue
+
+    func makeSQL(context: inout XLBuilder) {
+        context.null()
+    }
+}
+
+
+private struct LegacyQueryStatementProjection: XLRowReadable {
+    typealias Row = Int
+
+    func readRow(reader: XLRowReader) throws -> Int {
+        try reader.staticColumn(
+            LegacyDualQueryStatementExpression(),
+            alias: "value"
+        )
+    }
+}
+
+
+private struct LegacyDualQueryStatementExpression:
+    XLExpression,
+    XLQueryStatement
+{
+    typealias T = Int
+    typealias Row = Int
+
+    let components = select(1).components
+
+    func readRow(reader: XLRowReader) throws -> Int {
+        try components.readRow(reader: reader)
     }
 }
 

--- a/Tests/SQLTests/StaticRowDiagnosticTests.swift
+++ b/Tests/SQLTests/StaticRowDiagnosticTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import SwiftQL
+
+
+@SQLResult
+private struct StaticRowDiagnosticRecord: Equatable {
+    let leading: Int
+    let value: String
+}
+
+
+final class StaticRowDiagnosticTests: XCTestCase {
+
+    func testDescriptorMismatchIdentifiesFirstSlotAndCompleteContracts() throws {
+        let identity = try XLQuerySlotIdentity(
+            path: ["diagnostics", "shared-value"]
+        )
+        let layout = try makeLayout(identity: identity)
+        let expectedType = XLValueTypeIdentifier(
+            rawValue: "tests.diagnostics.expected"
+        )
+        let expectedStorage = XLValueStorageIdentifier(rawValue: "integer")
+        let expectedCodec = XLValueCodecIdentity(
+            key: XLValueCodecKey(
+                id: "tests.diagnostics.expected-codec",
+                version: 7
+            ),
+            valueTypeIdentifier: expectedType,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: expectedStorage
+        )
+        let expectedSlot = XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(1),
+            identity: identity,
+            valueTypeIdentifier: expectedType,
+            valueTypeName: "Diagnostics.ExpectedValue",
+            nullability: .nullable,
+            codecIdentity: expectedCodec,
+            storageIdentifier: expectedStorage,
+            codingContext: XLValueCodingContext(
+                site: .result,
+                path: XLValueCodingPath(["expected", "result"])
+            )
+        )
+        let expectedResults = try XLStaticQueryResultMetadata(
+            slots: [layout.metadata.results.slots[0], expectedSlot]
+        )
+        let descriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "static-row-diagnostics"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: "SELECT 0, 1",
+                dialectRequirement: XLDialectRequirement(
+                    identity: XLSQLiteDialect.identity
+                )
+            ),
+            parameters: [],
+            results: expectedResults,
+            cardinality: .exactlyOne
+        )
+
+        XCTAssertThrowsError(
+            try XLTypedStaticQueryDescriptor(
+                descriptor: descriptor,
+                layout: layout
+            )
+        ) { error in
+            guard case .descriptorResultsMismatch(let expected, let actual) =
+                    error as? XLStaticRowLayoutError else {
+                return XCTFail(
+                    "Expected descriptor result mismatch, received \(error)"
+                )
+            }
+            XCTAssertEqual(expected, expectedResults)
+            XCTAssertEqual(actual, layout.metadata.results)
+
+            let actualSlot = layout.metadata.results.slots[1]
+            let description = error.localizedDescription
+            XCTAssertTrue(
+                description.contains("First differing result position 1")
+            )
+            XCTAssertTrue(description.contains("identity: \(identity)"))
+            XCTAssertTrue(
+                description.contains(
+                    "type: \(expectedSlot.valueTypeName) [\(expectedSlot.valueTypeIdentifier)]"
+                )
+            )
+            XCTAssertTrue(
+                description.contains(
+                    "type: \(actualSlot.valueTypeName) [\(actualSlot.valueTypeIdentifier)]"
+                )
+            )
+            XCTAssertTrue(description.contains("nullability: nullable"))
+            XCTAssertTrue(description.contains("nullability: required"))
+            XCTAssertTrue(
+                description.contains("codec: \(expectedCodec.key.description)")
+            )
+            XCTAssertTrue(description.contains("codec: intrinsic/none"))
+            XCTAssertTrue(description.contains("storage: integer"))
+            XCTAssertTrue(description.contains("storage: text"))
+            XCTAssertTrue(
+                description.contains("coding context: result:expected.result")
+            )
+            XCTAssertTrue(
+                description.contains(
+                    "coding context: property:diagnostics.shared-value"
+                )
+            )
+        }
+    }
+
+    func testUnpositionedFieldDiagnosticRetainsIdentity() throws {
+        let identity = try XLQuerySlotIdentity(
+            path: ["diagnostics", "unpositioned"]
+        )
+        let field = try makeField(identity: identity)
+
+        XCTAssertThrowsError(try field.erased()) { error in
+            XCTAssertEqual(
+                error as? XLStaticRowLayoutError,
+                .fieldNotPositioned(identity: identity)
+            )
+            XCTAssertTrue(error.localizedDescription.contains("\(identity)"))
+            XCTAssertTrue(
+                error.localizedDescription.contains("positioned")
+            )
+        }
+    }
+
+    func testRequiredNullDiagnosticRetainsFieldAndCodecContext() throws {
+        let identity = try XLQuerySlotIdentity(
+            path: ["diagnostics", "required-null"]
+        )
+        let layout = try makeLayout(identity: identity)
+        let field = layout.metadata.fields[1]
+
+        XCTAssertThrowsError(
+            try layout.decode([.integer(0), .null])
+        ) { error in
+            XCTAssertEqual(
+                error as? XLStaticRowLayoutError,
+                .nullForRequiredField(field: field)
+            )
+            XCTAssertTrue(error.localizedDescription.contains("'value'"))
+            XCTAssertTrue(error.localizedDescription.contains("\(identity)"))
+            XCTAssertTrue(
+                error.localizedDescription.contains("codec intrinsic/none")
+            )
+            XCTAssertTrue(error.localizedDescription.contains("SQL NULL"))
+        }
+    }
+
+    func testStorageMismatchDiagnosticRetainsExpectedAndActualStorage() throws {
+        let identity = try XLQuerySlotIdentity(
+            path: ["diagnostics", "storage"]
+        )
+        let layout = try makeLayout(identity: identity)
+        let field = layout.metadata.fields[1]
+        let integerStorage = XLValueStorageIdentifier(rawValue: "integer")
+
+        XCTAssertThrowsError(
+            try layout.decode([.integer(0), .integer(1)])
+        ) { error in
+            XCTAssertEqual(
+                error as? XLStaticRowLayoutError,
+                .storageMismatch(field: field, actual: integerStorage)
+            )
+            XCTAssertTrue(error.localizedDescription.contains("'value'"))
+            XCTAssertTrue(error.localizedDescription.contains("\(identity)"))
+            XCTAssertTrue(error.localizedDescription.contains("storage text"))
+            XCTAssertTrue(error.localizedDescription.contains("not integer"))
+        }
+    }
+
+    private func makeLayout(
+        identity: XLQuerySlotIdentity
+    ) throws -> XLStaticRowLayout<
+        StaticRowDiagnosticRecord,
+        XLSQLiteDialect
+    > {
+        try StaticRowDiagnosticRecord.staticRowLayout(
+            using: XLSQLiteDialect.self,
+            leading: try XLStaticSelectField<
+                Int,
+                Int,
+                XLSQLiteDialect
+            >.intrinsic(
+                selecting: XLColumnResult<Int>(
+                    dependency: XLSelectResultDependency(),
+                    as: "leading"
+                ),
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["diagnostics", "leading"]
+                )
+            ),
+            value: makeField(identity: identity)
+        )
+    }
+
+    private func makeField(
+        identity: XLQuerySlotIdentity
+    ) throws -> XLStaticSelectField<String, String, XLSQLiteDialect> {
+        try XLStaticSelectField<String, String, XLSQLiteDialect>.intrinsic(
+            selecting: XLColumnResult<String>(
+                dependency: XLSelectResultDependency(),
+                as: "value"
+            ),
+            identifiedBy: identity
+        )
+    }
+}

--- a/Tests/SQLTests/StaticRowMacroHygieneTests.swift
+++ b/Tests/SQLTests/StaticRowMacroHygieneTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import SwiftQL
+
+
+@SQLResult
+private struct StaticRowMacroHygieneRecord: Equatable {
+    let reader: String
+    let row: Int
+}
+
+
+final class StaticRowMacroHygieneTests: XCTestCase {
+
+    func testReaderAndRowPropertiesCompileAndRoundTrip() throws {
+        let reader = try XLStaticSelectField<
+            String,
+            String,
+            XLSQLiteDialect
+        >.intrinsic(
+            selecting: XLColumnResult<String>(
+                dependency: XLSelectResultDependency(),
+                as: "reader"
+            ),
+            identifiedBy: XLQuerySlotIdentity(
+                path: ["macro-hygiene", "reader"]
+            )
+        )
+        let row = try XLStaticSelectField<
+            Int,
+            Int,
+            XLSQLiteDialect
+        >.intrinsic(
+            selecting: XLColumnResult<Int>(
+                dependency: XLSelectResultDependency(),
+                as: "row"
+            ),
+            identifiedBy: XLQuerySlotIdentity(
+                path: ["macro-hygiene", "row"]
+            )
+        )
+        let layout = try StaticRowMacroHygieneRecord.staticRowLayout(
+            using: XLSQLiteDialect.self,
+            reader: reader,
+            row: row
+        )
+        let expected = StaticRowMacroHygieneRecord(
+            reader: "value",
+            row: 7
+        )
+
+        XCTAssertEqual(
+            layout.metadata.fields.map(\.alias),
+            ["reader", "row"]
+        )
+        XCTAssertEqual(
+            try layout.encode(expected),
+            [.text("value"), .integer(7)]
+        )
+        XCTAssertEqual(
+            try layout.decode([.text("value"), .integer(7)]),
+            expected
+        )
+    }
+}

--- a/Tests/SwiftQLCodecIntegrationTests/NoDefaultLiteralStaticLayoutGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/NoDefaultLiteralStaticLayoutGRDBTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import GRDB
+import XCTest
+@testable import SwiftQL
+
+
+private struct NoDefaultCustomLiteral:
+    Equatable,
+    Sendable,
+    XLCustomType
+{
+    typealias T = Self
+
+    let value: String
+
+    init(_ value: String) {
+        self.value = value
+    }
+
+    init(reader: XLColumnReader, at index: Int) throws {
+        let stored = try reader.readText(at: index)
+        guard stored.hasPrefix("v1:") else {
+            throw NoDefaultLiteralTestError.invalidCustomLiteral(stored)
+        }
+        self.value = String(stored.dropFirst(3))
+    }
+
+    func bind(context: inout XLBindingContext) {
+        context.bindText(value: "v1:\(value)")
+    }
+
+    func makeSQL(context: inout XLBuilder) {
+        context.text("v1:\(value)")
+    }
+}
+
+
+private enum NoDefaultLiteralState: String, Sendable, XLEnum {
+    typealias T = Self
+
+    case queued
+    case ready
+}
+
+
+private struct ExplicitLegacyDefaultLiteral:
+    Equatable,
+    XLCustomType
+{
+    typealias T = Self
+
+    let value: String
+
+    static func sqlDefault() -> Self {
+        Self(value: "explicit-legacy-default")
+    }
+
+    init(value: String) {
+        self.value = value
+    }
+
+    init(reader: XLColumnReader, at index: Int) throws {
+        self.value = try reader.readText(at: index)
+    }
+
+    func bind(context: inout XLBindingContext) {
+        context.bindText(value: value)
+    }
+
+    func makeSQL(context: inout XLBuilder) {
+        context.text(value)
+    }
+}
+
+
+@SQLTable(name: "NoDefaultLiteralRecord")
+private struct NoDefaultLiteralRecord: Equatable {
+    let custom: NoDefaultCustomLiteral
+    let state: NoDefaultLiteralState
+}
+
+
+final class NoDefaultLiteralStaticLayoutGRDBTests: XCTestCase {
+
+    func testNoDefaultCustomLiteralAndEnumRoundTripThroughStaticLayout() throws {
+        let fixture = try NoDefaultLiteralFixture()
+        defer { fixture.tearDown() }
+
+        let customAdapter = XLV1LiteralCodec<NoDefaultCustomLiteral>(
+            key: XLValueCodecKey(
+                id: "tests.no-default-literal.custom",
+                version: 1
+            ),
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: "tests.no-default-literal.custom"
+            ),
+            storageClass: .text
+        )
+        let enumAdapter = XLV1LiteralCodec<NoDefaultLiteralState>(
+            key: XLValueCodecKey(
+                id: "tests.no-default-literal.state",
+                version: 1
+            ),
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: "tests.no-default-literal.state"
+            ),
+            storageClass: .text
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry()
+                .registering(customAdapter.codec)
+                .registering(enumAdapter.codec)
+        )
+        let database = try GRDBDatabase(
+            databasePool: fixture.pool,
+            codingConfiguration: configuration,
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
+        let table = XLSchema().table(
+            NoDefaultLiteralRecord.self,
+            as: "record"
+        )
+        let layout = try NoDefaultLiteralRecord.staticRowLayout(
+            using: XLSQLiteDialect.self,
+            custom: configuration.staticResultField(
+                NoDefaultCustomLiteral.self,
+                selecting: table.custom,
+                storedAs: String.self,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["no-default-literal", "custom"]
+                ),
+                using: database.dialect,
+                selection: .explicit(customAdapter.codec.identity.key)
+            ),
+            state: configuration.staticResultField(
+                NoDefaultLiteralState.self,
+                selecting: table.state,
+                storedAs: String.self,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["no-default-literal", "state"]
+                ),
+                using: database.dialect,
+                selection: .explicit(enumAdapter.codec.identity.key)
+            )
+        )
+
+        let expected = NoDefaultLiteralRecord(
+            custom: NoDefaultCustomLiteral("alpha"),
+            state: .ready
+        )
+        let encoded = try layout.encode(expected)
+        XCTAssertEqual(encoded, [.text("v1:alpha"), .text("ready")])
+
+        try fixture.pool.write { db in
+            try db.execute(
+                sql: """
+                    CREATE TABLE NoDefaultLiteralRecord (
+                        custom TEXT NOT NULL,
+                        state TEXT NOT NULL
+                    )
+                    """
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO NoDefaultLiteralRecord (custom, state)
+                    VALUES (?, ?)
+                    """,
+                arguments: StatementArguments(encoded.map(\.databaseValue))
+            )
+        }
+
+        let statement = sql { _ in
+            Select(layout)
+            From(table)
+        }
+        let encoding = try XLiteEncoder(dialect: database.dialect)
+            .makeValidatedSQL(statement)
+        let expectedSQL =
+            #"SELECT "record"."custom" AS "custom", "record"."state" AS "state" "#
+            + #"FROM "NoDefaultLiteralRecord" AS "record""#
+        XCTAssertEqual(
+            encoding.sql,
+            expectedSQL
+        )
+        let descriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "no-default-literal", "static-layout"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(validating: encoding),
+            parameters: [],
+            results: layout.metadata.results,
+            cardinality: .exactlyOne
+        )
+        let prepared = try database.prepareInvocation(
+            with: XLTypedStaticQueryDescriptor(
+                descriptor: descriptor,
+                layout: layout
+            )
+        )
+
+        XCTAssertEqual(
+            try prepared.fetchExactlyOne(
+                bindings: prepared.makeInvocationBindings()
+            ),
+            expected
+        )
+    }
+
+    func testExplicitLegacyDefaultRemainsTheProtocolWitness() {
+        XCTAssertEqual(
+            legacyDefault(ExplicitLegacyDefaultLiteral.self),
+            ExplicitLegacyDefaultLiteral(value: "explicit-legacy-default")
+        )
+    }
+}
+
+
+private enum NoDefaultLiteralTestError: Error {
+    case invalidCustomLiteral(String)
+}
+
+
+private struct NoDefaultLiteralFixture {
+    let url: URL
+    let pool: DatabasePool
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("sqlite")
+        pool = try DatabasePool(path: url.path)
+    }
+
+    func tearDown() {
+        try? pool.close()
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+
+private func legacyDefault<Value>(_: Value.Type) -> Value
+where Value: XLLiteral {
+    Value.sqlDefault()
+}

--- a/Tests/SwiftQLCodecIntegrationTests/StaticRowLayoutGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/StaticRowLayoutGRDBTests.swift
@@ -1,0 +1,791 @@
+import Foundation
+import GRDB
+import XCTest
+@testable import SwiftQL
+
+
+private enum StaticLayoutState: Equatable, Sendable {
+    case ready
+    case paused
+}
+
+
+private struct StaticLayoutMarker: Equatable, Sendable {
+    let value: String
+}
+
+
+@SQLTable(name: "StaticLayoutRecord")
+private struct StaticLayoutRecord: Equatable {
+    let timestamp: Date
+    let state: StaticLayoutState
+    let note: Date?
+    let left: StaticLayoutMarker
+    let right: StaticLayoutMarker
+}
+
+
+@SQLResult
+private struct EmptyStaticLayoutRow: Equatable {
+}
+
+
+@SQLTable(name: "StaticProjectionSource")
+private struct StaticProjectionSource: Equatable {
+    let raw: String
+    let amount: Int
+}
+
+
+@SQLResult
+private struct StaticProjectionRow: Equatable {
+    let decorated: StaticLayoutMarker
+    let incremented: Int
+}
+
+
+private struct ManualStaticLayoutRow: Equatable {
+    let value: String
+}
+
+
+private struct _SwiftQLStaticDialect: Equatable, Sendable {
+    let value: String
+}
+
+
+private struct StaticIdentifierBox<Value>: Equatable, Sendable
+where Value: Equatable & Sendable {
+    let value: Value
+}
+
+
+@SQLResult
+private struct StaticPropertyTypeIdentifierCollisionRow: Equatable {
+    let direct: _SwiftQLStaticDialect
+    let nested: StaticIdentifierBox<_SwiftQLStaticDialect>
+}
+
+
+@SQLResult
+private struct _swiftQLRowReader: Equatable {
+    let value: String
+}
+
+
+// Compiles the generated layout factory against every reserved-looking name
+// used by its deterministic allocator. Outer generic spellings must remain
+// the property value types, while method generics and locals avoid shadowing.
+@SQLResult
+private struct StaticGeneratedNameCollision<
+    Dialect,
+    _SwiftQLStaticDialect,
+    _SwiftQLStaticStorage0
+> {
+    let dialect: Dialect
+    let staticDialect: _SwiftQLStaticDialect
+    let storage: _SwiftQLStaticStorage0
+    let _swiftQLStaticField0: String
+    let _swiftQLStaticReader: String
+    let _swiftQLStaticRow: String
+}
+
+
+private struct TrappingDefaultLiteral:
+    Equatable,
+    Sendable,
+    XLExpression,
+    XLLiteral
+{
+    typealias T = Self
+
+    let rawValue: String
+
+    static func sqlDefault() -> Self {
+        fatalError("static layout construction called sqlDefault()")
+    }
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init(reader: XLColumnReader, at index: Int) throws {
+        self.rawValue = try reader.readText(at: index)
+    }
+
+    func bind(context: inout XLBindingContext) {
+        context.bindText(value: rawValue)
+    }
+
+    func makeSQL(context: inout XLBuilder) {
+        context.text(rawValue)
+    }
+}
+
+
+@SQLResult
+private struct TrappingDefaultRow: Equatable {
+    let value: TrappingDefaultLiteral
+}
+
+
+final class StaticRowLayoutGRDBTests: XCTestCase {
+
+    func testGeneratedLayoutPreservesConcretePropertyTypeIdentifiers() throws {
+        let storage = XLValueStorageIdentifier(rawValue: "text")
+        let directCodec = XLValueCodec<
+            _SwiftQLStaticDialect,
+            XLSQLiteDialect
+        >(
+            key: XLValueCodecKey(
+                id: "tests.static-layout.identifier.direct",
+                version: 1
+            ),
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: "tests.static-layout.identifier-direct"
+            ),
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: storage,
+            encode: { value, _, _ in .text("direct:\(value.value)") },
+            decode: { value, _, _ in
+                guard case .text(let text) = value,
+                      text.hasPrefix("direct:") else {
+                    throw StaticRowLayoutTestError.invalidValue
+                }
+                return _SwiftQLStaticDialect(
+                    value: String(text.dropFirst("direct:".count))
+                )
+            }
+        )
+        let nestedCodec = XLValueCodec<
+            StaticIdentifierBox<_SwiftQLStaticDialect>,
+            XLSQLiteDialect
+        >(
+            key: XLValueCodecKey(
+                id: "tests.static-layout.identifier.nested",
+                version: 1
+            ),
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: "tests.static-layout.identifier-nested"
+            ),
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: storage,
+            encode: { value, _, _ in
+                .text("nested:\(value.value.value)")
+            },
+            decode: { value, _, _ in
+                guard case .text(let text) = value,
+                      text.hasPrefix("nested:") else {
+                    throw StaticRowLayoutTestError.invalidValue
+                }
+                return StaticIdentifierBox(
+                    value: _SwiftQLStaticDialect(
+                        value: String(text.dropFirst("nested:".count))
+                    )
+                )
+            }
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry()
+                .registering(directCodec)
+                .registering(nestedCodec)
+        )
+        let dependency = XLSelectResultDependency()
+        let layout = try StaticPropertyTypeIdentifierCollisionRow
+            .staticRowLayout(
+                using: XLSQLiteDialect.self,
+                direct: configuration.staticResultField(
+                    _SwiftQLStaticDialect.self,
+                    selecting: XLColumnResult<_SwiftQLStaticDialect>(
+                        dependency: dependency,
+                        as: "direct"
+                    ),
+                    storedAs: String.self,
+                    identifiedBy: XLQuerySlotIdentity(
+                        path: ["identifier-collision", "direct"]
+                    ),
+                    using: XLSQLiteDialect(),
+                    selection: .explicit(directCodec.identity.key)
+                ),
+                nested: configuration.staticResultField(
+                    StaticIdentifierBox<_SwiftQLStaticDialect>.self,
+                    selecting: XLColumnResult<
+                        StaticIdentifierBox<_SwiftQLStaticDialect>
+                    >(
+                        dependency: dependency,
+                        as: "nested"
+                    ),
+                    storedAs: String.self,
+                    identifiedBy: XLQuerySlotIdentity(
+                        path: ["identifier-collision", "nested"]
+                    ),
+                    using: XLSQLiteDialect(),
+                    selection: .explicit(nestedCodec.identity.key)
+                )
+            )
+        let expected = StaticPropertyTypeIdentifierCollisionRow(
+            direct: _SwiftQLStaticDialect(value: "one"),
+            nested: StaticIdentifierBox(
+                value: _SwiftQLStaticDialect(value: "two")
+            )
+        )
+
+        XCTAssertEqual(
+            layout.metadata.fields.map(\.alias),
+            ["direct", "nested"]
+        )
+        XCTAssertEqual(
+            try layout.encode(expected),
+            [.text("direct:one"), .text("nested:two")]
+        )
+        XCTAssertEqual(
+            try layout.decode([.text("direct:one"), .text("nested:two")]),
+            expected
+        )
+    }
+
+    func testGeneratedLegacyReaderReservesNominalTypeIdentifier() throws {
+        let expression = XLColumnResult<String>(
+            dependency: XLSelectResultDependency(),
+            as: "value"
+        )
+        let generated = _swiftQLRowReader.SQLReader(value: expression)
+        let reader = XLColumnValuesRowReader<_swiftQLRowReader>()
+        reader.reset(
+            reader: XLSQLiteValueReader(values: [.text("round-trip")])
+        )
+
+        XCTAssertEqual(
+            try generated.readRow(reader: reader),
+            _swiftQLRowReader(value: "round-trip")
+        )
+    }
+
+    func testGeneratedResultLayoutProjectsComputedAliasesWithCapturedInvocation() throws {
+        let fixture = try StaticRowLayoutFixture()
+        defer { fixture.tearDown() }
+
+        let markerCodec = makeStaticLayoutCodecs().left
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(markerCodec)
+        )
+        let database = try GRDBDatabase(
+            databasePool: fixture.pool,
+            codingConfiguration: configuration,
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
+        try fixture.pool.write { db in
+            try db.execute(
+                sql: """
+                    CREATE TABLE StaticProjectionSource (
+                        raw TEXT NOT NULL,
+                        amount INTEGER NOT NULL
+                    )
+                    """
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO StaticProjectionSource (raw, amount)
+                    VALUES ('left:other', 3), ('left:same', 7)
+                    """
+            )
+        }
+
+        let table = XLSchema().table(
+            StaticProjectionSource.self,
+            as: "projection"
+        )
+        let decoratedField = try configuration.staticResultField(
+            StaticLayoutMarker.self,
+            selecting: table.raw + "-projected",
+            storedAs: String.self,
+            identifiedBy: XLQuerySlotIdentity(
+                path: ["static-layout", "decorated"]
+            ),
+            using: database.dialect,
+            selection: .explicit(markerCodec.identity.key)
+        )
+        let layout = try StaticProjectionRow.staticRowLayout(
+            using: XLSQLiteDialect.self,
+            decorated: decoratedField,
+            incremented: XLStaticSelectField<
+                Int,
+                Int,
+                XLSQLiteDialect
+            >.intrinsic(
+                selecting: table.amount + 1,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["static-layout", "incremented"]
+                )
+            )
+        )
+        let markerCapture = try database.queryCapture(
+            StaticLayoutMarker.self,
+            matching: decoratedField.expression,
+            identifiedBy: XLQuerySlotIdentity(
+                path: ["static-layout", "matching-marker"]
+            ),
+            selection: decoratedField.codecSelection
+        )
+
+        XCTAssertEqual(
+            layout.metadata.fields.map(\.alias),
+            ["decorated", "incremented"]
+        )
+        XCTAssertEqual(
+            layout.metadata.fields.map(\.result.codecIdentity?.key),
+            [markerCodec.identity.key, nil]
+        )
+        XCTAssertEqual(
+            markerCapture.storageIdentifier,
+            decoratedField.storageIdentifier
+        )
+        XCTAssertEqual(
+            markerCapture.declaration.codecIdentity,
+            decoratedField.selectedCodecIdentity
+        )
+
+        let statement = sql { _ in
+            Select(layout)
+            From(table)
+            Where(table.raw == markerCapture)
+        }
+        let encoding = try XLiteEncoder(dialect: database.dialect)
+            .makeValidatedSQL(statement)
+        XCTAssertTrue(
+            encoding.sql.contains(
+                "(\"projection\".\"raw\" || '-projected') AS \"decorated\""
+            )
+        )
+        XCTAssertTrue(
+            encoding.sql.contains(
+                "(\"projection\".\"amount\" + 1) AS \"incremented\""
+            )
+        )
+
+        let descriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "static-layout", "captured-projection"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(validating: encoding),
+            parameters: [
+                try markerCapture.staticQueryParameter(in: encoding),
+            ],
+            results: layout.metadata.results,
+            cardinality: .exactlyOne
+        )
+        let prepared = try database.prepareInvocation(
+            with: XLTypedStaticQueryDescriptor(
+                descriptor: descriptor,
+                layout: layout
+            )
+        )
+        let bindings = try prepared.makeInvocationBindings(
+            markerCapture.argument(StaticLayoutMarker(value: "same"))
+        )
+
+        XCTAssertEqual(prepared.parameterLayout.count, 1)
+        XCTAssertEqual(bindings.bindingCount, 1)
+        XCTAssertEqual(
+            try prepared.fetchExactlyOne(bindings: bindings),
+            StaticProjectionRow(
+                decorated: StaticLayoutMarker(value: "same-projected"),
+                incremented: 8
+            )
+        )
+    }
+
+    func testGeneratedLayoutRoundTripsPlainValuesWithDistinctPerFieldCodecs() throws {
+        let fixture = try StaticRowLayoutFixture()
+        defer { fixture.tearDown() }
+
+        let codecs = makeStaticLayoutCodecs()
+        let registry = try XLValueCodecRegistry()
+            .registering(codecs.date)
+            .registering(codecs.state)
+            .registering(codecs.left)
+            .registering(codecs.right)
+        let configuration = try XLValueCodingConfiguration(registry: registry)
+        let database = try GRDBDatabase(
+            databasePool: fixture.pool,
+            codingConfiguration: configuration,
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
+
+        let schema = XLSchema()
+        let table = schema.table(StaticLayoutRecord.self, as: "record")
+        let dialect = database.dialect
+        let layout = try StaticLayoutRecord.staticRowLayout(
+            using: XLSQLiteDialect.self,
+            timestamp: configuration.staticResultField(
+                Date.self,
+                selecting: table.timestamp,
+                storedAs: String.self,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["static-layout", "when"]
+                ),
+                using: dialect,
+                selection: .explicit(codecs.date.identity.key)
+            ),
+            state: configuration.staticResultField(
+                StaticLayoutState.self,
+                selecting: table.state,
+                storedAs: String.self,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["static-layout", "state"]
+                ),
+                using: dialect,
+                selection: .explicit(codecs.state.identity.key)
+            ),
+            note: configuration.staticResultField(
+                Date?.self,
+                selecting: table.note,
+                storedAs: String?.self,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["static-layout", "note"]
+                ),
+                using: dialect,
+                selection: .explicit(codecs.date.identity.key)
+            ),
+            left: configuration.staticResultField(
+                StaticLayoutMarker.self,
+                selecting: table.left,
+                storedAs: String.self,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["static-layout", "left"]
+                ),
+                using: dialect,
+                selection: .explicit(codecs.left.identity.key)
+            ),
+            right: configuration.staticResultField(
+                StaticLayoutMarker.self,
+                selecting: table.right,
+                storedAs: String.self,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["static-layout", "right"]
+                ),
+                using: dialect,
+                selection: .explicit(codecs.right.identity.key)
+            )
+        )
+
+        let expected = StaticLayoutRecord(
+            timestamp: Date(timeIntervalSince1970: 1_700_000_123),
+            state: .ready,
+            note: nil,
+            left: StaticLayoutMarker(value: "same"),
+            right: StaticLayoutMarker(value: "same")
+        )
+        let encoded = try layout.encode(expected)
+        XCTAssertEqual(
+            encoded,
+            [
+                .text("1700000123"),
+                .text("ready"),
+                .null,
+                .text("left:same"),
+                .text("right:same"),
+            ]
+        )
+        XCTAssertEqual(
+            layout.metadata.fields.map(\.result.codecIdentity?.key),
+            [
+                codecs.date.identity.key,
+                codecs.state.identity.key,
+                codecs.date.identity.key,
+                codecs.left.identity.key,
+                codecs.right.identity.key,
+            ]
+        )
+        XCTAssertEqual(
+            layout.metadata.fields.map(\.alias),
+            ["timestamp", "state", "note", "left", "right"]
+        )
+
+        try fixture.pool.write { db in
+            try db.execute(
+                sql: """
+                    CREATE TABLE StaticLayoutRecord (
+                        timestamp TEXT NOT NULL,
+                        state TEXT NOT NULL,
+                        note TEXT,
+                        left TEXT NOT NULL,
+                        right TEXT NOT NULL
+                    )
+                    """
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO StaticLayoutRecord
+                        (timestamp, state, note, left, right)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                arguments: StatementArguments(
+                    encoded.map(\.databaseValue)
+                )
+            )
+        }
+
+        let statement = sql { _ in
+            Select(layout)
+            From(table)
+        }
+        let encoding = try XLiteEncoder(dialect: dialect)
+            .makeValidatedSQL(statement)
+        XCTAssertEqual(
+            encoding.sql,
+            "SELECT \"record\".\"timestamp\" AS \"timestamp\", \"record\".\"state\" AS \"state\", \"record\".\"note\" AS \"note\", \"record\".\"left\" AS \"left\", \"record\".\"right\" AS \"right\" FROM \"StaticLayoutRecord\" AS \"record\""
+        )
+
+        let descriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "static-layout", "plain-values"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(validating: encoding),
+            parameters: [],
+            results: layout.metadata.results,
+            cardinality: .many
+        )
+        let typed = try XLTypedStaticQueryDescriptor(
+            descriptor: descriptor,
+            layout: layout
+        )
+        let prepared = try database.prepareInvocation(with: typed)
+        let bindings = try prepared.makeInvocationBindings()
+
+        XCTAssertEqual(try prepared.fetchAll(bindings: bindings), [expected])
+    }
+
+    func testGeneratedConstructionCallsNeitherSQLDefaultNorDecodeInitializer() throws {
+        let key = XLValueCodecKey(
+            id: "tests.static-layout.trapping",
+            version: 1
+        )
+        let codec = XLValueCodec<TrappingDefaultLiteral, XLSQLiteDialect>(
+            key: key,
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: "tests.trapping-default"
+            ),
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "text"),
+            encode: { value, _, _ in .text(value.rawValue) },
+            decode: { value, _, _ in
+                guard case .text(let text) = value else {
+                    throw StaticRowLayoutTestError.invalidValue
+                }
+                return TrappingDefaultLiteral(rawValue: text)
+            }
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(codec)
+        )
+        let dependency = XLSelectResultDependency()
+        let expression = XLColumnResult<TrappingDefaultLiteral>(
+            dependency: dependency,
+            as: "value"
+        )
+        var decodeCount = 0
+        let field = try configuration.staticResultField(
+            TrappingDefaultLiteral.self,
+            selecting: expression,
+            storedAs: String.self,
+            identifiedBy: XLQuerySlotIdentity(
+                path: ["static-layout", "trapping-value"]
+            ),
+            using: XLSQLiteDialect(),
+            selection: .explicit(key)
+        )
+        let generated = try TrappingDefaultRow.staticRowLayout(
+            using: XLSQLiteDialect.self,
+            value: field
+        )
+        let positioned = field.positioned(at: 0, alias: "value")
+        let observed = try XLStaticRowLayout<
+            TrappingDefaultRow,
+            XLSQLiteDialect
+        >(
+            fields: [try positioned.erased()],
+            decode: { reader in
+                decodeCount += 1
+                return TrappingDefaultRow(
+                    value: try positioned.read(from: reader)
+                )
+            },
+            encode: { row in [try positioned.encode(row.value)] }
+        )
+
+        _ = Select(generated)
+        let encoding = XLiteEncoder(dialect: XLSQLiteDialect()).makeSQL(
+            Select(observed)
+        )
+
+        XCTAssertEqual(encoding.sql, "SELECT \"value\" AS \"value\"")
+        XCTAssertEqual(decodeCount, 0)
+        XCTAssertEqual(
+            try observed.decode([.text("decoded")]),
+            TrappingDefaultRow(
+                value: TrappingDefaultLiteral(rawValue: "decoded")
+            )
+        )
+        XCTAssertEqual(decodeCount, 1)
+    }
+
+    func testGeneratedEmptyLayoutIsValueFreeUntilDecode() throws {
+        let layout = try EmptyStaticLayoutRow.staticRowLayout(
+            using: XLSQLiteDialect.self
+        )
+
+        XCTAssertTrue(layout.metadata.fields.isEmpty)
+        XCTAssertEqual(try layout.encode(EmptyStaticLayoutRow()), [])
+        _ = Select(layout)
+        XCTAssertEqual(try layout.decode([]), EmptyStaticLayoutRow())
+    }
+
+    func testManualLayoutClosuresCannotBypassFieldValidation() throws {
+        let positioned = try XLStaticSelectField<
+            String,
+            String,
+            XLSQLiteDialect
+        >.intrinsic(
+            selecting: XLColumnResult<String>(
+                dependency: XLSelectResultDependency(),
+                as: "value"
+            ),
+            identifiedBy: XLQuerySlotIdentity(
+                path: ["static-layout", "manual-validation"]
+            )
+        ).positioned(at: 0, alias: "value")
+        let erased = try positioned.erased()
+        let layout = try XLStaticRowLayout<
+            ManualStaticLayoutRow,
+            XLSQLiteDialect
+        >(
+            fields: [erased],
+            decode: { _ in ManualStaticLayoutRow(value: "ignored") },
+            encode: { _ in [.integer(1)] }
+        )
+
+        XCTAssertThrowsError(try layout.decode([.null])) { error in
+            XCTAssertEqual(
+                error as? XLStaticRowLayoutError,
+                .nullForRequiredField(field: erased.metadata)
+            )
+        }
+        XCTAssertThrowsError(
+            try layout.encode(ManualStaticLayoutRow(value: "ignored"))
+        ) { error in
+            XCTAssertEqual(
+                error as? XLStaticRowLayoutError,
+                .storageMismatch(
+                    field: erased.metadata,
+                    actual: XLValueStorageIdentifier(rawValue: "integer")
+                )
+            )
+        }
+    }
+}
+
+
+private enum StaticRowLayoutTestError: Error {
+    case invalidValue
+}
+
+
+private struct StaticRowLayoutFixture {
+    let url: URL
+    let pool: DatabasePool
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("sqlite")
+        pool = try DatabasePool(path: url.path)
+    }
+
+    func tearDown() {
+        try? pool.close()
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+
+private func makeStaticLayoutCodecs() -> (
+    date: XLValueCodec<Date, XLSQLiteDialect>,
+    state: XLValueCodec<StaticLayoutState, XLSQLiteDialect>,
+    left: XLValueCodec<StaticLayoutMarker, XLSQLiteDialect>,
+    right: XLValueCodec<StaticLayoutMarker, XLSQLiteDialect>
+) {
+    let storage = XLValueStorageIdentifier(rawValue: "text")
+    let date = XLValueCodec<Date, XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.static-layout.date", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "foundation.date"),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: storage,
+        encode: { value, _, _ in
+            .text(String(Int64(value.timeIntervalSince1970)))
+        },
+        decode: { value, _, _ in
+            guard case .text(let text) = value,
+                  let seconds = TimeInterval(text) else {
+                throw StaticRowLayoutTestError.invalidValue
+            }
+            return Date(timeIntervalSince1970: seconds)
+        }
+    )
+    let state = XLValueCodec<StaticLayoutState, XLSQLiteDialect>(
+        key: XLValueCodecKey(id: "tests.static-layout.state", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(
+            rawValue: "tests.static-layout-state"
+        ),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: storage,
+        encode: { value, _, _ in
+            .text(value == .ready ? "ready" : "paused")
+        },
+        decode: { value, _, _ in
+            guard case .text(let text) = value else {
+                throw StaticRowLayoutTestError.invalidValue
+            }
+            switch text {
+            case "ready": return .ready
+            case "paused": return .paused
+            default: throw StaticRowLayoutTestError.invalidValue
+            }
+        }
+    )
+    func markerCodec(
+        key: String,
+        prefix: String
+    ) -> XLValueCodec<StaticLayoutMarker, XLSQLiteDialect> {
+        XLValueCodec(
+            key: XLValueCodecKey(id: key, version: 1),
+            valueTypeIdentifier: XLValueTypeIdentifier(
+                rawValue: "tests.static-layout-marker"
+            ),
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: storage,
+            encode: { value, _, _ in
+                .text("\(prefix):\(value.value)")
+            },
+            decode: { value, _, _ in
+                guard case .text(let text) = value,
+                      text.hasPrefix("\(prefix):") else {
+                    throw StaticRowLayoutTestError.invalidValue
+                }
+                return StaticLayoutMarker(
+                    value: String(text.dropFirst(prefix.count + 1))
+                )
+            }
+        )
+    }
+    return (
+        date,
+        state,
+        markerCodec(key: "tests.static-layout.marker.left", prefix: "left"),
+        markerCodec(key: "tests.static-layout.marker.right", prefix: "right")
+    )
+}

--- a/Tests/SwiftQLCoreTests/StaticRowMetadataTests.swift
+++ b/Tests/SwiftQLCoreTests/StaticRowMetadataTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import SwiftQLCore
+
+
+final class StaticRowMetadataTests: XCTestCase {
+
+    func testPreservesDeclarationOrderAndDelegatesSlotValidation() throws {
+        let first = try field(alias: "name", index: 0, path: ["row", "name"])
+        let second = try field(alias: "AGE", index: 1, path: ["row", "age"])
+
+        let metadata = try XLStaticRowMetadata(fields: [first, second])
+
+        XCTAssertEqual(metadata.fields, [first, second])
+        XCTAssertEqual(metadata.results.slots, [first.result, second.result])
+    }
+
+    func testRejectsPositionMismatchBeforeCanonicalResultSorting() throws {
+        let misplaced = try field(
+            alias: "value",
+            index: 1,
+            path: ["row", "value"]
+        )
+
+        XCTAssertThrowsError(try XLStaticRowMetadata(fields: [misplaced])) {
+            XCTAssertEqual(
+                $0 as? XLStaticRowMetadataError,
+                .fieldPositionMismatch(
+                    field: misplaced,
+                    expected: XLLogicalResultIndex(0)
+                )
+            )
+        }
+    }
+
+    func testRejectsEmptyAndCanonicalCaseInsensitiveDuplicateAliases() throws {
+        let empty = try field(alias: "", index: 0, path: ["row", "empty"])
+        XCTAssertThrowsError(try XLStaticRowMetadata(fields: [empty])) {
+            XCTAssertEqual(
+                $0 as? XLStaticRowMetadataError,
+                .emptyFieldAlias(field: empty)
+            )
+        }
+
+        let composed = try field(
+            alias: "Caf\u{00E9}",
+            index: 0,
+            path: ["row", "first"]
+        )
+        let decomposed = try field(
+            alias: "CAFE\u{0301}",
+            index: 1,
+            path: ["row", "second"]
+        )
+        XCTAssertThrowsError(
+            try XLStaticRowMetadata(fields: [composed, decomposed])
+        ) {
+            XCTAssertEqual(
+                $0 as? XLStaticRowMetadataError,
+                .duplicateFieldAlias(
+                    alias: decomposed.alias,
+                    existing: composed,
+                    incoming: decomposed
+                )
+            )
+            XCTAssertTrue($0.localizedDescription.contains("codec"))
+            XCTAssertTrue($0.localizedDescription.contains("row/second"))
+        }
+    }
+
+    private func field(
+        alias: String,
+        index: Int,
+        path: [String]
+    ) throws -> XLStaticRowField {
+        let identity = try XLQuerySlotIdentity(path: path)
+        return XLStaticRowField(
+            alias: alias,
+            result: XLStaticQueryResultSlot(
+                index: XLLogicalResultIndex(index),
+                identity: identity,
+                valueTypeIdentifier: XLValueTypeIdentifier(
+                    rawValue: "tests.value"
+                ),
+                valueTypeName: "Tests.Value",
+                nullability: .required,
+                codecIdentity: nil,
+                storageIdentifier: XLValueStorageIdentifier(
+                    rawValue: "text"
+                ),
+                codingContext: XLValueCodingContext(
+                    site: .property,
+                    path: XLValueCodingPath(path)
+                )
+            )
+        )
+    }
+}


### PR DESCRIPTION
Closes #40

## Task identity

- Issue: lukevanin/swiftql#40 — Remove sqlDefault() requirements through static result descriptors
- Issue URL: https://github.com/lukevanin/swiftql/issues/40
- Codex task: lukevanin/swiftql#40 - Remove sqlDefault() requirements
- Codex task ID: 019f7610-5766-7ab1-b223-e1aaedeaff74
- Branch: `codex/40-remove-sqldefault-requirements-through-static-result-descriptors`
- Worktree: `/Users/lukevanin/Developer/Luke/swiftql-worktrees/40-remove-sqldefault-requirements-through-static-result-descriptors`

## Summary

- add driver-neutral static row-field metadata and immutable typed row layouts over the v1.2 result-slot contract
- generate straight-line `staticRowLayout(using:...)` factories without executing model initializers, `SQLReader`, or `sqlDefault()` during construction
- preserve concrete property identity, declaration order, alias, optionality, storage identifier, coding context, codec selector, and selected codec identity
- add intrinsic and contextual encoding/decoding, direct static SELECT rendering, typed descriptor/layout validation, and typed GRDB prepared-query execution
- keep existing `XLLiteral`, `XLCustomType`, `SQLReader`, `columns(...)`, and manual row-reader paths source-compatible for v1
- document the preferred static path and the remaining legacy compatibility boundary

## Acceptance evidence

- generated layouts defer model initialization until real row decoding and never call `sqlDefault()` while constructing query metadata
- real SQLite/GRDB tests cover intrinsic fields, optional fields, enums, aliases, projections, contextual codecs, distinct codec keys for one Swift type, empty layouts, invocation captures, and custom literals with no fake default
- macro expansion tests cover qualified/generic/optional/backticked properties, empty results, collision-free identifiers, and properties named `reader` / `row`
- structured diagnostics identify unpositioned fields, required NULLs, storage mismatches, and descriptor/result-slot mismatches
- the descriptor layer remains GRDB-free and the legacy v1 row-reader contract remains exercised

## Validation

- focused static-row, compatibility, descriptor, macro, and real-GRDB suites: 32 tests passed, 0 failures
- full `swift test`: 547 tests passed, 0 failures
- `scripts/ci/check-first-party-warnings.sh`: clean
- `scripts/ci/check-strict-concurrency.sh`: clean
- `scripts/ci/check-downstream-swift5-client.sh committed`: `SWIFTQL_DOWNSTREAM_SWIFT5_CLIENT ok`
- `./make-docs.sh`: DocC archive built and inspected successfully
- `git diff --check`: clean

## Verification artifacts

No screenshot or video is applicable to this API/runtime change. The strongest evidence is the committed macro-expansion coverage plus real SQLite/GRDB execution tests listed above.

## Compatibility boundary

This is additive for v1.x. Existing legacy result introspection remains available, and explicit `sqlDefault()` witnesses keep their current behavior. Removing obsolete protocol requirements is intentionally deferred to v2.