### PR TITLE
Audit SwiftQL v1.2 release readiness

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "[v1.2 Housekeeping] Update the SwiftQL agent SKILL.md",
-  "issue_number": 222,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/222",
+  "task_name": "[v1.2 Housekeeping] Audit release readiness and milestone closure",
+  "issue_number": 223,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/223",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#222 - Update the SwiftQL agent SKILL.md",
+  "codex_session_title": "lukevanin/swiftql#223 - Audit v1.2 release readiness and milestone closure",
   "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/222-v12-skill",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/222-v12-skill"
+  "task_branch": "codex/223-v12-audit",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/223-v12-audit"
 }

--- a/Documentation/ReleaseAudits/v1.2.md
+++ b/Documentation/ReleaseAudits/v1.2.md
@@ -1,0 +1,155 @@
+# SwiftQL v1.2 release-readiness audit
+
+Audited on 19 July 2026 against the live
+[v1.2 milestone](https://github.com/lukevanin/swiftql/milestone/6) and
+`origin/main` at `39ab80d6352186a0cfd761c2478faf2368019d01`.
+
+## Verdict
+
+**Ready for milestone closure.** SwiftQL's v1.2 implementation, compatibility,
+documentation, migration, validation, coverage, and performance evidence agree
+with the release boundary in `ROADMAP.md`. No product, correctness,
+compatibility, packaging, security, documentation, or performance blocker was
+found for closing issue
+[#223](https://github.com/lukevanin/swiftql/issues/223) and milestone 6.
+
+This is not a claim that `v1.2.0` has been published. The changelog correctly
+remains `Unreleased`, and no remote `v1.2.0` tag or GitHub Release existed at
+audit time. The exact post-milestone publication and independent verification
+work is tracked outside milestone 6 by
+[#274](https://github.com/lukevanin/swiftql/issues/274).
+
+## Verified facts
+
+### Live planning state
+
+- The live milestone contained 27 repository issues: 26 closed and only this
+  audit issue open. Its title, description, and issue membership match the v1.2
+  dialect-aware core and binding foundation in `ROADMAP.md`.
+- Every dependency and coordinating issue named by #223 was closed:
+  [#221](https://github.com/lukevanin/swiftql/issues/221),
+  [#222](https://github.com/lukevanin/swiftql/issues/222),
+  [#250](https://github.com/lukevanin/swiftql/issues/250),
+  [#248](https://github.com/lukevanin/swiftql/issues/248),
+  [#252](https://github.com/lukevanin/swiftql/issues/252),
+  [#253](https://github.com/lukevanin/swiftql/issues/253),
+  [#131](https://github.com/lukevanin/swiftql/issues/131),
+  [#188](https://github.com/lukevanin/swiftql/issues/188),
+  [#129](https://github.com/lukevanin/swiftql/issues/129),
+  [#82](https://github.com/lukevanin/swiftql/issues/82), and
+  [#189](https://github.com/lukevanin/swiftql/issues/189).
+- No open issue carried the `bug` or `security` label. No milestone issue needed
+  to be closed as stale, duplicate, or superseded during this audit.
+- Repository TODOs encountered during the audit are already bounded outside
+  v1.2. In particular, legacy anonymous-result removal belongs to
+  [#90](https://github.com/lukevanin/swiftql/issues/90) in v2, safer aggregate
+  grouping belongs to [#11](https://github.com/lukevanin/swiftql/issues/11) in
+  v1.3, and hosted-runner replacement for the Swift 5.9 lane belongs to
+  [#164](https://github.com/lukevanin/swiftql/issues/164).
+
+### Shipped boundary and migration record
+
+- `Package.swift` retains `swift-tools-version: 5.9`, iOS 16, macOS 13, and the
+  `SwiftQLCore`, `SwiftQL`, and diagnostic `swiftql-benchmark` products.
+- `SwiftQLCore` is GRDB-free. The application-facing `SwiftQL` product owns the
+  macros, typed DSL, contextual codecs, and the current GRDB-backed SQLite
+  implementation. v1.2 does not claim another public dialect, driver, Linux
+  runtime, asynchronous cursor, or Swift 6 language mode.
+- `CHANGELOG.md` accounts for the milestone's user-visible additions, behavior
+  changes, fixes, compatibility guarantees, and migration boundaries. Existing
+  high-level request, binding, custom-type, literal, result, and separator APIs
+  remain available throughout SwiftQL 1.x.
+- `README.md`, the twelve-article DocC catalog, `COMPATIBILITY.md`, and the root
+  `SKILL.md` consistently describe immutable invocation bindings, static query
+  descriptors, dialect/driver ownership, contextual codecs, prepared-handle
+  lifetime, current SQLite/GRDB support, and the task-local high-level request
+  boundary.
+- The checked-in Swift 5 downstream package compiles and executes the exact
+  minimal query snippet shown in `SKILL.md`. Documentation catalog tests keep
+  every other Swift fence connected to an executable scenario.
+
+### Correctness, compatibility, and evidence
+
+- The complete local package suite passed with 593 tests. Focused v1.2 contract
+  suites also passed for dialects/drivers, descriptors, immutable bindings,
+  contextual codecs, static row layouts, query capture, incremental GRDB row
+  decoding, shared SQLite value/storage cases, transaction invariants, and
+  request compatibility.
+- GitHub Swift compatibility run
+  [29670659581](https://github.com/lukevanin/swiftql/actions/runs/29670659581)
+  passed all nine jobs for the final v1.2 skill change: exact Swift 5.9 and
+  Swift 6.0 support points, Swift 6.1-6.3 clean resolution, committed and clean
+  dependency graphs, first-party warnings, complete strict concurrency,
+  downstream Swift 5 execution, release fixtures, and two-run source-coverage
+  reproducibility. Main run
+  [29671011219](https://github.com/lukevanin/swiftql/actions/runs/29671011219)
+  repeated all nine successful jobs against the exact `39ab80d6` merge commit.
+- GitHub Documentation run
+  [29670659649](https://github.com/lukevanin/swiftql/actions/runs/29670659649)
+  passed its warnings-as-errors DocC build for the same PR head. Main run
+  [29671011259](https://github.com/lukevanin/swiftql/actions/runs/29671011259)
+  then built and deployed the exact `39ab80d6` documentation artifact and
+  verified the deployed commit and catalog pages.
+- The pinned source-coverage baseline records deterministic first-party source
+  selection and complete provenance. Coverage percentages remain diagnostic,
+  while missing production sources outside the explicit zero-region allowance
+  fail the gate.
+- Shared SQLite storage/value and transaction manifests run through both the
+  core contracts and production GRDB adapter. Unsupported capabilities are
+  explicit semantic results rather than hidden skips.
+- The independent cross-library SQLite baseline and the issue #248 streaming
+  comparison preserve equivalent workloads, correctness checksums, timing
+  boundaries, toolchain/dependency provenance, and machine-readable raw
+  samples. Performance evidence is diagnostic; there is no misleading absolute
+  latency threshold.
+
+### Release controls
+
+- `scripts/ci/test-release-workflow.sh` covers ref validation, reachability,
+  changelog checks, deterministic assets, read-only dry runs, draft recovery,
+  idempotent publication, conflict handling, and release verification fixtures.
+- Immutable GitHub Releases were enabled at audit time.
+- The repository-owned `Protect v-prefixed release tags` ruleset was active,
+  matched exactly `refs/tags/v*`, had no bypass actors, and contained only the
+  update- and deletion-blocking rules. The current user could not bypass it.
+- `scripts/ci/check-release-readiness.sh` intentionally retains the historical
+  v1.1-only server-side check and prints a skip marker for later versions.
+  Therefore it is not v1.2 milestone evidence. `RELEASING.md` says so
+  explicitly, and #274 requires fresh live milestone verification before
+  tagging and again in the preserved release record.
+
+## Remaining work and disposition
+
+| Item | Disposition | Milestone blocker? |
+| --- | --- | --- |
+| Close #223 and milestone 6 after this audit merges | Final bookkeeping step owned by this audit | No |
+| Date the `1.2.0` changelog, exercise safe test tags, create the protected production tag, publish, and independently verify the immutable release | [#274](https://github.com/lukevanin/swiftql/issues/274), intentionally outside the closed implementation milestone | No |
+| GitHub's `actions/checkout` Node.js 20 deprecation annotation | Upstream action/runtime maintenance notice; all affected jobs currently execute successfully on GitHub's forced Node.js 24 runtime | No |
+| Hosted `macos-14` retirement on 2 November 2026 | [#164](https://github.com/lukevanin/swiftql/issues/164) owns replacement without silently dropping Swift 5.9 | No |
+
+There are no untracked audit TODOs. If a final PR or `main` validation fails,
+the verdict changes to **not ready** and that failure blocks closure until it is
+fixed or captured by a correctly scoped issue and an explicit release decision.
+
+## Reproduction commands
+
+The audit used these non-destructive repository and GitHub checks:
+
+```sh
+gh api repos/lukevanin/swiftql/milestones/6
+gh api --paginate 'repos/lukevanin/swiftql/issues?milestone=6&state=all&per_page=100'
+git log --first-parent --oneline v1.1.0..origin/main
+git ls-remote --tags origin refs/tags/v1.2.0
+gh release view v1.2.0 --repo lukevanin/swiftql
+scripts/ci/test-release-workflow.sh
+swift test
+scripts/ci/check-downstream-swift5-client.sh committed
+scripts/ci/check-first-party-warnings.sh
+scripts/ci/check-strict-concurrency.sh
+./make-docs.sh /tmp/swiftql-v1.2-audit-docs
+git diff --check
+```
+
+Exact local scheduler run identities and the final PR/main workflow URLs are
+preserved in #223 and its pull request so this checked-in record does not imply
+that a mutable CI run is part of the source contract.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,9 @@ matrix, and built the exact commit's validated DocC artifact.
 
 1. Merge every retained v1.2 issue, complete audit issue #223, and close
    milestone 6 with no open issues. Verify the live milestone rather than a
-   local planning file:
+   local planning file. The checked-in
+   [v1.2 release-readiness audit](Documentation/ReleaseAudits/v1.2.md) records
+   the pre-tag verdict and evidence:
 
    ```sh
    gh api repos/lukevanin/swiftql/milestones/6 |


### PR DESCRIPTION
## Summary

- add a durable v1.2 release-readiness audit with an explicit **ready for milestone closure** verdict
- reconcile all 27 live milestone issues, the roadmap, changelog, package products/platforms, compatibility matrix, README, DocC catalog, SKILL.md, coverage, performance evidence, and release controls
- link the audit from `RELEASING.md`
- track the intentionally post-milestone publication and independent verification work in #274

## Audit result

- milestone 6 had 26 closed issues and only #223 open at audit time
- all #223 dependencies and coordinating issues are closed
- no open issue carries the `bug` or `security` label
- no v1.2 product, correctness, compatibility, packaging, security, documentation, or performance blocker was found
- `v1.2.0` remains correctly unreleased and untagged; #274 owns test tags, changelog dating, protected publication, immutable asset verification, and final evidence outside milestone 6
- immutable releases are enabled and the repository-owned `Protect v-prefixed release tags` ruleset is active, exact, bypass-free, and non-bypassable

## Validation

- full `swift test`: 593 passed — scheduler `run-323c9a4e-187b-4417-ae4e-116a42302c7e`
- `scripts/ci/check-downstream-swift5-client.sh committed`: `SWIFTQL_DOWNSTREAM_SWIFT5_CLIENT ok`
- `./make-docs.sh /private/tmp/swiftql-v1.2-audit-docs-223`: warnings-as-errors and output validation passed — scheduler `run-3aa005a2-50b1-4953-a0c2-b58754a30ed2`
- `scripts/ci/check-first-party-warnings.sh`: clean — scheduler `run-f2be94ae-cc05-4123-b9d2-76fb8a9e964f`
- `scripts/ci/check-strict-concurrency.sh`: clean — scheduler `run-436c660b-d32a-447d-8e72-bc226cac3e35`
- `scripts/ci/test-release-workflow.sh`: `SWIFTQL_RELEASE_WORKFLOW_TESTS ok`
- `git diff --check`: passed
- exact main Swift compatibility run 29671011219: all nine jobs passed
- exact main Documentation run 29671011259: build, deployment, provenance, and catalog verification passed

Local Swift validation used Xcode 26.5 / Swift 6.3.2 in Swift 5 language mode. This PR's GitHub compatibility workflow remains authoritative for exact Swift 5.9 and Swift 6.0–6.3 support points.

Closes #223