### PR TITLE
Refresh v1.2 public documentation

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "XLSeparator: Use semantic separator instead of literal (e.g. .list, .tuple)",
-  "issue_number": 85,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/85",
+  "task_name": "[v1.2 Housekeeping] Refresh README and public documentation",
+  "issue_number": 221,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/221",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#85 - Semantic SQL separators",
+  "codex_session_title": "lukevanin/swiftql#221 - Refresh v1.2 public documentation",
   "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/85-semantic-xlseparator",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/85-semantic-xlseparator"
+  "task_branch": "codex/221-v12-docs",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/221-v12-docs"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,86 @@
 # Changelog
 
+## [1.2.0] - Unreleased
+
+### Added
+
+- Added the GRDB-free `SwiftQLCore` product with orthogonal SQL-dialect,
+  dialect-value, logical-statement, validated database-driver, and transaction
+  contracts. The existing `SwiftQL` product remains the application-facing
+  facade with the current GRDB-backed SQLite implementation.
+- Added immutable `XLStaticQueryDescriptor` definitions with durable canonical
+  identities, explicit dialect requirements, parameter/result layouts,
+  referenced entities, and cardinality. Raw prepared static-query handles are
+  database-bound and `Sendable` without retaining a physical statement.
+- Added generated static row layouts for `@SQLTable` and `@SQLResult`, including
+  contextual value encoding and typed decoding without constructing default
+  model instances or requiring `sqlDefault()`.
+- Added immutable, value-free `XLQueryCapture` declarations and fresh
+  `XLInvocationBindings` packets. Repeated calls keep runtime values out of
+  logical requests, descriptors, identities, and statement caches.
+- Added immutable contextual value-codec registries and database configuration
+  snapshots. One Swift type can select different versioned SQLite
+  representations without a process-global registry or retroactive literal
+  conformance.
+- Added shared adapter-neutral SQLite value/storage and transaction contract
+  suites, each exercised against the production GRDB driver with stable case
+  identities and durable semantic oracles.
+- Added an independent cross-library SQLite benchmark baseline and a
+  reproducible first-party source-coverage topology check.
+
+### Changed
+
+- GRDB result rows are stepped and decoded incrementally while their leased
+  connection is active. Public `fetchAll()` and `fetchOne()` behavior remains
+  eager and source-compatible, but intermediate GRDB and normalized row arrays
+  are no longer retained.
+- Literal decoding now uses a scoped field reader, and the sequential row reader
+  is a value type, removing per-row reference allocation from the legacy typed
+  decode path.
+- `Select` no longer requires the result type itself to conform to `XLResult`;
+  typed selection is carried by its row layout. Existing `XLResult` models
+  continue to compile.
+- First-party SQL renderers now use semantic `XLSeparator.list` and `.tuple`
+  names. The legacy `.comma`, `.space`, raw-value, and custom-string separator
+  APIs remain available throughout v1.
+- Table and common-table `FROM` dependencies now share one dependency model,
+  including value-semantic recursive common-table definitions and references.
+
+### Fixed
+
+- Non-finite `Double` literals now fail through validated encoding instead of
+  emitting invalid SQLite tokens or silently changing the value.
+- `COLLATE` names render as SQL grammar tokens, fluent `INSERT ... SELECT`
+  clause chains execute against real SQLite, and the query builder's
+  missing-`FROM` failure is covered by its documented contract.
+- Generic list composition now implements `BETWEEN`, static result descriptors
+  remove hidden default-value requirements, and separator cleanup preserves
+  byte-identical SQL and binding order.
+
+### Migration
+
+Existing `makeRequest(with:)`, `XLNamedBindingReference`, `XLCustomType`,
+`XLLiteral`, `XLResult`, explicit packet, and raw separator APIs remain
+source-compatible in SwiftQL 1.x. No application must adopt the lower-level
+v1.2 contracts merely to keep an existing query working.
+
+For a new reusable query that needs durable identity, cross-task raw-value
+execution, or contextual result layouts, construct and register an
+`XLStaticQueryDescriptor` before opening a database, prepare it against that
+database, and create a fresh `XLInvocationBindings` packet for every call. Do
+not share the current `XLRequest` facade across tasks; it remains task-local.
+
+Prefer `XLValueCodec` plus an immutable `XLValueCodingConfiguration` when one
+application type has multiple persisted representations. Keep a legacy
+`XLCustomType` wrapper only when preserving its existing v1 storage bytes and
+introspection behavior is required. Changing a codec key, version, stable type
+identifier, dialect, or storage identifier is a schema/data migration.
+
+Validated encoding is now the explicit error boundary for unsupported literal
+values such as non-finite `Double`. Code that constructs SQL from untrusted or
+computed floating-point values should propagate that error instead of assuming
+every `Double` has a SQLite literal spelling.
+
 ## [1.1.0] - 2026-07-17
 
 ### Added

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,6 +6,42 @@ series currently listed by Swift Package Index: Swift 6.0 through Swift 6.3.
 All Swift 6 compilers run the package in Swift 5 language mode; SwiftQL does not
 opt into Swift 6 language mode.
 
