### PR TITLE
Remove scalar Select result constraints

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Change column reader implementation to a struct to avoid runtime heap allocation.",
-  "issue_number": 39,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/39",
+  "task_name": "Research: Remove Row type constraint from Select",
+  "issue_number": 44,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/44",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#39 - Make the row reader a struct",
+  "codex_session_title": "lukevanin/swiftql#44 - Remove Select row constraints",
   "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/39-change-column-reader-implementation-to-a-struct",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/39-change-column-reader-implementation-to-a-struct"
+  "task_branch": "codex/44-research-remove-row-type-constraint-from-select",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/44-research-remove-row-type-constraint-from-select"
 }

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -30,6 +30,7 @@ private struct DownstreamToken: Equatable {
 enum FixtureError: Error {
     case invalidCoreContract
     case invalidLiteralReaderBridge
+    case invalidRowReaderCompatibility
     case invalidCodecValue(XLSQLiteValue)
     case unexpectedPacketResult(Int?)
     case unexpectedStaticQueryResult(Int64)
@@ -44,6 +45,15 @@ private struct DownstreamColumnReader: XLColumnReader {
     func readReal(at index: Int) -> Double { Double(value + index) }
     func readText(at index: Int) -> String { String(value + index) }
     func readBlob(at index: Int) -> Data { Data() }
+}
+
+private struct DownstreamRowReader: XLRowReader {
+    func column<T>(
+        _ expression: any XLExpression<T>,
+        alias: XLName
+    ) -> T where T: XLLiteral {
+        T.sqlDefault()
+    }
 }
 
 private struct LegacyReaderLiteral: XLLiteral {
@@ -77,6 +87,13 @@ private func validateLiteralReaderCompatibility() throws {
     let current = try FieldReaderLiteral(reader: columns, at: 2)
     guard legacy.value == 42, current.value == 42 else {
         throw FixtureError.invalidLiteralReaderBridge
+    }
+}
+
+private func validateRowReaderCompatibility() throws {
+    let value = try Select(42).readRow(reader: DownstreamRowReader())
+    guard value == Int.sqlDefault() else {
+        throw FixtureError.invalidRowReaderCompatibility
     }
 }
 
@@ -295,6 +312,7 @@ private func executeFixture(
 
 private func runFixture() throws {
     try validateLiteralReaderCompatibility()
+    try validateRowReaderCompatibility()
     let codingConfiguration = try validateCoreContractProduct()
 
     let directory = FileManager.default.temporaryDirectory

--- a/Sources/SwiftQL/Builders/QueryBuilder.swift
+++ b/Sources/SwiftQL/Builders/QueryBuilder.swift
@@ -60,7 +60,10 @@ public struct QueryBuilder<Row> {
     /// Creates a query builder using an expression. The expression should use one or more fields in one or
     /// more tables in the from clause.
     ///
-    public init(select expression: any XLExpression<Row>) where Row: XLExpression & XLLiteral {
+    /// The logical result type is unconstrained. Contextual-only values still
+    /// require a static row layout to supply result codec metadata.
+    ///
+    public init(select expression: any XLExpression<Row>) {
         self.init(select: Select(expression))
     }
     

--- a/Sources/SwiftQL/SQLFunctionalSyntax.swift
+++ b/Sources/SwiftQL/SQLFunctionalSyntax.swift
@@ -307,7 +307,13 @@ public func select<T>(_ result: T) -> XLQuerySelectStatement<T.Row> where T: XLR
 ///
 /// Constructs a select statement that returns a scalar value.
 ///
-public func select<T>(_ expression: any XLExpression<T>) -> XLQuerySelectStatement<T> where T: XLExpression & XLLiteral {
+/// The logical result type is unconstrained. Bare contextual values can be
+/// rendered here, but decoding them requires an ``XLStaticRowLayout`` carrying
+/// result codec metadata.
+///
+public func select<T>(
+    _ expression: any XLExpression<T>
+) -> XLQuerySelectStatement<T> {
     makeQuery(select: Select(expression))
 }
 
@@ -371,4 +377,3 @@ public func delete<T>(_ table: T) -> XLDeleteTableStatement<T> where T: XLMetaWr
     let components = XLDeleteStatementComponents(delete: Delete(table))
     return XLDeleteTableStatement(components: components)
 }
-

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -57,17 +57,30 @@ public struct Select<Row>: XLEncodable, XLRowReadable {
         try row(reader)
     }
     
-    public init(@XLScalarExpressionBuilder _ expression: @escaping () -> some XLExpression<Row>) where Row: XLExpression & XLLiteral {
+    /// Builds a scalar select without requiring the logical result type to
+    /// adopt the legacy expression and literal protocols.
+    ///
+    /// Bare contextual values can be rendered by this initializer, but their
+    /// row decoding still requires an ``XLStaticRowLayout`` carrying codec
+    /// metadata. The legacy path reports ``XLStaticRowReadError/staticLayoutRequired(valueType:alias:)``
+    /// instead of fabricating a value.
+    public init(
+        @XLScalarExpressionBuilder _ expression: @escaping () -> some XLExpression<Row>
+    ) {
         self.fields = expression()
         self.row = { reader in
-            try reader.column(expression(), alias: "c0")
+            try reader.staticColumn(expression(), alias: "c0")
         }
     }
-    
-    public init(_ expression: any XLExpression<Row>) where Row: XLExpression & XLLiteral {
+
+    /// Builds an unconstrained scalar select.
+    ///
+    /// Bare contextual values still require an ``XLStaticRowLayout`` to carry
+    /// the codec metadata needed during row decoding.
+    public init(_ expression: any XLExpression<Row>) {
         self.fields = expression
         self.row = { reader in
-            try reader.column(expression, alias: "c0")
+            try reader.staticColumn(expression, alias: "c0")
         }
     }
 }

--- a/Sources/SwiftQL/Statements/SQLWithStatement.swift
+++ b/Sources/SwiftQL/Statements/SQLWithStatement.swift
@@ -24,8 +24,12 @@ public struct XLWithStatement {
    public func select<T>(_ t: T) -> XLQuerySelectStatement<T.Row> where T: XLRowReadable {
        XLQuerySelectStatement(components: XLQueryStatementComponents(commonTables: commonTables, select: Select(t)))
    }
-   
-   public func select<T>(_ expression: any XLExpression<T>) -> XLQuerySelectStatement<T> where T: XLExpression & XLLiteral {
+
+   /// Builds a factored scalar select without constraining its logical result
+   /// type. Contextual-only values still need a static row layout for decoding.
+   public func select<T>(
+       _ expression: any XLExpression<T>
+   ) -> XLQuerySelectStatement<T> {
        XLQuerySelectStatement(components: XLQueryStatementComponents(commonTables: commonTables, select: Select(expression)))
    }
 

--- a/Tests/SQLTests/SQLRequestCompatibilityTests.swift
+++ b/Tests/SQLTests/SQLRequestCompatibilityTests.swift
@@ -7,6 +7,45 @@ import XCTest
 
 final class SQLRequestCompatibilityTests: XCTestCase {
 
+    func testScalarSelectAcceptsAnUnconstrainedLogicalResultType() throws {
+        let expression = LegacyContextOnlyExpression()
+        let direct: Select<LegacyContextOnlyValue> = Select(expression)
+        let built: Select<LegacyContextOnlyValue> = Select { expression }
+        let functional: XLQuerySelectStatement<LegacyContextOnlyValue> =
+            select(expression)
+        let factored: XLQuerySelectStatement<LegacyContextOnlyValue> =
+            XLWithStatement([]).select(expression)
+        let dynamic: QueryBuilder<LegacyContextOnlyValue> = QueryBuilder(
+            select: expression
+        )
+        let encoder = XLiteEncoder(dialect: XLSQLiteDialect())
+
+        XCTAssertEqual(encoder.makeSQL(direct).sql, "SELECT NULL")
+        XCTAssertEqual(encoder.makeSQL(built).sql, "SELECT NULL")
+        XCTAssertEqual(encoder.makeSQL(functional).sql, "SELECT NULL")
+        XCTAssertEqual(encoder.makeSQL(factored).sql, "SELECT NULL")
+        _ = dynamic
+
+        XCTAssertThrowsError(
+            try direct.readRow(reader: LegacyManualRowReader())
+        ) { error in
+            guard case .staticLayoutRequired(let valueType, let alias) =
+                    error as? XLStaticRowReadError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(valueType.contains("LegacyContextOnlyValue"))
+            XCTAssertEqual(alias, "c0")
+        }
+    }
+
+    func testScalarSelectKeepsLegacyLiteralRowDecoding() throws {
+        let reader = LegacyManualRowReader()
+        let statement = Select(42)
+
+        XCTAssertEqual(try statement.readRow(reader: reader), Int.sqlDefault())
+        XCTAssertEqual(reader.readCount, 1)
+    }
+
     func testLegacyRowReaderConformerKeepsOriginalColumnRequirement() throws {
         let reader = LegacyManualRowReader()
 


### PR DESCRIPTION
## Summary

- remove the legacy `XLExpression & XLLiteral` result constraints from both scalar `Select` initializers
- remove the matching result constraints from top-level `select`, `XLWithStatement.select`, and `QueryBuilder.init(select:)`
- decode scalar rows through the source-compatible unconstrained `staticColumn` seam
- preserve the constrained `XLRowReader.column` requirement so existing external conformers still compile
- document that bare contextual scalar expressions require static-layout codec metadata

## Research conclusion

The Select constraints can be removed safely, but the legacy reader requirement cannot be made unconstrained without breaking external conformers. A bare contextual expression can now form and render a scalar select. If executed through legacy row decoding, it reports the existing structured `staticLayoutRequired` error; `XLStaticRowLayout` remains the executable contextual-codec path.

Scalar subquery constraints are intentionally unchanged because `XLSubquery` still needs a literal decoding carrier.

## Validation

- focused Select, QueryBuilder, expression-builder, GRDB execution, compatibility, and contextual-codec suite — 111 passed
- `swift test` — 588 passed
- `./make-docs.sh <fresh output>` — passed with warnings as errors
- downstream Swift 5 consumer, including external constrained `XLRowReader` conformance — passed (scheduler `run-71497613-702f-47fc-a946-43f62397631b`)
- first-party warning gate — clean (scheduler `run-7db9f561-aa69-4628-ae98-c5bf13ee9715`)
- complete strict-concurrency gate — clean (scheduler `run-547c45e0-c68a-41b1-8c92-2b3a13409eaf`)
- `git diff --check` — passed

Closes #44