### PR TITLE
Add the v1.2 SwiftQL agent skill

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "[v1.2 Housekeeping] Refresh README and public documentation",
-  "issue_number": 221,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/221",
+  "task_name": "[v1.2 Housekeeping] Update the SwiftQL agent SKILL.md",
+  "issue_number": 222,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/222",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#221 - Refresh v1.2 public documentation",
+  "codex_session_title": "lukevanin/swiftql#222 - Update the SwiftQL agent SKILL.md",
   "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/221-v12-docs",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/221-v12-docs"
+  "task_branch": "codex/222-v12-skill",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/222-v12-skill"
 }

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift
@@ -1,0 +1,37 @@
+// swiftql-skill-example-begin
+import SwiftQL
+
+@SQLTable(name: "SkillPerson")
+struct SkillPerson: Equatable {
+    let id: String
+    let name: String
+}
+
+enum SkillQueryError: Error {
+    case missingNameParameter
+}
+
+func fetchSkillPeople(
+    named name: String,
+    from database: GRDBDatabase
+) throws -> [SkillPerson] {
+    let nameParameter = XLNamedBindingReference<String>(name: "name")
+    let query = sql { schema in
+        let person = schema.table(SkillPerson.self)
+        Select(person)
+        From(person)
+        Where(person.name == nameParameter)
+    }
+    let request = database.makeRequest(with: query)
+    guard let nameSlot = request.parameterLayout.slot(for: .named("name")) else {
+        throw SkillQueryError.missingNameParameter
+    }
+    let bindings = try XLInvocationBindings<XLSQLiteValue>(
+        layout: request.parameterLayout,
+        bindings: [
+            try XLInvocationBinding(slot: nameSlot, value: .text(name)),
+        ]
+    ).validatingComplete()
+    return try request.fetchAll(bindings: bindings)
+}
+// swiftql-skill-example-end

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -35,6 +35,7 @@ enum FixtureError: Error {
     case invalidCodecValue(XLSQLiteValue)
     case unexpectedPacketResult(Int?)
     case unexpectedStaticQueryResult(Int64)
+    case unexpectedSkillQueryResult([SkillPerson])
     case unexpectedResult(PersonSummary?)
 }
 
