### PR TITLE
Make the sequential row reader a scoped value

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Use a FieldReader instead of a column reader & index",
-  "issue_number": 35,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/35",
+  "task_name": "Change column reader implementation to a struct to avoid runtime heap allocation.",
+  "issue_number": 39,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/39",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#35 - Use a FieldReader",
+  "codex_session_title": "lukevanin/swiftql#39 - Make the row reader a struct",
   "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/35-use-a-fieldreader-instead-of-a-column-reader-index",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/35-use-a-fieldreader-instead-of-a-column-reader-index"
+  "task_branch": "codex/39-change-column-reader-implementation-to-a-struct",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/39-change-column-reader-implementation-to-a-struct"
 }

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -83,8 +83,6 @@ package struct GRDBRowDecoder<Output> {
 
     private let reader: any XLRowReadable<Output>
 
-    private let columnReader = XLColumnValuesRowReader<Output>()
-
     package init(reader: any XLRowReadable<Output>) {
         self.reader = reader
     }
@@ -94,8 +92,11 @@ package struct GRDBRowDecoder<Output> {
     }
 
     func decode(values: [XLSQLiteValue]) throws -> Output {
-        columnReader.reset(reader: XLSQLiteValueReader(values: values))
-        return try reader.readRow(reader: columnReader)
+        try XLColumnValuesRowReader<Output>.withReader(
+            XLSQLiteValueReader(values: values)
+        ) { columnReader in
+            try reader.readRow(reader: columnReader)
+        }
     }
 }
 