+## v1.2 public products and runtime boundaries
+
+The package supports iOS 16 or later and macOS 13 or later. Its public products
+have separate responsibilities:
+
+- `SwiftQLCore` is the GRDB-free contract layer for SQL dialects, dialect
+  values, logical statements, immutable parameter layouts and invocation
+  packets, static query descriptors, and database drivers. It is intended for
+  adapter packages and does not provide a usable SQLite connection by itself.
+- `SwiftQL` is the application-facing library. It includes `SwiftQLCore`, the
+  macros and typed SQL DSL, contextual value codecs, and the current
+  GRDB-backed SQLite driver.
+- `swiftql-benchmark` is a repository performance diagnostic executable, not an
+  application runtime dependency or a database adapter.
+
+The manifest's dependency lower bounds are SwiftSyntax 509.0.0, GRDB 6.29.3,
+and the Swift-DocC plugin 1.0.0. Committed-resolution jobs prove the checked-in
+graph; clean-resolution jobs prove that the declared ranges still resolve and
+pass. The exact resolved versions and loaded SQLite source ID are CI evidence,
+not a promise that every future dependency version in those ranges is already
+supported.
+
+In v1.2, an `XLStaticQueryDescriptor` and `XLInvocationBindings` are immutable,
+database-independent values. A raw `GRDBPreparedStaticQuery` or
+`GRDBPreparedInvocation` is `Sendable` and database-bound without owning a
+connection-bound statement. The high-level `XLRequest` facade and
+closure-backed typed static-row wrapper remain task-local. Each execution may
+lease a different connection and prepare or cache a physical GRDB statement on
+that connection. These ownership rules are part of the supported API contract,
+not only implementation details.
+
+SwiftQL currently ships only a SQLite dialect and a GRDB database driver. The
+core protocols are extension seams, not claims that another dialect, driver,
+Linux runtime, nested transaction/savepoint API, asynchronous cursor, or
+Swift 6 language mode is supported in v1.2.
+
 ## Pinned Apple support points
 
 | Support point | GitHub runner | Xcode | Swift | macOS SDK |
@@ -186,7 +222,7 @@ single non-mutating command:
 
 The command treats first-party DocC diagnostics as errors, writes the static
 site to the ignored `docs/` directory, and validates the SwiftQL landing page
-and all ten source articles. Pass an existing external destination when a
+and all twelve source articles. Pass an existing external destination when a
 separate output is useful, for example `./make-docs.sh /tmp/swiftql-docs`.
 The command never stages or commits files.
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,43 @@ their SQL meaning.
   Create basic tables and construct typed inserts, updates, and deletes with
   the same SQL-shaped API.
 - **[Bindings and results](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/).**