@@ -226,6 +227,14 @@ private func executeFixture(
     try database.makeRequest(
         with: sqlInsert(Person(id: "grace", name: "Grace Hopper", age: 85))
     ).execute()
+    try database.makeRequest(with: sqlCreate(SkillPerson.self)).execute()
+    try database.makeRequest(
+        with: sqlInsert(SkillPerson(id: "ada", name: "Ada Lovelace"))
+    ).execute()
+    let skillPeople = try fetchSkillPeople(named: "Ada Lovelace", from: database)
+    guard skillPeople == [SkillPerson(id: "ada", name: "Ada Lovelace")] else {
+        throw FixtureError.unexpectedSkillQueryResult(skillPeople)
+    }
 
     let token = try database.contextualBinding(
         DownstreamToken.self,

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: swiftql
+description: Use when Codex works in a Swift package or Apple application that uses SwiftQL to define typed tables or results, build or modify SQLite queries, pass immutable bindings, add contextual codecs, prepare reusable static queries, integrate a database adapter, or diagnose SwiftQL execution boundaries. Follow the shipped v1.2 API on this repository's main branch; do not use this skill to teach SQL generally or to claim unshipped dialects, drivers, or concurrency features.
+---
+
+# SwiftQL
+
+Use SwiftQL as a typed, SQL-shaped SQLite DSL. Keep schema objects, query
+structure, and invocation values separate, and verify every API against the
+checked-out package version before editing consumer code.
+
+## Establish the package boundary
+
+- Add `https://github.com/lukevanin/swiftql.git` with Swift Package Manager and
+  attach the `SwiftQL` library product to each application target that imports
+  it.
+- Depend on the application-facing `SwiftQL` product for macros, the DSL,
+  contextual codecs, and the GRDB-backed SQLite driver.
+- Depend directly on `SwiftQLCore` only when implementing a dialect or database
+  adapter. It deliberately contains no usable GRDB connection.
+- Require Swift tools 5.9, Swift 5 language mode, iOS 16 or later, or macOS 13
+  or later. SwiftQL v1.2 supports Apple platforms, SQLite syntax, and the GRDB
+  driver only.
+- Read [the changelog](CHANGELOG.md) before choosing a package requirement.
+  While `1.2.0` is `Unreleased`, pin an intentional source revision for v1.2
+  APIs; use the published semantic version only after that tag exists.
+
+## Follow the preferred application workflow
+
+1. Declare stored rows with `@SQLTable` and projections with `@SQLResult`.
+2. Build a statement with `sql { schema in ... }`; obtain table references from
+   that closure instead of constructing column names as strings.
+3. Create one logical request with `GRDBDatabase.makeRequest(with:)`.
+4. For parameters, retain the request and construct a fresh immutable
+   `XLInvocationBindings<XLSQLiteValue>` packet for every call. Treat a missing
+   binding differently from a present SQL `NULL`.
+5. Call `fetchAll(bindings:)`, `fetchOne(bindings:)`, or `execute(bindings:)`.
+   Let preparation, binding, driver, and decoding errors propagate unless the
+   application has an explicit error policy.
+
+The following complete example is compiled and executed by the maintained
+Swift 5 consumer fixture.
+
+<!-- compile-test: IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift -->
+```swift
+import SwiftQL
+
+@SQLTable(name: "SkillPerson")
+struct SkillPerson: Equatable {
+    let id: String
+    let name: String
+}
+
+enum SkillQueryError: Error {
+    case missingNameParameter
+}
+
+func fetchSkillPeople(
+    named name: String,
+    from database: GRDBDatabase
+) throws -> [SkillPerson] {
+    let nameParameter = XLNamedBindingReference<String>(name: "name")
+    let query = sql { schema in
+        let person = schema.table(SkillPerson.self)
+        Select(person)
+        From(person)
+        Where(person.name == nameParameter)
+    }
+    let request = database.makeRequest(with: query)
+    guard let nameSlot = request.parameterLayout.slot(for: .named("name")) else {
+        throw SkillQueryError.missingNameParameter
+    }
+    let bindings = try XLInvocationBindings<XLSQLiteValue>(
+        layout: request.parameterLayout,
+        bindings: [
+            try XLInvocationBinding(slot: nameSlot, value: .text(name)),
+        ]
+    ).validatingComplete()
+    return try request.fetchAll(bindings: bindings)
+}
+```
+
+Use `sqlCreate` only for basic table creation. It does not add declared SQLite
+type names, primary keys, uniqueness, foreign keys, indexes, or migrations, and
+it never upgrades an existing table. Keep production schema evolution in an
+explicit application-owned migration system.
+
+## Use the v1.2 reusable-query boundary deliberately
+
+Choose a static query when the definition needs durable identity, explicit
+parameter and result metadata, cardinality, registration before a database is
+opened, or a raw-value handle that can cross tasks.
+
+- Declare invocation inputs with `XLQueryCapture`; runtime Swift values are not
+  inferred from bare variables in the runtime DSL.
+- Render and validate the statement, then construct an immutable
+  `XLStaticQueryDescriptor`. Never store a database, connection, prepared
+  statement, or invocation value in the descriptor.
+- Give each definition a stable `XLQueryDefinitionIdentity`; persist its
+  canonical bytes or hex, never Swift `hashValue`. Increment the version when
+  the canonical contract intentionally changes.
+- Prepare the descriptor through `GRDBDatabase.prepareInvocation(with:)`, then
+  make a fresh packet for each call. Match the prepared operation to the
+  descriptor cardinality.
+- Use macro-generated static row layouts for contextual-only properties or
+  typed static decoding. The raw `GRDBPreparedStaticQuery` is `Sendable`; the
+  closure-backed typed layout wrapper remains task-local in v1.2.
+
+Read the canonical [static-query guide](https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/)
+for descriptor construction, captures, cardinality, preparation, and typed
+layouts rather than reproducing those contracts in consumer comments.
+
+## Respect dialect, driver, and codec ownership
+
+- Let `XLSQLiteDialect` own SQLite grammar, placeholder spelling, identifiers,
+  storage classes, and required capabilities. Let the driver own connections,
+  physical statements, transport binding, execution, and row reads.
+- Keep physical statements on the connection that prepared them. A logical
+  request or prepared handle is database-bound but does not own one physical
+  statement across a pool.
+- Prefer immutable contextual `XLValueCodec` registrations when one Swift type
+  has one or more database representations. Select codecs deterministically,
+  snapshot the configuration in the database or prepared handle, and treat a
+  codec key or version change as a schema/data compatibility decision.
+- Use intrinsic `Bool`, `Int`, finite `Double`, `String`, and `Data` storage
+  directly. Use prepared contextual parameters and result codecs for other
+  application values. Reject missing, duplicate, wrong-layout, wrong-storage,
+  and nullability-mismatched bindings before execution.
+- Decode ordinary queries into their selected `@SQLTable` or `@SQLResult` row.
+  For a raw static handle, validate result layout and cardinality before using
+  `resultCodec(_:identifiedBy:)` to decode contextual values.
+- Treat `XLInvocationBindingError` and `XLRequestBindingError` as caller
+  contract failures. Adapter authors should preserve structured
+  `XLDatabaseContractError` categories; the established GRDB facade can still
+  expose `DatabaseError` or `XLColumnReadError` where its compatibility policy
+  requires those concrete errors.
+
+Read [contextual codecs](https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/)
+and [prepared execution boundaries](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/)
+for the exact selection order, structured errors, row lifetime, and driver
+contracts.
+
+## Keep transactions and migrations explicit
+
+- Do not invent a high-level `GRDBDatabase.transaction` API. The shipped v1.2
+  transaction contract is the lower-level driver's synchronous
+  `withValidatedTransaction` helper.
+- Use only the pinned connection inside its transaction body. Do not re-enter
+  the root pool. A returned body commits; a thrown body rolls back and preserves
+  the body error.
+- Do not claim nested transactions, savepoints, task-cancellation hooks, or a
+  separate single-connection GRDB capability in v1.2.
+- Treat migrations as application or driver work. `sqlCreate` is not a
+  migration engine.
+
+## Avoid compatibility and escape-hatch traps
+
+- Keep existing `makeRequest(with:)`, mutating `set`, `XLCustomType`, legacy
+  literal readers, and raw `XLSQLiteValue` code working when maintaining v1
+  clients. For new code, prefer explicit invocation packets, `XLFieldReader`,
+  contextual codecs, and static descriptors where their added guarantees are
+  needed.
+- Do not share `XLRequest` across tasks; it is not `Sendable`. Use the raw
+  prepared invocation/static handles for supported cross-task raw-value work.
+- Do not turn runtime values into identifiers, ordering choices, placeholder
+  counts, or SQL grammar. Bind values; keep grammar and identifiers in the
+  Swift expression graph.
+- SwiftQL exposes no general raw-fragment API. When unsupported SQL genuinely
+  requires a direct GRDB escape hatch, isolate it at the application boundary,
+  allowlist any dynamic grammar or identifiers, and bind all data values.
+- Do not use deprecated pre-XL names such as `SQLNamedBindingReference`, or
+  represent NaN/non-finite `Double` values as inline SQLite numeric tokens.
+
+Check [the README](README.md) and [compatibility matrix](COMPATIBILITY.md) before
+changing product, platform, dependency, or concurrency claims.
+
+## Validate repository changes
+
+Run commands from the repository root. Keep the committed dependency graph for
+ordinary validation; use clean resolution only when dependency behavior is the
+subject of the task.
+
+```sh
+swift test --filter SQLSkillDocumentationTests
+scripts/ci/check-downstream-swift5-client.sh committed
+swift test
+./make-docs.sh docs
+scripts/ci/check-first-party-warnings.sh
+scripts/ci/check-strict-concurrency.sh
+```
+
+Run the warnings and strict-concurrency gates with a supported Xcode. Use the
+required GitHub compatibility matrix for exact Swift 5.9 and Swift 6.0-6.3
+evidence; do not silently substitute another local compiler.

--- a/Tests/SQLTests/SQLSkillDocumentationTests.swift
+++ b/Tests/SQLTests/SQLSkillDocumentationTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import XCTest
+
+
+final class SQLSkillDocumentationTests: XCTestCase {
+
+    func testSkillUsesCurrentCodexMetadataAndBoundedInstructions() throws {
+        let contents = try skillContents()
+        let lines = contents.components(separatedBy: .newlines)
+        let normalizedContents = normalizedWhitespace(contents)
+
+        XCTAssertEqual(lines.first, "---")
+        guard let closingFrontmatter = lines.dropFirst().firstIndex(of: "---") else {
+            return XCTFail("SKILL.md must close its YAML frontmatter.")
+        }
+        let metadata = Array(lines[1 ..< closingFrontmatter])
+        XCTAssertEqual(
+            metadata.filter { $0.hasPrefix("name:") },
+            ["name: swiftql"]
+        )
+        XCTAssertEqual(metadata.filter { $0.hasPrefix("description:") }.count, 1)
+        XCTAssertEqual(
+            metadata.filter { $0.contains(":") }.count,
+            2,
+            "Codex skill metadata must contain only name and description."
+        )
+        XCTAssertLessThan(lines.count, 220, "Keep the repository skill concise.")
+
+        for forbidden in [
+            "/Users/",
+            "/Applications/",
+            "DEVELOPER_DIR=",
+            "sudo ",
+            "rm -",
+            "git clean",
+            "git reset",
+        ] {
+            XCTAssertFalse(contents.contains(forbidden), "SKILL.md contains '\(forbidden)'.")
+        }
+
+        for required in [
+            "https://github.com/lukevanin/swiftql.git",
+            "`SwiftQLCore` only when implementing a dialect or database adapter",
+            "fresh immutable `XLInvocationBindings<XLSQLiteValue>` packet",
+            "`XLStaticQueryDescriptor`",
+            "runtime Swift values are not inferred from bare variables",
+            "`XLValueCodec`",
+            "`XLInvocationBindingError` and `XLRequestBindingError`",
+            "Do not invent a high-level `GRDBDatabase.transaction` API",
+            "`sqlCreate` is not a migration engine",
+            "SwiftQL exposes no general raw-fragment API",
+            "`XLRequest` across tasks; it is not `Sendable`",
+            "Swift 5.9 and Swift 6.0-6.3 evidence",
+        ] {
+            XCTAssertTrue(
+                normalizedContents.contains(required),
+                "SKILL.md is missing '\(required)'."
+            )
+        }
+    }
+
+    func testEverySwiftSnippetIsTheCompiledConsumerFixture() throws {
+        let skill = try skillContents()
+        let sourceURL = repositoryRootURL().appendingPathComponent(
+            "IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift"
+        )
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        let expected = try text(
+            between: "// swiftql-skill-example-begin\n",
+            and: "\n// swiftql-skill-example-end",
+            in: source
+        )
+
+        XCTAssertEqual(
+            skill.components(separatedBy: "```swift\n").count - 1,
+            1,
+            "Every added Swift fence needs an explicit compiled fixture."
+        )
+        let actual = try text(between: "```swift\n", and: "\n```", in: skill)
+        XCTAssertEqual(actual, expected)
+        XCTAssertTrue(
+            skill.contains(
+                "<!-- compile-test: IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift -->"
+            )
+        )
+    }
+
+    func testSkillLinksResolveAndCommandsStayRepositoryRelative() throws {
+        let root = repositoryRootURL()
+        let contents = try skillContents()
+
+        for path in ["README.md", "CHANGELOG.md", "COMPATIBILITY.md"] {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(path).path))
+            XCTAssertTrue(contents.contains("](\(path))"), "SKILL.md must link \(path).")
+        }
+        for canonicalURL in [
+            "https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/",
+            "https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/",
+            "https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/",
+        ] {
+            XCTAssertTrue(contents.contains(canonicalURL))
+        }
+
+        let shell = try text(between: "```sh\n", and: "\n```", in: contents)
+        XCTAssertEqual(
+            shell.components(separatedBy: .newlines),
+            [
+                "swift test --filter SQLSkillDocumentationTests",
+                "scripts/ci/check-downstream-swift5-client.sh committed",
+                "swift test",
+                "./make-docs.sh docs",
+                "scripts/ci/check-first-party-warnings.sh",
+                "scripts/ci/check-strict-concurrency.sh",
+            ]
+        )
+    }
+
+    private func skillContents() throws -> String {
+        try String(
+            contentsOf: repositoryRootURL().appendingPathComponent("SKILL.md"),
+            encoding: .utf8
+        )
+    }
+
+    private func text(
+        between opening: String,
+        and closing: String,
+        in contents: String
+    ) throws -> String {
+        guard
+            let start = contents.range(of: opening)?.upperBound,
+            let end = contents.range(of: closing, range: start ..< contents.endIndex)?.lowerBound
+        else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return String(contents[start ..< end])
+    }
+
+    private func normalizedWhitespace(_ contents: String) -> String {
+        contents
+            .split(whereSeparator: { $0.isWhitespace })
+            .map { "\($0)" }
+            .joined(separator: " ")
+    }
+
+    private func repositoryRootURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}


