### PR TITLE
Use a field reader for literal decoding

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Stream and decode GRDB result rows incrementally",
-  "issue_number": 248,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/248",
+  "task_name": "Use a FieldReader instead of a column reader & index",
+  "issue_number": 35,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/35",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#248 - Stream GRDB result rows incrementally",
+  "codex_session_title": "lukevanin/swiftql#35 - Use a FieldReader",
   "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/248-stream-and-decode-grdb-result-rows-incrementally",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/248-stream-and-decode-grdb-result-rows-incrementally"
+  "task_branch": "codex/35-use-a-fieldreader-instead-of-a-column-reader-index",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/35-use-a-fieldreader-instead-of-a-column-reader-index"
 }

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -29,10 +29,55 @@ private struct DownstreamToken: Equatable {
 
 enum FixtureError: Error {
     case invalidCoreContract
+    case invalidLiteralReaderBridge
     case invalidCodecValue(XLSQLiteValue)
     case unexpectedPacketResult(Int?)
     case unexpectedStaticQueryResult(Int64)
     case unexpectedResult(PersonSummary?)
+}
+
+private struct DownstreamColumnReader: XLColumnReader {
+    let value: Int
+
+    func isNull(at index: Int) -> Bool { false }
+    func readInteger(at index: Int) -> Int { value + index }
+    func readReal(at index: Int) -> Double { Double(value + index) }
+    func readText(at index: Int) -> String { String(value + index) }
+    func readBlob(at index: Int) -> Data { Data() }
+}
+
+private struct LegacyReaderLiteral: XLLiteral {
+    let value: Int
+
+    init(reader: XLColumnReader, at index: Int) throws {
+        self.value = try reader.readInteger(at: index)
+    }
+
+    func bind(context: inout XLBindingContext) {
+        context.bindInteger(value: value)
+    }
+}
+
+private struct FieldReaderLiteral: XLLiteral {
+    let value: Int
+
+    init(reader: XLFieldReader) throws {
+        self.value = try reader.readInteger()
+    }
+
+    func bind(context: inout XLBindingContext) {
+        context.bindInteger(value: value)
+    }
+}
+
+private func validateLiteralReaderCompatibility() throws {
+    let columns = DownstreamColumnReader(value: 40)
+    let field = XLFieldReader(reader: columns, at: 2)
+    let legacy = try LegacyReaderLiteral(reader: field)
+    let current = try FieldReaderLiteral(reader: columns, at: 2)
+    guard legacy.value == 42, current.value == 42 else {
+        throw FixtureError.invalidLiteralReaderBridge
+    }
 }
 
 private func validateCoreContractProduct() throws -> XLValueCodingConfiguration {
@@ -249,6 +294,7 @@ private func executeFixture(
 }
 
 private func runFixture() throws {
+    try validateLiteralReaderCompatibility()
     let codingConfiguration = try validateCoreContractProduct()
 
     let directory = FileManager.default.temporaryDirectory

--- a/Sources/SwiftQL/SQLExpression.swift
+++ b/Sources/SwiftQL/SQLExpression.swift
@@ -95,14 +95,22 @@ public protocol XLLiteral: XLBindable {
     static func sqlDefault() -> Self
     
     ///
-    /// Initializes an instance from a database column.
+    /// Initializes an instance from one database field.
     ///
-    /// - Parameter reader: Reads values of columns.
-    /// - Parameter index: Index of the column which should be read.
+    /// - Parameter reader: Reads the single field owned by this literal.
     ///
-    /// Custom types should read the column at the provided index using the method for the relevant intrinsic type.
+    /// Custom types should use the method for the relevant intrinsic type. The
+    /// field reader already owns the correct column index.
     ///
-    init(reader: XLColumnReader, at index: Int) throws
+    init(reader: XLFieldReader) throws
+
+    /// Initializes an instance from a database column and separate index.
+    ///
+    /// This v1 compatibility requirement lets existing literal conformers keep
+    /// compiling. New conformers should implement `init(reader:)` with an
+    /// ``XLFieldReader``. The default implementations bridge in both directions,
+    /// so every conformer must implement at least one of the two initializers.
+    init(reader: any XLColumnReader, at index: Int) throws
     
     ///
     /// Wraps occurrences of the type with an expression.
@@ -116,6 +124,19 @@ public protocol XLLiteral: XLBindable {
 }
 
 extension XLLiteral {
+    public init(reader: XLFieldReader) throws {
+        self = try Self(
+            reader: reader.columnReader,
+            at: reader.index
+        )
+    }
+
+    public init(reader: any XLColumnReader, at index: Int) throws {
+        self = try Self(
+            reader: XLFieldReader(reader: reader, at: index)
+        )
+    }
+
     public static func sqlDefault() -> Self {
         let typeName = String(reflecting: Self.self)
         preconditionFailure(
@@ -359,11 +380,11 @@ public protocol XLEnum: XLLiteral, XLExpression, XLEquatable, XLComparable, RawR
 
 extension XLEnum {
         
-    public init(reader: XLColumnReader, at index: Int) throws {
-        let rawValue = try RawValue(reader: reader, at: index)
+    public init(reader: XLFieldReader) throws {
+        let rawValue = try RawValue(reader: reader)
         guard let value = Self(rawValue: rawValue) else {
             throw XLColumnReadError(
-                index: index,
+                index: reader.index,
                 expectedType: String(describing: Self.self),
                 failure: .invalidValue(actualValue: String(reflecting: rawValue))
             )
@@ -442,12 +463,12 @@ extension Optional: XLLiteral where Wrapped: XLLiteral {
         Wrapped.sqlDefault()
     }
 
-    public init(reader: XLColumnReader, at index: Int) throws {
-        if try reader.isNull(at: index) {
+    public init(reader: XLFieldReader) throws {
+        if try reader.isNull() {
             self = nil
         }
         else {
-            self = try Wrapped(reader: reader, at: index)
+            self = try Wrapped(reader: reader)
         }
     }
     

--- a/Sources/SwiftQL/SQLMeta.swift
+++ b/Sources/SwiftQL/SQLMeta.swift
@@ -163,6 +163,55 @@ public protocol XLColumnReader {
 }
 
 
+/// Reads one field from a database result or custom-function argument.
+///
+/// A field reader binds a column reader to one zero-based index. Literal
+/// decoders therefore receive only the field they own and cannot accidentally
+/// read a neighboring column by carrying or modifying a separate index.
+public struct XLFieldReader {
+
+    /// The zero-based index bound to this field.
+    public let index: Int
+
+    let columnReader: any XLColumnReader
+
+    /// Creates a reader for one field in a column-oriented value source.
+    ///
+    /// - Parameters:
+    ///   - reader: The underlying column-oriented value source.
+    ///   - index: The zero-based index this field reader owns.
+    public init(reader: any XLColumnReader, at index: Int) {
+        self.columnReader = reader
+        self.index = index
+    }
+
+    /// Returns whether this field contains SQL `NULL`.
+    public func isNull() throws -> Bool {
+        try columnReader.isNull(at: index)
+    }
+
+    /// Reads this field as an integer.
+    public func readInteger() throws -> Int {
+        try columnReader.readInteger(at: index)
+    }
+
+    /// Reads this field as a real number.
+    public func readReal() throws -> Double {
+        try columnReader.readReal(at: index)
+    }
+
+    /// Reads this field as text.
+    public func readText() throws -> String {
+        try columnReader.readText(at: index)
+    }
+
+    /// Reads this field as a BLOB.
+    public func readBlob() throws -> Data {
+        try columnReader.readBlob(at: index)
+    }
+}
+
+
 ///
 /// Reads the value for columns in rows returned by a select query statement.
 ///
@@ -346,7 +395,9 @@ final class XLColumnValuesRowReader<Output>: XLRowReader {
         defer {
             count += 1
         }
-        return try T.init(reader: reader, at: count)
+        return try T.init(
+            reader: XLFieldReader(reader: reader, at: count)
+        )
     }
 
     func dialectValue<Dialect>(

--- a/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
@@ -331,8 +331,8 @@ struct MyUUID: XLCustomType, XLComparable, Equatable, Sendable {
     }
 
     // 3. Initialize the custom type from a database field.
-    public init(reader: XLColumnReader, at index: Int) throws {
-        let rawValue = try reader.readText(at: index)
+    public init(reader: XLFieldReader) throws {
+        let rawValue = try reader.readText()
         guard let wrappedValue = UUID(uuidString: rawValue) else {
             throw ReadError.invalidUUID(rawValue)
         }
@@ -369,9 +369,16 @@ into SwiftQL's generic comparison operators.
 2. Add `public typealias T = Self`. This tells the compiler that SQL expressions
 using this type produce `MyUUID` values.
 
-3. Implement the initializer. The initializer takes an `XLColumnReader` and an 
-index. The `XLColumnReader` lets us read the native data from the database. The
-`index` represents the column which we need to read.
+3. Implement the initializer. The initializer takes an `XLFieldReader`, which
+is already bound to the result field owned by this literal. It lets us read the
+native data without accepting or forwarding a separate column index.
+
+Existing v1 literal types that implement
+`init(reader: XLColumnReader, at: Int)` remain source compatible. A bridge wraps
+that column reader and index in an `XLFieldReader` when SwiftQL decodes a row.
+New literal types should implement the field-reader initializer shown above;
+the reverse bridge also keeps the older call shape working. Every literal type
+must implement at least one of those initializers.
 
 Our UUID is encoded as a `String`, which translates to a SQLite `TEXT` value. We
 read the text value, validate it as a Foundation `UUID`, then instantiate our
@@ -467,8 +474,8 @@ struct SQLDate: XLCustomType, XLComparable, Equatable {
         return formatter
     }()
 
-    public init(reader: XLColumnReader, at index: Int) throws {
-        let rawValue = try reader.readReal(at: index)
+    public init(reader: XLFieldReader) throws {
+        let rawValue = try reader.readReal()
         guard let wrappedValue = Date(julianDay: rawValue) else {
             throw ReadError.invalidJulianDay(rawValue)
         }
@@ -576,7 +583,7 @@ implicitly: declare the actual v1 storage class, test existing rows, and retain
 the old representation until a deliberate migration has completed.
 
 The adapter calls the literal's existing `bind(context:)` and
-`init(reader:at:)` implementations; it does not call `sqlDefault()`. A new
+`init(reader:)` implementations; it does not call `sqlDefault()`. A new
 `XLCustomType` can therefore omit an explicit placeholder when all of its result
 decoding uses generated static layouts. Keep an explicit placeholder on older
 types for as long as legacy result introspection remains in use.

--- a/Sources/SwiftQL/SwiftQL.docc/Enums.md
+++ b/Sources/SwiftQL/SwiftQL.docc/Enums.md
@@ -62,7 +62,7 @@ enum JobState: String, XLEnum {
 ```
 
 The raw-value declaration supplies `RawRepresentable`. `XLEnum` supplies
-``XLLiteral/init(reader:at:)``, ``XLBindable/bind(context:)``, and SQL literal
+``XLLiteral/init(reader:)``, ``XLBindable/bind(context:)``, and SQL literal
 encoding by delegating to the enum's raw value.
 
 ## Use enums in tables and query results

--- a/Sources/SwiftQL/Types/Intrinsic.swift
+++ b/Sources/SwiftQL/Types/Intrinsic.swift
@@ -18,8 +18,8 @@ extension Bool: XLExpression, XLLiteral, XLEquatable, XLComparable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) throws {
-        self = try reader.readInteger(at: index) != 0
+    public init(reader: XLFieldReader) throws {
+        self = try reader.readInteger() != 0
     }
     
     public func bind(context: inout XLBindingContext) {
@@ -43,8 +43,8 @@ extension Int: XLExpression, XLLiteral, XLEquatable, XLComparable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) throws {
-        self = try reader.readInteger(at: index)
+    public init(reader: XLFieldReader) throws {
+        self = try reader.readInteger()
     }
     
     public func bind(context: inout XLBindingContext) {
@@ -68,8 +68,8 @@ extension Double: XLExpression, XLLiteral, XLEquatable, XLComparable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) throws {
-        self = try reader.readReal(at: index)
+    public init(reader: XLFieldReader) throws {
+        self = try reader.readReal()
     }
     
     public func bind(context: inout XLBindingContext) {
@@ -106,8 +106,8 @@ extension String: XLExpression, XLLiteral, XLEquatable, XLComparable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) throws {
-        self = try reader.readText(at: index)
+    public init(reader: XLFieldReader) throws {
+        self = try reader.readText()
     }
     
     public func bind(context: inout XLBindingContext) {
@@ -131,8 +131,8 @@ extension Data: XLExpression, XLLiteral, XLEquatable {
     
     public typealias T = Self
     
-    public init(reader: XLColumnReader, at index: Int) throws {
-        self = try reader.readBlob(at: index)
+    public init(reader: XLFieldReader) throws {
+        self = try reader.readBlob()
     }
     
     public func bind(context: inout XLBindingContext) {

--- a/Tests/SQLTests/SQLColumnReadErrorTests.swift
+++ b/Tests/SQLTests/SQLColumnReadErrorTests.swift
@@ -118,7 +118,9 @@ final class XLColumnReadErrorTests: XCTestCase {
         XCTAssertEqual(try reader.readText(at: 2), "text")
         XCTAssertEqual(try reader.readBlob(at: 3), Data([0x00, 0xff]))
         XCTAssertTrue(try reader.isNull(at: 4))
-        XCTAssertNil(try Int?(reader: reader, at: 4))
+        XCTAssertNil(
+            try Int?(reader: XLFieldReader(reader: reader, at: 4))
+        )
     }
 
     func testAdaptersUseStorageClassConversionsConsistently() throws {

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -91,8 +91,8 @@ struct MyUUID: XLCustomType, XLComparable, Equatable, Sendable {
         self.wrappedValue = wrappedValue
     }
 
-    public init(reader: XLColumnReader, at index: Int) throws {
-        let rawValue = try reader.readText(at: index)
+    public init(reader: XLFieldReader) throws {
+        let rawValue = try reader.readText()
         guard let wrappedValue = UUID(uuidString: rawValue) else {
             throw ReadError.invalidUUID(rawValue)
         }
@@ -136,8 +136,8 @@ struct SQLDate: XLCustomType, XLComparable, Equatable {
         return formatter
     }()
 
-    public init(reader: XLColumnReader, at index: Int) throws {
-        let rawValue = try reader.readReal(at: index)
+    public init(reader: XLFieldReader) throws {
+        let rawValue = try reader.readReal()
         guard let wrappedValue = Date(julianDay: rawValue) else {
             throw ReadError.invalidJulianDay(rawValue)
         }
@@ -406,8 +406,8 @@ extension Date: XLCustomType, XLComparable {
     public typealias T = Self
     
     // Decode the date from a SwiftQL result.
-    public init(reader: XLColumnReader, at index: Int) throws {
-        let rawValue = try reader.readReal(at: index)
+    public init(reader: XLFieldReader) throws {
+        let rawValue = try reader.readReal()
         guard let value = Date(julianDay: rawValue) else {
             throw ReadError.invalidJulianDay(rawValue)
         }

--- a/Tests/SQLTests/SQLQueryCaptureTests.swift
+++ b/Tests/SQLTests/SQLQueryCaptureTests.swift
@@ -480,7 +480,7 @@ private struct UnknownLiteral: XLExpression, XLLiteral {
 
     init() {}
 
-    init(reader: XLColumnReader, at index: Int) throws {
+    init(reader: XLFieldReader) throws {
         self.init()
     }
 

--- a/Tests/SQLTests/XLFieldReaderTests.swift
+++ b/Tests/SQLTests/XLFieldReaderTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import XCTest
+@testable import SwiftQL
+
+
+final class XLFieldReaderTests: XCTestCase {
+
+    func testFieldReaderBindsEveryReadToOneIndex() throws {
+        let columns = RecordingColumnReader()
+        let field = XLFieldReader(reader: columns, at: 7)
+
+        XCTAssertEqual(field.index, 7)
+        XCTAssertFalse(try field.isNull())
+        XCTAssertEqual(try field.readInteger(), 107)
+        XCTAssertEqual(try field.readReal(), 7.5)
+        XCTAssertEqual(try field.readText(), "field-7")
+        XCTAssertEqual(try field.readBlob(), Data([0x07]))
+        XCTAssertEqual(
+            columns.calls,
+            [
+                .isNull(7),
+                .integer(7),
+                .real(7),
+                .text(7),
+                .blob(7),
+            ]
+        )
+    }
+
+    func testFieldReaderPreservesStructuredErrorIndex() {
+        let expected = XLColumnReadError(
+            index: 3,
+            expectedType: "Int",
+            failure: .typeMismatch(actualType: "TEXT")
+        )
+        let field = XLFieldReader(
+            reader: ThrowingColumnReader(error: expected),
+            at: 3
+        )
+
+        XCTAssertThrowsError(try field.readInteger()) { error in
+            XCTAssertEqual(error as? XLColumnReadError, expected)
+        }
+    }
+
+    func testSequentialRowReaderCreatesOneFieldPerColumn() throws {
+        let columns = RecordingColumnReader()
+        let row = XLColumnValuesRowReader<(Int, String)>()
+        row.reset(reader: columns)
+
+        let integer: Int = try row.column(0, alias: "integer")
+        let text: String = try row.column("", alias: "text")
+
+        XCTAssertEqual(integer, 100)
+        XCTAssertEqual(text, "field-1")
+        XCTAssertEqual(columns.calls, [.integer(0), .text(1)])
+    }
+
+    func testExistingColumnReaderLiteralConformerUsesFieldBridge() throws {
+        let columns = RecordingColumnReader()
+        let literal = try LegacyColumnReaderLiteral(
+            reader: XLFieldReader(reader: columns, at: 4)
+        )
+
+        XCTAssertEqual(literal.value, 104)
+        XCTAssertEqual(columns.calls, [.integer(4)])
+    }
+
+    func testNewFieldReaderLiteralConformerSupportsLegacyCallShape() throws {
+        let columns = RecordingColumnReader()
+        let literal = try FieldReaderLiteral(reader: columns, at: 2)
+
+        XCTAssertEqual(literal.value, 102)
+        XCTAssertEqual(columns.calls, [.integer(2)])
+    }
+}
+
+
+private final class RecordingColumnReader: XLColumnReader {
+
+    enum Call: Equatable {
+        case isNull(Int)
+        case integer(Int)
+        case real(Int)
+        case text(Int)
+        case blob(Int)
+    }
+
+    private(set) var calls: [Call] = []
+
+    func isNull(at index: Int) -> Bool {
+        calls.append(.isNull(index))
+        return false
+    }
+
+    func readInteger(at index: Int) -> Int {
+        calls.append(.integer(index))
+        return index + 100
+    }
+
+    func readReal(at index: Int) -> Double {
+        calls.append(.real(index))
+        return Double(index) + 0.5
+    }
+
+    func readText(at index: Int) -> String {
+        calls.append(.text(index))
+        return "field-\(index)"
+    }
+
+    func readBlob(at index: Int) -> Data {
+        calls.append(.blob(index))
+        return Data([UInt8(index)])
+    }
+}
+
+
+private struct ThrowingColumnReader: XLColumnReader {
+    let error: XLColumnReadError
+
+    func isNull(at index: Int) throws -> Bool {
+        throw error
+    }
+
+    func readInteger(at index: Int) throws -> Int {
+        throw error
+    }
+
+    func readReal(at index: Int) throws -> Double {
+        throw error
+    }
+
+    func readText(at index: Int) throws -> String {
+        throw error
+    }
+
+    func readBlob(at index: Int) throws -> Data {
+        throw error
+    }
+}
+
+
+private struct LegacyColumnReaderLiteral: XLLiteral {
+    let value: Int
+
+    init(reader: any XLColumnReader, at index: Int) throws {
+        self.value = try reader.readInteger(at: index)
+    }
+
+    func bind(context: inout XLBindingContext) {
+        context.bindInteger(value: value)
+    }
+}
+
+
+private struct FieldReaderLiteral: XLLiteral {
+    let value: Int
+
+    init(reader: XLFieldReader) throws {
+        self.value = try reader.readInteger()
+    }
+
+    func bind(context: inout XLBindingContext) {
+        context.bindInteger(value: value)
+    }
+}

--- a/Tests/SwiftQLCodecIntegrationTests/ContextualValueCodecGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/ContextualValueCodecGRDBTests.swift
@@ -740,8 +740,8 @@ private struct LegacyEpoch: Equatable, XLLiteral, Sendable {
         self.value = value
     }
 
-    init(reader: XLColumnReader, at index: Int) throws {
-        self.value = try reader.readInteger(at: index)
+    init(reader: XLFieldReader) throws {
+        self.value = try reader.readInteger()
     }
 }
 

--- a/Tests/SwiftQLCodecIntegrationTests/NoDefaultLiteralStaticLayoutGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/NoDefaultLiteralStaticLayoutGRDBTests.swift
@@ -17,8 +17,8 @@ private struct NoDefaultCustomLiteral:
         self.value = value
     }
 
-    init(reader: XLColumnReader, at index: Int) throws {
-        let stored = try reader.readText(at: index)
+    init(reader: XLFieldReader) throws {
+        let stored = try reader.readText()
         guard stored.hasPrefix("v1:") else {
             throw NoDefaultLiteralTestError.invalidCustomLiteral(stored)
         }
@@ -59,8 +59,8 @@ private struct ExplicitLegacyDefaultLiteral:
         self.value = value
     }
 
-    init(reader: XLColumnReader, at index: Int) throws {
-        self.value = try reader.readText(at: index)
+    init(reader: XLFieldReader) throws {
+        self.value = try reader.readText()
     }
 
     func bind(context: inout XLBindingContext) {

--- a/Tests/SwiftQLCodecIntegrationTests/StaticRowLayoutGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/StaticRowLayoutGRDBTests.swift
@@ -120,8 +120,8 @@ private struct TrappingDefaultLiteral:
         self.rawValue = rawValue
     }
 
-    init(reader: XLColumnReader, at index: Int) throws {
-        self.rawValue = try reader.readText(at: index)
+    init(reader: XLFieldReader) throws {
+        self.rawValue = try reader.readText()
     }
 
     func bind(context: inout XLBindingContext) {


### PR DESCRIPTION
## Summary

Implements #35 by introducing a public `XLFieldReader` that binds one `XLColumnReader` to one zero-based index. Production row decoding now gives each `XLLiteral` only its own field and built-in/custom literals use index-free `isNull()`, `readInteger()`, `readReal()`, `readText()`, and `readBlob()` operations.

## Design and compatibility

- `XLLiteral.init(reader: XLFieldReader)` is the preferred decoding requirement.
- The existing `init(reader: XLColumnReader, at:)` requirement remains available.
- Default implementations bridge both ways: existing old-only external conformers continue to decode through the new production path, and new field-reader-only conformers still support older callers.
- Every conformer must implement at least one initializer; that rule is documented and exercised in both unit tests and the external Swift 5 fixture.
- `XLFieldReader` exposes its read-only index for structured domain errors but does not expose the underlying column reader, so a literal cannot redirect itself to an adjacent column.
- #39's separate conversion of the row reader to a struct remains out of scope.

## Tests and documentation

- Added `XLFieldReaderTests` for one-index forwarding across every storage operation, structured error identity/index, sequential row fields, old-only conformers, and new-only conformers.
- Migrated intrinsic, enum, optional, custom-type, static-layout, query-capture, and documentation examples to the field-scoped API.
- Extended the real external Swift 5 language-mode executable to compile and execute both compatibility directions.
- Updated Custom Types and Enum DocC guidance.

## Validation

- Focused field contract: 5/5 passed.
- Focused literal/GRDB/codec/docs regression: 65/65 passed.
- Full `swift test`: 582/582 passed.
- External Swift 5 compatibility executable: passed (`run-bfd479c5-3229-4f8f-a485-b44708135cf0`).
- DocC warnings-as-errors site build and catalog inspection: passed.
- First-party warnings gate: clean (`run-44f25078-f6d4-4bdc-86d2-ef29d3b364be`).
- Complete strict-concurrency gate: clean (`run-678061a0-3928-4190-b173-947641163b4a`).
- `git diff --check`: clean.

Closes #35