### PR TITLE
Use semantic SQL separators

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Research: Remove Row type constraint from Select",
-  "issue_number": 44,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/44",
+  "task_name": "XLSeparator: Use semantic separator instead of literal (e.g. .list, .tuple)",
+  "issue_number": 85,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/85",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#44 - Remove Select row constraints",
+  "codex_session_title": "lukevanin/swiftql#85 - Semantic SQL separators",
   "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/44-research-remove-row-type-constraint-from-select",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/44-research-remove-row-type-constraint-from-select"
+  "task_branch": "codex/85-semantic-xlseparator",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/85-semantic-xlseparator"
 }

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -31,6 +31,7 @@ enum FixtureError: Error {
     case invalidCoreContract
     case invalidLiteralReaderBridge
     case invalidRowReaderCompatibility
+    case invalidSeparatorCompatibility
     case invalidCodecValue(XLSQLiteValue)
     case unexpectedPacketResult(Int?)
     case unexpectedStaticQueryResult(Int64)
@@ -94,6 +95,36 @@ private func validateRowReaderCompatibility() throws {
     let value = try Select(42).readRow(reader: DownstreamRowReader())
     guard value == Int.sqlDefault() else {
         throw FixtureError.invalidRowReaderCompatibility
+    }
+}
+
+private struct DownstreamSeparatorProbe: XLEncodable {
+    let separator: XLSeparator
+
+    func makeSQL(context: inout XLBuilder) {
+        context.list(separator: separator) { list in
+            list.listItem { $0.integer(1) }
+            list.listItem { $0.integer(2) }
+        }
+    }
+}
+
+private func validateSeparatorCompatibility() throws {
+    let legacy = XLSeparator(rawValue: ", ")
+    let encoder = XLiteEncoder(formatter: XLiteFormatter())
+    let listSQL = encoder.makeSQL(
+        DownstreamSeparatorProbe(separator: .list)
+    ).sql
+    let tupleSQL = encoder.makeSQL(
+        DownstreamSeparatorProbe(separator: .tuple)
+    ).sql
+    guard legacy == .comma,
+          XLSeparator.comma.rawValue == ", ",
+          XLSeparator.space.rawValue == " ",
+          listSQL == "1, 2",
+          tupleSQL == "1 2"
+    else {
+        throw FixtureError.invalidSeparatorCompatibility
     }
 }
 
@@ -313,6 +344,7 @@ private func executeFixture(
 private func runFixture() throws {
     try validateLiteralReaderCompatibility()
     try validateRowReaderCompatibility()
+    try validateSeparatorCompatibility()
     let codingConfiguration = try validateCoreContractProduct()
 
     let directory = FileManager.default.temporaryDirectory

--- a/Sources/SwiftQL/Operators/InOperator.swift
+++ b/Sources/SwiftQL/Operators/InOperator.swift
@@ -29,14 +29,14 @@ extension XLExpression {
     public func `in`(_ expressions: [any XLExpression<T>]) -> some XLExpression<Bool> {
         XLInValueExpression(
             lhs: self,
-            rhs: XLCompoundExpression<Any>(separator: .comma, expressions: expressions)
+            rhs: XLCompoundExpression<Any>(separator: .list, expressions: expressions)
         )
     }
 
     public func `in`<Wrapped>(_ expressions: [any XLExpression<Wrapped>]) -> some XLExpression<Optional<Bool>> where T == Optional<Wrapped> {
         XLInValueExpression(
             lhs: self,
-            rhs: XLCompoundExpression<Any>(separator: .comma, expressions: expressions)
+            rhs: XLCompoundExpression<Any>(separator: .list, expressions: expressions)
         )
     }
 

--- a/Sources/SwiftQL/SQLCaseWhenThen.swift
+++ b/Sources/SwiftQL/SQLCaseWhenThen.swift
@@ -31,7 +31,7 @@ private struct ConstantCaseComponents {
 
     public func makeSQL(context: inout XLBuilder) {
         context.parenthesis { context in
-            context.block(beginsWith: "CASE", endsWith: "END", separator: .space) { context in
+            context.block(beginsWith: "CASE", endsWith: "END", separator: .tuple) { context in
                 condition.makeSQL(context: &context)
                 for expression in expressions {
                     expression(&context)
@@ -166,7 +166,7 @@ private struct VariableCaseComponents {
 
     func makeSQL(context: inout XLBuilder) {
         context.parenthesis { context in
-            context.block(beginsWith: "CASE", endsWith: "END", separator: .space) { context in
+            context.block(beginsWith: "CASE", endsWith: "END", separator: .tuple) { context in
                 for expression in expressions {
                     expression(&context)
                 }

--- a/Sources/SwiftQL/SQLEncoder.swift
+++ b/Sources/SwiftQL/SQLEncoder.swift
@@ -51,15 +51,11 @@ extension XLEncodable {
 ///
 struct XLEncodableList: XLEncodable {
 
-    var separator: String
+    var separator: XLSeparator
     
     var expressions: [any XLEncodable]
     
     init(separator: XLSeparator, expressions: [any XLEncodable]) {
-        self.init(separator: separator.rawValue, expressions: expressions)
-    }
-
-    init(separator: String, expressions: [any XLEncodable]) {
         self.separator = separator
         self.expressions = expressions
     }
@@ -449,6 +445,18 @@ public protocol XLBuilder {
 }
 
 extension XLBuilder {
+
+    /// Adds a list whose delimiter communicates its SQL grammar role.
+    ///
+    /// The existing string-based protocol requirement remains the compatibility
+    /// seam for external builders. This overload maps semantic separators onto
+    /// that established spelling.
+    public mutating func list(
+        separator: XLSeparator,
+        items: ListBuilder
+    ) {
+        list(separator: separator.rawValue, items: items)
+    }
 
     public mutating func valueEncodingFailed(
         _ error: XLSQLValueEncodingError

--- a/Sources/SwiftQL/SQLExpression.swift
+++ b/Sources/SwiftQL/SQLExpression.swift
@@ -647,13 +647,23 @@ public struct XLQualifiedSelectColumnName: XLQualifiedName, Equatable {
 
 
 ///
-/// Delimiter used to encode SQLite expressions.
+/// A semantic delimiter used to encode SQL expressions.
 ///
-public enum XLSeparator: String {
+/// Use ``list`` for comma-delimited SQL items and ``tuple`` for adjacent
+/// grammar tokens. The literal-named enum cases remain available for source
+/// compatibility with existing builders.
+///
+public enum XLSeparator: String, Sendable {
     case elided = ""
     case space = " "
     case comma = ", "
     case newline = "\n"
+
+    /// Separates adjacent SQL grammar tokens with whitespace.
+    public static let tuple: Self = .space
+
+    /// Separates entries in an SQL list with a comma and whitespace.
+    public static let list: Self = .comma
 }
 
 
@@ -675,7 +685,7 @@ struct XLCompoundExpression<T>: XLExpression {
     }
     
     public func makeSQL(context: inout XLBuilder) {
-        context.list(separator: separator.rawValue) { listBuilder in
+        context.list(separator: separator) { listBuilder in
             for expression in expressions {
                 listBuilder.listItem { builder in
                     expression.makeSQL(context: &builder)

--- a/Sources/SwiftQL/SQLMeta.swift
+++ b/Sources/SwiftQL/SQLMeta.swift
@@ -353,7 +353,7 @@ final class XLColumnsDefinitionRowReader: XLRowReader, XLEncodable {
     }
     
     func makeSQL(context: inout XLBuilder) {
-        context.list(separator: ", ") { listBuilder in
+        context.list(separator: .list) { listBuilder in
             for (name, expression) in zip(names, expressions) {
                 listBuilder.listItem { builder in
                     builder.alias(name, expression: expression.makeSQL)

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -580,7 +580,7 @@ public struct Descending: XLOrderingTerm {
 ///
 @resultBuilder public struct XLOrderingTermsBuilder {
     public static func buildBlock(_ components: XLOrderingTerm...) -> any XLEncodable {
-        XLEncodableList(separator: ", ", expressions: components)
+        XLEncodableList(separator: .list, expressions: components)
     }
 }
 
@@ -597,7 +597,7 @@ public struct OrderBy: XLQueryComponent {
     }
     
     internal init(terms: [any XLOrderingTerm]) {
-        self.orderingTerms = XLEncodableList(separator: .comma, expressions: terms)
+        self.orderingTerms = XLEncodableList(separator: .list, expressions: terms)
     }
 
     public func makeSQL(context: inout XLBuilder) {
@@ -677,11 +677,11 @@ public struct GroupBy: XLQueryComponent {
     private let columns: any XLEncodable
     
     public init(_ columns: any XLExpression...) {
-        self.columns = XLEncodableList(separator: .comma, expressions: columns)
+        self.columns = XLEncodableList(separator: .list, expressions: columns)
     }
 
     public init(_ columns: [any XLExpression]) {
-        self.columns = XLEncodableList(separator: .comma, expressions: columns)
+        self.columns = XLEncodableList(separator: .list, expressions: columns)
     }
 
     public func makeSQL(context: inout XLBuilder) {

--- a/Sources/SwiftQL/SQLStaticRowLayout.swift
+++ b/Sources/SwiftQL/SQLStaticRowLayout.swift
@@ -386,7 +386,7 @@ where Dialect: XLValueCodingDialect {
     }
 
     public func makeSQL(context: inout XLBuilder) {
-        context.list(separator: ", ") { list in
+        context.list(separator: .list) { list in
             for field in fields {
                 list.listItem { builder in
                     builder.alias(

--- a/Sources/SwiftQL/SQLiteEncoding.swift
+++ b/Sources/SwiftQL/SQLiteEncoding.swift
@@ -411,7 +411,7 @@ public struct XLiteBuilder: XLBuilder {
     }
 
     public func build() -> String {
-        _tokens.joined(separator: XLSeparator.space.rawValue)
+        _tokens.joined(separator: XLSeparator.tuple.rawValue)
     }
 
     public func entities() -> Set<String> {
@@ -558,14 +558,14 @@ public struct XLiteBuilder: XLBuilder {
     }
 
     public mutating func simpleFunction(name: String, parameters: (inout XLListBuilder) -> Void) {
-        var listBuilder: XLListBuilder = XLiteListBuilder(formatter: formatter, separator: ", ")
+        var listBuilder: XLListBuilder = XLiteListBuilder(formatter: formatter, separator: .list)
         parameters(&listBuilder)
         append(name + "(" + listBuilder.build() + ")")
         _entities.formUnion(listBuilder.entities())
     }
 
     public mutating func aggregateFunction(name: String, distinct: Bool, parameters: (inout XLListBuilder) -> Void) {
-        var listBuilder: XLListBuilder = XLiteListBuilder(formatter: formatter, separator: ", ")
+        var listBuilder: XLListBuilder = XLiteListBuilder(formatter: formatter, separator: .list)
         parameters(&listBuilder)
         if distinct {
             append(name + "(DISTINCT " + listBuilder.build() + ")")
@@ -622,6 +622,10 @@ public struct XLiteListBuilder: XLListBuilder {
         self.formatter = formatter
     }
 
+    init(formatter: XLFormatter, separator: XLSeparator) {
+        self.init(formatter: formatter, separator: separator.rawValue)
+    }
+
     public func build() -> String {
         _tokens.joined(separator: separator)
     }
@@ -655,7 +659,7 @@ public struct XLiteCommonTablesBuilder: XLCommonTablesBuilder {
     }
 
     public func build() -> String {
-        _tokens.joined(separator: ", ")
+        _tokens.joined(separator: XLSeparator.list.rawValue)
     }
 
     public func entities() -> Set<String> {
@@ -685,7 +689,7 @@ public struct XLiteColumnDefinitionsBuilder: XLColumnDefinitionsBuilder {
     }
 
     public func build() -> String {
-        _tokens.joined(separator: ", ")
+        _tokens.joined(separator: XLSeparator.list.rawValue)
     }
 
     ///
@@ -700,6 +704,6 @@ public struct XLiteColumnDefinitionsBuilder: XLColumnDefinitionsBuilder {
         if !nullable {
             components.append("NOT NULL")
         }
-        _tokens.append(components.joined(separator: " "))
+        _tokens.append(components.joined(separator: XLSeparator.tuple.rawValue))
     }
 }

--- a/Tests/SQLTests/SQLDialectEncodingContractTests.swift
+++ b/Tests/SQLTests/SQLDialectEncodingContractTests.swift
@@ -95,7 +95,56 @@ private struct MixedLegacyAndTypedParameterProbe: XLEncodable {
 }
 
 
+private struct SemanticSeparatorProbe: XLEncodable {
+
+    let separator: XLSeparator
+
+    func makeSQL(context: inout XLBuilder) {
+        context.list(separator: separator) { list in
+            list.listItem { $0.integer(1) }
+            list.listItem { $0.integer(2) }
+        }
+    }
+}
+
+
+private struct LiteralSeparatorProbe: XLEncodable {
+
+    func makeSQL(context: inout XLBuilder) {
+        context.list(separator: " | ") { list in
+            list.listItem { $0.integer(1) }
+            list.listItem { $0.integer(2) }
+        }
+    }
+}
+
+
 final class SQLDialectEncodingContractTests: XCTestCase {
+
+    func testSemanticSeparatorsPreserveEstablishedSQLiteSpellings() {
+        func requireSendable<T: Sendable>(_ value: T) {}
+
+        requireSendable(XLSeparator.list)
+        XCTAssertEqual(XLSeparator.list, .comma)
+        XCTAssertEqual(XLSeparator.list.rawValue, ", ")
+        XCTAssertEqual(XLSeparator.tuple, .space)
+        XCTAssertEqual(XLSeparator.tuple.rawValue, " ")
+        XCTAssertEqual(XLSeparator(rawValue: ", "), .comma)
+
+        let encoder = XLiteEncoder(formatter: XLiteFormatter())
+        XCTAssertEqual(
+            encoder.makeSQL(SemanticSeparatorProbe(separator: .list)).sql,
+            "1, 2"
+        )
+        XCTAssertEqual(
+            encoder.makeSQL(SemanticSeparatorProbe(separator: .tuple)).sql,
+            "1 2"
+        )
+        XCTAssertEqual(
+            encoder.makeSQL(LiteralSeparatorProbe()).sql,
+            "1 | 2"
+        )
+    }
 
     private func parameterSlot(
         index: Int,


### PR DESCRIPTION
## Summary

- add source-compatible semantic `XLSeparator.list` and `.tuple`
- add a semantic `XLBuilder.list` overload while preserving the `String` protocol requirement and legacy raw/literal APIs
- migrate first-party list/tuple grammar rendering and add `Sendable` plus downstream compatibility coverage
- preserve SQL spelling byte for byte

## Validation

- focused semantic contract test passed
- `swift test` — 589 passed
- DocC with warnings as errors passed
- downstream Swift 5 passed (`run-4cec0ebb-af90-4e4a-ada5-3242f1fed5ee`)
- first-party warnings clean (`run-f6739834-26a6-4e8f-a82a-0b9fafc6ebd0`)
- strict concurrency clean (`run-0f24c4d9-ae9b-4adc-adb2-929dd0ddba2d`)
- `git diff --check` passed

Closes #85