### PR TITLE
Prepare SwiftQL v1.2.0 release

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "[v1.2 Housekeeping] Audit release readiness and milestone closure",
-  "issue_number": 223,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/223",
+  "task_name": "Release SwiftQL v1.2.0",
+  "issue_number": 274,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/274",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#223 - Audit v1.2 release readiness and milestone closure",
+  "codex_session_title": "lukevanin/swiftql#274 - Release SwiftQL v1.2.0",
   "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
   "codex_session_url": null,
-  "task_branch": "codex/223-v12-audit",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/223-v12-audit"
+  "task_branch": "codex/274-release-swiftql-v1-2-0",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/274-release-swiftql-v1-2-0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.2.0] - Unreleased
+## [1.2.0] - 2026-07-19
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -173,13 +173,13 @@ Add the following line to the `dependencies` section in your `Package.swift`
 file:
 
 ```text
-.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.1.0")
+.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.2.0")
 ```
 
-`1.1.0` is the latest published package while the v1.2 changelog is marked
-`Unreleased`. The examples above use APIs retained by v1.2. Adopt the new v1.2
-static-query surface only after pinning a source revision intentionally or
-after the `1.2.0` tag is published.
+`1.2.0` is the latest published package. The examples above use APIs retained
+by v1.2, and the v1.2 static-query surface is available from that semantic
+version. Pin a source revision only when intentionally testing later changes
+from `main`.
 
 ### Xcode
 
@@ -197,8 +197,8 @@ For project guarantees and direction:
 
 - [Compiler compatibility](COMPATIBILITY.md) records the supported Swift
   toolchains and reproducible CI matrix.
-- [Changelog](CHANGELOG.md) distinguishes released behavior from the v1.2
-  surface currently on `main` and records migration guidance.
+- [Changelog](CHANGELOG.md) records released behavior and v1.2 migration
+  guidance.
 - [Performance benchmarks](BENCHMARKS.md) measure query construction,
   preparation, caching, binding, execution, and decoding.
 - [First-party source coverage](Coverage/README.md) preserves the reproducible

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing SwiftQL
 
 SwiftQL releases use `vMAJOR.MINOR.PATCH` tags beginning with `v1.1.0`. This
-guide uses the pending `v1.2.0` release as its concrete example. The historical
+guide uses the `v1.2.0` release as its concrete example. The historical
 `1.0.0` tag and release are intentionally unchanged.
 
 The [Verified release workflow](.github/workflows/release.yml) treats a tag as

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,8 +22,8 @@ checked-out package version before editing consumer code.
   or later. SwiftQL v1.2 supports Apple platforms, SQLite syntax, and the GRDB
   driver only.
 - Read [the changelog](CHANGELOG.md) before choosing a package requirement.
-  While `1.2.0` is `Unreleased`, pin an intentional source revision for v1.2
-  APIs; use the published semantic version only after that tag exists.
+  Use the published `1.2.0` semantic version for v1.2 APIs. Pin a source
+  revision only when intentionally testing later changes from `main`.
 
 ## Follow the preferred application workflow
 

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -17,13 +17,13 @@ introduction to SQL, see the
 Add the latest published SwiftQL package to your dependencies:
 
 ```text
-.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.1.0")
+.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.2.0")
 ```
 
-Version 1.1.0 remains the published package while the v1.2 changelog is marked
-`Unreleased`. This guide's basic request path is retained by v1.2. Use the new
-static-query and contextual-codec APIs from `main` only when pinning a source
-revision intentionally, or after the `1.2.0` tag is published.
+Version 1.2.0 is the published package. This guide's basic request path remains
+supported in v1.2, and its static-query and contextual-codec APIs are available
+from version 1.2.0 or later. Pin a source revision only when intentionally
+testing later changes from `main`.
 
 Then add `SwiftQL` to the dependencies of your target and import the module in
 files that use it. The package requires Swift tools 5.9 and targets iOS 16 or

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -258,7 +258,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "fresh `XLInvocationBindings` value",
                 "every call. Invocation values never become identifiers",
                 "`SwiftQLCore` exposes GRDB-free",