-  Reuse requests with typed named bindings, then decode `fetchAll()` and
-  `fetchOne()` results directly into Swift values.
+  Keep invocation values in fresh immutable binding packets, then decode
+  `fetchAll()` and `fetchOne()` results directly into Swift values.
+- **[Static query contracts](https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/).**
+  Define database-independent SQL, parameter, result, identity, and cardinality
+  metadata before opening a database, then prepare it against a compatible
+  driver.
 - **[Live data](https://lukevanin.github.io/swiftql/documentation/swiftql/livequeries/).**
   Observe typed query results through GRDB-backed Combine publishers that track
   the database region a query reads.
 - **Your domain.** Extend SQLite with Swift enums, custom value types, and
   type-safe custom SQL functions.
+
+## The v1.2 reusable-query boundary
+
+SwiftQL v1.2 separates the reusable SQL contract from each database invocation.
+An `XLStaticQueryDescriptor` contains rendered SQL, dialect requirements,
+parameter and result layouts, stable identity, and cardinality; it contains no
+database, connection, statement, or runtime value. Prepare that descriptor
+against a `GRDBDatabase`, then create a fresh `XLInvocationBindings` value for
+every call. Invocation values never become identifiers or SQL grammar tokens.
+
+The products have distinct roles:
+
+- `SwiftQLCore` exposes GRDB-free dialect, value, statement, binding, and driver
+  contracts for adapter authors.
+- `SwiftQL` is the application-facing product. It includes the macros, typed SQL
+  DSL, contextual codecs, and the current GRDB-backed SQLite driver.
+
+The existing `makeRequest(with:)`, named-binding, `XLCustomType`, and raw-value
+APIs remain source-compatible throughout v1. High-level requests are
+database-bound and the current `XLRequest` facade is not `Sendable`. Prefer a
+static descriptor and its prepared handle when durable identity or cross-task
+raw-value invocation matters. See the
+[static-query guide](https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/),
+[prepared-statement boundaries](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/),
+and [contextual-codec migration](https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/)
+for the complete contracts and current limitations.
 
 ## SQL-shaped, not ORM-shaped
 
@@ -146,6 +176,11 @@ file:
 .package(url: "https://github.com/lukevanin/swiftql.git", from: "1.1.0")
 ```
 
+`1.1.0` is the latest published package while the v1.2 changelog is marked
+`Unreleased`. The examples above use APIs retained by v1.2. Adopt the new v1.2
+static-query surface only after pinning a source revision intentionally or
+after the `1.2.0` tag is published.
+
 ### Xcode
 
 Refer to Apple's documentation [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app#Add-a-package-dependency),
@@ -162,6 +197,8 @@ For project guarantees and direction:
 
 - [Compiler compatibility](COMPATIBILITY.md) records the supported Swift
   toolchains and reproducible CI matrix.
+- [Changelog](CHANGELOG.md) distinguishes released behavior from the v1.2
+  surface currently on `main` and records migration guidance.
 - [Performance benchmarks](BENCHMARKS.md) measure query construction,
   preparation, caching, binding, execution, and decoding.
 - [First-party source coverage](Coverage/README.md) preserves the reproducible

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,18 +1,32 @@
 # Releasing SwiftQL
 
-SwiftQL releases use `vMAJOR.MINOR.PATCH` tags beginning with `v1.1.0`. The
-historical `1.0.0` tag and release are intentionally unchanged.
+SwiftQL releases use `vMAJOR.MINOR.PATCH` tags beginning with `v1.1.0`. This
+guide uses the pending `v1.2.0` release as its concrete example. The historical
+`1.0.0` tag and release are intentionally unchanged.
 
 The [Verified release workflow](.github/workflows/release.yml) treats a tag as
 an untrusted request. It publishes only after it has proved that the exact tag
-commit is still reachable from `main`, run the complete Swift 5.9 and Swift 6.0
-compatibility matrix, and built the exact commit's validated DocC artifact.
+commit is still reachable from `main`, run the complete Swift compatibility
+matrix, and built the exact commit's validated DocC artifact.
 
 ## Before a release
 
-1. Merge every retained issue for the release. For `v1.1.0`, milestone 7 must
-   have only tracking issue #118 and release issue #119 open. The workflow
-   checks this before validation and again immediately before publication.
+1. Merge every retained v1.2 issue, complete audit issue #223, and close
+   milestone 6 with no open issues. Verify the live milestone rather than a
+   local planning file:
+
+   ```sh
+   gh api repos/lukevanin/swiftql/milestones/6 |
+     jq -e '
+       .title == "v1.2" and
+       .state == "closed" and
+       .open_issues == 0'
+   ```
+
+   `scripts/ci/check-release-readiness.sh` retains the historical one-time
+   server-side gate for `v1.1.0` and deliberately skips later versions. It is
+   not proof of v1.2 milestone readiness; preserve the command output and #223
+   audit evidence in the v1.2 release issue.
 2. Confirm the latest `main` runs of **Swift compatibility** and
    **Documentation** pass. Verify the deployed documentation provenance names
    that `main` commit.
@@ -97,7 +111,8 @@ compatibility matrix, and built the exact commit's validated DocC artifact.
    This server-side rule closes the otherwise unavoidable network-sized race
    between the workflow's last tag check and release publication. Do not prove
    the rule with a disposable `v...` tag: the rule intentionally prevents that
-   tag from being deleted. Its first end-to-end proof is the real `v1.1.0` tag.
+   tag from being deleted. Its first end-to-end proof was the historical
+   `v1.1.0` tag; verify that the same rule remains active before `v1.2.0`.
 7. Record the exact remote commit. Do not release from an unpushed local commit.
 
 ```sh
@@ -114,11 +129,11 @@ They can never enter the write-capable publication job.
 
 Run these one at a time after the release workflow has landed on `main`:
 
-- `release-test/v1.1.999` at `origin/main` must pass through the dry-run job and
+- `release-test/v1.2.999` at `origin/main` must pass through the dry-run job and
   create no GitHub Release.
 - `release-test/not-semver` must fail tag validation before compiler or
   documentation jobs start.
-- A valid test tag such as `release-test/v1.1.998` on a temporary commit that is
+- A valid test tag such as `release-test/v1.2.998` on a temporary commit that is
   not reachable from `main` must fail the reachability gate.
 
 After recording the workflow URLs and confirming that no release was created,
@@ -131,8 +146,8 @@ Create one annotated tag at the recorded `origin/main` commit and push only
 that tag:
 
 ```sh
-git tag -a v1.1.0 "$release_sha" -m "SwiftQL v1.1.0"
-git push origin refs/tags/v1.1.0
+git tag -a v1.2.0 "$release_sha" -m "SwiftQL v1.2.0"
+git push origin refs/tags/v1.2.0
 ```
 
 The release workflow:
@@ -141,8 +156,8 @@ The release workflow:
 2. proves the commit is reachable from current `origin/main`;
 3. invokes the reusable four-lane compatibility workflow;
 4. invokes the reusable documentation workflow without deploying Pages;
-5. packages the Pages tar as `swiftql-docc-v1.1.0.tar.gz` and creates
-   `swiftql-release-v1.1.0.json` plus `SHA256SUMS`;
+5. packages the Pages tar as `swiftql-docc-v1.2.0.tar.gz` and creates
+   `swiftql-release-v1.2.0.json` plus `SHA256SUMS`;
 6. creates a draft GitHub Release with generated notes and an exact commit/run
    marker;
 7. uploads and verifies all three assets, then immediately refetches and
@@ -171,16 +186,19 @@ succeeds, independently verify:
 - the release API reports `immutable: true`, and the production tag ruleset is
   still active;
 - GitHub verifies the immutable release attestation with
-  `gh release verify v1.1.0 --repo lukevanin/swiftql`, and each downloaded asset
-  passes `gh release verify-asset v1.1.0 PATH --repo lukevanin/swiftql`;
+  `gh release verify v1.2.0 --repo lukevanin/swiftql`, and each downloaded asset
+  passes `gh release verify-asset v1.2.0 PATH --repo lukevanin/swiftql`;
 - the release has exactly the DocC archive, manifest, and checksum assets;
 - API asset digests match `SHA256SUMS`, and the manifest maps the tag to the
   exact commit and workflow run; and
 - the historical `1.0.0` tag and release are unchanged.
 
-For `v1.1.0`, post the evidence on #119 and close #119 first. Re-fetch it to
-confirm closure, then close tracking issue #118. This order is part of the
-release gate.
+For `v1.2.0`, #223 is the pre-tag milestone audit, not proof that a release was
+published. Before tagging, create or identify one dedicated v1.2 release issue
+outside the closed milestone. Post the tag-run, release, asset, attestation, and
+ruleset evidence there; close it only after every check above passes. Re-fetch
+the issue to confirm closure. Do not reopen #223 or the v1.2 milestone merely to
+store post-tag evidence.
 
 ## Recovery
 

--- a/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
@@ -5,10 +5,11 @@ Create custom scalar types for table columns.
 ## Overview
 
 SwiftQL has built-in support for `Bool`, `Int`, `Double`, `String`, and `Data`.
-Use a contextual value codec for a different application type or when one Swift
-type has more than one valid database representation. A codec pairs throwing
-encode and decode closures with stable type, dialect, storage, name, and version
-metadata. It does not require a property wrapper or a retroactive conformance.
+Use the v1.2 contextual value-codec API for a different application type or
+when one Swift type has more than one valid database representation. A codec
+pairs throwing encode and decode closures with stable type, dialect, storage,
+name, and version metadata. It does not require a property wrapper or a
+retroactive conformance.
 
 The older `XLCustomType` literal path remains source compatible. Existing types
 can keep an explicit legacy introspection placeholder, while new types that use

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -14,11 +14,16 @@ introduction to SQL, see the
 
 ## Add SwiftQL to your project
 
-Add SwiftQL v1.1 or later to your package dependencies:
+Add the latest published SwiftQL package to your dependencies:
 
 ```text
 .package(url: "https://github.com/lukevanin/swiftql.git", from: "1.1.0")
 ```
+
+Version 1.1.0 remains the published package while the v1.2 changelog is marked
+`Unreleased`. This guide's basic request path is retained by v1.2. Use the new
+static-query and contextual-codec APIs from `main` only when pinning a source
+revision intentionally, or after the `1.2.0` tag is published.
 
 Then add `SwiftQL` to the dependencies of your target and import the module in
 files that use it. The package requires Swift tools 5.9 and targets iOS 16 or

--- a/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
@@ -5,9 +5,10 @@ typed parameter metadata, flat result layouts, and explicit row cardinality.
 
 ## Overview
 
-An `XLStaticQueryDescriptor` is the complete static contract for one rendered
-statement. It retains SQL, dialect requirements, referenced entities, parameter
-slots, result slots, and cardinality. It does not retain a database, connection,
+Introduced in v1.2, an `XLStaticQueryDescriptor` is the complete static contract
+for one rendered statement. It retains SQL, dialect requirements, referenced
+entities, parameter slots, result slots, and cardinality. It does not retain a
+database, connection,
 physical statement, codec registry, or invocation value. You can therefore
 construct and register descriptors before opening a database, then prepare the
 same descriptor against a compatible database when it is needed.

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -53,6 +53,32 @@ typed API. The current API covers a practical subset of SQLite, with unsupported
 syntax called out in the relevant guides. SwiftQL also provides utilities for
 safely casting types when needed.
 
+## v1.2 boundaries
+
+SwiftQL v1.2 separates database-independent query definitions from database
+execution. An `XLStaticQueryDescriptor` retains rendered SQL, dialect
+requirements, immutable parameter and result metadata, stable identity, and
+cardinality without retaining a database, physical statement, or invocation
+value. Prepare it against a `GRDBDatabase`, then give every call a fresh
+`XLInvocationBindings` packet. See <doc:StaticQueries> for construction,
+identity, preparation, and cardinality rules.
+
+`SwiftQLCore` contains the GRDB-free dialect, value, logical-statement, binding,
+and driver contracts needed by adapter packages. The `SwiftQL` product is the
+application-facing compatibility facade: it adds the macros, typed SQL DSL,
+contextual codecs, and the current GRDB-backed SQLite implementation. Dialects
+own SQL spelling and value storage rules; drivers own connections, physical
+preparation, binding transport, execution, and row transport. See
+<doc:GettingStarted> for connection, transaction, and prepared-statement
+ownership.
+
+Existing v1 requests, named bindings, `XLCustomType` wrappers, and explicit
+raw-value APIs remain source-compatible. The current `XLRequest` facade is
+database-bound and not `Sendable`; prepared raw static-query handles are
+`Sendable`, while closure-backed typed row-layout wrappers remain task-local.
+Use <doc:CustomTypes> when one Swift type needs contextual or multiple SQLite
+representations.
+
 ## When to use SwiftQL
 
 SwiftQL provides a safer way to write SQL to interact with an SQLite database, 

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -249,6 +249,79 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         }
     }
 