### PR DESCRIPTION
## Summary

- add a concise root `SKILL.md` with current Codex metadata and the shipped SwiftQL v1.2 application, static-query, dialect/driver, codec, transaction, migration, compatibility, and escape-hatch boundaries
- add one minimal immutable-binding query example and keep it byte-for-byte synchronized with a maintained Swift 5 consumer source
- execute that example against real SQLite in the downstream fixture and add focused regression checks for metadata, canonical links, safe commands, and v1.2 claims

## Validation

- Codex skill metadata validator: `Skill is valid!`
- `swift test --filter SQLSkillDocumentationTests`: 3 passed
- `scripts/ci/check-downstream-swift5-client.sh committed`: `SWIFTQL_DOWNSTREAM_SWIFT5_CLIENT ok`
- `swift test --filter SQLRequestCompatibilityTests`: 8 passed
- `swift test --filter SQLInvocationBindingsTests`: 13 passed
- full `swift test`: 593 passed — scheduler `run-7cfaaa6a-90b5-411f-a4ea-416372eb055b`
- `./make-docs.sh docs`: warnings-as-errors and catalog output check passed — scheduler `run-24152538-6675-4cd8-afc7-bddc18d62fee`
- `scripts/ci/check-first-party-warnings.sh`: clean — scheduler `run-baffd6d4-353e-4751-9978-967e975eb76f`
- `scripts/ci/check-strict-concurrency.sh`: clean — scheduler `run-adca7885-ac0e-497d-a9fe-6b99b16d0852`
- all three canonical DocC URLs referenced by the skill returned HTTP 200

Local validation used Xcode 26.5 / Swift 6.3.2 in Swift 5 language mode. The required GitHub compatibility workflow remains authoritative for exact Swift 5.9 and Swift 6.0-6.3 support points.

Closes #222