### PR TITLE
Define fallible encoding for non-finite Double literals

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Remove sqlDefault() requirements through static result descriptors",
-  "issue_number": 40,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/40",
+  "task_name": "Define fallible encoding for non-finite Double literals",
+  "issue_number": 147,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/147",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#40 - Remove sqlDefault() requirements through static result descriptors",
-  "codex_session_id": "019f6fcb-bfd9-7522-9d7c-c78fefd5c7fa",
+  "codex_session_title": "lukevanin/swiftql#147 - Define fallible Double literal encoding",
+  "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/40-remove-sqldefault-requirements-through-static-result-descriptors",
-  "task_worktree_path": "/Users/lukevanin/Developer/Luke/swiftql-worktrees/40-remove-sqldefault-requirements-through-static-result-descriptors"
+  "task_branch": "codex/147-define-fallible-encoding-for-non-finite-double-literals",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/147-define-fallible-encoding-for-non-finite-double-literals"
 }

--- a/Sources/SwiftQL/GRDBDatabaseDriver.swift
+++ b/Sources/SwiftQL/GRDBDatabaseDriver.swift
@@ -83,14 +83,18 @@ struct GRDBInvocationExecutor: Sendable {
 
     let parameterLayoutError: XLInvocationBindingError?
 
+    let valueEncodingError: XLSQLValueEncodingError?
+
     init(
         driver: GRDBDatabaseDriver,
         logicalStatement: XLLogicalPreparedStatement,
-        parameterLayoutError: XLInvocationBindingError? = nil
+        parameterLayoutError: XLInvocationBindingError? = nil,
+        valueEncodingError: XLSQLValueEncodingError? = nil
     ) {
         self.driver = driver
         self.logicalStatement = logicalStatement
         self.parameterLayoutError = parameterLayoutError
+        self.valueEncodingError = valueEncodingError
     }
 
     var parameterLayout: XLParameterLayout {
@@ -151,6 +155,9 @@ struct GRDBInvocationExecutor: Sendable {
     func sqlitePacket(
         _ bindings: any XLInvocationBindingPacket
     ) throws -> XLInvocationBindings<XLSQLiteValue> {
+        if let valueEncodingError {
+            throw valueEncodingError
+        }
         if let parameterLayoutError {
             throw parameterLayoutError
         }
@@ -170,6 +177,14 @@ struct GRDBInvocationExecutor: Sendable {
         }
         let validatedPacket = try packet.validatingComplete()
         for binding in validatedPacket.bindings {
+            if case .real(let value) = binding.value,
+               let error = XLSQLValueEncodingError.bindingFailure(
+                   for: value,
+                   valueType: binding.slot.valueTypeName,
+                   context: binding.slot.codingContext
+               ) {
+                throw error
+            }
             if let codecIdentity = binding.slot.codecIdentity,
                codecIdentity.dialectIdentifier != driver.dialect.descriptor.identity {
                 throw XLInvocationBindingError.preparedCodecDialectMismatch(
@@ -334,6 +349,17 @@ struct GRDBDatabaseDriverConnection: XLDatabaseDriverConnection {
                 key: key,
                 message: "Indexed binding positions must be zero or greater."
             )
+        }
+        if case .real(let real) = value,
+           let error = XLSQLValueEncodingError.bindingFailure(
+               for: real,
+               valueType: String(reflecting: Double.self),
+               context: XLValueCodingContext(
+                   site: .parameter,
+                   path: XLValueCodingPath(key.valueEncodingPathComponent)
+               )
+           ) {
+            throw error
         }
         var result = statement
         result.bindings[key] = value
@@ -512,6 +538,18 @@ extension XLSQLiteValue {
             return value.databaseValue
         case .blob(let value):
             return value.databaseValue
+        }
+    }
+}
+
+
+private extension XLBindingKey {
+    var valueEncodingPathComponent: String {
+        switch self {
+        case .named(let name):
+            return name
+        case .indexed(let index):
+            return String(index)
         }
     }
 }

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -152,13 +152,15 @@ struct GRDBRequest<Row>: XLRequest {
         reader: any XLRowReadable<Row>,
         logicalStatement: XLLogicalPreparedStatement,
         parameterLayoutError: XLInvocationBindingError? = nil,
+        valueEncodingError: XLSQLValueEncodingError? = nil,
         liveQueryRetryPolicy: GRDBLiveQueryRetryPolicy,
         liveQueryRetryScheduler: GRDBLiveQueryRetryScheduler
     ) {
         self.executor = GRDBInvocationExecutor(
             driver: driver,
             logicalStatement: logicalStatement,
-            parameterLayoutError: parameterLayoutError
+            parameterLayoutError: parameterLayoutError,
+            valueEncodingError: valueEncodingError
         )
         self.codingConfiguration = codingConfiguration
         self.logger = logger
@@ -397,12 +399,14 @@ struct GRDBWriteRequest: XLWriteRequest {
         codingConfiguration: XLValueCodingConfiguration,
         logger: XLLogger?,
         logicalStatement: XLLogicalPreparedStatement,
-        parameterLayoutError: XLInvocationBindingError? = nil
+        parameterLayoutError: XLInvocationBindingError? = nil,
+        valueEncodingError: XLSQLValueEncodingError? = nil
     ) {
         self.executor = GRDBInvocationExecutor(
             driver: driver,
             logicalStatement: logicalStatement,
-            parameterLayoutError: parameterLayoutError
+            parameterLayoutError: parameterLayoutError,
+            valueEncodingError: valueEncodingError
         )
         self.codingConfiguration = codingConfiguration
         self.logger = logger
@@ -822,6 +826,7 @@ public struct GRDBDatabase: XLDatabase {
             reader: statement,
             logicalStatement: logicalStatement(for: encoding),
             parameterLayoutError: preparedParameterLayoutError(for: encoding),
+            valueEncodingError: encoding.valueEncodingError,
             liveQueryRetryPolicy: liveQueryRetryPolicy,
             liveQueryRetryScheduler: liveQueryRetryScheduler
         )
@@ -841,7 +846,8 @@ public struct GRDBDatabase: XLDatabase {
             executor: GRDBInvocationExecutor(
                 driver: driver,
                 logicalStatement: logicalStatement(for: encoding),
-                parameterLayoutError: preparedParameterLayoutError(for: encoding)
+                parameterLayoutError: preparedParameterLayoutError(for: encoding),
+                valueEncodingError: encoding.valueEncodingError
             )
         )
     }
@@ -905,7 +911,8 @@ public struct GRDBDatabase: XLDatabase {
             codingConfiguration: codingConfiguration,
             logger: logger,
             logicalStatement: logicalStatement(for: encoding),
-            parameterLayoutError: preparedParameterLayoutError(for: encoding)
+            parameterLayoutError: preparedParameterLayoutError(for: encoding),
+            valueEncodingError: encoding.valueEncodingError
         )
     }
 

--- a/Sources/SwiftQL/LegacyLiteralValueCodec.swift
+++ b/Sources/SwiftQL/LegacyLiteralValueCodec.swift
@@ -34,10 +34,19 @@ public struct XLV1LiteralCodec<Value>: Sendable where Value: XLLiteral & Sendabl
             storageIdentifier: XLValueStorageIdentifier(
                 rawValue: storageClass.rawValue
             ),
-            encode: { value, _, _ in
+            encode: { value, _, codingContext in
                 var context: any XLBindingContext = _XLV1LiteralBindingContext()
                 value.bind(context: &context)
-                return (context as! _XLV1LiteralBindingContext).value
+                let encoded = (context as! _XLV1LiteralBindingContext).value
+                if case .real(let real) = encoded,
+                   let error = XLSQLValueEncodingError.bindingFailure(
+                       for: real,
+                       valueType: String(reflecting: Value.self),
+                       context: codingContext
+                   ) {
+                    throw error
+                }
+                return encoded
             },
             decode: { value, _, _ in
                 try Value(

--- a/Sources/SwiftQL/SQLEncoder.swift
+++ b/Sources/SwiftQL/SQLEncoder.swift
@@ -108,18 +108,26 @@ public struct XLEncoding {
     /// boundary can reject the statement before preparing it.
     public let parameterLayoutError: XLInvocationBindingError?
 
+    /// The first deterministic value-rendering failure encountered while
+    /// building `sql`. The nonthrowing v1 encoder retains this error so every
+    /// validated or executable boundary can reject the statement before
+    /// SQLite parses partial SQL.
+    public let valueEncodingError: XLSQLValueEncodingError?
+
     public init(
         sql: String,
         entities: Set<String>,
         dialectRequirement: XLDialectRequirement,
         parameterLayout: XLParameterLayout = .empty,
-        parameterLayoutError: XLInvocationBindingError? = nil
+        parameterLayoutError: XLInvocationBindingError? = nil,
+        valueEncodingError: XLSQLValueEncodingError? = nil
     ) {
         self.sql = sql
         self.entities = entities
         self.dialectRequirement = dialectRequirement
         self.parameterLayout = parameterLayout
         self.parameterLayoutError = parameterLayoutError
+        self.valueEncodingError = valueEncodingError
     }
 }
 
@@ -256,6 +264,11 @@ public protocol XLBuilder {
     /// - Parameter value: Double literal.
     ///
     mutating func real(_ value: Double)
+
+    /// Records a value-rendering failure without emitting an invalid SQL
+    /// token. Builders that predate fallible rendering remain source
+    /// compatible through the default implementation.
+    mutating func valueEncodingFailed(_ error: XLSQLValueEncodingError)
     
     ///
     /// Adds a `String` literal.
@@ -436,6 +449,10 @@ public protocol XLBuilder {
 }
 
 extension XLBuilder {
+
+    public mutating func valueEncodingFailed(
+        _ error: XLSQLValueEncodingError
+    ) {}
 
     public mutating func parameter(_ slot: XLParameterSlot) {
         switch slot.key {

--- a/Sources/SwiftQL/SQLQueryCapture.swift
+++ b/Sources/SwiftQL/SQLQueryCapture.swift
@@ -218,6 +218,9 @@ where Literal: XLLiteral, Dialect: XLValueCodingDialect {
     public func staticQueryParameter(
         in encoding: XLEncoding
     ) throws -> XLStaticQueryParameterMetadata {
+        if let error = encoding.valueEncodingError {
+            throw error
+        }
         if let error = encoding.parameterLayoutError {
             throw error
         }
@@ -292,11 +295,12 @@ extension XLQueryCapture where Dialect == XLSQLiteDialect {
                 return .integer(Int64(value))
             }
             if let value = value as? Double {
-                guard value.isFinite else {
-                    throw XLQueryCaptureError.nonFiniteReal(
-                        identity: identity,
-                        value: String(describing: value)
-                    )
+                if let error = XLSQLValueEncodingError.bindingFailure(
+                    for: value,
+                    valueType: inputTypeName,
+                    context: codingContext
+                ) {
+                    throw error
                 }
                 return .real(value)
             }

--- a/Sources/SwiftQL/SQLStaticQueryDescriptor.swift
+++ b/Sources/SwiftQL/SQLStaticQueryDescriptor.swift
@@ -10,6 +10,9 @@ extension XLStaticStatementDefinition {
     /// descriptors retain only deterministic SQL, dialect requirements,
     /// referenced entities, and immutable parameter metadata.
     public init(validating encoding: XLEncoding) throws {
+        if let valueEncodingError = encoding.valueEncodingError {
+            throw valueEncodingError
+        }
         if let parameterLayoutError = encoding.parameterLayoutError {
             throw parameterLayoutError
         }

--- a/Sources/SwiftQL/SQLStaticRowLayout.swift
+++ b/Sources/SwiftQL/SQLStaticRowLayout.swift
@@ -618,7 +618,16 @@ where Dialect == XLSQLiteDialect, Value: XLLiteral, Storage == Value {
             encode: { value in
                 var context: any XLBindingContext = _XLStaticLiteralBindingContext()
                 value.bind(context: &context)
-                return (context as! _XLStaticLiteralBindingContext).value
+                let encoded = (context as! _XLStaticLiteralBindingContext).value
+                if case .real(let real) = encoded,
+                   let error = XLSQLValueEncodingError.bindingFailure(
+                       for: real,
+                       valueType: metadata.typeName,
+                       context: codingContext
+                   ) {
+                    throw error
+                }
+                return encoded
             }
         )
     }

--- a/Sources/SwiftQL/SQLValueEncodingError.swift
+++ b/Sources/SwiftQL/SQLValueEncodingError.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+
+/// A non-finite IEEE 754 value that cannot be represented by an inline SQLite
+/// numeric literal.
+public enum XLNonFiniteRealValue: String, Equatable, Sendable, CustomStringConvertible {
+    case notANumber = "NaN"
+    case positiveInfinity = "+infinity"
+    case negativeInfinity = "-infinity"
+
+    /// Classifies a non-finite `Double`, or returns `nil` for a finite value.
+    public init?(_ value: Double) {
+        if value.isNaN {
+            self = .notANumber
+        }
+        else if value == .infinity {
+            self = .positiveInfinity
+        }
+        else if value == -.infinity {
+            self = .negativeInfinity
+        }
+        else {
+            return nil
+        }
+    }
+
+    public var description: String {
+        rawValue
+    }
+}
+
+
+/// Structured failures at SQLite's real-value rendering and binding boundary.
+public enum XLSQLValueEncodingError:
+    Error,
+    Equatable,
+    Sendable,
+    LocalizedError
+{
+    /// SQLite has no portable bare numeric token for NaN or infinity.
+    case nonFiniteRealLiteral(
+        value: XLNonFiniteRealValue,
+        expressionType: String
+    )
+
+    /// SQLite converts a bound IEEE 754 NaN to SQL `NULL`, which would change
+    /// the caller's value semantics.
+    case realBindingWouldBecomeNull(
+        value: XLNonFiniteRealValue,
+        valueType: String,
+        context: XLValueCodingContext
+    )
+
+    public var errorDescription: String? {
+        switch self {
+        case .nonFiniteRealLiteral(let value, let expressionType):
+            return "Cannot render \(value) from \(expressionType) as an inline SQLite real literal. SQLite has no valid bare numeric token for this value; use a bound parameter when its SQLite binding semantics are acceptable."
+        case .realBindingWouldBecomeNull(let value, let valueType, let context):
+            return "Cannot bind \(value) from \(valueType) at \(context): SQLite would normalize the value to SQL NULL."
+        }
+    }
+}
+
+
+extension XLSQLValueEncodingError {
+    static func bindingFailure(
+        for value: Double,
+        valueType: String,
+        context: XLValueCodingContext
+    ) -> Self? {
+        guard value.isNaN, let classified = XLNonFiniteRealValue(value) else {
+            return nil
+        }
+        return .realBindingWouldBecomeNull(
+            value: classified,
+            valueType: valueType,
+            context: context
+        )
+    }
+}

--- a/Sources/SwiftQL/SQLiteEncoding.swift
+++ b/Sources/SwiftQL/SQLiteEncoding.swift
@@ -54,7 +54,8 @@ public struct XLiteEncoder: XLEncoder {
                 capabilities: requirementRecorder.capabilities
             ),
             parameterLayout: requirementRecorder.parameterLayout,
-            parameterLayoutError: requirementRecorder.parameterLayoutError
+            parameterLayoutError: requirementRecorder.parameterLayoutError,
+            valueEncodingError: requirementRecorder.valueEncodingError
         )
     }
 
@@ -62,6 +63,9 @@ public struct XLiteEncoder: XLEncoder {
     /// declarations before a prepared handle is created.
     public func makeValidatedSQL(_ expression: XLEncodable) throws -> XLEncoding {
         let encoding = makeSQL(expression)
+        if let error = encoding.valueEncodingError {
+            throw error
+        }
         if let error = encoding.parameterLayoutError {
             throw error
         }
@@ -78,11 +82,19 @@ private final class XLiteDialectRequirementRecorder {
 
     private(set) var parameterLayoutError: XLInvocationBindingError?
 
+    private(set) var valueEncodingError: XLSQLValueEncodingError?
+
     private var physicalIndexByKey: [XLBindingKey: Int] = [:]
 
     private var slotByPhysicalIndex: [Int: XLParameterSlot] = [:]
 
     private var largestPhysicalIndex = 0
+
+    func recordValueEncodingError(_ error: XLSQLValueEncodingError) {
+        if valueEncodingError == nil {
+            valueEncodingError = error
+        }
+    }
 
     func recordLegacyParameter(key: XLBindingKey) {
         let existing = parameterLayout.slot(for: key)
@@ -227,6 +239,8 @@ private protocol XLiteParameterRecordingFormatter: XLFormatter {
     func formatParameter(_ slot: XLParameterSlot) -> String
 
     func formatParameter(_ declaration: XLParameterDeclaration) -> String
+
+    func recordValueEncodingError(_ error: XLSQLValueEncodingError)
 }
 
 
@@ -299,6 +313,10 @@ private struct XLiteRequirementRecordingFormatter: XLiteParameterRecordingFormat
             return base.indexedBinding(index)
         }
     }
+
+    func recordValueEncodingError(_ error: XLSQLValueEncodingError) {
+        recorder.recordValueEncodingError(error)
+    }
 }
 
 
@@ -330,7 +348,10 @@ public struct XLiteFormatter: XLFormatter {
     }
 
     public func real(_ value: Double) -> String {
-        String(value)
+        guard value.isFinite else {
+            return ""
+        }
+        return String(value)
     }
 
     public func text(_ text: String) -> String {
@@ -410,7 +431,26 @@ public struct XLiteBuilder: XLBuilder {
     }
 
     public mutating func real(_ value: Double) {
+        if let classified = XLNonFiniteRealValue(value) {
+            valueEncodingFailed(
+                .nonFiniteRealLiteral(
+                    value: classified,
+                    expressionType: String(reflecting: Double.self)
+                )
+            )
+            return
+        }
         append(formatter.real(value))
+    }
+
+    public mutating func valueEncodingFailed(
+        _ error: XLSQLValueEncodingError
+    ) {
+        guard let recordingFormatter =
+                formatter as? any XLiteParameterRecordingFormatter else {
+            return
+        }
+        recordingFormatter.recordValueEncodingError(error)
     }
 
     public mutating func text(_ value: String) {

--- a/Sources/SwiftQL/SwiftQL.docc/RealValues.md
+++ b/Sources/SwiftQL/SwiftQL.docc/RealValues.md
@@ -1,0 +1,49 @@
+# Real Values
+
+Render and bind SQLite `REAL` values without changing non-finite `Double`
+semantics.
+
+## Inline literals
+
+SQLite does not define bare numeric literal tokens for NaN or positive and
+negative infinity. SwiftQL therefore renders only finite `Double` values
+inline. ``XLiteEncoder/makeValidatedSQL(_:)`` throws
+``XLSQLValueEncodingError/nonFiniteRealLiteral(value:expressionType:)`` for
+all three non-finite values before SQLite parses the statement.
+
+The source-compatible nonthrowing ``XLiteEncoder/makeSQL(_:)`` overload never
+emits `nan` or `inf`. It retains the failure in
+``XLEncoding/valueEncodingError``; every SwiftQL execution and static-descriptor
+boundary checks that error before preparing SQL.
+
+Use validated rendering when constructing standalone encodings:
+
+<!-- test: XLDocumentationTests.testDocumentationRealValues -->
+```swift
+do {
+    _ = try XLiteEncoder(dialect: XLSQLiteDialect())
+        .makeValidatedSQL(Double.infinity)
+}
+catch let error as XLSQLValueEncodingError {
+    // The error identifies the rejected value and expression type.
+    print(error.localizedDescription)
+}
+```
+
+## Bound values
+
+SQLite's C binding API preserves positive and negative infinity as `REAL`, so
+SwiftQL permits both values through bound parameters. SQLite converts a bound
+IEEE 754 NaN to SQL `NULL`; SwiftQL rejects that value with
+``XLSQLValueEncodingError/realBindingWouldBecomeNull(value:valueType:context:)``
+instead of silently changing its meaning. The error retains the parameter or
+property coding context.
+
+This policy applies to legacy mutable requests, immutable invocation packets,
+intrinsic query captures, contextual codecs that produce SQLite `REAL` values,
+and the GRDB driver boundary. Supplying a normalized
+`XLSQLiteValue.real(_:)` directly does not bypass the NaN check.
+
+Finite values, including the largest finite magnitude, the least nonzero
+magnitude, negative values, and signed zero, remain valid inline and bound
+values. Their runtime representation follows SQLite's native `REAL` behavior.

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -85,6 +85,7 @@ replacing SQLite's runtime type rules.
 - <doc:StaticQueries>
 - <doc:LiveQueries>
 - <doc:Expressions>
+- <doc:RealValues>
 - <doc:BuiltinFunctions>
 - <doc:FunctionalSyntax>
 

--- a/Sources/SwiftQL/Types/Intrinsic.swift
+++ b/Sources/SwiftQL/Types/Intrinsic.swift
@@ -81,6 +81,15 @@ extension Double: XLExpression, XLLiteral, XLEquatable, XLComparable {
     }
     
     public func makeSQL(context: inout XLBuilder) {
+        if let value = XLNonFiniteRealValue(self) {
+            context.valueEncodingFailed(
+                .nonFiniteRealLiteral(
+                    value: value,
+                    expressionType: String(reflecting: Self.self)
+                )
+            )
+            return
+        }
         context.real(self)
     }
     

--- a/Tests/SQLTests/GRDBDriverContractTests.swift
+++ b/Tests/SQLTests/GRDBDriverContractTests.swift
@@ -63,6 +63,83 @@ final class GRDBDriverContractTests: XCTestCase {
         )
     }
 
+    func testRealBindingRejectsNaNBeforeSQLiteCanNormalizeItToNull() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        var driver = GRDBDatabaseDriver(
+            databasePool: fixture.databasePool,
+            dialect: XLSQLiteDialect()
+        )
+        let logicalStatement = makeLogicalStatement(
+            for: driver,
+            sql: "SELECT :value"
+        )
+
+        try driver.withReadConnection { connection in
+            let statement = try connection.prepare(logicalStatement)
+            XCTAssertThrowsError(
+                try connection.bind(
+                    .real(.nan),
+                    to: .named("value"),
+                    in: statement
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? XLSQLValueEncodingError,
+                    .realBindingWouldBecomeNull(
+                        value: .notANumber,
+                        valueType: String(reflecting: Double.self),
+                        context: XLValueCodingContext(
+                            site: .parameter,
+                            path: XLValueCodingPath("value")
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    func testSQLiteRealBindingsPreserveInfinitiesAndFiniteEdges() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        var driver = GRDBDatabaseDriver(
+            databasePool: fixture.databasePool,
+            dialect: XLSQLiteDialect()
+        )
+        let logicalStatement = makeLogicalStatement(
+            for: driver,
+            sql: "SELECT :value, typeof(:value)"
+        )
+        let values = [
+            Double.infinity,
+            -Double.infinity,
+            Double.greatestFiniteMagnitude,
+            -Double.greatestFiniteMagnitude,
+            Double.leastNonzeroMagnitude,
+            -Double.leastNonzeroMagnitude,
+            -0.0,
+        ]
+
+        for value in values {
+            let row = try driver.withReadConnection { connection in
+                var statement = try connection.prepare(logicalStatement)
+                statement = try connection.bind(
+                    .real(value),
+                    to: .named("value"),
+                    in: statement
+                )
+                return try XCTUnwrap(connection.fetchOne(statement))
+            }
+            guard case .real(let actual) = row[0] else {
+                return XCTFail("Expected REAL for \(value), received \(row[0]).")
+            }
+            XCTAssertEqual(actual, value)
+            XCTAssertEqual(row[1], .text("real"))
+        }
+    }
+
     func testConnectionRejectsMismatchesBeforePhysicalPreparation() throws {
         let fixture = try makeFixture()
         defer { fixture.tearDown() }

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -38,6 +38,10 @@ private let documentationTests = [
         XLDocumentationTests.testDocumentationExpressions
     ),
     DocumentationTestReference(
+        "XLDocumentationTests.testDocumentationRealValues",
+        XLDocumentationTests.testDocumentationRealValues
+    ),
+    DocumentationTestReference(
         "XLDocumentationTests.testDocumentationEnumValues",
         XLDocumentationTests.testDocumentationEnumValues
     ),
@@ -85,6 +89,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         "GettingStarted.md": "XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings",
         "LiveQueries.md": "XLDocumentationTests.testDocumentationLiveQueryPublishers",
         "Queries.md": "XLDocumentationTests.testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs",
+        "RealValues.md": "XLDocumentationTests.testDocumentationRealValues",
         "StaticQueries.md": "XLDocumentationTests.testDocumentationStaticQueries",
         "SwiftQL.md": "XLDocumentationTests.testDocumentationQuickStart",
     ]

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1257,6 +1257,23 @@ extension XLDocumentationTests {
         let _: (XLSyntaxTests) -> () -> Void = XLSyntaxTests.test_TextBinding_In_Subquery
     }
 
+    func testDocumentationRealValues() throws {
+        do {
+            _ = try XLiteEncoder(dialect: XLSQLiteDialect())
+                .makeValidatedSQL(Double.infinity)
+            XCTFail("Expected inline infinity to fail validation.")
+        }
+        catch let error as XLSQLValueEncodingError {
+            XCTAssertEqual(
+                error,
+                .nonFiniteRealLiteral(
+                    value: .positiveInfinity,
+                    expressionType: String(reflecting: Double.self)
+                )
+            )
+        }
+    }
+
     func testDocumentationEnumValues() throws {
         try database.makeRequest(with: sqlCreate(Job.self)).execute()
 

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -89,6 +89,54 @@ final class XLExecutionTests: XCTestCase {
         XCTAssertEqual(try compoundNegationRequest.fetchOne(), -12)
     }
 
+    func testInlineNonFiniteRealFailsBeforeSQLitePreparation() {
+        for (value, classified) in [
+            (Double.nan, XLNonFiniteRealValue.notANumber),
+            (.infinity, .positiveInfinity),
+            (-.infinity, .negativeInfinity),
+        ] {
+            let statement = sql { _ in Select(value) }
+            XCTAssertThrowsError(
+                try database.makeRequest(with: statement).fetchOne()
+            ) { error in
+                XCTAssertEqual(
+                    error as? XLSQLValueEncodingError,
+                    .nonFiniteRealLiteral(
+                        value: classified,
+                        expressionType: String(reflecting: Double.self)
+                    )
+                )
+            }
+        }
+    }
+
+    func testLegacyDoubleBindingRejectsNaNAndPreservesInfinities() throws {
+        let value = XLNamedBindingReference<Double>(name: "value")
+        let statement = sql { _ in Select(value) }
+        var rejected = database.makeRequest(with: statement)
+        rejected.set(value, .nan)
+
+        XCTAssertThrowsError(try rejected.fetchOne()) { error in
+            XCTAssertEqual(
+                error as? XLSQLValueEncodingError,
+                .realBindingWouldBecomeNull(
+                    value: .notANumber,
+                    valueType: String(reflecting: Double.self),
+                    context: XLValueCodingContext(
+                        site: .parameter,
+                        path: XLValueCodingPath("value")
+                    )
+                )
+            )
+        }
+
+        for expected in [Double.infinity, -.infinity] {
+            var request = database.makeRequest(with: statement)
+            request.set(value, expected)
+            XCTAssertEqual(try request.fetchOne(), expected)
+        }
+    }
+
     func testBitwiseNotExecutesForIntegerLiteralsColumnsAndComposedExpressions() throws {
         let literal: any XLExpression<Int> = 12
         let literalStatement = sql { _ in

--- a/Tests/SQLTests/SQLSyntaxTests.swift
+++ b/Tests/SQLTests/SQLSyntaxTests.swift
@@ -9,6 +9,15 @@ import XCTest
 import SwiftQL
 
 
+private struct RawRealRenderingProbe: XLEncodable {
+    let value: Double
+
+    func makeSQL(context: inout XLBuilder) {
+        context.real(value)
+    }
+}
+
+
 final class XLSyntaxTests: XCTestCase {
     
     
@@ -68,6 +77,86 @@ final class XLSyntaxTests: XCTestCase {
     func test_RealLiteral() {
         let expression: Double = 17.4
         XCTAssertEqual(encoder.makeSQL(expression).sql, "17.4")
+    }
+
+
+    func test_NonFiniteRealLiteralsFailWithoutRenderingBareTokens() {
+        let cases: [(Double, XLNonFiniteRealValue)] = [
+            (.nan, .notANumber),
+            (.infinity, .positiveInfinity),
+            (-.infinity, .negativeInfinity),
+        ]
+
+        for (value, classified) in cases {
+            let encoding = encoder.makeSQL(value)
+            let loweredSQL = encoding.sql.lowercased()
+
+            XCTAssertFalse(loweredSQL.contains("nan"))
+            XCTAssertFalse(loweredSQL.contains("inf"))
+            XCTAssertEqual(
+                encoding.valueEncodingError,
+                .nonFiniteRealLiteral(
+                    value: classified,
+                    expressionType: String(reflecting: Double.self)
+                )
+            )
+            XCTAssertThrowsError(try encoder.makeValidatedSQL(value)) { error in
+                XCTAssertEqual(
+                    error as? XLSQLValueEncodingError,
+                    encoding.valueEncodingError
+                )
+            }
+            XCTAssertThrowsError(
+                try XLStaticStatementDefinition(validating: encoding)
+            ) { error in
+                XCTAssertEqual(
+                    error as? XLSQLValueEncodingError,
+                    encoding.valueEncodingError
+                )
+            }
+        }
+    }
+
+
+    func test_FormatterNeverReturnsInvalidNonFiniteRealTokens() {
+        let formatter = XLiteFormatter()
+        for value in [Double.nan, .infinity, -.infinity] {
+            let token = formatter.real(value).lowercased()
+            XCTAssertFalse(token.contains("nan"))
+            XCTAssertFalse(token.contains("inf"))
+        }
+    }
+
+
+    func test_BuilderRejectsNonFiniteRealFromCustomExpression() {
+        XCTAssertThrowsError(
+            try encoder.makeValidatedSQL(
+                RawRealRenderingProbe(value: .infinity)
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLSQLValueEncodingError,
+                .nonFiniteRealLiteral(
+                    value: .positiveInfinity,
+                    expressionType: String(reflecting: Double.self)
+                )
+            )
+        }
+    }
+
+
+    func test_FiniteRealEdgeLiteralsRemainRenderable() throws {
+        for value in [
+            Double.greatestFiniteMagnitude,
+            -Double.greatestFiniteMagnitude,
+            Double.leastNonzeroMagnitude,
+            -Double.leastNonzeroMagnitude,
+            -0.0,
+        ] {
+            let encoding = try encoder.makeValidatedSQL(value)
+            XCTAssertNil(encoding.valueEncodingError)
+            XCTAssertFalse(encoding.sql.isEmpty)
+        }
     }
     
     

--- a/Tests/SwiftQLCodecIntegrationTests/QueryCaptureGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/QueryCaptureGRDBTests.swift
@@ -405,7 +405,7 @@ final class QueryCaptureGRDBTests: XCTestCase {
         }
     }
 
-    func testIntrinsicDoubleRejectsValuesSQLiteWouldNormalizeToNull() throws {
+    func testIntrinsicDoubleRejectsNaNAndPreservesBoundInfinities() throws {
         let fixture = try makeQueryCaptureDatabase()
         defer { fixture.tearDown() }
         let capture = try XLQueryCapture<Double, Double, XLSQLiteDialect>
@@ -418,16 +418,31 @@ final class QueryCaptureGRDBTests: XCTestCase {
             definition: ["tests", "query-capture", "non-finite"]
         )
 
-        for value in [Double.nan, .infinity, -.infinity] {
-            XCTAssertThrowsError(try prepared.makeInvocationBindings {
+        XCTAssertThrowsError(try prepared.makeInvocationBindings {
+            try $0.bind(.nan, to: capture)
+        }) { error in
+            XCTAssertNil(
+                error as? XLValueCodecError,
+                "Intrinsic captures should preserve the structured value error."
+            )
+            XCTAssertEqual(
+                error as? XLSQLValueEncodingError,
+                .realBindingWouldBecomeNull(
+                    value: .notANumber,
+                    valueType: String(reflecting: Double.self),
+                    context: capture.declaration.codingContext
+                )
+            )
+        }
+
+        for value in [Double.infinity, -.infinity] {
+            let packet = try prepared.makeInvocationBindings {
                 try $0.bind(value, to: capture)
-            }) { error in
-                guard case .nonFiniteReal(let identity, _) =
-                        error as? XLQueryCaptureError else {
-                    return XCTFail("Unexpected error: \(error)")
-                }
-                XCTAssertEqual(identity, capture.identity)
             }
+            XCTAssertEqual(
+                try prepared.fetchExactlyOneValues(bindings: packet),
+                [.real(value)]
+            )
         }
     }
 


### PR DESCRIPTION
Closes #147

## Task identity

- Repository: `lukevanin/swiftql`
- Issue: #147 — Define fallible encoding for non-finite Double literals
- Milestone: v1.2
- Head: `codex/147-define-fallible-encoding-for-non-finite-double-literals`

## Summary

- Add structured `XLSQLValueEncodingError` failures at SQLite real-literal and binding boundaries.
- Reject inline NaN, positive infinity, and negative infinity before SQLite parses partial SQL.
- Reject bound NaN before SQLite normalizes it to SQL `NULL`; preserve bound positive and negative infinity as SQLite `REAL`.
- Propagate the first value-rendering error through encodings, static descriptors, query captures, legacy codecs, immutable invocation packets, and the GRDB execution boundary.
- Document the behavior and compile-test the new DocC article.

## Semantics

| Double value | Inline literal | Bound parameter |
| --- | --- | --- |
| finite values and signed zero | accepted | accepted |
| NaN | structured failure | structured failure before SQLite can produce `NULL` |
| +infinity / -infinity | structured failure | accepted and preserved as SQLite `REAL` |

The existing nonthrowing encoder remains source-compatible: it emits no invalid `nan`/`inf` token and retains the structured error for validated/executable boundaries. The new `XLBuilder` callback has a default implementation for existing custom builders.

## Validation

All commands ran through the local work scheduler.

- Focused syntax, driver, execution, capture, and documentation tests: 150 tests, 0 failures — `run-a84182ca-835e-4df4-95de-c9ca930709e6`
- Complete suite: 556 tests, 0 failures — `run-0adbf5b0-9384-495f-b8a6-aacca1c7aa01`
- First-party warnings: clean — `run-e723e690-b126-44c5-b556-91439aed59e4`
- Strict concurrency warnings: clean — `run-81964858-674c-4e69-8115-1de804621b2d`
- Downstream Swift 5 client: passed — `run-1dcaa199-a8e6-45db-9d9a-ceede7bd60ed`
- DocC archive generation: passed — `run-06a5e93b-c217-4ce2-9f25-601d4f86644b`
- `git diff --cached --check`: passed before commit

## Verification artifact

No visual artifact is applicable to this value-encoding/API correctness change. The acceptance evidence is executable coverage against the real SQLite/GRDB boundary plus compiled DocC.