+    func testV12PublicDocumentsShareReleaseAndBoundaryContract() throws {
+        let repositoryRoot = repositoryRootURL()
+        let requiredPhrasesByPath = [
+            "README.md": [
+                "## The v1.2 reusable-query boundary",
+                "An `XLStaticQueryDescriptor` contains rendered SQL",
+                "fresh `XLInvocationBindings` value",
+                "every call. Invocation values never become identifiers",
+                "`SwiftQLCore` exposes GRDB-free",
+                "latest published package while the v1.2 changelog is marked",
+            ],
+            "COMPATIBILITY.md": [
+                "## v1.2 public products and runtime boundaries",
+                "iOS 16 or later and macOS 13 or later",
+                "SwiftSyntax 509.0.0, GRDB 6.29.3",
+                "The high-level `XLRequest` facade",
+                "only a SQLite dialect and a GRDB database driver",
+                "all twelve source articles",
+            ],
+            "CHANGELOG.md": [
+                "## [1.2.0] - Unreleased",
+                "Added the GRDB-free `SwiftQLCore` product",
+                "Added immutable `XLStaticQueryDescriptor` definitions",
+                "GRDB result rows are stepped and decoded incrementally",
+                "Existing `makeRequest(with:)`",
+            ],
+            "RELEASING.md": [
+                "complete audit issue #223",
+                ".title == \"v1.2\"",
+                "not proof of v1.2 milestone readiness",
+                "the pending `v1.2.0` release",
+                "dedicated v1.2 release issue",
+            ],
+            "Sources/SwiftQL/SwiftQL.docc/SwiftQL.md": [
+                "## v1.2 boundaries",
+                "database-independent query definitions",
+                "`SwiftQLCore` contains the GRDB-free",
+                "The current `XLRequest` facade is",
+            ],
+            "Sources/SwiftQL/SwiftQL.docc/GettingStarted.md": [
+                "v1.2 changelog is marked",
+                "basic request path is retained by v1.2",
+                "after the `1.2.0` tag is published",
+            ],
+            "scripts/ci/check-docc-output.sh": [
+                "realvalues|Real Values",
+                "staticqueries|Static queries",
+            ],
+        ]
+
+        for (path, requiredPhrases) in requiredPhrasesByPath {
+            let contents = try String(
+                contentsOf: repositoryRoot.appendingPathComponent(path),
+                encoding: .utf8
+            )
+            for phrase in requiredPhrases {
+                XCTAssertTrue(
+                    contents.contains(phrase),
+                    "\(path) is missing the v1.2 contract phrase '\(phrase)'."
+                )
+            }
+        }
+
+        let changelog = try String(
+            contentsOf: repositoryRoot.appendingPathComponent("CHANGELOG.md"),
+            encoding: .utf8
+        )
+        let firstReleaseHeading = changelog
+            .components(separatedBy: .newlines)
+            .first(where: { $0.hasPrefix("## [") })
+        XCTAssertEqual(firstReleaseHeading, "## [1.2.0] - Unreleased")
+    }
+
     func testREADMERepositoryLinksResolveWithExactCase() throws {
         let repositoryRoot = repositoryRootURL()
         let readme = try String(
@@ -274,6 +347,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             Set(repositoryLinks),
             [
                 "BENCHMARKS.md",
+                "CHANGELOG.md",
                 "COMPATIBILITY.md",
                 "Coverage/README.md",
                 "LICENSE.md",

--- a/scripts/ci/check-docc-output.sh
+++ b/scripts/ci/check-docc-output.sh
@@ -35,6 +35,8 @@ generictableparameters|Generic Table Parameters
 gettingstarted|Getting started
 livequeries|Live Queries
 queries|Select Queries
+realvalues|Real Values
+staticqueries|Static queries
 ARTICLES
 
     printf 'SWIFTQL_DOCC_OUTPUT ok %s\n' "$output"


### PR DESCRIPTION
## Summary

- reconcile README and DocC with v1.2's static-query, immutable-binding, codec, dialect, and driver boundaries
- add an unreleased v1.2 changelog and update release guidance to the live milestone-6 process
- document product, platform, dependency, concurrency, and unsupported-operation boundaries
- extend documentation regression coverage to all twelve source articles

## Validation

- `swift test --filter SQLDocumentationCatalogTests` — 7 passed
- `swift test --filter XLDocumentationTests` — 33 passed
- `swift test` — 590 passed
- `./make-docs.sh <external destination>` — DocC warnings-as-errors passed and all twelve articles verified
- `scripts/ci/test-release-workflow.sh` — passed
- downstream Swift 5 language-mode client passed on installed Swift 6.3 (`run-e8c76eff-8b5f-4913-aab6-e87edef3567c`)
- first-party warning gate passed on Swift 6.3 (`run-41d523dc-f007-45ff-bca4-5a1e1c12dca0`)
- complete strict-concurrency gate passed on Swift 6.3 (`run-78a8110f-7700-4639-96be-b74fddbd33ba`)
- `git diff --check` passed

Local Xcode 16.2 was not installed, so the exact pinned Swift 5.9/6.0 lanes remain gated by this PR's GitHub compatibility matrix.

Closes #221