-                "latest published package while the v1.2 changelog is marked",
+                "`1.2.0` is the latest published package",
             ],
             "COMPATIBILITY.md": [
                 "## v1.2 public products and runtime boundaries",
@@ -269,7 +269,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "all twelve source articles",
             ],
             "CHANGELOG.md": [
-                "## [1.2.0] - Unreleased",
+                "## [1.2.0] - 2026-07-19",
                 "Added the GRDB-free `SwiftQLCore` product",
                 "Added immutable `XLStaticQueryDescriptor` definitions",
                 "GRDB result rows are stepped and decoded incrementally",
@@ -279,7 +279,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "complete audit issue #223",
                 ".title == \"v1.2\"",
                 "not proof of v1.2 milestone readiness",
-                "the pending `v1.2.0` release",
+                "uses the `v1.2.0` release as its concrete example",
                 "dedicated v1.2 release issue",
             ],
             "Sources/SwiftQL/SwiftQL.docc/SwiftQL.md": [
@@ -289,9 +289,9 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "The current `XLRequest` facade is",
             ],
             "Sources/SwiftQL/SwiftQL.docc/GettingStarted.md": [
-                "v1.2 changelog is marked",
-                "basic request path is retained by v1.2",
-                "after the `1.2.0` tag is published",
+                "Version 1.2.0 is the published package",
+                "This guide's basic request path remains",
+                "from version 1.2.0 or later",
             ],
             "scripts/ci/check-docc-output.sh": [
                 "realvalues|Real Values",
@@ -319,7 +319,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         let firstReleaseHeading = changelog
             .components(separatedBy: .newlines)
             .first(where: { $0.hasPrefix("## [") })
-        XCTAssertEqual(firstReleaseHeading, "## [1.2.0] - Unreleased")
+        XCTAssertEqual(firstReleaseHeading, "## [1.2.0] - 2026-07-19")
     }
 
     func testREADMERepositoryLinksResolveWithExactCase() throws {


### PR DESCRIPTION
Tracks #274. Do not close #274 when this PR merges; the release issue closes only after the published `v1.2.0` release passes independent verification.

## Task
- Name: Release SwiftQL v1.2.0
- Issue: #274
- URL: https://github.com/lukevanin/swiftql/issues/274
- Workspace repository: `lukevanin/swiftql`
- Branch: `codex/274-release-swiftql-v1-2-0`
- Worktree: `/private/tmp/swiftql-worktrees/274-release-swiftql-v1-2-0`

## Codex Session
- Title: `lukevanin/swiftql#274 - Release SwiftQL v1.2.0`
- ID: `019f7610-5766-7ab1-b223-e1aaedeaff74`
- URL: unavailable in the current tool context

## Summary
- Record issue #274 as the active release-execution task in `.codex/task.json`.
- Replace `## [1.2.0] - Unreleased` with `## [1.2.0] - 2026-07-19`.
- Update only release-status metadata so the tagged README, DocC guide, and repository skill install `1.2.0` rather than claiming `1.1.0` is current.
- Update the documentation contract test and releasing-guide wording to match the published-state transition.
- Make no product, package-manifest, workflow, protection, API, feature, or migration-content changes.

## Requirement-to-Evidence Mapping
- Requirement: date the 1.2.0 changelog only after all safe test tags pass.
  - Implementation: exact dated heading in `CHANGELOG.md`.
  - Evidence: all three required rehearsals are recorded on #274.
  - Result: passed.
- Requirement: make the tagged documentation truthful at publication.
  - Implementation: README and Getting Started package examples now use `1.2.0`; the root skill and release guide no longer call v1.2 pending/unreleased.
  - Evidence: focused document/skill tests, full suite, and warnings-as-errors DocC output.
  - Result: passed.
- Requirement: keep release execution traceable without prematurely closing the issue.
  - Implementation: issue-specific task metadata and an explicit non-closing #274 link.
  - Result: #274 remains open through post-publication verification.

## Tests
- Focused document/skill contract tests: 10 passed — scheduler `run-98c5477f-8dc6-4228-8e76-ca4dadcf4e20`.
- Full `swift test`: 593 passed — scheduler `run-c36ff0fd-e30b-449f-be15-fa87996476d7`.
- Warnings-as-errors DocC build: `SWIFTQL_DOCC_OUTPUT ok` — scheduler `run-3a282a48-bc24-4137-b2ba-0450bb7460da`.
- `scripts/ci/check-release-changelog.sh v1.2.0 v1.2.0` — passed.
- `scripts/ci/test-release-workflow.sh` — passed.
- `git diff --check` — passed.
- Dry run: https://github.com/lukevanin/swiftql/actions/runs/29681540024 — full matrix/docs/dry-run passed, publish skipped, no release.
- Invalid SemVer: https://github.com/lukevanin/swiftql/actions/runs/29682003768 — ref validation failed, all downstream work skipped.
- Unreachable ref: https://github.com/lukevanin/swiftql/actions/runs/29682075275 — reachability failed, all downstream work skipped.

## Verification Artifacts
Visual artifacts are not applicable. The browser-accessible workflow runs, generated DocC artifact, exact release metadata diff, and #274 evidence comments are the authoritative artifacts.

## Validation Needed
After merge, re-fetch exact `origin/main`, verify main CI and protection/settings again, then create the one annotated production tag and independently verify the immutable release.

## Key Decisions
- The release issue is linked but deliberately not auto-closed by this PR.
- The first PR-head CI correctly caught hard-coded `Unreleased` expectations and stale 1.1 installation guidance. The correction is limited to release-state metadata and its tests.
- The release workflow remains the only publisher; this PR does not create a tag or release.

## Concerns and Potential Red Flags
- Production publication is irreversible after GitHub marks the release immutable, so the tag will not be created until this corrected head is green, merged, and every pre-tag invariant is rechecked.
- GitHub's Node.js 20 action deprecation annotations remain non-failing and are tracked separately from this release.