--- a/Sources/SwiftQL/SQLMeta.swift
+++ b/Sources/SwiftQL/SQLMeta.swift
@@ -215,7 +215,11 @@ public struct XLFieldReader {
 ///
 /// Reads the value for columns in rows returned by a select query statement.
 ///
-public protocol XLRowReader: AnyObject {
+/// A database-provided row reader is borrowed for the duration of one
+/// ``XLRowReadable/readRow(reader:)`` call. Do not retain it or capture it in an
+/// escaping closure.
+///
+public protocol XLRowReader {
     
     ///
     /// Reads and returns the value for the current column.
@@ -360,25 +364,37 @@ final class XLColumnsDefinitionRowReader: XLRowReader, XLEncodable {
 }
 
 
+/// Reads the columns for one row returned by a select query statement.
 ///
-/// Reads the columns for a row returned by a select query statement.
-///
-final class XLColumnValuesRowReader<Output>: XLRowReader {
-    
-    private var count: Int = 0
-    
-    private var reader: XLColumnReader!
-    
-    init() {
+/// The value stores only a pointer to state borrowed from ``withReader(_:body:)``.
+/// Keeping the representation pointer-sized lets the `XLRowReader` existential
+/// carry it inline instead of allocating the previous reader class.
+struct XLColumnValuesRowReader<Output>: XLRowReader {
+
+    private struct State {
+        var count: Int = 0
+        let reader: any XLColumnReader
     }
-    
+
+    private let state: UnsafeMutablePointer<State>
+
+    private init(state: UnsafeMutablePointer<State>) {
+        self.state = state
+    }
+
+    /// Borrows sequential row-reading state for one synchronous operation.
     ///
-    /// Resets the reader state so that the next call to the `column` method will return the first column in
-    /// the row.
-    ///
-    func reset(reader: XLColumnReader) {
-        count = 0
-        self.reader = reader
+    /// `body` must not let the supplied reader escape. The pointer remains
+    /// valid only until `body` returns or throws.
+    @inline(__always)
+    static func withReader<Result>(
+        _ reader: any XLColumnReader,
+        body: (Self) throws -> Result
+    ) rethrows -> Result {
+        var state = State(reader: reader)
+        return try withUnsafeMutablePointer(to: &state) { state in
+            try body(Self(state: state))
+        }
     }
     
     ///
@@ -392,11 +408,15 @@ final class XLColumnValuesRowReader<Output>: XLRowReader {
     }
 
     private func readValue<T>() throws -> T where T: XLLiteral {
+        let index = state.pointee.count
         defer {
-            count += 1
+            state.pointee.count += 1
         }
         return try T.init(
-            reader: XLFieldReader(reader: reader, at: count)
+            reader: XLFieldReader(
+                reader: state.pointee.reader,
+                at: index
+            )
         )
     }
 
@@ -404,11 +424,13 @@ final class XLColumnValuesRowReader<Output>: XLRowReader {
         at index: Int,
         using dialect: Dialect
     ) throws -> Dialect.Value where Dialect: XLValueCodingDialect {
-        guard let staticReader = reader as? any XLStaticColumnReader else {
+        guard let staticReader = state.pointee.reader as? any XLStaticColumnReader else {
             throw XLStaticRowReadError.rawDialectValuesUnavailable(
                 index: index,
                 dialect: dialect.descriptor.identity,
-                readerType: String(reflecting: type(of: reader as Any))
+                readerType: String(
+                    reflecting: type(of: state.pointee.reader as Any)
+                )
             )
         }
         return try staticReader.dialectValue(at: index, using: dialect)
@@ -440,6 +462,9 @@ private func _xlReadLegacyStaticColumn<Literal, Value>(
 
 ///
 /// Reads rows from a database using an `XLRowReader`.
+///
+/// The reader passed to ``readRow(reader:)`` is borrowed for that call. An
+/// implementation must not store it or capture it in an escaping closure.
 ///
 public protocol XLRowReadable<Row> {
     associatedtype Row

--- a/Tests/SQLTests/XLFieldReaderTests.swift
+++ b/Tests/SQLTests/XLFieldReaderTests.swift
@@ -45,15 +45,67 @@ final class XLFieldReaderTests: XCTestCase {
 
     func testSequentialRowReaderCreatesOneFieldPerColumn() throws {
         let columns = RecordingColumnReader()
-        let row = XLColumnValuesRowReader<(Int, String)>()
-        row.reset(reader: columns)
+        try XLColumnValuesRowReader<(Int, String)>.withReader(columns) { row in
+            let integer: Int = try row.column(0, alias: "integer")
+            let text: String = try row.column("", alias: "text")
 
-        let integer: Int = try row.column(0, alias: "integer")
-        let text: String = try row.column("", alias: "text")
-
-        XCTAssertEqual(integer, 100)
-        XCTAssertEqual(text, "field-1")
+            XCTAssertEqual(integer, 100)
+            XCTAssertEqual(text, "field-1")
+        }
         XCTAssertEqual(columns.calls, [.integer(0), .text(1)])
+    }
+
+    func testSequentialRowReaderIsPointerSizedAndStartsEachScopeAtZero() throws {
+        XCTAssertEqual(
+            MemoryLayout<XLColumnValuesRowReader<Int>>.size,
+            MemoryLayout<UnsafeMutableRawPointer>.size
+        )
+        XCTAssertEqual(
+            MemoryLayout<XLColumnValuesRowReader<Int>>.stride,
+            MemoryLayout<UnsafeMutableRawPointer>.stride
+        )
+
+        let columns = RecordingColumnReader()
+        for _ in 0..<2 {
+            try XLColumnValuesRowReader<Int>.withReader(columns) { row in
+                let value: Int = try row.column(0, alias: "value")
+                XCTAssertEqual(value, 100)
+            }
+        }
+        XCTAssertEqual(columns.calls, [.integer(0), .integer(0)])
+    }
+
+    func testSequentialRowReaderAdvancesAfterThrownDecode() throws {
+        let columns = RecordingColumnReader()
+        try XLColumnValuesRowReader<Int>.withReader(columns) { row in
+            XCTAssertThrowsError(
+                try row.column(ThrowingLiteral(), alias: "invalid")
+            ) { error in
+                XCTAssertEqual(error as? FieldReaderTestError, .expected)
+            }
+            let value: Int = try row.column(0, alias: "value")
+            XCTAssertEqual(value, 101)
+        }
+        XCTAssertEqual(columns.calls, [.integer(0), .integer(1)])
+    }
+
+    func testSequentialRowReaderForwardsStaticDialectValues() throws {
+        try XLColumnValuesRowReader<Int>.withReader(
+            XLSQLiteValueReader(values: [.text("raw")])
+        ) { row in
+            XCTAssertEqual(
+                try row.dialectValue(at: 0, using: XLSQLiteDialect()),
+                .text("raw")
+            )
+        }
+    }
+
+    func testGRDBRowDecoderResetsScopedStateAfterFailure() throws {
+        let decoder = GRDBRowDecoder(reader: SingleIntegerRowReader())
+
+        XCTAssertThrowsError(try decoder.decode(values: [.text("invalid")]))
+        XCTAssertEqual(try decoder.decode(values: [.integer(42)]), 42)
+        XCTAssertEqual(try decoder.decode(values: [.integer(84)]), 84)
     }
 
     func testExistingColumnReaderLiteralConformerUsesFieldBridge() throws {
@@ -162,5 +214,37 @@ private struct FieldReaderLiteral: XLLiteral {
 
     func bind(context: inout XLBindingContext) {
         context.bindInteger(value: value)
+    }
+}
+
+
+private enum FieldReaderTestError: Error, Equatable {
+    case expected
+}
+
+
+private struct ThrowingLiteral: XLExpression, XLLiteral {
+    typealias T = Self
+
+    init() {}
+
+    init(reader: XLFieldReader) throws {
+        _ = try reader.readInteger()
+        throw FieldReaderTestError.expected
+    }
+
+    func bind(context: inout XLBindingContext) {
+        context.bindNull()
+    }
+
+    func makeSQL(context: inout XLBuilder) {
+        context.null()
+    }
+}
+
+
+private struct SingleIntegerRowReader: XLRowReadable {
+    func readRow(reader: XLRowReader) throws -> Int {
+        try reader.column(0, alias: "value")
     }
 }

--- a/Tests/SwiftQLCodecIntegrationTests/StaticRowLayoutGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/StaticRowLayoutGRDBTests.swift
@@ -261,15 +261,14 @@ final class StaticRowLayoutGRDBTests: XCTestCase {
             as: "value"
         )
         let generated = _swiftQLRowReader.SQLReader(value: expression)
-        let reader = XLColumnValuesRowReader<_swiftQLRowReader>()
-        reader.reset(
-            reader: XLSQLiteValueReader(values: [.text("round-trip")])
-        )
-
-        XCTAssertEqual(
-            try generated.readRow(reader: reader),
-            _swiftQLRowReader(value: "round-trip")
-        )
+        try XLColumnValuesRowReader<_swiftQLRowReader>.withReader(
+            XLSQLiteValueReader(values: [.text("round-trip")])
+        ) { reader in
+            XCTAssertEqual(
+                try generated.readRow(reader: reader),
+                _swiftQLRowReader(value: "round-trip")
+            )
+        }
     }
 
     func testGeneratedResultLayoutProjectsComputedAliasesWithCapturedInvocation() throws {


### PR DESCRIPTION
## Summary

- replace the reusable `XLColumnValuesRowReader` class with a pointer-sized struct
- keep its mutable column cursor in stack-scoped state borrowed only during one synchronous row decode
- remove the stored reader instance from `GRDBRowDecoder` and create a fresh scoped reader per row
- document the borrowed lifetime on the public row-reading protocols
- preserve sequential, error, static-dialect, generated-row, GRDB, and publisher behavior

## Key decisions

- The public `XLRowReader` methods remain nonmutating; existing conformers and `XLRowReadable.readRow(reader:)` call sites do not require `mutating` or `inout` changes.
- Removing the `AnyObject` constraint is a source-compatible relaxation that permits the internal struct conformance.
- The struct stores one unsafe pointer and therefore fits inline in the existential container. Its pointed-to state exists only inside a nonescaping factory closure.
- This change claims removal of the explicit reader-class allocation. It does not claim a broad end-to-end latency improvement.

## Validation

- `swift test --filter 'XLFieldReaderTests|XLColumnReadErrorTests|GRDBDriverContractTests|StaticRowLayoutGRDBTests'` — 46 passed
- `swift test` — 586 passed
- `./make-docs.sh <fresh output>` — passed with warnings as errors
- downstream Swift 5 client — passed (scheduler `run-367134a3-b5c7-4be1-a6ed-c133878a2c00`)
- first-party warning gate — clean (scheduler `run-8625b264-2e18-4720-89e0-5ba5a4ceaab8`)
- complete strict-concurrency gate — clean (scheduler `run-6e46bb83-03aa-44e4-bcb7-7188bdc4e19f`)
- `git diff --check` — passed

Closes #39