### PR TITLE
Add a shared SQLite storage and value conformance suite

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Define fallible encoding for non-finite Double literals",
-  "issue_number": 147,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/147",
+  "task_name": "Add a shared SQLite storage and value conformance suite",
+  "issue_number": 252,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/252",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#147 - Define fallible Double literal encoding",
+  "codex_session_title": "lukevanin/swiftql#252 - Add SQLite value conformance suite",
   "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/147-define-fallible-encoding-for-non-finite-double-literals",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/147-define-fallible-encoding-for-non-finite-double-literals"
+  "task_branch": "codex/252-add-a-shared-sqlite-storage-and-value-conformance-suite",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/252-add-a-shared-sqlite-storage-and-value-conformance-suite"
 }

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,15 @@ let package = Package(
             name: "SwiftQLCore"
         ),
 
+        // Test-only, adapter-neutral SQLite value cases shared by core contract
+        // tests and concrete database-adapter integration tests.
+        .target(
+            name: "SwiftQLSQLiteConformanceFixtures",
+            dependencies: ["SwiftQLCore"],
+            path: "Tests/SwiftQLSQLiteConformanceFixtures",
+            resources: [.process("SQLiteValueConformanceManifest.json")]
+        ),
+
         // Macro implementation that performs the source transformation of a macro.
         .macro(
             name: "SQLMacros",
@@ -75,7 +84,10 @@ let package = Package(
         // A test target used to develop the macro implementation.
         .testTarget(
             name: "SwiftQLCoreTests",
-            dependencies: ["SwiftQLCore"]
+            dependencies: [
+                "SwiftQLCore",
+                "SwiftQLSQLiteConformanceFixtures",
+            ]
         ),
 
         .testTarget(
@@ -96,6 +108,7 @@ let package = Package(
             name: "SQLTests",
             dependencies: [
                 "SwiftQL",
+                "SwiftQLSQLiteConformanceFixtures",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ]
         ),
@@ -106,6 +119,7 @@ let package = Package(
             name: "SwiftQLCodecIntegrationTests",
             dependencies: [
                 "SwiftQL",
+                "SwiftQLSQLiteConformanceFixtures",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ]
         ),

--- a/Tests/SQLTests/GRDBDriverContractTests.swift
+++ b/Tests/SQLTests/GRDBDriverContractTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import GRDB
 import XCTest
 @testable import SwiftQL
+import SwiftQLSQLiteConformanceFixtures
 
 
 @SQLTable(name: "GRDBDriverContractRecord")
@@ -15,6 +16,366 @@ final class GRDBDriverContractTests: XCTestCase {
 
     private enum TransactionAbort: Error, Equatable {
         case requested
+    }
+
+    func testSharedSQLiteStorageCasesRoundTripWithTypeofEvidence() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        var driver = GRDBDatabaseDriver(
+            databasePool: fixture.databasePool,
+            dialect: XLSQLiteDialect()
+        )
+        let logicalStatement = makeLogicalStatement(
+            for: driver,
+            sql: "SELECT :value, typeof(:value), length(:value)"
+        )
+
+        for testCase in SQLiteValueConformanceFixtures.storageCases {
+            switch testCase.expectation {
+            case .bindingRejected:
+                XCTAssertThrowsError(
+                    try driver.withReadConnection { connection in
+                        let statement = try connection.prepare(logicalStatement)
+                        _ = try connection.bind(
+                            testCase.value,
+                            to: .named("value"),
+                            in: statement
+                        )
+                    },
+                    testCase.id.rawValue
+                ) { error in
+                    XCTAssertEqual(
+                        error as? XLSQLValueEncodingError,
+                        .realBindingWouldBecomeNull(
+                            value: .notANumber,
+                            valueType: String(reflecting: Double.self),
+                            context: XLValueCodingContext(
+                                site: .parameter,
+                                path: XLValueCodingPath("value")
+                            )
+                        ),
+                        testCase.id.rawValue
+                    )
+                }
+            case .roundTrip:
+                let row = try driver.withReadConnection { connection in
+                    var statement = try connection.prepare(logicalStatement)
+                    statement = try connection.bind(
+                        testCase.value,
+                        to: .named("value"),
+                        in: statement
+                    )
+                    return try XCTUnwrap(connection.fetchOne(statement))
+                }
+                XCTAssertEqual(row[0], testCase.value, testCase.id.rawValue)
+                XCTAssertEqual(
+                    row[1],
+                    .text(testCase.expectedStorage.rawValue),
+                    testCase.id.rawValue
+                )
+                if case .blob(let data) = testCase.value {
+                    XCTAssertEqual(
+                        row[2],
+                        .integer(Int64(data.count)),
+                        testCase.id.rawValue
+                    )
+                }
+            }
+        }
+    }
+
+    func testSharedUnicodeCasePreservesCanonicalVariantsWithoutConflatingBytes() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let composed = "é"
+        let decomposed = "e\u{301}"
+        XCTAssertEqual(
+            composed,
+            decomposed,
+            SQLiteValueConformanceCaseID.unicodeText.rawValue
+        )
+
+        var driver = GRDBDatabaseDriver(
+            databasePool: fixture.databasePool,
+            dialect: XLSQLiteDialect()
+        )
+        let statement = makeLogicalStatement(
+            for: driver,
+            sql: """
+                SELECT
+                    :composed, hex(:composed),
+                    :decomposed, hex(:decomposed),
+                    :composed = :decomposed
+                """
+        )
+        let row = try driver.withReadConnection { connection in
+            var prepared = try connection.prepare(statement)
+            prepared = try connection.bind(
+                .text(composed),
+                to: .named("composed"),
+                in: prepared
+            )
+            prepared = try connection.bind(
+                .text(decomposed),
+                to: .named("decomposed"),
+                in: prepared
+            )
+            return try XCTUnwrap(connection.fetchOne(prepared))
+        }
+
+        XCTAssertEqual(row[0], .text(composed))
+        XCTAssertEqual(row[1], .text("C3A9"))
+        XCTAssertEqual(row[2], .text(decomposed))
+        XCTAssertEqual(row[3], .text("65CC81"))
+        XCTAssertEqual(
+            row[4],
+            .integer(0),
+            SQLiteValueConformanceCaseID.unicodeText.rawValue
+        )
+    }
+
+    func testSharedSQLiteAffinityCasesAssertValueTypeAndState() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        var driver = GRDBDatabaseDriver(
+            databasePool: fixture.databasePool,
+            dialect: XLSQLiteDialect()
+        )
+        let create = makeLogicalStatement(
+            for: driver,
+            sql: """
+                CREATE TABLE value_affinity (
+                    id TEXT PRIMARY KEY,
+                    integer_value INTEGER,
+                    text_value TEXT,
+                    real_value REAL
+                )
+                """
+        )
+        let insert = makeLogicalStatement(
+            for: driver,
+            sql: """
+                INSERT INTO value_affinity (
+                    id, integer_value, text_value, real_value
+                ) VALUES (
+                    :id, :integer_value, :text_value, :real_value
+                )
+                """
+        )
+        let select = makeLogicalStatement(
+            for: driver,
+            sql: """
+                SELECT
+                    integer_value, typeof(integer_value),
+                    text_value, typeof(text_value),
+                    real_value, typeof(real_value)
+                FROM value_affinity
+                WHERE id = 'affinity'
+                """
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+            var statement = try connection.prepare(insert)
+            statement = try connection.bind(
+                .text("affinity"),
+                to: .named("id"),
+                in: statement
+            )
+            statement = try connection.bind(
+                .text("42"),
+                to: .named("integer_value"),
+                in: statement
+            )
+            statement = try connection.bind(
+                .integer(42),
+                to: .named("text_value"),
+                in: statement
+            )
+            statement = try connection.bind(
+                .integer(42),
+                to: .named("real_value"),
+                in: statement
+            )
+            try connection.execute(statement)
+        }
+
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(connection.fetchOne(connection.prepare(select)))
+        }
+        XCTAssertEqual(
+            Array(row[0 ... 1]),
+            [.integer(42), .text("integer")],
+            SQLiteValueConformanceCaseID.numericTextIntegerAffinity.rawValue
+        )
+        XCTAssertEqual(
+            Array(row[2 ... 3]),
+            [.text("42"), .text("text")],
+            SQLiteValueConformanceCaseID.integerTextAffinity.rawValue
+        )
+        XCTAssertEqual(
+            Array(row[4 ... 5]),
+            [.real(42), .text("real")],
+            SQLiteValueConformanceCaseID.integerRealAffinity.rawValue
+        )
+    }
+
+    func testSharedNamedRepeatedAndNullVersusMissingCases() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        var driver = GRDBDatabaseDriver(
+            databasePool: fixture.databasePool,
+            dialect: XLSQLiteDialect()
+        )
+        let repeated = makeLogicalStatement(
+            for: driver,
+            sql: "SELECT :value, :value, typeof(:value)"
+        )
+        let noRow = makeLogicalStatement(
+            for: driver,
+            sql: "SELECT NULL WHERE 0"
+        )
+
+        let repeatedRow = try driver.withReadConnection { connection in
+            var statement = try connection.prepare(repeated)
+            statement = try connection.bind(
+                .text("shared"),
+                to: .named("value"),
+                in: statement
+            )
+            return try XCTUnwrap(connection.fetchOne(statement))
+        }
+        XCTAssertEqual(
+            repeatedRow,
+            [.text("shared"), .text("shared"), .text("text")],
+            SQLiteValueConformanceCaseID.repeatedNamedBinding.rawValue
+        )
+        XCTAssertEqual(
+            repeatedRow[0],
+            .text("shared"),
+            SQLiteValueConformanceCaseID.namedBinding.rawValue
+        )
+
+        let nullRow = try driver.withReadConnection { connection in
+            var statement = try connection.prepare(repeated)
+            statement = try connection.bind(
+                .null,
+                to: .named("value"),
+                in: statement
+            )
+            return try XCTUnwrap(connection.fetchOne(statement))
+        }
+        XCTAssertEqual(
+            nullRow,
+            [.null, .null, .text("null")],
+            SQLiteValueConformanceCaseID.optionalNullVersusMissing.rawValue
+        )
+        let missingRow = try driver.withReadConnection { connection in
+            try connection.fetchOne(connection.prepare(noRow))
+        }
+        XCTAssertNil(
+            missingRow,
+            SQLiteValueConformanceCaseID.optionalNullVersusMissing.rawValue
+        )
+    }
+
+    func testSharedMalformedValueCasesReturnStructuredErrorsAfterRealSQLite() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        var driver = GRDBDatabaseDriver(
+            databasePool: fixture.databasePool,
+            dialect: XLSQLiteDialect()
+        )
+        let overflow = makeLogicalStatement(
+            for: driver,
+            sql: "SELECT :value"
+        )
+        let overflowRow = try driver.withReadConnection { connection in
+            var statement = try connection.prepare(overflow)
+            statement = try connection.bind(
+                .real(Double(Int64.max)),
+                to: .named("value"),
+                in: statement
+            )
+            return try XCTUnwrap(connection.fetchOne(statement))
+        }
+        XCTAssertThrowsError(
+            try XLSQLiteValueReader(values: overflowRow).readInteger(at: 0),
+            SQLiteValueConformanceCaseID.integerOverflow.rawValue
+        ) { error in
+            XCTAssertEqual(
+                error as? XLColumnReadError,
+                XLColumnReadError(
+                    index: 0,
+                    expectedType: "Int",
+                    failure: .typeMismatch(actualType: "REAL")
+                )
+            )
+        }
+
+        let invalidUTF8 = try XCTUnwrap(
+            SQLiteValueConformanceFixtures.storageCases.first {
+                $0.id == .invalidUTF8Blob
+            }
+        )
+        let invalidUTF8Row = try driver.withReadConnection { connection in
+            var statement = try connection.prepare(overflow)
+            statement = try connection.bind(
+                invalidUTF8.value,
+                to: .named("value"),
+                in: statement
+            )
+            return try XCTUnwrap(connection.fetchOne(statement))
+        }
+        XCTAssertThrowsError(
+            try XLSQLiteValueReader(values: invalidUTF8Row).readText(at: 0),
+            invalidUTF8.id.rawValue
+        ) { error in
+            XCTAssertEqual(
+                error as? XLColumnReadError,
+                XLColumnReadError(
+                    index: 0,
+                    expectedType: "String",
+                    failure: .typeMismatch(actualType: "BLOB")
+                )
+            )
+        }
+
+        let values = makeLogicalStatement(
+            for: driver,
+            sql: """
+                SELECT 0 AS position, 7 AS value
+                UNION ALL
+                SELECT 1 AS position, 'invalid' AS value
+                ORDER BY position
+                """
+        )
+        let rows = try driver.withReadConnection { connection in
+            try connection.fetchAll(connection.prepare(values))
+        }
+        XCTAssertEqual(
+            try XLSQLiteValueReader(values: rows[0]).readInteger(at: 1),
+            7,
+            SQLiteValueConformanceCaseID.decodeAfterValidRow.rawValue
+        )
+        XCTAssertThrowsError(
+            try XLSQLiteValueReader(values: rows[1]).readInteger(at: 1),
+            SQLiteValueConformanceCaseID.decodeAfterValidRow.rawValue
+        ) { error in
+            XCTAssertEqual(
+                error as? XLColumnReadError,
+                XLColumnReadError(
+                    index: 1,
+                    expectedType: "Int",
+                    failure: .typeMismatch(actualType: "TEXT")
+                )
+            )
+        }
     }
 
     func testAllSQLiteStorageClassesRoundTripThroughOneLogicalStatement() throws {

--- a/Tests/SwiftQLCodecIntegrationTests/ContextualValueCodecGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/ContextualValueCodecGRDBTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import GRDB
 import XCTest
 @testable import SwiftQL
+import SwiftQLSQLiteConformanceFixtures
 
 
 @SQLTable(name: "CodecSnapshotRecord")
@@ -358,6 +359,214 @@ final class ContextualValueCodecGRDBTests: XCTestCase {
         try oldBuiltDatabase.databasePool.close()
     }
 
+    func testSharedValueCasesUseNamedDefaultEnumAndOptionalCodecsThroughGRDB() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let textCodec = makeSharedConformanceTextCodec()
+        let integerCodec = makeSharedConformanceIntegerCodec()
+        let registry = try XLValueCodecRegistry()
+            .registering(textCodec)
+            .registering(integerCodec)
+        let codingConfiguration = try XLValueCodingConfiguration(
+            registry: registry,
+            defaultCodecKeys: [integerCodec.identity.key]
+        )
+        let dialect = XLSQLiteDialect()
+        let textParameterContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(
+                SQLiteValueConformanceCaseID.namedTextCodec.rawValue
+            )
+        )
+        let integerParameterContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(
+                SQLiteValueConformanceCaseID.defaultIntegerCodec.rawValue
+            )
+        )
+        let optionalParameterContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(
+                SQLiteValueConformanceCaseID.optionalNullVersusMissing.rawValue
+            )
+        )
+        let textValue = try codingConfiguration.encode(
+            SharedConformanceMode.ready,
+            using: dialect,
+            context: textParameterContext,
+            selection: XLValueCodecSelection(
+                explicitCodecKey: textCodec.identity.key
+            )
+        )
+        let integerValue = try codingConfiguration.encode(
+            SharedConformanceMode.waiting,
+            using: dialect,
+            context: integerParameterContext
+        )
+        let optionalValue = try codingConfiguration.encodeOptional(
+            Optional<SharedConformanceMode>.none,
+            using: dialect,
+            context: optionalParameterContext
+        )
+
+        var driver = GRDBDatabaseDriver(
+            databasePool: fixture.databasePool,
+            dialect: dialect
+        )
+        let create = logicalStatement(
+            for: driver,
+            sql: """
+                CREATE TABLE shared_value_codecs (
+                    text_value TEXT NOT NULL,
+                    integer_value INTEGER NOT NULL,
+                    optional_value TEXT
+                )
+                """
+        )
+        let insert = logicalStatement(
+            for: driver,
+            sql: """
+                INSERT INTO shared_value_codecs (
+                    text_value, integer_value, optional_value
+                ) VALUES (
+                    :text_value, :integer_value, :optional_value
+                )
+                """
+        )
+        let select = logicalStatement(
+            for: driver,
+            sql: """
+                SELECT
+                    text_value, typeof(text_value),
+                    integer_value, typeof(integer_value),
+                    optional_value, typeof(optional_value)
+                FROM shared_value_codecs
+                """
+        )
+        let selectMismatch = logicalStatement(
+            for: driver,
+            sql: "SELECT 1, typeof(1)"
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+            var statement = try connection.prepare(insert)
+            statement = try connection.bind(
+                textValue,
+                to: .named("text_value"),
+                in: statement
+            )
+            statement = try connection.bind(
+                integerValue,
+                to: .named("integer_value"),
+                in: statement
+            )
+            statement = try connection.bind(
+                optionalValue,
+                to: .named("optional_value"),
+                in: statement
+            )
+            try connection.execute(statement)
+        }
+
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(connection.fetchOne(connection.prepare(select)))
+        }
+        XCTAssertEqual(
+            Array(row[0 ... 1]),
+            [.text("ready"), .text("text")],
+            SQLiteValueConformanceCaseID.namedTextCodec.rawValue
+        )
+        XCTAssertEqual(
+            Array(row[2 ... 3]),
+            [.integer(2), .text("integer")],
+            SQLiteValueConformanceCaseID.defaultIntegerCodec.rawValue
+        )
+        XCTAssertEqual(
+            Array(row[4 ... 5]),
+            [.null, .text("null")],
+            SQLiteValueConformanceCaseID.optionalNullVersusMissing.rawValue
+        )
+
+        let decodedText: SharedConformanceMode = try codingConfiguration.decode(
+            SharedConformanceMode.self,
+            from: row[0],
+            using: dialect,
+            context: XLValueCodingContext(
+                site: .result,
+                path: textParameterContext.path
+            ),
+            selection: XLValueCodecSelection(
+                explicitCodecKey: textCodec.identity.key
+            )
+        )
+        let decodedInteger: SharedConformanceMode = try codingConfiguration.decode(
+            SharedConformanceMode.self,
+            from: row[2],
+            using: dialect,
+            context: XLValueCodingContext(
+                site: .result,
+                path: integerParameterContext.path
+            )
+        )
+        let decodedOptional: SharedConformanceMode? = try codingConfiguration.decodeOptional(
+            SharedConformanceMode.self,
+            from: row[4],
+            using: dialect,
+            context: XLValueCodingContext(
+                site: .result,
+                path: optionalParameterContext.path
+            )
+        )
+        XCTAssertEqual(
+            decodedText,
+            .ready,
+            SQLiteValueConformanceCaseID.textRawValueEnum.rawValue
+        )
+        XCTAssertEqual(decodedInteger, .waiting)
+        XCTAssertNil(decodedOptional)
+
+        let mismatchRow = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(connection.prepare(selectMismatch))
+            )
+        }
+        let mismatchContext = XLValueCodingContext(
+            site: .result,
+            path: XLValueCodingPath(
+                SQLiteValueConformanceCaseID.storageMismatch.rawValue
+            )
+        )
+        XCTAssertEqual(
+            mismatchRow,
+            [.integer(1), .text("integer")],
+            SQLiteValueConformanceCaseID.storageMismatch.rawValue
+        )
+        XCTAssertThrowsError(
+            try codingConfiguration.decode(
+                SharedConformanceMode.self,
+                from: mismatchRow[0],
+                using: dialect,
+                context: mismatchContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: textCodec.identity.key
+                )
+            ),
+            SQLiteValueConformanceCaseID.storageMismatch.rawValue
+        ) { error in
+            XCTAssertEqual(
+                error as? XLValueCodecError,
+                .storageMismatch(
+                    codec: textCodec.identity.key,
+                    expected: textCodec.identity.storageIdentifier,
+                    actual: XLValueStorageIdentifier(rawValue: "integer"),
+                    context: mismatchContext
+                )
+            )
+        }
+    }
+
     private func makeDateCodecs() -> (
         text: XLValueCodec<Date, XLSQLiteDialect>,
         integer: XLValueCodec<Date, XLSQLiteDialect>
@@ -435,6 +644,65 @@ final class ContextualValueCodecGRDBTests: XCTestCase {
 private enum DateCodecFixtureError: Error {
     case invalidText
     case invalidInteger
+}
+
+
+private enum SharedConformanceMode: String, Equatable, Sendable {
+    case ready
+    case waiting
+}
+
+
+private func makeSharedConformanceTextCodec() -> XLValueCodec<
+    SharedConformanceMode,
+    XLSQLiteDialect
+> {
+    XLValueCodec(
+        key: XLValueCodecKey(id: "conformance.shared-mode-text", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(
+            rawValue: "swiftql.conformance.shared-mode"
+        ),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: XLValueStorageIdentifier(rawValue: "text"),
+        encode: { value, _, _ in
+            .text(value.rawValue)
+        },
+        decode: { value, _, _ in
+            guard case .text(let rawValue) = value,
+                  let mode = SharedConformanceMode(rawValue: rawValue) else {
+                throw DateCodecFixtureError.invalidText
+            }
+            return mode
+        }
+    )
+}
+
+
+private func makeSharedConformanceIntegerCodec() -> XLValueCodec<
+    SharedConformanceMode,
+    XLSQLiteDialect
+> {
+    XLValueCodec(
+        key: XLValueCodecKey(id: "conformance.shared-mode-integer", version: 1),
+        valueTypeIdentifier: XLValueTypeIdentifier(
+            rawValue: "swiftql.conformance.shared-mode"
+        ),
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: XLValueStorageIdentifier(rawValue: "integer"),
+        encode: { value, _, _ in
+            .integer(value == .ready ? 1 : 2)
+        },
+        decode: { value, _, _ in
+            switch value {
+            case .integer(1):
+                return .ready
+            case .integer(2):
+                return .waiting
+            default:
+                throw DateCodecFixtureError.invalidInteger
+            }
+        }
+    )
 }
 
 

--- a/Tests/SwiftQLCoreTests/SQLiteValueConformanceBoundaryTests.swift
+++ b/Tests/SwiftQLCoreTests/SQLiteValueConformanceBoundaryTests.swift
@@ -13,15 +13,6 @@ final class SQLiteValueConformanceBoundaryTests: XCTestCase {
             grouping: manifest.records,
             by: \.id
         )
-        let pinnedCommits = [
-            "groue/GRDB.swift": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
-            "stephencelis/SQLite.swift": "ccaae3d01fd655be40f20665f1f61dc6deecec27",
-            "Lighter-swift/Lighter": "3486fc08d580aa3a87cd29ede023ba291a90de8b",
-            "marcoarment/Blackbird": "0960ffc7649e9c35cfdb5f6b0b98216a34e8c09a",
-            "vapor/fluent-kit": "6f8844284df4f797d2a81721511d053357d97b56",
-            "lukevanin/swiftql": "03f504a1e47e0580b2c20eeeecea104cb9d7f2a9",
-        ]
-
         XCTAssertEqual(manifest.schemaVersion, 1)
         XCTAssertEqual(manifest.coordinationIssue, 190)
         XCTAssertEqual(
@@ -42,7 +33,8 @@ final class SQLiteValueConformanceBoundaryTests: XCTestCase {
             )
             XCTAssertEqual(
                 record.provenance.commit,
-                pinnedCommits[record.provenance.repository],
+                SQLiteValueConformanceFixtures
+                    .pinnedProvenanceCommitsByRepository[record.provenance.repository],
                 id.rawValue
             )
             XCTAssertFalse(record.provenance.path.isEmpty, id.rawValue)

--- a/Tests/SwiftQLCoreTests/SQLiteValueConformanceBoundaryTests.swift
+++ b/Tests/SwiftQLCoreTests/SQLiteValueConformanceBoundaryTests.swift
@@ -1,0 +1,319 @@
+import Foundation
+import XCTest
+
+import SwiftQLCore
+import SwiftQLSQLiteConformanceFixtures
+
+
+final class SQLiteValueConformanceBoundaryTests: XCTestCase {
+
+    func testManifestAccountsForEveryStableCaseAndPinnedProvenance() throws {
+        let manifest = try SQLiteValueConformanceManifest.load()
+        let recordsByID = Dictionary(
+            grouping: manifest.records,
+            by: \.id
+        )
+        let pinnedCommits = [
+            "groue/GRDB.swift": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+            "stephencelis/SQLite.swift": "ccaae3d01fd655be40f20665f1f61dc6deecec27",
+            "Lighter-swift/Lighter": "3486fc08d580aa3a87cd29ede023ba291a90de8b",
+            "marcoarment/Blackbird": "0960ffc7649e9c35cfdb5f6b0b98216a34e8c09a",
+            "vapor/fluent-kit": "6f8844284df4f797d2a81721511d053357d97b56",
+            "lukevanin/swiftql": "03f504a1e47e0580b2c20eeeecea104cb9d7f2a9",
+        ]
+
+        XCTAssertEqual(manifest.schemaVersion, 1)
+        XCTAssertEqual(manifest.coordinationIssue, 190)
+        XCTAssertEqual(
+            Set(recordsByID.keys),
+            Set(SQLiteValueConformanceCaseID.allCases)
+        )
+
+        for id in SQLiteValueConformanceCaseID.allCases {
+            let records = try XCTUnwrap(recordsByID[id], id.rawValue)
+            XCTAssertEqual(records.count, 1, "Duplicate manifest ID: \(id.rawValue)")
+            let record = try XCTUnwrap(records.first)
+            XCTAssertFalse(record.category.isEmpty, id.rawValue)
+            XCTAssertFalse(record.evidenceLayers.isEmpty, id.rawValue)
+            XCTAssertEqual(
+                URL(string: record.sqliteDocumentationURL)?.scheme,
+                "https",
+                id.rawValue
+            )
+            XCTAssertEqual(
+                record.provenance.commit,
+                pinnedCommits[record.provenance.repository],
+                id.rawValue
+            )
+            XCTAssertFalse(record.provenance.path.isEmpty, id.rawValue)
+            XCTAssertFalse(record.provenance.upstreamCase.isEmpty, id.rawValue)
+            XCTAssertFalse(record.provenance.licenseDisposition.isEmpty, id.rawValue)
+            XCTAssertFalse(record.provenance.adaptationNotes.isEmpty, id.rawValue)
+        }
+    }
+
+    func testSharedStorageCasesCrossSQLiteDialectAndInvocationBoundaries() throws {
+        let dialect = XLSQLiteDialect()
+        let cases = SQLiteValueConformanceFixtures.storageCases
+        let slots = cases.enumerated().map { offset, testCase in
+            parameterSlot(
+                index: offset,
+                name: testCase.id.rawValue,
+                nullability: testCase.expectedStorage == .null ? .nullable : .required
+            )
+        }
+        let layout = try XLParameterLayout(slots: slots)
+        var packet = XLInvocationBindings<XLSQLiteValue>(layout: layout)
+
+        for (testCase, slot) in zip(cases, slots) {
+            XCTAssertEqual(
+                testCase.value.storageType,
+                testCase.expectedStorage,
+                testCase.id.rawValue
+            )
+            XCTAssertEqual(
+                dialect.stableStorageIdentifier(for: testCase.value),
+                storageIdentifier(testCase.expectedStorage),
+                testCase.id.rawValue
+            )
+            packet = try packet.binding(testCase.value, to: slot)
+        }
+
+        XCTAssertEqual(packet.bindingCount, cases.count)
+        XCTAssertTrue(packet.isComplete)
+        for testCase in cases {
+            let binding = try XCTUnwrap(
+                packet.binding(for: .named(testCase.id.rawValue)),
+                testCase.id.rawValue
+            )
+            XCTAssertEqual(
+                binding.value.storageType,
+                testCase.expectedStorage,
+                testCase.id.rawValue
+            )
+        }
+    }
+
+    func testNamedAndRepeatedBindingsRetainOneLogicalIdentity() throws {
+        let namedID = SQLiteValueConformanceCaseID.namedBinding
+        let repeatedID = SQLiteValueConformanceCaseID.repeatedNamedBinding
+        let named = parameterSlot(index: 0, name: namedID.rawValue)
+        let repeated = parameterSlot(index: 1, name: repeatedID.rawValue)
+        let layout = try XLParameterLayout(
+            slots: [repeated, named, repeated]
+        )
+        var packet = XLInvocationBindings<XLSQLiteValue>(layout: layout)
+        packet = try packet.binding(.text("named"), to: named)
+        packet = try packet.binding(.integer(252), to: repeated)
+
+        XCTAssertEqual(layout.count, 2, repeatedID.rawValue)
+        XCTAssertEqual(packet.bindings.map(\.slot), [named, repeated])
+        XCTAssertEqual(
+            packet.binding(for: .named(namedID.rawValue))?.value,
+            .text("named")
+        )
+        XCTAssertEqual(
+            packet.binding(for: .named(repeatedID.rawValue))?.value,
+            .integer(252)
+        )
+        XCTAssertNoThrow(try packet.validatingComplete())
+    }
+
+    func testOptionalEnumNamedAndDefaultCodecsShareSQLiteStoragePolicy() throws {
+        let textCodec = makeTextCodec()
+        let integerCodec = makeIntegerCodec()
+        let registry = try XLValueCodecRegistry()
+            .registering(textCodec)
+            .registering(integerCodec)
+        let configuration = try XLValueCodingConfiguration(
+            registry: registry,
+            defaultCodecKeys: [integerCodec.identity.key]
+        )
+        let dialect = XLSQLiteDialect()
+        let context = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(
+                SQLiteValueConformanceCaseID.textRawValueEnum.rawValue
+            )
+        )
+
+        let namedText = try configuration.encode(
+            ConformanceMode.ready,
+            using: dialect,
+            context: context,
+            selection: XLValueCodecSelection(
+                explicitCodecKey: textCodec.identity.key
+            )
+        )
+        XCTAssertEqual(
+            namedText,
+            .text(ConformanceMode.ready.rawValue),
+            SQLiteValueConformanceCaseID.namedTextCodec.rawValue
+        )
+
+        let defaultInteger = try configuration.encode(
+            ConformanceMode.waiting,
+            using: dialect,
+            context: context
+        )
+        XCTAssertEqual(
+            defaultInteger,
+            .integer(2),
+            SQLiteValueConformanceCaseID.defaultIntegerCodec.rawValue
+        )
+
+        let decodedText: ConformanceMode = try configuration.decode(
+            ConformanceMode.self,
+            from: namedText,
+            using: dialect,
+            context: context,
+            selection: XLValueCodecSelection(
+                explicitCodecKey: textCodec.identity.key
+            )
+        )
+        XCTAssertEqual(decodedText, .ready)
+
+        let encodedNull = try configuration.encodeOptional(
+            Optional<ConformanceMode>.none,
+            using: dialect,
+            context: context
+        )
+        let decodedNull: ConformanceMode? = try configuration.decodeOptional(
+            ConformanceMode.self,
+            from: encodedNull,
+            using: dialect,
+            context: context
+        )
+        XCTAssertEqual(encodedNull, .null)
+        XCTAssertNil(
+            decodedNull,
+            SQLiteValueConformanceCaseID.optionalNullVersusMissing.rawValue
+        )
+    }
+
+    func testCodecStorageMismatchRetainsCaseAndCodingContext() throws {
+        let codec = makeTextCodec()
+        let configuration = try XLValueCodingConfiguration(
+            registry: XLValueCodecRegistry().registering(codec)
+        )
+        let context = XLValueCodingContext(
+            site: .result,
+            path: XLValueCodingPath(
+                SQLiteValueConformanceCaseID.storageMismatch.rawValue
+            )
+        )
+
+        XCTAssertThrowsError(
+            try configuration.decode(
+                ConformanceMode.self,
+                from: XLSQLiteValue.integer(1),
+                using: XLSQLiteDialect(),
+                context: context,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: codec.identity.key
+                )
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLValueCodecError,
+                .storageMismatch(
+                    codec: codec.identity.key,
+                    expected: storageIdentifier(.text),
+                    actual: storageIdentifier(.integer),
+                    context: context
+                )
+            )
+        }
+    }
+}
+
+
+private enum ConformanceMode: String, Equatable, Sendable {
+    case ready
+    case waiting
+}
+
+
+private enum ConformanceCodecFailure: Error {
+    case invalidValue
+}
+
+
+private let conformanceValueType = XLValueTypeIdentifier(
+    rawValue: "swiftql.conformance.mode"
+)
+
+
+private func makeTextCodec() -> XLValueCodec<ConformanceMode, XLSQLiteDialect> {
+    XLValueCodec(
+        key: XLValueCodecKey(id: "swiftql.conformance.mode.text", version: 1),
+        valueTypeIdentifier: conformanceValueType,
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: storageIdentifier(.text),
+        encode: { value, _, _ in
+            .text(value.rawValue)
+        },
+        decode: { value, _, _ in
+            guard case .text(let rawValue) = value,
+                  let decoded = ConformanceMode(rawValue: rawValue) else {
+                throw ConformanceCodecFailure.invalidValue
+            }
+            return decoded
+        }
+    )
+}
+
+
+private func makeIntegerCodec() -> XLValueCodec<ConformanceMode, XLSQLiteDialect> {
+    XLValueCodec(
+        key: XLValueCodecKey(id: "swiftql.conformance.mode.integer", version: 1),
+        valueTypeIdentifier: conformanceValueType,
+        dialectIdentifier: XLSQLiteDialect.identity,
+        storageIdentifier: storageIdentifier(.integer),
+        encode: { value, _, _ in
+            .integer(value == .ready ? 1 : 2)
+        },
+        decode: { value, _, _ in
+            guard case .integer(let rawValue) = value else {
+                throw ConformanceCodecFailure.invalidValue
+            }
+            switch rawValue {
+            case 1:
+                return .ready
+            case 2:
+                return .waiting
+            default:
+                throw ConformanceCodecFailure.invalidValue
+            }
+        }
+    )
+}
+
+
+private func parameterSlot(
+    index: Int,
+    name: String,
+    nullability: XLParameterNullability = .required
+) -> XLParameterSlot {
+    XLParameterSlot(
+        index: XLLogicalParameterIndex(index),
+        key: .named(name),
+        valueTypeIdentifier: XLValueTypeIdentifier(
+            rawValue: "swiftql.conformance.sqlite-value"
+        ),
+        valueTypeName: String(reflecting: XLSQLiteValue.self),
+        nullability: nullability,
+        codecIdentity: nil,
+        codingContext: XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(name)
+        )
+    )
+}
+
+
+private func storageIdentifier(
+    _ storage: XLSQLiteStorageClass
+) -> XLValueStorageIdentifier {
+    XLValueStorageIdentifier(rawValue: storage.rawValue)
+}

--- a/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteValueConformanceFixtures.swift
+++ b/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteValueConformanceFixtures.swift
@@ -70,6 +70,18 @@ public struct SQLiteValueConformanceCase: Sendable {
 
 public enum SQLiteValueConformanceFixtures {
 
+    /// Exact upstream revisions used by the checked-in provenance manifest.
+    /// Keeping these pins with the shared fixtures lets every adapter validate
+    /// the same evidence without introducing adapter names into core tests.
+    public static let pinnedProvenanceCommitsByRepository: [String: String] = [
+        "groue/GRDB.swift": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "stephencelis/SQLite.swift": "ccaae3d01fd655be40f20665f1f61dc6deecec27",
+        "Lighter-swift/Lighter": "3486fc08d580aa3a87cd29ede023ba291a90de8b",
+        "marcoarment/Blackbird": "0960ffc7649e9c35cfdb5f6b0b98216a34e8c09a",
+        "vapor/fluent-kit": "6f8844284df4f797d2a81721511d053357d97b56",
+        "lukevanin/swiftql": "03f504a1e47e0580b2c20eeeecea104cb9d7f2a9",
+    ]
+
     /// Cases that cross both the driver-neutral SQLite dialect boundary and a
     /// real SQLite connection. NaN remains a normalized `REAL` at the pure
     /// dialect layer, while the concrete binding boundary rejects it before

--- a/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteValueConformanceFixtures.swift
+++ b/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteValueConformanceFixtures.swift
@@ -1,0 +1,206 @@
+import Foundation
+import SwiftQLCore
+
+
+/// Stable identifiers shared by adapter-neutral and real-SQLite value tests.
+///
+/// These identifiers are intentionally independent of XCTest method names so
+/// future SQLite adapters can run the same semantic cases unchanged.
+public enum SQLiteValueConformanceCaseID:
+    String,
+    CaseIterable,
+    Codable,
+    Hashable,
+    Sendable
+{
+    case nullStorage = "storage.null"
+    case minimumInteger = "storage.integer.minimum"
+    case maximumInteger = "storage.integer.maximum"
+    case finiteReal = "storage.real.finite"
+    case positiveInfinity = "storage.real.positive-infinity"
+    case negativeInfinity = "storage.real.negative-infinity"
+    case rejectedNaN = "storage.real.nan-rejected"
+    case emptyText = "storage.text.empty"
+    case unicodeText = "storage.text.unicode"
+    case emptyBlob = "storage.blob.empty"
+    case embeddedZeroBlob = "storage.blob.embedded-zero"
+    case invalidUTF8Blob = "storage.blob.invalid-utf8"
+    case numericTextIntegerAffinity = "affinity.integer.numeric-text"
+    case integerTextAffinity = "affinity.text.integer"
+    case integerRealAffinity = "affinity.real.integer"
+    case optionalNullVersusMissing = "optional.null-vs-missing"
+    case textRawValueEnum = "enum.text.round-trip"
+    case namedTextCodec = "codec.named.text"
+    case defaultIntegerCodec = "codec.default.integer"
+    case namedBinding = "binding.named"
+    case repeatedNamedBinding = "binding.repeated-named"
+    case integerOverflow = "failure.integer-overflow"
+    case storageMismatch = "failure.storage-mismatch"
+    case decodeAfterValidRow = "failure.decode-after-valid-row"
+}
+
+
+public enum SQLiteValueConformanceExpectation: String, Sendable {
+    case roundTrip
+    case bindingRejected
+}
+
+
+/// One normalized value case that both core-only and adapter integration tests
+/// can consume without importing a concrete database adapter.
+public struct SQLiteValueConformanceCase: Sendable {
+    public let id: SQLiteValueConformanceCaseID
+    public let value: XLSQLiteValue
+    public let expectedStorage: XLSQLiteStorageClass
+    public let expectation: SQLiteValueConformanceExpectation
+
+    public init(
+        id: SQLiteValueConformanceCaseID,
+        value: XLSQLiteValue,
+        expectedStorage: XLSQLiteStorageClass,
+        expectation: SQLiteValueConformanceExpectation = .roundTrip
+    ) {
+        self.id = id
+        self.value = value
+        self.expectedStorage = expectedStorage
+        self.expectation = expectation
+    }
+}
+
+
+public enum SQLiteValueConformanceFixtures {
+
+    /// Cases that cross both the driver-neutral SQLite dialect boundary and a
+    /// real SQLite connection. NaN remains a normalized `REAL` at the pure
+    /// dialect layer, while the concrete binding boundary rejects it before
+    /// SQLite can silently normalize it to SQL NULL.
+    public static let storageCases: [SQLiteValueConformanceCase] = [
+        SQLiteValueConformanceCase(
+            id: .nullStorage,
+            value: .null,
+            expectedStorage: .null
+        ),
+        SQLiteValueConformanceCase(
+            id: .minimumInteger,
+            value: .integer(.min),
+            expectedStorage: .integer
+        ),
+        SQLiteValueConformanceCase(
+            id: .maximumInteger,
+            value: .integer(.max),
+            expectedStorage: .integer
+        ),
+        SQLiteValueConformanceCase(
+            id: .finiteReal,
+            value: .real(42.125),
+            expectedStorage: .real
+        ),
+        SQLiteValueConformanceCase(
+            id: .positiveInfinity,
+            value: .real(.infinity),
+            expectedStorage: .real
+        ),
+        SQLiteValueConformanceCase(
+            id: .negativeInfinity,
+            value: .real(-.infinity),
+            expectedStorage: .real
+        ),
+        SQLiteValueConformanceCase(
+            id: .rejectedNaN,
+            value: .real(.nan),
+            expectedStorage: .real,
+            expectation: .bindingRejected
+        ),
+        SQLiteValueConformanceCase(
+            id: .emptyText,
+            value: .text(""),
+            expectedStorage: .text
+        ),
+        SQLiteValueConformanceCase(
+            id: .unicodeText,
+            value: .text("SwiftQL: é / e\u{301} / 你好 / 🌍"),
+            expectedStorage: .text
+        ),
+        SQLiteValueConformanceCase(
+            id: .emptyBlob,
+            value: .blob(Data()),
+            expectedStorage: .blob
+        ),
+        SQLiteValueConformanceCase(
+            id: .embeddedZeroBlob,
+            value: .blob(Data([0x00, 0x41, 0x00, 0xff])),
+            expectedStorage: .blob
+        ),
+        SQLiteValueConformanceCase(
+            id: .invalidUTF8Blob,
+            value: .blob(Data([0xff, 0xfe, 0x00])),
+            expectedStorage: .blob
+        ),
+    ]
+
+    public static let storageCaseIDs = Set(storageCases.map(\.id))
+}
+
+
+/// Checked-in provenance used by issue #252 and designed to be incorporated
+/// into the broader #190 inventory without becoming a competing syntax ledger.
+public struct SQLiteValueConformanceManifest: Decodable, Sendable {
+    public let schemaVersion: Int
+    public let coordinationIssue: Int
+    public let records: [Record]
+
+    public struct Record: Decodable, Sendable {
+        public let id: SQLiteValueConformanceCaseID
+        public let category: String
+        public let evidenceLayers: [String]
+        public let sqliteDocumentationURL: String
+        public let provenance: Provenance
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case category
+            case evidenceLayers = "evidence_layers"
+            case sqliteDocumentationURL = "sqlite_documentation_url"
+            case provenance
+        }
+    }
+
+    public struct Provenance: Decodable, Sendable {
+        public let repository: String
+        public let commit: String
+        public let path: String
+        public let upstreamCase: String
+        public let licenseDisposition: String
+        public let adaptationNotes: String
+
+        private enum CodingKeys: String, CodingKey {
+            case repository
+            case commit
+            case path
+            case upstreamCase = "upstream_case"
+            case licenseDisposition = "license_disposition"
+            case adaptationNotes = "adaptation_notes"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case coordinationIssue = "coordination_issue"
+        case records
+    }
+
+    public static func load() throws -> Self {
+        guard let url = Bundle.module.url(
+            forResource: "SQLiteValueConformanceManifest",
+            withExtension: "json"
+        ) else {
+            throw SQLiteValueConformanceManifestError.missingResource
+        }
+        return try JSONDecoder().decode(Self.self, from: Data(contentsOf: url))
+    }
+}
+
+
+public enum SQLiteValueConformanceManifestError: Error {
+    case missingResource
+}

--- a/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteValueConformanceManifest.json
+++ b/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteValueConformanceManifest.json
@@ -1,0 +1,342 @@
+{
+  "schema_version": 1,
+  "coordination_issue": 190,
+  "records": [
+    {
+      "id": "storage.null",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "groue/GRDB.swift",
+        "commit": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "path": "Tests/GRDBTests/Core/DatabaseValueTests.swift",
+        "upstream_case": "DatabaseValueTests.testDatabaseValueAsDatabaseValueConvertible",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Retains the five-storage-class semantic oracle and explicit SQL NULL identity."
+      }
+    },
+    {
+      "id": "storage.integer.minimum",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "groue/GRDB.swift",
+        "commit": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "path": "Tests/GRDBTests/Core/NumericOverflowTests.swift",
+        "upstream_case": "NumericOverflowTests.testLowInt64FromDoubleOverflows",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Uses Int64.min as a direct INTEGER storage boundary before separate conversion-overflow cases."
+      }
+    },
+    {
+      "id": "storage.integer.maximum",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "groue/GRDB.swift",
+        "commit": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "path": "Tests/GRDBTests/Core/NumericOverflowTests.swift",
+        "upstream_case": "NumericOverflowTests.testHighInt64FromDoubleOverflows",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Uses Int64.max as a direct INTEGER storage boundary before separate conversion-overflow cases."
+      }
+    },
+    {
+      "id": "storage.real.finite",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "groue/GRDB.swift",
+        "commit": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "path": "Tests/GRDBTests/Core/DatabaseValueTests.swift",
+        "upstream_case": "DatabaseValueTests.testDatabaseValueAsDatabaseValueConvertible",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Preserves a non-integral IEEE 754 value and verifies SQLite REAL storage."
+      }
+    },
+    {
+      "id": "storage.real.positive-infinity",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/c3ref/bind_blob.html",
+      "provenance": {
+        "repository": "lukevanin/swiftql",
+        "commit": "03f504a1e47e0580b2c20eeeecea104cb9d7f2a9",
+        "path": "Tests/SQLTests/GRDBDriverContractTests.swift",
+        "upstream_case": "GRDBDriverContractTests.testSQLiteRealBindingsPreserveInfinitiesAndFiniteEdges",
+        "license_disposition": "MIT; existing SwiftQL contract reused by stable case ID",
+        "adaptation_notes": "Promotes the issue #147 positive-infinity binding behavior into the shared matrix."
+      }
+    },
+    {
+      "id": "storage.real.negative-infinity",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/c3ref/bind_blob.html",
+      "provenance": {
+        "repository": "lukevanin/swiftql",
+        "commit": "03f504a1e47e0580b2c20eeeecea104cb9d7f2a9",
+        "path": "Tests/SQLTests/GRDBDriverContractTests.swift",
+        "upstream_case": "GRDBDriverContractTests.testSQLiteRealBindingsPreserveInfinitiesAndFiniteEdges",
+        "license_disposition": "MIT; existing SwiftQL contract reused by stable case ID",
+        "adaptation_notes": "Promotes the issue #147 negative-infinity binding behavior into the shared matrix."
+      }
+    },
+    {
+      "id": "storage.real.nan-rejected",
+      "category": "structured-failure",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/c3ref/bind_blob.html",
+      "provenance": {
+        "repository": "lukevanin/swiftql",
+        "commit": "03f504a1e47e0580b2c20eeeecea104cb9d7f2a9",
+        "path": "Tests/SQLTests/GRDBDriverContractTests.swift",
+        "upstream_case": "GRDBDriverContractTests.testRealBindingRejectsNaNBeforeSQLiteCanNormalizeItToNull",
+        "license_disposition": "MIT; existing SwiftQL contract reused by stable case ID",
+        "adaptation_notes": "Promotes issue #147's structured NaN rejection without treating SQLite NULL normalization as success."
+      }
+    },
+    {
+      "id": "storage.text.empty",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "marcoarment/Blackbird",
+        "commit": "0960ffc7649e9c35cfdb5f6b0b98216a34e8c09a",
+        "path": "Tests/BlackbirdTests/BlackbirdTests.swift",
+        "upstream_case": "BlackbirdTests.testValueConversions",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Extends the text conversion case to distinguish an empty TEXT value from SQL NULL."
+      }
+    },
+    {
+      "id": "storage.text.unicode",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "marcoarment/Blackbird",
+        "commit": "0960ffc7649e9c35cfdb5f6b0b98216a34e8c09a",
+        "path": "Tests/BlackbirdTests/BlackbirdTests.swift",
+        "upstream_case": "BlackbirdTests.testValueConversions",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Uses composed and decomposed accents plus non-Latin text and emoji in one exact round trip."
+      }
+    },
+    {
+      "id": "storage.blob.empty",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/c3ref/bind_blob.html",
+      "provenance": {
+        "repository": "stephencelis/SQLite.swift",
+        "commit": "ccaae3d01fd655be40f20665f1f61dc6deecec27",
+        "path": "Tests/SQLiteTests/Core/StatementTests.swift",
+        "upstream_case": "StatementTests.test_zero_sized_blob_returns_null",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Keeps a zero-byte BLOB distinct from SQL NULL despite SQLite's null-pointer C representation."
+      }
+    },
+    {
+      "id": "storage.blob.embedded-zero",
+      "category": "storage",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/c3ref/bind_blob.html",
+      "provenance": {
+        "repository": "stephencelis/SQLite.swift",
+        "commit": "ccaae3d01fd655be40f20665f1f61dc6deecec27",
+        "path": "Tests/SQLiteTests/Core/BlobTests.swift",
+        "upstream_case": "BlobTests.test_toHex",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Uses embedded zero and non-UTF-8 bytes to prove length-aware BLOB binding."
+      }
+    },
+    {
+      "id": "storage.blob.invalid-utf8",
+      "category": "structured-failure",
+      "evidence_layers": ["dialect-boundary", "sqlite-grdb", "column-reader"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "stephencelis/SQLite.swift",
+        "commit": "ccaae3d01fd655be40f20665f1f61dc6deecec27",
+        "path": "Tests/SQLiteTests/Core/BlobTests.swift",
+        "upstream_case": "BlobTests.test_equality",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Preserves arbitrary bytes as BLOB and requires structured failure when decoded as text."
+      }
+    },
+    {
+      "id": "affinity.integer.numeric-text",
+      "category": "affinity",
+      "evidence_layers": ["sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#type_affinity",
+      "provenance": {
+        "repository": "stephencelis/SQLite.swift",
+        "commit": "ccaae3d01fd655be40f20665f1f61dc6deecec27",
+        "path": "Tests/SQLiteTests/Schema/SchemaTests.swift",
+        "upstream_case": "SchemaTests.test_createTable",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Extends declared INTEGER coverage with real SQLite coercion and typeof evidence."
+      }
+    },
+    {
+      "id": "affinity.text.integer",
+      "category": "affinity",
+      "evidence_layers": ["sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#type_affinity",
+      "provenance": {
+        "repository": "Lighter-swift/Lighter",
+        "commit": "3486fc08d580aa3a87cd29ede023ba291a90de8b",
+        "path": "Tests/EntityGenTests/Fixtures.swift",
+        "upstream_case": "northwindSchema.OrderDetail",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Turns generated declared-type coverage into a semantic TEXT-affinity coercion check."
+      }
+    },
+    {
+      "id": "affinity.real.integer",
+      "category": "affinity",
+      "evidence_layers": ["sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#type_affinity",
+      "provenance": {
+        "repository": "Lighter-swift/Lighter",
+        "commit": "3486fc08d580aa3a87cd29ede023ba291a90de8b",
+        "path": "Tests/EntityGenTests/Fixtures.swift",
+        "upstream_case": "northwindSchema.OrderDetail",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Turns generated DOUBLE declared-type coverage into a semantic REAL-affinity coercion check."
+      }
+    },
+    {
+      "id": "optional.null-vs-missing",
+      "category": "optional",
+      "evidence_layers": ["codec-boundary", "invocation-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/nulls.html",
+      "provenance": {
+        "repository": "vapor/fluent-kit",
+        "commit": "6f8844284df4f797d2a81721511d053357d97b56",
+        "path": "Tests/FluentKitTests/OptionalFieldQueryTests.swift",
+        "upstream_case": "OptionalFieldQueryTests.testInsertNull",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Separates an explicit NULL row value from a query that returns no row."
+      }
+    },
+    {
+      "id": "enum.text.round-trip",
+      "category": "raw-value-enum",
+      "evidence_layers": ["codec-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "groue/GRDB.swift",
+        "commit": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "path": "Tests/GRDBTests/Core/DatabaseValueConvertible/RawRepresentable+DatabaseValueConvertibleTests.swift",
+        "upstream_case": "RawRepresentableDatabaseValueConvertibleTests.testGrape",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Uses an application-owned text raw-value enum and SwiftQL contextual codec."
+      }
+    },
+    {
+      "id": "codec.named.text",
+      "category": "contextual-codec",
+      "evidence_layers": ["codec-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "vapor/fluent-kit",
+        "commit": "6f8844284df4f797d2a81721511d053357d97b56",
+        "path": "Tests/FluentKitTests/OptionalEnumQueryTests.swift",
+        "upstream_case": "OptionalEnumQueryTests.testInsertNonNull",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Exercises explicit named representation selection without importing ORM field policy."
+      }
+    },
+    {
+      "id": "codec.default.integer",
+      "category": "contextual-codec",
+      "evidence_layers": ["codec-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "Lighter-swift/Lighter",
+        "commit": "3486fc08d580aa3a87cd29ede023ba291a90de8b",
+        "path": "Tests/EntityGenTests/ASTRecordBindGenerationTests.swift",
+        "upstream_case": "ASTRecordBindGenerationTests.testPersonStatementBindWithLocalHelpers",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Exercises SwiftQL's configured default representation at the same pre-adapter boundary."
+      }
+    },
+    {
+      "id": "binding.named",
+      "category": "binding-identity",
+      "evidence_layers": ["invocation-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/lang_expr.html#parameters",
+      "provenance": {
+        "repository": "groue/GRDB.swift",
+        "commit": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "path": "Tests/GRDBTests/Core/Statement/StatementArgumentsTests.swift",
+        "upstream_case": "StatementArgumentsTests.testNamedStatementArguments",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Uses SwiftQL's immutable binding packet and real driver instead of GRDB argument containers."
+      }
+    },
+    {
+      "id": "binding.repeated-named",
+      "category": "binding-identity",
+      "evidence_layers": ["invocation-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/lang_expr.html#parameters",
+      "provenance": {
+        "repository": "groue/GRDB.swift",
+        "commit": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "path": "Tests/GRDBTests/Core/Statement/StatementArgumentsTests.swift",
+        "upstream_case": "StatementArgumentsTests.testReusedNamedStatementArguments",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Proves one logical slot supplies all occurrences of the same SQLite named parameter."
+      }
+    },
+    {
+      "id": "failure.integer-overflow",
+      "category": "structured-failure",
+      "evidence_layers": ["column-reader", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "groue/GRDB.swift",
+        "commit": "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "path": "Tests/GRDBTests/Core/NumericOverflowTests.swift",
+        "upstream_case": "NumericOverflowTests.testHighInt64FromDoubleOverflows",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Requires a structured type mismatch instead of trapping or truncating an out-of-range REAL."
+      }
+    },
+    {
+      "id": "failure.storage-mismatch",
+      "category": "structured-failure",
+      "evidence_layers": ["codec-boundary", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "marcoarment/Blackbird",
+        "commit": "0960ffc7649e9c35cfdb5f6b0b98216a34e8c09a",
+        "path": "Tests/BlackbirdTests/BlackbirdTests.swift",
+        "upstream_case": "BlackbirdTests.testValueConversions",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Rejects incompatible storage through SwiftQL's contextual codec before value reinterpretation."
+      }
+    },
+    {
+      "id": "failure.decode-after-valid-row",
+      "category": "structured-failure",
+      "evidence_layers": ["column-reader", "sqlite-grdb"],
+      "sqlite_documentation_url": "https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes",
+      "provenance": {
+        "repository": "marcoarment/Blackbird",
+        "commit": "0960ffc7649e9c35cfdb5f6b0b98216a34e8c09a",
+        "path": "Tests/BlackbirdTests/BlackbirdTests.swift",
+        "upstream_case": "BlackbirdTests.testColumnTypes",
+        "license_disposition": "MIT; behavior rewritten against SwiftQL public contracts; no source copied",
+        "adaptation_notes": "Confirms a later malformed row fails without invalidating an earlier successfully decoded row."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #252

## Task identity

- Repository: `lukevanin/swiftql`
- Issue: #252 — Add a shared SQLite storage and value conformance suite
- Milestone: v1.2
- Base commit: `03f504a1e47e0580b2c20eeeecea104cb9d7f2a9`
- Head commit: `f6434dfea7d884ff288e90e21d5554fe1434b129`
- Worktree: `/private/tmp/swiftql-worktrees/252-add-a-shared-sqlite-storage-and-value-conformance-suite`

## Summary

- Add a test-only, GRDB-free `SwiftQLSQLiteConformanceFixtures` target with 24 stable case IDs and normalized SQLite storage cases reusable by core and concrete adapters.
- Add a checked-in, machine-readable provenance manifest pinned to the exact GRDB, SQLite.swift, Lighter, Blackbird, Fluent Kit, and SwiftQL source commits coordinated by #190.
- Exercise the shared IDs at the SwiftQLCore dialect/invocation/codec boundary and through the current GRDB-backed SQLite driver.
- Assert values, storage classes, SQLite `typeof(...)`, byte lengths, affinity/coercion state, binding identity, codec selection, and exact structured errors.

## Adopted-case coverage

- All SQLite storage classes: NULL, Int64 extrema, finite REAL, positive/negative infinity, rejected NaN, empty/Unicode TEXT, and empty/embedded-zero/invalid-UTF-8 BLOB.
- INTEGER, TEXT, and REAL affinity coercion with stored-value and `typeof` evidence.
- Explicit NULL versus no row, text raw-value enum round trips, named/default contextual codecs, and named/repeated parameters.
- Structured integer-overflow, codec storage-mismatch, invalid BLOB-as-text, and decode-after-valid-row failures.
- Composed/decomposed Unicode canonical equality is separated from SQLite's byte-preserving BINARY comparison.

## Files changed

- `Package.swift`
- `Tests/SwiftQLSQLiteConformanceFixtures/SQLiteValueConformanceFixtures.swift`
- `Tests/SwiftQLSQLiteConformanceFixtures/SQLiteValueConformanceManifest.json`
- `Tests/SwiftQLCoreTests/SQLiteValueConformanceBoundaryTests.swift`
- `Tests/SQLTests/GRDBDriverContractTests.swift`
- `Tests/SwiftQLCodecIntegrationTests/ContextualValueCodecGRDBTests.swift`

## Validation

- Exact required focused filter: 45 tests, 0 failures — scheduler `run-9aa87dc3-e9b8-4186-81c7-ba021ffd7f2c`.
- New shared/core/GRDB cases: 22 tests, 0 failures — scheduler `run-8e9cdc80-1f84-4121-936d-40ef1519e2c0`.
- Full `swift test`: 567 tests, 0 failures — scheduler `run-0ce2b5b6-0cfd-470d-8ebe-86888ea8a5a5`.
- First-party compiler warnings: clean — scheduler `run-cd4da094-b08b-4ac3-a872-a905d4d933e7`.
- Strict concurrency: clean, including dependency and unclassified-warning buckets — scheduler `run-03aadd34-d93e-436f-b87d-9b20930c4e78`.
- Committed Swift 5 downstream client: passed — scheduler `run-c773876c-7ecc-4cf0-a51c-2cbf1b3964a4`.
- DocC warnings-as-errors and output verification: passed — scheduler `run-c6b7dac5-1b8c-4e8c-be8f-2f9760cc252f`.

- Post-CI-fix core-boundary checker: passed — scheduler `run-118156e1-bc73-4f3f-bde4-c2196c7b39ec`.
- Post-CI-fix exact required filter: 45 tests, 0 failures — scheduler `run-6c1a28b4-7489-4cfa-b92e-dcdc52c70cf3`.
- Post-CI-fix shared/core/GRDB cases: 22 tests, 0 failures — scheduler `run-2c849672-840e-425b-84ae-5db6495af6c2`.
- Post-CI-fix full `swift test`: 567 tests, 0 failures — scheduler `run-5a93aebd-858c-45d2-a395-73e198cb2f56`.

## Audit and limitations

- Resolved a release-tooling false positive by moving pinned upstream commit strings from the core test into the shared fixture target; production code and the boundary checker are unchanged.
- No public API or persisted representation changed; all additions are test infrastructure and tests.
- No codec policy moved into GRDB, no silent coercion/clamping/stringification was added, and no substantial upstream source was copied.
- No cases are skipped or gated, so no new blocker was added to #190.
- Affinity assertions intentionally remain real-SQLite evidence because affinity has no adapter-neutral semantic oracle.
- No visual artifact is applicable to this test-infrastructure-only change.