### PR TITLE
Research explicit versioned schema migrations

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Release SwiftQL v1.2.0",
-  "issue_number": 274,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/274",
+  "task_name": "Research explicit versioned schema migrations beyond catalog bootstrap",
+  "issue_number": 216,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/216",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#274 - Release SwiftQL v1.2.0",
-  "codex_session_id": "019f7610-5766-7ab1-b223-e1aaedeaff74",
+  "codex_session_title": "lukevanin/swiftql#216 - Research explicit versioned schema migrations",
+  "codex_session_id": "019f7a20-d672-7c92-8899-b1f5e051e808",
   "codex_session_url": null,
-  "task_branch": "codex/274-release-swiftql-v1-2-0",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/274-release-swiftql-v1-2-0"
+  "task_branch": "codex/216-research-explicit-versioned-schema-migrations",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/216-research-explicit-versioned-schema-migrations"
 }

--- a/Documentation/Architecture/VersionedSchemaMigrations.md
+++ b/Documentation/Architecture/VersionedSchemaMigrations.md
@@ -12,9 +12,10 @@ definitions the execution source of truth. Schema diffs may produce read-only
 reports and confirmation-required proposals, but a live schema difference or a
 changed Swift model must never execute a migration by itself.
 
-Migration support remains future P4 work. It does not block
-[catalog bootstrap #215](https://github.com/lukevanin/swiftql/issues/215) or the
-v2 catalog release.
+Migration support is scheduled for the post-v2
+[v2.x milestone](https://github.com/lukevanin/swiftql/milestone/11). It does not
+block [catalog bootstrap #215](https://github.com/lukevanin/swiftql/issues/215)
+or the v2 catalog release.
 
 ## Decision summary
 

--- a/Documentation/Architecture/VersionedSchemaMigrations.md
+++ b/Documentation/Architecture/VersionedSchemaMigrations.md
@@ -1,0 +1,406 @@
+# Explicit Versioned Schema Migrations
+
+## Status
+
+This note records the research and SQLite prototype for
+[issue #216](https://github.com/lukevanin/swiftql/issues/216). The prototype
+lives entirely in `SchemaMigrationArchitecturePrototypeTests.swift`; it is not
+a supported API.
+
+The recommendation is to make user-authored, immutable, forward-only migration
+definitions the execution source of truth. Schema diffs may produce read-only
+reports and confirmation-required proposals, but a live schema difference or a
+changed Swift model must never execute a migration by itself.
+
+Migration support remains future P4 work. It does not block
+[catalog bootstrap #215](https://github.com/lukevanin/swiftql/issues/215) or the
+v2 catalog release.
+
+## Decision summary
+
+SwiftQL should eventually provide:
+
+1. Catalog-owned semantic schema snapshots and fingerprints.
+2. An immutable ordered migration registry with stable definition hashes.
+3. An auditable, namespaced history table for SwiftQL-managed execution.
+4. Dialect-specific migration operations behind an adapter-neutral executor.
+5. One atomic transaction per migration, with the history row committed in the
+   same transaction as the schema and data change.
+6. Explicit baseline adoption for an existing unmanaged database.
+7. A separate external-runner mode for applications that already use GRDB or
+   another migration framework.
+8. Forward-only application behavior. Downgrade means restore a backup or ship
+   a new explicit forward recovery migration, not automatically reverse code.
+
+The initial implementation should be SQLite-specific. Other dialects may reuse
+registry and snapshot concepts, but they must own their grammar, capabilities,
+locking, transaction rules, and validation.
+
+## Why current SwiftQL cannot migrate safely
+
+The current boundaries are useful foundations, but none is a migration system:
+
+- `sqlCreate` and generated `MetaCreate` currently render table/column names and
+  nullability. They do not preserve complete types, defaults, keys, checks,
+  indexes, triggers, or views. Typed DDL remains tracked by
+  [#139](https://github.com/lukevanin/swiftql/issues/139).
+- `XLValueCodecIdentity` already has stable codec, value-type, dialect, and
+  storage identities. A codec key/version change is explicitly a data
+  migration, so these identities must participate in schema fingerprints.
+- `XLDatabaseDriver.withValidatedTransaction` proves pinned-connection commit
+  and rollback behavior, but the migration path also needs a serialized/barrier
+  writer, schema inspection, runtime dialect version, foreign-key policy outside
+  the transaction, and history access.
+- Each ordinary `GRDBInvocationExecutor.execute` call starts its own
+  transaction. Calling several write requests cannot provide one atomic
+  multi-statement migration.
+- `GRDBDatabase` initializes `XLSQLiteDialect` without a runtime SQLite version.
+  Migration capability selection therefore cannot safely assume which native
+  `ALTER TABLE` forms exist.
+- Catalog bootstrap is intentionally create-missing only. `CREATE TABLE IF NOT
+  EXISTS` neither proves compatibility nor upgrades an existing table.
+
+## Strategy comparison
+
+| Strategy | Role | Decision |
+| --- | --- | --- |
+| Explicit user-authored migrations | Durable source describing old state, target state, data mapping, validation, and risk | Primary execution model |
+| Generated proposals requiring confirmation | Authoring aid that emits exact fingerprints, warnings, unresolved mappings, and reviewable source/artifacts | Recommended after snapshots exist |
+| Live schema diff that executes automatically | Infers intent from model/live drift | Rejected |
+
+The distinction is important. A diff can observe that `full_name` disappeared
+and `display_name` appeared. It cannot know whether that is a rename, a new
+field, intentional data loss, or two unrelated changes. The same ambiguity
+exists for type, constraint, and codec changes.
+
+## Recommended contract
+
+The names below are illustrative. The responsibilities and ownership are the
+decision.
+
+```swift
+struct XLSchemaMigration<Dialect> {
+    let catalogID: XLCatalogID
+    let sequence: Int
+    let migrationID: XLMigrationID
+    let definitionFingerprint: XLMigrationDefinitionFingerprint
+    let fromSchema: XLSchemaSnapshot
+    let toSchema: XLSchemaSnapshot
+    let dialectRequirement: XLDialectRequirement
+    let foreignKeyPolicy: XLForeignKeyMigrationPolicy
+    let risk: XLMigrationRisk
+    let operations: [Dialect.MigrationOperation]
+    let validations: [Dialect.MigrationValidation]
+}
+```
+
+### Catalog and fingerprint ownership
+
+- A stable catalog identity owns a specific set of schema objects. Unrelated
+  user-managed tables are outside its fingerprint.
+- A schema snapshot is a semantic, immutable value produced from typed DDL and
+  catalog metadata. It includes tables, columns, physical storage, nullability,
+  defaults, keys, constraints, indexes, triggers, views, dialect capabilities,
+  and codec identities.
+- A dialect inspector converts the live database into the same semantic shape.
+  Fingerprints are computed from canonical snapshot values, not raw formatted
+  SQL alone.
+- Every migration freezes both its old and new snapshot. Migration source must
+  not reach into the latest application model to reconstruct a historical
+  state.
+- SQLite cannot introspect Swift codec meaning from a database file. Historical
+  codec/storage metadata therefore comes from the frozen migration definition
+  and committed history. An unmanaged baseline needs explicit adoption against
+  a supplied expected snapshot.
+- The migration definition fingerprint covers the immutable operation tree,
+  mappings, risk acknowledgement, dialect requirements, and validations. It
+  cannot be derived from an opaque Swift closure identity.
+
+The prototype found one concrete canonicalization requirement: SQLite stores a
+directly created table as `CREATE TABLE members ...`, but after rebuilding and
+renaming it may store `CREATE TABLE "members" ...`. Those schemas are equivalent.
+A raw `sqlite_schema.sql` hash rejected the valid migration; the passing
+prototype canonicalizes the object-name quoting before hashing. Production
+fingerprints should use the typed semantic representation from #139 and test
+all supported SQLite object forms.
+
+### Registry and ordering
+
+Each catalog owns a contiguous positive sequence. Registration order is
+explicit, not inferred from identifiers, filenames, model declaration order, or
+timestamps.
+
+Before database access, registry validation requires:
+
+- unique catalog/sequence and catalog/migration-ID pairs;
+- no sequence gaps;
+- each migration's `from` fingerprint equals its predecessor's `to`
+  fingerprint;
+- every dialect/capability requirement is declared; and
+- every destructive operation has an explicit acknowledgement and validation.
+
+After acquiring the migration writer, stored history must be an exact prefix of
+the registered definitions. A renamed, removed, reordered, or modified applied
+migration is a structured error. Unknown future history means the database is
+too new; an older app must refuse migration/writes instead of trying to
+downgrade.
+
+### History
+
+SwiftQL-managed mode should use a namespaced internal table rather than SQLite
+header pragmas. The prototype uses this shape:
+
+```sql
+CREATE TABLE _swiftql_schema_migrations (
+    catalog_id TEXT NOT NULL,
+    sequence INTEGER NOT NULL CHECK (sequence > 0),
+    migration_id TEXT NOT NULL,
+    definition_fingerprint TEXT NOT NULL,
+    from_schema_fingerprint TEXT NOT NULL,
+    to_schema_fingerprint TEXT NOT NULL,
+    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (catalog_id, sequence),
+    UNIQUE (catalog_id, migration_id)
+);
+```
+
+Production may add dialect/runtime version, application build identity, duration,
+or a validation summary. The required invariant is that the history row is
+inserted after postflight validation and in the same transaction as the change.
+
+`PRAGMA schema_version` is SQLite-owned statement-cache state; writing it can
+cause stale statements or corruption. `PRAGMA user_version` is application-owned
+but is only one shared integer, cannot represent multiple catalogs or immutable
+definition hashes, and may already belong to a host framework. Neither is the
+migration ledger.
+
+## Execution algorithm
+
+For each pending migration, the executor should:
+
+1. Acquire one adapter-owned serialized/barrier writer. Migrations should run
+   before queries, observations, or prepared handles are exposed.
+2. Validate the registered list and re-read stored history under that writer.
+3. Inspect the catalog-owned live schema and require the exact `from`
+   fingerprint.
+4. Validate runtime dialect identity, version, and capabilities.
+5. Select the declared foreign-key policy. For a SQLite rebuild, disable
+   `PRAGMA foreign_keys` before beginning the transaction and remember the prior
+   state.
+6. Start an immediate transaction.
+7. Execute the frozen dialect-owned operations.
+8. Run data-copy invariants and custom validation queries.
+9. Run `PRAGMA foreign_key_check` when deferred checks are required, then the
+   declared integrity checks.
+10. Inspect the live target and require the exact `to` fingerprint.
+11. Insert the history row.
+12. Commit.
+13. Restore the original foreign-key setting outside the transaction, preserving
+    the primary operation/commit error if restoration also fails.
+
+SQLite documents that changing `PRAGMA foreign_keys` inside a transaction is a
+no-op. This is why migration execution needs a boundary above the existing
+transaction closure, not just another statement type.
+
+### Transaction and recovery policy
+
+Use one transaction per migration, not one transaction for all pending
+migrations. This gives each released version one durable checkpoint and lets a
+restart resume at the first unapplied definition. Within one migration, schema,
+data, validation, and history remain atomic.
+
+If an operation, copy check, foreign-key check, target fingerprint, or history
+insert fails, the transaction rolls back. An application-level interruption is
+the same: no history row means the version was not committed. SQLite is designed
+to recover interrupted transactions, but the prototype only injected thrown
+errors; it did not perform power-loss or process-kill testing.
+
+SQLite permits only one writer. Use an immediate transaction so lock failure is
+reported before expensive copy work. Busy retry/timeouts belong to the adapter
+policy and must be visible in the result.
+
+### Downgrades
+
+The initial contract is forward-only:
+
+- `migrate(upTo:)` may stop at a registered future target only when the database
+  has not already passed it.
+- An older app opening newer history receives a `databaseTooNew` result and
+  should remain read-only only if its compatibility policy explicitly proves
+  that safe.
+- Reversing a destructive transform is not generally possible. Recovery is a
+  backup restore or a new explicit forward migration.
+- A future reversible-migration feature would need separately authored and
+  tested reverse operations; it must not be synthesized from the forward plan.
+
+## SQLite table rebuild
+
+The prototype evolves a real seeded `members` table by:
+
+- renaming `full_name` to `display_name` through an explicit mapping;
+- removing `legacy_code` only after mapping it into a new checked `status`
+  column;
+- adding a nonempty-name check and an active/inactive check/default;
+- preserving the primary key and foreign key to `teams`;
+- recreating a renamed composite index and a rewritten audit trigger;
+- comparing every copied row and transformed value before dropping the source;
+- checking foreign keys and database integrity; and
+- comparing the rebuilt live schema with an independently created v2 schema.
+
+It follows SQLite's safe order:
+
+1. Create a collision-free new table with the target definition.
+2. Copy using explicit target columns and source expressions, never `SELECT *`.
+3. Validate the copy.
+4. Drop the old table.
+5. Rename the new table to the final name.
+6. Recreate declared indexes, triggers, and affected views.
+
+The superficially similar rename-old/create-new/copy/drop order is unsafe
+because SQLite may rewrite references in triggers, views, and foreign keys.
+
+## What can be generated
+
+| Change | Generator behavior | Execution requirement |
+| --- | --- | --- |
+| Snapshot/fingerprint/diff report | Generate automatically, read-only | None |
+| Create missing object | Keep in explicit bootstrap #215 | Never call it migration |
+| Add nullable/defaulted column or index | May generate a proposal after dialect/version checks | User accepts immutable source/registry definition |
+| Possible table/column rename | Report candidates only | Explicit old-to-new mapping |
+| Drop table/column or remove constraint/index | Mark destructive | Explicit acknowledgement and validation/data disposition |
+| Type/nullability/key/check/unique change | Mark data-dependent | Explicit transform plus failure/copy validation |
+| Codec key/version/storage change | Mark data migration even if Swift type is unchanged | Old and new codecs plus explicit transform/validation |
+| Trigger/view rewrite | Report dependency and target definition | Explicit target semantics; never blind text cloning |
+| Unsupported dialect/object | Blocking diagnostic | Add dialect/object support or use an audited raw escape hatch |
+
+A raw dialect-specific operation may be necessary, but it must still declare
+before/after fingerprints, capability requirements, risk, and validation. It
+does not become portable merely because it is wrapped in a shared Swift type.
+
+## Existing migration frameworks
+
+SwiftQL must not force existing applications to replace a mature migration
+runner. Provide two explicit modes:
+
+### SwiftQL-managed mode
+
+SwiftQL owns registry ordering, its namespaced history table, the transaction,
+foreign-key policy, validation, and result.
+
+### External-runner mode
+
+GRDB `DatabaseMigrator` or another framework owns ordering, journal, serialized
+writer, transaction, and recovery. SwiftQL supplies one frozen operation with
+preflight/postflight validation and declares the required foreign-key policy.
+It does not create `_swiftql_schema_migrations`, start a nested transaction, or
+claim the migration was applied.
+
+An application must choose one owner per catalog. Running two independent
+histories over the same objects is rejected. GRDB's existing behavior is a good
+SQLite reference: named migrations run once in order, each in its own
+transaction; rebuild migrations defer foreign-key enforcement, check all foreign
+keys before commit, and restore enforcement afterward.
+
+## Dialect and adapter responsibilities
+
+Shared core owns identities, immutable registry/history values, semantic schema
+concepts, risk classifications, and structured outcomes.
+
+Each dialect owns:
+
+- supported native alter operations and minimum server/runtime versions;
+- rebuild or alternative lowering rules;
+- identifier and schema-object canonicalization;
+- type, storage, default, constraint, index, trigger, and view semantics;
+- transaction/locking requirements; and
+- introspection needed for a live snapshot.
+
+Each adapter owns serialized connection access, statement execution, binding,
+transactions, cancellation/busy policy, foreign-key/configuration state, and
+error normalization.
+
+The SQLite prototype is evidence only for SQLite 3.51.0. It says nothing about
+PostgreSQL transactional DDL, MySQL implicit commits, SQL Server batches, or
+their online migration features.
+
+## Required rejections and edge cases
+
+Initial implementations should reject rather than weaken validation when they
+encounter:
+
+- ambiguous renames or unmapped target columns;
+- a changed applied migration definition;
+- missing, gapped, or unknown future history;
+- an unexpected catalog-owned live object;
+- codec changes without both historical and target semantics;
+- unsupported virtual/FTS tables, generated columns, STRICT/WITHOUT ROWID
+  options, partial/expression indexes, or dependent triggers/views;
+- foreign-key cycles without a proven deferred-check plan;
+- attached/temp schemas when only `main` is supported;
+- attempts to migrate after statements/observers are already active; or
+- insufficient disk/lock budget for a table rebuild.
+
+Large table rebuilds can need roughly another copy of the table plus journal/WAL
+space and can hold the writer for a long time. Chunked or online migration is a
+separate architecture, not an automatic fallback. The executor should expose
+estimates/progress hooks where possible and fail before destructive steps when
+the required capability or resource policy is absent.
+
+## Prototype evidence
+
+Validation command:
+
+```text
+swift test --filter SchemaMigrationArchitecturePrototypeTests
+```
+
+Environment:
+
+- SQLite CLI/runtime family checked during the run: 3.51.0.
+- Apple Swift 6.3.2, target `arm64-apple-macosx26.0`.
+- Five focused tests, zero failures.
+
+The tests prove:
+
+- a real v1-to-v2 SQLite rebuild preserves/transforms seeded rows;
+- row values, removed/renamed/new columns, foreign keys, checks, defaults,
+  index, trigger, audit data, integrity, and target fingerprint are inspected;
+- reapplying the same definition is idempotent;
+- unexpected live schema fails before mutation;
+- a copy constraint failure rolls back and restores foreign-key enforcement;
+- an injected failure after rebuild validation but before history insertion
+  restores the complete v1 schema/data/history; and
+- changed history plus ambiguous rename/codec/dialect proposals fail explicitly.
+
+## Prototype limitations
+
+- The prototype is private test code over GRDB, not an adapter-neutral public
+  implementation.
+- Its FNV-1a fingerprint and narrow SQLite quote canonicalization demonstrate
+  the contract but are not production fingerprint algorithms.
+- It uses small in-memory tables and synchronous execution.
+- It does not test a process kill, power loss, disk full, busy timeout,
+  concurrent process, attached database, huge copy, views, virtual tables,
+  generated columns, STRICT/WITHOUT ROWID, or cross-dialect behavior.
+- It uses explicit SQL to freeze the historical schemas because #139 and the
+  complete catalog metadata are not implemented yet.
+
+## Accepted follow-up issues
+
+- [#276 — Catalog-owned live-schema snapshots and migration fingerprints](https://github.com/lukevanin/swiftql/issues/276)
+- [#277 — Immutable versioned migration registry and history contract](https://github.com/lukevanin/swiftql/issues/277)
+- [#278 — Atomic SQLite migration executor and history commit boundary](https://github.com/lukevanin/swiftql/issues/278)
+- [#279 — Typed SQLite table rebuilds with explicit data transforms](https://github.com/lukevanin/swiftql/issues/279)
+- [#280 — Catalog migration integration and bootstrap handoff](https://github.com/lukevanin/swiftql/issues/280)
+- [#281 — Read-only schema diffs and confirmation-required proposals](https://github.com/lukevanin/swiftql/issues/281)
+
+## References
+
+- [SQLite ALTER TABLE and the generalized rebuild procedure](https://www.sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes)
+- [SQLite transaction behavior](https://www.sqlite.org/lang_transaction.html)
+- [SQLite PRAGMA reference](https://www.sqlite.org/pragma.html)
+- [SQLite foreign-key behavior](https://www.sqlite.org/foreignkeys.html)
+- [GRDB 6.29.3 migration guidance](https://github.com/groue/GRDB.swift/blob/v6.29.3/Documentation/Migrations.md)
+- [Typed DDL #139](https://github.com/lukevanin/swiftql/issues/139)
+- [Catalog bootstrap #215](https://github.com/lukevanin/swiftql/issues/215)
+- [GRDB adapter boundary #113](https://github.com/lukevanin/swiftql/issues/113)

--- a/Documentation/Architecture/VersionedSchemaMigrations.md
+++ b/Documentation/Architecture/VersionedSchemaMigrations.md
@@ -12,10 +12,10 @@ definitions the execution source of truth. Schema diffs may produce read-only
 reports and confirmation-required proposals, but a live schema difference or a
 changed Swift model must never execute a migration by itself.
 
-Migration support is scheduled for the post-v2
-[v2.x milestone](https://github.com/lukevanin/swiftql/milestone/11). It does not
-block [catalog bootstrap #215](https://github.com/lukevanin/swiftql/issues/215)
-or the v2 catalog release.
+Migration support is scheduled for
+[v2.5](https://github.com/lukevanin/swiftql/milestone/11). It does not block
+[catalog bootstrap #215](https://github.com/lukevanin/swiftql/issues/215) or the
+v2 catalog release.
 
 ## Decision summary
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,6 +56,7 @@ Version numbers express the intended order of work, not release dates.
 | [v1.4](https://github.com/lukevanin/swiftql/milestone/9) | Common SQLite feature coverage | A documented, useful SQLite subset |
 | [v1.5](https://github.com/lukevanin/swiftql/milestone/1) | Query declarations, ergonomics, and v2 preview | The future API validated without silently raising the v1 toolchain floor |
 | [v2](https://github.com/lukevanin/swiftql/milestone/10) | Generated database catalogs, Swift 6, and a stable dialect-aware API | Fluent catalog-scoped queries plus intentional naming, package, DDL, and adapter cleanup |
+| [v2.x](https://github.com/lukevanin/swiftql/milestone/11) | Explicit versioned schema migrations | A post-v2 additive release; its exact minor is assigned after v2 stabilizes without renumbering the existing adapter and backend milestones |
 | [v2.1](https://github.com/lukevanin/swiftql/milestone/2) | Native SQLite adapter | Direct SQLite C execution as an alternative to GRDB |
 | [v2.2](https://github.com/lukevanin/swiftql/milestone/5) | PostgreSQL | Native PostgreSQL syntax and adapter |
 | [v2.3](https://github.com/lukevanin/swiftql/milestone/4) | MySQL | Native MySQL syntax and adapter |
@@ -76,6 +77,7 @@ Key planning and foundation issues:
 | v1.4 | [SQLite coverage index](https://github.com/lukevanin/swiftql/issues/115), [direct scalar CTE rows](https://github.com/lukevanin/swiftql/issues/43) |
 | v1.5 | [ergonomics index](https://github.com/lukevanin/swiftql/issues/116), [macro index](https://github.com/lukevanin/swiftql/issues/117), [prepared handles](https://github.com/lukevanin/swiftql/issues/18), [lazy typed result set](https://github.com/lukevanin/swiftql/issues/249), [@SQLQuery prototype](https://github.com/lukevanin/swiftql/issues/26), [Date text](https://github.com/lukevanin/swiftql/issues/61) and [numeric codecs](https://github.com/lukevanin/swiftql/issues/62), [UUID codecs](https://github.com/lukevanin/swiftql/issues/192), [interactive DocC tutorial](https://github.com/lukevanin/swiftql/issues/27), [macro regression corpus](https://github.com/lukevanin/swiftql/issues/256), [compile scalability benchmarks](https://github.com/lukevanin/swiftql/issues/257), [runtime workload research](https://github.com/lukevanin/swiftql/issues/259) |
 | v2 | [generated database catalogs and fluent table references](https://github.com/lukevanin/swiftql/issues/217), [Swift 6 mode](https://github.com/lukevanin/swiftql/issues/133), [typed DDL](https://github.com/lukevanin/swiftql/issues/139), [GRDB adapter boundary](https://github.com/lukevanin/swiftql/issues/113), [XL migration](https://github.com/lukevanin/swiftql/issues/33), [catalog stress fixtures](https://github.com/lukevanin/swiftql/issues/258) |
+| v2.x | [schema-migration research](https://github.com/lukevanin/swiftql/issues/216), [semantic snapshots and fingerprints](https://github.com/lukevanin/swiftql/issues/276), [immutable registry and history](https://github.com/lukevanin/swiftql/issues/277), [atomic SQLite executor](https://github.com/lukevanin/swiftql/issues/278), [typed SQLite rebuilds](https://github.com/lukevanin/swiftql/issues/279), [catalog lifecycle integration](https://github.com/lukevanin/swiftql/issues/280), [read-only diffs and proposals](https://github.com/lukevanin/swiftql/issues/281) |
 | v2.1 | [native SQLite adapter](https://github.com/lukevanin/swiftql/issues/136), [Linux CI](https://github.com/lukevanin/swiftql/issues/135), [VDBE research](https://github.com/lukevanin/swiftql/issues/138), [shared-corpus adapter parity](https://github.com/lukevanin/swiftql/issues/260) |
 | v2.2 | [PostgreSQL vertical slice](https://github.com/lukevanin/swiftql/issues/137) |
 | v2.3 | [MySQL vertical slice](https://github.com/lukevanin/swiftql/issues/130) |
@@ -649,6 +651,29 @@ Use the major-version boundary for intentional API and package cleanup:
   compiler;
 - document source migration, concurrency behavior, and compatibility
   boundaries.
+
+### v2.x — Explicit Versioned Schema Migrations
+
+Ship schema evolution as an additive post-v2 release built on the stable v2
+catalog, typed DDL, codec metadata, dialect capability, and adapter boundaries.
+The exact minor number remains deliberately unassigned until v2 stabilizes;
+this milestone does not delay v2 or renumber the existing v2.1-v2.4 adapter and
+backend milestones.
+
+- compare catalog-owned live schema with deterministic semantic snapshots and
+  fingerprints before and after every migration;
+- execute only immutable, explicitly ordered, forward-only migration
+  definitions with an auditable history contract;
+- apply each SQLite migration and its history record in one atomic transaction,
+  with explicit foreign-key, validation, recovery, and too-new database policy;
+- provide typed SQLite table rebuilds with explicit column mappings, data
+  transforms, dependent-object recreation, and copy validation;
+- keep bootstrap, validation, baseline adoption, and migration as separate
+  catalog lifecycle operations;
+- support external migration runners without double journaling or nested
+  transaction ownership; and
+- generate schema differences and migration proposals only as read-only,
+  confirmation-required authoring aids, never as model-drift execution.
 
 ### v2.1 — Native SQLite Adapter
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,11 +56,11 @@ Version numbers express the intended order of work, not release dates.
 | [v1.4](https://github.com/lukevanin/swiftql/milestone/9) | Common SQLite feature coverage | A documented, useful SQLite subset |
 | [v1.5](https://github.com/lukevanin/swiftql/milestone/1) | Query declarations, ergonomics, and v2 preview | The future API validated without silently raising the v1 toolchain floor |
 | [v2](https://github.com/lukevanin/swiftql/milestone/10) | Generated database catalogs, Swift 6, and a stable dialect-aware API | Fluent catalog-scoped queries plus intentional naming, package, DDL, and adapter cleanup |
-| [v2.x](https://github.com/lukevanin/swiftql/milestone/11) | Explicit versioned schema migrations | A post-v2 additive release; its exact minor is assigned after v2 stabilizes without renumbering the existing adapter and backend milestones |
 | [v2.1](https://github.com/lukevanin/swiftql/milestone/2) | Native SQLite adapter | Direct SQLite C execution as an alternative to GRDB |
 | [v2.2](https://github.com/lukevanin/swiftql/milestone/5) | PostgreSQL | Native PostgreSQL syntax and adapter |
 | [v2.3](https://github.com/lukevanin/swiftql/milestone/4) | MySQL | Native MySQL syntax and adapter |
 | [v2.4](https://github.com/lukevanin/swiftql/milestone/3) | SQL Server | Native T-SQL syntax and adapter |
+| [v2.5](https://github.com/lukevanin/swiftql/milestone/11) | Explicit versioned schema migrations | Catalog-owned, forward-only schema evolution after the v2 catalog and adapter foundations are established |
 
 The v1 milestones are sequential quality and architecture layers. Work on a
 small PostgreSQL proof may start before v2 is frozen so the shared core is
@@ -77,11 +77,11 @@ Key planning and foundation issues:
 | v1.4 | [SQLite coverage index](https://github.com/lukevanin/swiftql/issues/115), [direct scalar CTE rows](https://github.com/lukevanin/swiftql/issues/43) |
 | v1.5 | [ergonomics index](https://github.com/lukevanin/swiftql/issues/116), [macro index](https://github.com/lukevanin/swiftql/issues/117), [prepared handles](https://github.com/lukevanin/swiftql/issues/18), [lazy typed result set](https://github.com/lukevanin/swiftql/issues/249), [@SQLQuery prototype](https://github.com/lukevanin/swiftql/issues/26), [Date text](https://github.com/lukevanin/swiftql/issues/61) and [numeric codecs](https://github.com/lukevanin/swiftql/issues/62), [UUID codecs](https://github.com/lukevanin/swiftql/issues/192), [interactive DocC tutorial](https://github.com/lukevanin/swiftql/issues/27), [macro regression corpus](https://github.com/lukevanin/swiftql/issues/256), [compile scalability benchmarks](https://github.com/lukevanin/swiftql/issues/257), [runtime workload research](https://github.com/lukevanin/swiftql/issues/259) |
 | v2 | [generated database catalogs and fluent table references](https://github.com/lukevanin/swiftql/issues/217), [Swift 6 mode](https://github.com/lukevanin/swiftql/issues/133), [typed DDL](https://github.com/lukevanin/swiftql/issues/139), [GRDB adapter boundary](https://github.com/lukevanin/swiftql/issues/113), [XL migration](https://github.com/lukevanin/swiftql/issues/33), [catalog stress fixtures](https://github.com/lukevanin/swiftql/issues/258) |
-| v2.x | [schema-migration research](https://github.com/lukevanin/swiftql/issues/216), [semantic snapshots and fingerprints](https://github.com/lukevanin/swiftql/issues/276), [immutable registry and history](https://github.com/lukevanin/swiftql/issues/277), [atomic SQLite executor](https://github.com/lukevanin/swiftql/issues/278), [typed SQLite rebuilds](https://github.com/lukevanin/swiftql/issues/279), [catalog lifecycle integration](https://github.com/lukevanin/swiftql/issues/280), [read-only diffs and proposals](https://github.com/lukevanin/swiftql/issues/281) |
 | v2.1 | [native SQLite adapter](https://github.com/lukevanin/swiftql/issues/136), [Linux CI](https://github.com/lukevanin/swiftql/issues/135), [VDBE research](https://github.com/lukevanin/swiftql/issues/138), [shared-corpus adapter parity](https://github.com/lukevanin/swiftql/issues/260) |
 | v2.2 | [PostgreSQL vertical slice](https://github.com/lukevanin/swiftql/issues/137) |
 | v2.3 | [MySQL vertical slice](https://github.com/lukevanin/swiftql/issues/130) |
 | v2.4 | [SQL Server vertical slice](https://github.com/lukevanin/swiftql/issues/134) |
+| v2.5 | [schema-migration research](https://github.com/lukevanin/swiftql/issues/216), [semantic snapshots and fingerprints](https://github.com/lukevanin/swiftql/issues/276), [immutable registry and history](https://github.com/lukevanin/swiftql/issues/277), [atomic SQLite executor](https://github.com/lukevanin/swiftql/issues/278), [typed SQLite rebuilds](https://github.com/lukevanin/swiftql/issues/279), [catalog lifecycle integration](https://github.com/lukevanin/swiftql/issues/280), [read-only diffs and proposals](https://github.com/lukevanin/swiftql/issues/281) |
 
 ## Generated Database Catalogs and Fluent Table References
 
@@ -652,29 +652,6 @@ Use the major-version boundary for intentional API and package cleanup:
 - document source migration, concurrency behavior, and compatibility
   boundaries.
 
-### v2.x — Explicit Versioned Schema Migrations
-
-Ship schema evolution as an additive post-v2 release built on the stable v2
-catalog, typed DDL, codec metadata, dialect capability, and adapter boundaries.
-The exact minor number remains deliberately unassigned until v2 stabilizes;
-this milestone does not delay v2 or renumber the existing v2.1-v2.4 adapter and
-backend milestones.
-
-- compare catalog-owned live schema with deterministic semantic snapshots and
-  fingerprints before and after every migration;
-- execute only immutable, explicitly ordered, forward-only migration
-  definitions with an auditable history contract;
-- apply each SQLite migration and its history record in one atomic transaction,
-  with explicit foreign-key, validation, recovery, and too-new database policy;
-- provide typed SQLite table rebuilds with explicit column mappings, data
-  transforms, dependent-object recreation, and copy validation;
-- keep bootstrap, validation, baseline adoption, and migration as separate
-  catalog lifecycle operations;
-- support external migration runners without double journaling or nested
-  transaction ownership; and
-- generate schema differences and migration proposals only as read-only,
-  confirmation-required authoring aids, never as model-drift execution.
-
 ### v2.1 — Native SQLite Adapter
 
 Provide a direct SQLite C adapter that can replace the GRDB adapter:
@@ -712,6 +689,26 @@ T-SQL semantics directly, publish a supported-feature matrix, use
 database-bound prepared handles, and validate against supported live SQL Server
 versions. Native `uniqueidentifier`, `datetime2`, and string mappings remain
 distinct from SQLite and PostgreSQL representations.
+
+### v2.5 — Explicit Versioned Schema Migrations
+
+Ship schema evolution on the stable v2 catalog, typed DDL, codec metadata,
+dialect capability, and adapter boundaries:
+
+- compare catalog-owned live schema with deterministic semantic snapshots and
+  fingerprints before and after every migration;
+- execute only immutable, explicitly ordered, forward-only migration
+  definitions with an auditable history contract;
+- apply each SQLite migration and its history record in one atomic transaction,
+  with explicit foreign-key, validation, recovery, and too-new database policy;
+- provide typed SQLite table rebuilds with explicit column mappings, data
+  transforms, dependent-object recreation, and copy validation;
+- keep bootstrap, validation, baseline adoption, and migration as separate
+  catalog lifecycle operations;
+- support external migration runners without double journaling or nested
+  transaction ownership; and
+- generate schema differences and migration proposals only as read-only,
+  confirmation-required authoring aids, never as model-drift execution.
 
 Post-v2 adapter ordering may change if research, maintainership, or driver
 maturity changes, but backend-specific public syntax remains the architectural

--- a/Tests/SQLTests/SchemaMigrationArchitecturePrototypeTests.swift
+++ b/Tests/SQLTests/SchemaMigrationArchitecturePrototypeTests.swift
@@ -1,0 +1,1232 @@
+import Foundation
+import GRDB
+import XCTest
+
+@testable import SwiftQL
+
+
+final class SchemaMigrationArchitecturePrototypeTests: XCTestCase {
+
+    func testExplicitRebuildPreservesDataAndVerifiesTargetSchema() throws {
+        let fixture = try PrototypeMigrationFixture()
+        let fingerprints = try fixture.referenceFingerprints()
+        try fixture.installVersionOne(expectedFingerprint: fingerprints.v1)
+
+        let plan = fixture.versionTwoPlan(fingerprints: fingerprints)
+        XCTAssertEqual(
+            try fixture.executor.apply(plan),
+            .applied(sequence: 2, migrationID: plan.migrationID)
+        )
+
+        try fixture.databaseQueue.read { database in
+            XCTAssertNotNil(
+                try String.fetchOne(database, sql: "SELECT sqlite_version()")
+            )
+            XCTAssertEqual(
+                try PrototypeSchemaFingerprint.capture(
+                    database,
+                    catalog: plan.toCatalog
+                ),
+                fingerprints.v2
+            )
+            XCTAssertEqual(
+                try PrototypeMemberV2.fetchAll(database),
+                [
+                    PrototypeMemberV2(
+                        id: 1,
+                        teamID: 1,
+                        displayName: "Alice Adams",
+                        nickname: "Al",
+                        status: "active"
+                    ),
+                    PrototypeMemberV2(
+                        id: 2,
+                        teamID: 1,
+                        displayName: "Bob Brown",
+                        nickname: nil,
+                        status: "inactive"
+                    ),
+                ]
+            )
+            XCTAssertEqual(
+                try PrototypeAuditRow.fetchAll(database),
+                [
+                    PrototypeAuditRow(
+                        memberID: 1,
+                        oldName: "Alice",
+                        newName: "Alice Adams"
+                    )
+                ]
+            )
+            XCTAssertEqual(
+                try String.fetchAll(
+                    database,
+                    sql: "PRAGMA integrity_check"
+                ),
+                ["ok"]
+            )
+            XCTAssertTrue(
+                try Row.fetchAll(database, sql: "PRAGMA foreign_key_check").isEmpty
+            )
+            XCTAssertEqual(
+                try Int.fetchOne(database, sql: "PRAGMA foreign_keys"),
+                1
+            )
+
+            let columns = try String.fetchAll(
+                database,
+                sql: "SELECT name FROM pragma_table_xinfo('members') ORDER BY cid"
+            )
+            XCTAssertEqual(
+                columns,
+                ["id", "team_id", "display_name", "nickname", "status"]
+            )
+            XCTAssertFalse(columns.contains("full_name"))
+            XCTAssertFalse(columns.contains("legacy_code"))
+
+            let schemaObjects = try PrototypeSchemaObject.fetchAll(
+                database,
+                sql: """
+                    SELECT type, name, tbl_name, COALESCE(sql, '') AS sql
+                    FROM sqlite_schema
+                    WHERE tbl_name = 'members'
+                    ORDER BY type, name
+                    """
+            )
+            XCTAssertTrue(
+                schemaObjects.contains {
+                    $0.type == "index"
+                        && $0.name == "members_team_display_name_idx"
+                }
+            )
+            XCTAssertTrue(
+                schemaObjects.contains {
+                    $0.type == "trigger"
+                        && $0.name == "members_display_name_audit"
+                }
+            )
+        }
+
+        try fixture.databaseQueue.write { database in
+            try database.execute(
+                sql: "UPDATE members SET display_name = ? WHERE id = ?",
+                arguments: ["Alice A.", 1]
+            )
+            XCTAssertEqual(
+                try PrototypeAuditRow.fetchAll(database),
+                [
+                    PrototypeAuditRow(
+                        memberID: 1,
+                        oldName: "Alice",
+                        newName: "Alice Adams"
+                    ),
+                    PrototypeAuditRow(
+                        memberID: 1,
+                        oldName: "Alice Adams",
+                        newName: "Alice A."
+                    ),
+                ]
+            )
+
+            XCTAssertThrowsError(
+                try database.execute(
+                    sql: """
+                        INSERT INTO members (
+                            id, team_id, display_name, nickname, status
+                        ) VALUES (3, 999, 'Invalid team', NULL, 'active')
+                        """
+                )
+            ) { error in
+                XCTAssertEqual(
+                    (error as? DatabaseError)?.extendedResultCode,
+                    .SQLITE_CONSTRAINT_FOREIGNKEY
+                )
+            }
+            XCTAssertThrowsError(
+                try database.execute(
+                    sql: """
+                        INSERT INTO members (
+                            id, team_id, display_name, nickname, status
+                        ) VALUES (3, 1, 'Invalid status', NULL, 'unknown')
+                        """
+                )
+            ) { error in
+                XCTAssertEqual(
+                    (error as? DatabaseError)?.resultCode,
+                    .SQLITE_CONSTRAINT
+                )
+            }
+            XCTAssertThrowsError(
+                try database.execute(
+                    sql: """
+                        INSERT INTO members (
+                            id, team_id, display_name, nickname, status
+                        ) VALUES (3, 1, '', NULL, 'active')
+                        """
+                )
+            ) { error in
+                XCTAssertEqual(
+                    (error as? DatabaseError)?.resultCode,
+                    .SQLITE_CONSTRAINT
+                )
+            }
+        }
+
+        XCTAssertEqual(
+            try fixture.executor.apply(plan),
+            .alreadyApplied(sequence: 2, migrationID: plan.migrationID)
+        )
+        XCTAssertEqual(try fixture.history(), [1, 2])
+    }
+
+    func testUnexpectedLiveSchemaIsRejectedBeforeMutation() throws {
+        let fixture = try PrototypeMigrationFixture()
+        let fingerprints = try fixture.referenceFingerprints()
+        try fixture.installVersionOne(expectedFingerprint: fingerprints.v1)
+        try fixture.databaseQueue.write { database in
+            try database.execute(
+                sql: "CREATE INDEX members_unexpected_idx ON members(nickname)"
+            )
+        }
+
+        let plan = fixture.versionTwoPlan(fingerprints: fingerprints)
+        XCTAssertThrowsError(try fixture.executor.apply(plan)) { error in
+            guard case .schemaDivergence(
+                stage: .before,
+                expected: fingerprints.v1,
+                actual: let actual
+            )? = error as? PrototypeMigrationError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertNotEqual(actual, fingerprints.v1)
+        }
+
+        XCTAssertEqual(try fixture.history(), [1])
+        try fixture.databaseQueue.read { database in
+            XCTAssertTrue(try database.tableExists("members"))
+            XCTAssertFalse(try database.tableExists("__swiftql_new_members"))
+            XCTAssertEqual(
+                try Int.fetchOne(database, sql: "PRAGMA foreign_keys"),
+                1
+            )
+            XCTAssertTrue(
+                try String.fetchAll(
+                    database,
+                    sql: """
+                        SELECT name FROM sqlite_schema
+                        WHERE type = 'index' AND tbl_name = 'members'
+                        """
+                ).contains("members_unexpected_idx")
+            )
+        }
+    }
+
+    func testCopyConstraintFailureRollsBackAndRestoresForeignKeys() throws {
+        let fixture = try PrototypeMigrationFixture()
+        let fingerprints = try fixture.referenceFingerprints()
+        try fixture.installVersionOne(expectedFingerprint: fingerprints.v1)
+        try fixture.databaseQueue.write { database in
+            try database.execute(
+                sql: "UPDATE members SET full_name = '' WHERE id = 2"
+            )
+        }
+
+        let plan = fixture.versionTwoPlan(fingerprints: fingerprints)
+        XCTAssertThrowsError(try fixture.executor.apply(plan)) { error in
+            XCTAssertEqual(
+                (error as? DatabaseError)?.resultCode,
+                .SQLITE_CONSTRAINT
+            )
+        }
+
+        try assertVersionOneWasRestored(
+            fixture,
+            expectedFingerprint: fingerprints.v1
+        )
+    }
+
+    func testFailureAfterRebuildValidationRollsBackBeforeJournalCommit() throws {
+        let fixture = try PrototypeMigrationFixture()
+        let fingerprints = try fixture.referenceFingerprints()
+        try fixture.installVersionOne(expectedFingerprint: fingerprints.v1)
+
+        var plan = fixture.versionTwoPlan(fingerprints: fingerprints)
+        plan.injectFailureAfterValidation = true
+        XCTAssertThrowsError(try fixture.executor.apply(plan)) { error in
+            XCTAssertEqual(
+                error as? PrototypeMigrationError,
+                .simulatedInterruption
+            )
+        }
+
+        try assertVersionOneWasRestored(
+            fixture,
+            expectedFingerprint: fingerprints.v1
+        )
+    }
+
+    func testHistoryAndAmbiguousChangesFailExplicitly() throws {
+        let fixture = try PrototypeMigrationFixture()
+        let fingerprints = try fixture.referenceFingerprints()
+        try fixture.installVersionOne(expectedFingerprint: fingerprints.v1)
+
+        var driftedPlan = fixture.versionTwoPlan(fingerprints: fingerprints)
+        driftedPlan.definitionFingerprint = "changed-after-release"
+        try fixture.databaseQueue.write { database in
+            try database.execute(
+                sql: """
+                    INSERT INTO _swiftql_schema_migrations (
+                        catalog_id,
+                        sequence,
+                        migration_id,
+                        definition_fingerprint,
+                        from_schema_fingerprint,
+                        to_schema_fingerprint
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                arguments: [
+                    driftedPlan.catalogID,
+                    driftedPlan.sequence,
+                    driftedPlan.migrationID,
+                    "released-definition",
+                    driftedPlan.fromFingerprint.rawValue,
+                    driftedPlan.toFingerprint.rawValue,
+                ]
+            )
+        }
+
+        XCTAssertThrowsError(try fixture.executor.apply(driftedPlan)) { error in
+            XCTAssertEqual(
+                error as? PrototypeMigrationError,
+                .historyDrift(sequence: 2, migrationID: driftedPlan.migrationID)
+            )
+        }
+
+        XCTAssertThrowsError(
+            try PrototypeProposalPolicy.requireUserIntent(
+                .possibleRename(from: "full_name", to: "display_name")
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? PrototypeMigrationError,
+                .userIntentRequired(
+                    "Possible rename full_name -> display_name cannot be inferred."
+                )
+            )
+        }
+        XCTAssertThrowsError(
+            try PrototypeProposalPolicy.requireUserIntent(
+                .codecChange(
+                    column: "status",
+                    from: "status-text@1",
+                    to: "status-int@1"
+                )
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? PrototypeMigrationError,
+                .userIntentRequired(
+                    "Codec change status-text@1 -> status-int@1 for status needs an explicit data transform."
+                )
+            )
+        }
+        XCTAssertThrowsError(
+            try PrototypeProposalPolicy.requireUserIntent(
+                .unsupportedDialect("postgresql")
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? PrototypeMigrationError,
+                .unsupportedDialect("postgresql")
+            )
+        }
+    }
+
+    private func assertVersionOneWasRestored(
+        _ fixture: PrototypeMigrationFixture,
+        expectedFingerprint: PrototypeSchemaFingerprint
+    ) throws {
+        XCTAssertEqual(try fixture.history(), [1])
+        try fixture.databaseQueue.read { database in
+            XCTAssertEqual(
+                try PrototypeSchemaFingerprint.capture(
+                    database,
+                    catalog: .versionOne
+                ),
+                expectedFingerprint
+            )
+            XCTAssertTrue(try database.tableExists("members"))
+            XCTAssertFalse(try database.tableExists("__swiftql_new_members"))
+            XCTAssertEqual(
+                try String.fetchOne(
+                    database,
+                    sql: "SELECT full_name FROM members WHERE id = 1"
+                ),
+                "Alice Adams"
+            )
+            XCTAssertEqual(
+                try Int.fetchOne(database, sql: "PRAGMA foreign_keys"),
+                1
+            )
+            XCTAssertTrue(
+                try Row.fetchAll(database, sql: "PRAGMA foreign_key_check").isEmpty
+            )
+        }
+    }
+}
+
+
+private struct PrototypeMigrationFixture {
+    let databaseQueue: DatabaseQueue
+    let executor: PrototypeSQLiteMigrationExecutor
+
+    init() throws {
+        let databaseQueue = try DatabaseQueue()
+        self.databaseQueue = databaseQueue
+        self.executor = PrototypeSQLiteMigrationExecutor(
+            databaseQueue: databaseQueue
+        )
+    }
+
+    func referenceFingerprints() throws -> (
+        v1: PrototypeSchemaFingerprint,
+        v2: PrototypeSchemaFingerprint
+    ) {
+        let versionOne = try DatabaseQueue()
+        try versionOne.write { database in
+            try createSharedSchema(database)
+            try createVersionOneMembersSchema(database)
+        }
+        let versionTwo = try DatabaseQueue()
+        try versionTwo.write { database in
+            try createSharedSchema(database)
+            try createVersionTwoMembersSchema(database, tableName: "members")
+            try createVersionTwoDependents(database)
+        }
+        return (
+            try versionOne.read {
+                try PrototypeSchemaFingerprint.capture(
+                    $0,
+                    catalog: .versionOne
+                )
+            },
+            try versionTwo.read {
+                try PrototypeSchemaFingerprint.capture(
+                    $0,
+                    catalog: .versionTwo
+                )
+            }
+        )
+    }
+
+    func installVersionOne(
+        expectedFingerprint: PrototypeSchemaFingerprint
+    ) throws {
+        try databaseQueue.write { database in
+            try createSharedSchema(database)
+            try createVersionOneMembersSchema(database)
+            try seedVersionOneData(database)
+        }
+        try executor.adoptBaseline(
+            catalog: .versionOne,
+            expectedFingerprint: expectedFingerprint
+        )
+    }
+
+    func versionTwoPlan(
+        fingerprints: (
+            v1: PrototypeSchemaFingerprint,
+            v2: PrototypeSchemaFingerprint
+        )
+    ) -> PrototypeSQLiteMigrationPlan {
+        let definitionComponents = [
+            "library@2",
+            createVersionTwoMembersSQL(tableName: "__swiftql_new_members"),
+            copyVersionTwoMembersSQL,
+            "DROP TABLE members",
+            "ALTER TABLE __swiftql_new_members RENAME TO members",
+            createVersionTwoIndexSQL,
+            createVersionTwoTriggerSQL,
+            "copy-validation:row-id-values-status",
+            "foreign-key-check:all",
+            "integrity-check",
+        ]
+        return PrototypeSQLiteMigrationPlan(
+            catalogID: PrototypeCatalog.versionTwo.id,
+            sequence: 2,
+            migrationID: "members-v2-rebuild",
+            previousMigrationID: "adopt-library-v1",
+            definitionFingerprint: PrototypeStableFingerprint.make(
+                definitionComponents
+            ),
+            fromCatalog: .versionOne,
+            toCatalog: .versionTwo,
+            fromFingerprint: fingerprints.v1,
+            toFingerprint: fingerprints.v2,
+            foreignKeyPolicy: .deferredFullCheck,
+            migrate: rebuildMembersToVersionTwo
+        )
+    }
+
+    func history() throws -> [Int] {
+        try databaseQueue.read { database in
+            try Int.fetchAll(
+                database,
+                sql: """
+                    SELECT sequence
+                    FROM _swiftql_schema_migrations
+                    WHERE catalog_id = ?
+                    ORDER BY sequence
+                    """,
+                arguments: [PrototypeCatalog.versionOne.id]
+            )
+        }
+    }
+}
+
+
+private enum PrototypeMigrationOutcome: Equatable {
+    case applied(sequence: Int, migrationID: String)
+    case alreadyApplied(sequence: Int, migrationID: String)
+}
+
+
+private enum PrototypeMigrationStage: String, Equatable {
+    case before
+    case after
+}
+
+
+private enum PrototypeMigrationError: Error, Equatable {
+    case baselineAlreadyAdopted
+    case schemaDivergence(
+        stage: PrototypeMigrationStage,
+        expected: PrototypeSchemaFingerprint,
+        actual: PrototypeSchemaFingerprint
+    )
+    case historyGap(expectedPreviousSequence: Int, actual: Int?)
+    case historyDrift(sequence: Int, migrationID: String)
+    case copiedDataMismatch
+    case integrityCheckFailed([String])
+    case simulatedInterruption
+    case userIntentRequired(String)
+    case unsupportedDialect(String)
+}
+
+
+private enum PrototypeForeignKeyPolicy: Equatable {
+    case immediate
+    case deferredFullCheck
+}
+
+
+private struct PrototypeSQLiteMigrationPlan {
+    let catalogID: String
+    let sequence: Int
+    let migrationID: String
+    let previousMigrationID: String
+    var definitionFingerprint: String
+    let fromCatalog: PrototypeCatalog
+    let toCatalog: PrototypeCatalog
+    let fromFingerprint: PrototypeSchemaFingerprint
+    let toFingerprint: PrototypeSchemaFingerprint
+    let foreignKeyPolicy: PrototypeForeignKeyPolicy
+    var injectFailureAfterValidation = false
+    let migrate: (Database) throws -> Void
+}
+
+
+private struct PrototypeSQLiteMigrationExecutor {
+    let databaseQueue: DatabaseQueue
+
+    func adoptBaseline(
+        catalog: PrototypeCatalog,
+        expectedFingerprint: PrototypeSchemaFingerprint
+    ) throws {
+        try databaseQueue.writeWithoutTransaction { database in
+            try createHistoryTable(database)
+            try database.inTransaction(.immediate) {
+                let existingCount = try Int.fetchOne(
+                    database,
+                    sql: """
+                        SELECT COUNT(*)
+                        FROM _swiftql_schema_migrations
+                        WHERE catalog_id = ?
+                        """,
+                    arguments: [catalog.id]
+                ) ?? 0
+                guard existingCount == 0 else {
+                    throw PrototypeMigrationError.baselineAlreadyAdopted
+                }
+                let actual = try PrototypeSchemaFingerprint.capture(
+                    database,
+                    catalog: catalog
+                )
+                guard actual == expectedFingerprint else {
+                    throw PrototypeMigrationError.schemaDivergence(
+                        stage: .before,
+                        expected: expectedFingerprint,
+                        actual: actual
+                    )
+                }
+                try database.execute(
+                    sql: """
+                        INSERT INTO _swiftql_schema_migrations (
+                            catalog_id,
+                            sequence,
+                            migration_id,
+                            definition_fingerprint,
+                            from_schema_fingerprint,
+                            to_schema_fingerprint
+                        ) VALUES (?, 1, ?, ?, ?, ?)
+                        """,
+                    arguments: [
+                        catalog.id,
+                        "adopt-library-v1",
+                        PrototypeStableFingerprint.make([
+                            "explicit-baseline-adoption",
+                            expectedFingerprint.rawValue,
+                        ]),
+                        "unmanaged",
+                        expectedFingerprint.rawValue,
+                    ]
+                )
+                return .commit
+            }
+        }
+    }
+
+    func apply(
+        _ plan: PrototypeSQLiteMigrationPlan
+    ) throws -> PrototypeMigrationOutcome {
+        var outcome: PrototypeMigrationOutcome?
+        try databaseQueue.writeWithoutTransaction { database in
+            try createHistoryTable(database)
+            try withForeignKeyPolicy(plan.foreignKeyPolicy, database: database) {
+                try database.inTransaction(.immediate) {
+                    if let existing = try historyRow(
+                        plan.sequence,
+                        catalogID: plan.catalogID,
+                        database: database
+                    ) {
+                        guard existing.migrationID == plan.migrationID,
+                              existing.definitionFingerprint
+                                == plan.definitionFingerprint,
+                              existing.fromSchemaFingerprint
+                                == plan.fromFingerprint.rawValue,
+                              existing.toSchemaFingerprint
+                                == plan.toFingerprint.rawValue else {
+                            throw PrototypeMigrationError.historyDrift(
+                                sequence: plan.sequence,
+                                migrationID: plan.migrationID
+                            )
+                        }
+                        let actual = try PrototypeSchemaFingerprint.capture(
+                            database,
+                            catalog: plan.toCatalog
+                        )
+                        guard actual == plan.toFingerprint else {
+                            throw PrototypeMigrationError.schemaDivergence(
+                                stage: .after,
+                                expected: plan.toFingerprint,
+                                actual: actual
+                            )
+                        }
+                        outcome = .alreadyApplied(
+                            sequence: plan.sequence,
+                            migrationID: plan.migrationID
+                        )
+                        return .commit
+                    }
+
+                    let previous = try lastHistoryRow(
+                        catalogID: plan.catalogID,
+                        database: database
+                    )
+                    guard previous?.sequence == plan.sequence - 1,
+                          previous?.migrationID == plan.previousMigrationID,
+                          previous?.toSchemaFingerprint
+                            == plan.fromFingerprint.rawValue else {
+                        throw PrototypeMigrationError.historyGap(
+                            expectedPreviousSequence: plan.sequence - 1,
+                            actual: previous?.sequence
+                        )
+                    }
+
+                    let before = try PrototypeSchemaFingerprint.capture(
+                        database,
+                        catalog: plan.fromCatalog
+                    )
+                    guard before == plan.fromFingerprint else {
+                        throw PrototypeMigrationError.schemaDivergence(
+                            stage: .before,
+                            expected: plan.fromFingerprint,
+                            actual: before
+                        )
+                    }
+
+                    try plan.migrate(database)
+                    if case .deferredFullCheck = plan.foreignKeyPolicy {
+                        try database.checkForeignKeys()
+                    }
+                    let integrity = try String.fetchAll(
+                        database,
+                        sql: "PRAGMA integrity_check"
+                    )
+                    guard integrity == ["ok"] else {
+                        throw PrototypeMigrationError.integrityCheckFailed(
+                            integrity
+                        )
+                    }
+                    let after = try PrototypeSchemaFingerprint.capture(
+                        database,
+                        catalog: plan.toCatalog
+                    )
+                    guard after == plan.toFingerprint else {
+                        throw PrototypeMigrationError.schemaDivergence(
+                            stage: .after,
+                            expected: plan.toFingerprint,
+                            actual: after
+                        )
+                    }
+                    if plan.injectFailureAfterValidation {
+                        throw PrototypeMigrationError.simulatedInterruption
+                    }
+
+                    try database.execute(
+                        sql: """
+                            INSERT INTO _swiftql_schema_migrations (
+                                catalog_id,
+                                sequence,
+                                migration_id,
+                                definition_fingerprint,
+                                from_schema_fingerprint,
+                                to_schema_fingerprint
+                            ) VALUES (?, ?, ?, ?, ?, ?)
+                            """,
+                        arguments: [
+                            plan.catalogID,
+                            plan.sequence,
+                            plan.migrationID,
+                            plan.definitionFingerprint,
+                            plan.fromFingerprint.rawValue,
+                            plan.toFingerprint.rawValue,
+                        ]
+                    )
+                    outcome = .applied(
+                        sequence: plan.sequence,
+                        migrationID: plan.migrationID
+                    )
+                    return .commit
+                }
+            }
+        }
+        return try XCTUnwrap(outcome)
+    }
+
+    private func withForeignKeyPolicy(
+        _ policy: PrototypeForeignKeyPolicy,
+        database: Database,
+        operation: () throws -> Void
+    ) throws {
+        let foreignKeysWereEnabled = try Bool.fetchOne(
+            database,
+            sql: "PRAGMA foreign_keys"
+        ) ?? false
+        let shouldDisable = foreignKeysWereEnabled
+            && policy == .deferredFullCheck
+        if shouldDisable {
+            try database.execute(sql: "PRAGMA foreign_keys = OFF")
+        }
+
+        var operationError: Error?
+        do {
+            try operation()
+        }
+        catch {
+            operationError = error
+        }
+
+        var restorationError: Error?
+        if shouldDisable {
+            do {
+                try database.execute(sql: "PRAGMA foreign_keys = ON")
+            }
+            catch {
+                restorationError = error
+            }
+        }
+        if let operationError {
+            throw operationError
+        }
+        if let restorationError {
+            throw restorationError
+        }
+    }
+
+    private func createHistoryTable(_ database: Database) throws {
+        try database.execute(
+            sql: """
+                CREATE TABLE IF NOT EXISTS _swiftql_schema_migrations (
+                    catalog_id TEXT NOT NULL,
+                    sequence INTEGER NOT NULL CHECK (sequence > 0),
+                    migration_id TEXT NOT NULL,
+                    definition_fingerprint TEXT NOT NULL,
+                    from_schema_fingerprint TEXT NOT NULL,
+                    to_schema_fingerprint TEXT NOT NULL,
+                    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (catalog_id, sequence),
+                    UNIQUE (catalog_id, migration_id)
+                )
+                """
+        )
+    }
+
+    private func historyRow(
+        _ sequence: Int,
+        catalogID: String,
+        database: Database
+    ) throws -> PrototypeHistoryRow? {
+        try PrototypeHistoryRow.fetchOne(
+            database,
+            sql: """
+                SELECT
+                    sequence,
+                    migration_id,
+                    definition_fingerprint,
+                    from_schema_fingerprint,
+                    to_schema_fingerprint
+                FROM _swiftql_schema_migrations
+                WHERE catalog_id = ? AND sequence = ?
+                """,
+            arguments: [catalogID, sequence]
+        )
+    }
+
+    private func lastHistoryRow(
+        catalogID: String,
+        database: Database
+    ) throws -> PrototypeHistoryRow? {
+        try PrototypeHistoryRow.fetchOne(
+            database,
+            sql: """
+                SELECT
+                    sequence,
+                    migration_id,
+                    definition_fingerprint,
+                    from_schema_fingerprint,
+                    to_schema_fingerprint
+                FROM _swiftql_schema_migrations
+                WHERE catalog_id = ?
+                ORDER BY sequence DESC
+                LIMIT 1
+                """,
+            arguments: [catalogID]
+        )
+    }
+}
+
+
+private struct PrototypeHistoryRow: FetchableRecord, Decodable {
+    let sequence: Int
+    let migrationID: String
+    let definitionFingerprint: String
+    let fromSchemaFingerprint: String
+    let toSchemaFingerprint: String
+
+    enum CodingKeys: String, CodingKey {
+        case sequence
+        case migrationID = "migration_id"
+        case definitionFingerprint = "definition_fingerprint"
+        case fromSchemaFingerprint = "from_schema_fingerprint"
+        case toSchemaFingerprint = "to_schema_fingerprint"
+    }
+}
+
+
+private struct PrototypeSchemaFingerprint:
+    RawRepresentable,
+    Equatable,
+    CustomStringConvertible
+{
+    let rawValue: String
+
+    var description: String {
+        rawValue
+    }
+
+    static func capture(
+        _ database: Database,
+        catalog: PrototypeCatalog
+    ) throws -> Self {
+        let names = catalog.ownedSchemaNames
+        let placeholders = Array(repeating: "?", count: names.count).joined(
+            separator: ", "
+        )
+        let objects = try PrototypeSchemaObject.fetchAll(
+            database,
+            sql: """
+                SELECT type, name, tbl_name, COALESCE(sql, '') AS sql
+                FROM sqlite_schema
+                WHERE name IN (\(placeholders))
+                   OR tbl_name IN (\(placeholders))
+                ORDER BY type, name, tbl_name
+                """,
+            arguments: StatementArguments(names + names)
+        )
+        let components = objects.map(\.stableComponent)
+            + catalog.semanticComponents.sorted()
+        return Self(rawValue: PrototypeStableFingerprint.make(components))
+    }
+}
+
+
+private struct PrototypeSchemaObject: FetchableRecord, Decodable {
+    let type: String
+    let name: String
+    let tableName: String
+    let sql: String
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case name
+        case tableName = "tbl_name"
+        case sql
+    }
+
+    var stableComponent: String {
+        [
+            type,
+            name,
+            tableName,
+            canonicalSQL,
+        ]
+            .joined(separator: "\u{1f}")
+    }
+
+    /// SQLite adds identifier quotes when a rebuilt table is renamed. The
+    /// schema remains semantically equivalent, so the prototype canonicalizes
+    /// quotes around the object's own stable names before fingerprinting.
+    private var canonicalSQL: String {
+        var result = sql.split(whereSeparator: \.isWhitespace).joined(
+            separator: " "
+        )
+        for identifier in Set([name, tableName]) {
+            result = result.replacingOccurrences(
+                of: "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\"",
+                with: identifier
+            )
+        }
+        return result
+    }
+}
+
+
+private struct PrototypeCatalog {
+    let id: String
+    let ownedSchemaNames: [String]
+    let semanticComponents: [String]
+
+    static let versionOne = PrototypeCatalog(
+        id: "library",
+        ownedSchemaNames: ["teams", "members", "member_audit"],
+        semanticComponents: [
+            "catalog:library@1",
+            "members.id:swift.int@1:sqlite:integer:primary-key",
+            "members.team_id:swift.int@1:sqlite:integer:required",
+            "members.full_name:swift.string@1:sqlite:text:required",
+            "members.nickname:swift.optional-string@1:sqlite:text:nullable",
+            "members.legacy_code:legacy-code-text@1:sqlite:text:required",
+        ]
+    )
+
+    static let versionTwo = PrototypeCatalog(
+        id: "library",
+        ownedSchemaNames: ["teams", "members", "member_audit"],
+        semanticComponents: [
+            "catalog:library@2",
+            "members.id:swift.int@1:sqlite:integer:primary-key",
+            "members.team_id:swift.int@1:sqlite:integer:required",
+            "members.display_name:swift.string@1:sqlite:text:required",
+            "members.nickname:swift.optional-string@1:sqlite:text:nullable",
+            "members.status:status-text@1:sqlite:text:required",
+        ]
+    )
+}
+
+
+private enum PrototypeStableFingerprint {
+    static func make(_ components: [String]) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in components.joined(separator: "\u{1e}").utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(format: "%016llx", hash)
+    }
+}
+
+
+private enum PrototypeSchemaChange {
+    case possibleRename(from: String, to: String)
+    case codecChange(column: String, from: String, to: String)
+    case unsupportedDialect(String)
+}
+
+
+private enum PrototypeProposalPolicy {
+    static func requireUserIntent(_ change: PrototypeSchemaChange) throws {
+        switch change {
+        case .possibleRename(let from, let to):
+            throw PrototypeMigrationError.userIntentRequired(
+                "Possible rename \(from) -> \(to) cannot be inferred."
+            )
+        case .codecChange(let column, let from, let to):
+            throw PrototypeMigrationError.userIntentRequired(
+                "Codec change \(from) -> \(to) for \(column) needs an explicit data transform."
+            )
+        case .unsupportedDialect(let dialect):
+            throw PrototypeMigrationError.unsupportedDialect(dialect)
+        }
+    }
+}
+
+
+private struct PrototypeMemberV1: FetchableRecord, Decodable, Equatable {
+    let id: Int
+    let teamID: Int
+    let fullName: String
+    let nickname: String?
+    let legacyCode: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case teamID = "team_id"
+        case fullName = "full_name"
+        case nickname
+        case legacyCode = "legacy_code"
+    }
+
+    static func fetchAll(_ database: Database) throws -> [Self] {
+        try Self.fetchAll(
+            database,
+            sql: """
+                SELECT id, team_id, full_name, nickname, legacy_code
+                FROM members
+                ORDER BY id
+                """
+        )
+    }
+}
+
+
+private struct PrototypeMemberV2: FetchableRecord, Decodable, Equatable {
+    let id: Int
+    let teamID: Int
+    let displayName: String
+    let nickname: String?
+    let status: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case teamID = "team_id"
+        case displayName = "display_name"
+        case nickname
+        case status
+    }
+
+    static func fetchAll(_ database: Database) throws -> [Self] {
+        try Self.fetchAll(
+            database,
+            sql: """
+                SELECT id, team_id, display_name, nickname, status
+                FROM members
+                ORDER BY id
+                """
+        )
+    }
+}
+
+
+private struct PrototypeAuditRow: FetchableRecord, Decodable, Equatable {
+    let memberID: Int
+    let oldName: String
+    let newName: String
+
+    enum CodingKeys: String, CodingKey {
+        case memberID = "member_id"
+        case oldName = "old_name"
+        case newName = "new_name"
+    }
+
+    static func fetchAll(_ database: Database) throws -> [Self] {
+        try Self.fetchAll(
+            database,
+            sql: """
+                SELECT member_id, old_name, new_name
+                FROM member_audit
+                ORDER BY rowid
+                """
+        )
+    }
+}
+
+
+private func createSharedSchema(_ database: Database) throws {
+    try database.execute(
+        sql: """
+            CREATE TABLE teams (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE member_audit (
+                member_id INTEGER NOT NULL,
+                old_name TEXT NOT NULL,
+                new_name TEXT NOT NULL
+            );
+            """
+    )
+}
+
+
+private func createVersionOneMembersSchema(_ database: Database) throws {
+    try database.execute(
+        sql: """
+            CREATE TABLE members (
+                id INTEGER PRIMARY KEY,
+                team_id INTEGER NOT NULL
+                    REFERENCES teams(id) ON DELETE CASCADE,
+                full_name TEXT NOT NULL,
+                nickname TEXT,
+                legacy_code TEXT NOT NULL
+            );
+            CREATE INDEX members_team_name_idx
+                ON members(team_id, full_name);
+            CREATE TRIGGER members_name_audit
+            AFTER UPDATE OF full_name ON members
+            BEGIN
+                INSERT INTO member_audit(member_id, old_name, new_name)
+                VALUES (OLD.id, OLD.full_name, NEW.full_name);
+            END;
+            """
+    )
+}
+
+
+private func seedVersionOneData(_ database: Database) throws {
+    try database.execute(
+        sql: """
+            INSERT INTO teams(id, name) VALUES (1, 'Core');
+            INSERT INTO members(
+                id, team_id, full_name, nickname, legacy_code
+            ) VALUES
+                (1, 1, 'Alice', 'Al', 'enabled'),
+                (2, 1, 'Bob Brown', NULL, 'disabled');
+            UPDATE members SET full_name = 'Alice Adams' WHERE id = 1;
+            """
+    )
+}
+
+
+private func createVersionTwoMembersSchema(
+    _ database: Database,
+    tableName: String
+) throws {
+    try database.execute(sql: createVersionTwoMembersSQL(tableName: tableName))
+}
+
+
+private func createVersionTwoDependents(_ database: Database) throws {
+    try database.execute(
+        sql: "\(createVersionTwoIndexSQL);\n\(createVersionTwoTriggerSQL);"
+    )
+}
+
+
+private func rebuildMembersToVersionTwo(_ database: Database) throws {
+    let before = try PrototypeMemberV1.fetchAll(database)
+    try createVersionTwoMembersSchema(
+        database,
+        tableName: "__swiftql_new_members"
+    )
+    try database.execute(sql: copyVersionTwoMembersSQL)
+
+    let copied = try PrototypeMemberV2.fetchAll(
+        database,
+        sql: """
+            SELECT id, team_id, display_name, nickname, status
+            FROM __swiftql_new_members
+            ORDER BY id
+            """
+    )
+    let expected = before.map {
+        PrototypeMemberV2(
+            id: $0.id,
+            teamID: $0.teamID,
+            displayName: $0.fullName,
+            nickname: $0.nickname,
+            status: $0.legacyCode == "disabled" ? "inactive" : "active"
+        )
+    }
+    guard copied == expected else {
+        throw PrototypeMigrationError.copiedDataMismatch
+    }
+
+    try database.execute(sql: "DROP TABLE members")
+    try database.execute(
+        sql: "ALTER TABLE __swiftql_new_members RENAME TO members"
+    )
+    try createVersionTwoDependents(database)
+
+    guard try PrototypeMemberV2.fetchAll(database) == expected else {
+        throw PrototypeMigrationError.copiedDataMismatch
+    }
+}
+
+
+private func createVersionTwoMembersSQL(tableName: String) -> String {
+    """
+    CREATE TABLE \(tableName) (
+        id INTEGER PRIMARY KEY,
+        team_id INTEGER NOT NULL
+            REFERENCES teams(id) ON DELETE CASCADE,
+        display_name TEXT NOT NULL CHECK (length(display_name) > 0),
+        nickname TEXT,
+        status TEXT NOT NULL DEFAULT 'active'
+            CHECK (status IN ('active', 'inactive'))
+    )
+    """
+}
+
+
+private let copyVersionTwoMembersSQL = """
+    INSERT INTO __swiftql_new_members (
+        id, team_id, display_name, nickname, status
+    )
+    SELECT
+        id,
+        team_id,
+        full_name,
+        nickname,
+        CASE legacy_code
+            WHEN 'disabled' THEN 'inactive'
+            ELSE 'active'
+        END
+    FROM members
+    """
+
+
+private let createVersionTwoIndexSQL = """
+    CREATE INDEX members_team_display_name_idx
+        ON members(team_id, display_name)
+    """
+
+
+private let createVersionTwoTriggerSQL = """
+    CREATE TRIGGER members_display_name_audit
+    AFTER UPDATE OF display_name ON members
+    BEGIN
+        INSERT INTO member_audit(member_id, old_name, new_name)
+        VALUES (OLD.id, OLD.display_name, NEW.display_name);
+    END
+    """


### PR DESCRIPTION
Closes #216

## Task

- Repository: `lukevanin/swiftql`
- Issue: [#216 — Research explicit versioned schema migrations beyond catalog bootstrap](https://github.com/lukevanin/swiftql/issues/216)
- Branch: `codex/216-research-explicit-versioned-schema-migrations`
- Worktree: `/private/tmp/swiftql-worktrees/216-research-explicit-versioned-schema-migrations`
- Codex task: `lukevanin/swiftql#216 - Research explicit versioned schema migrations`
- Codex task ID: `019f7a20-d672-7c92-8899-b1f5e051e808`
- Codex task URL: unavailable from the local app

## Summary

- Adds a checked-in architecture report recommending immutable, explicit, forward-only user-authored migrations.
- Defines catalog-owned semantic snapshots and fingerprints, exact history ordering, transaction/recovery behavior, SQLite rebuild rules, codec/storage metadata handling, and an external-runner integration mode.
- Separates read-only generated diffs/proposals from execution; inferred renames, lossy conversions, arbitrary data transforms, and unsupported dialect lowering are rejected.
- Adds a private executable prototype over real SQLite/GRDB, without introducing a production migration API.
- Schedules the accepted implementation work in the [v2.5 milestone](https://github.com/lukevanin/swiftql/milestone/11) and records that boundary in `ROADMAP.md`.

## Requirement-to-evidence map

| Issue requirement | Evidence |
| --- | --- |
| Compare user-authored migrations, generated proposals, and diff tooling | [Architecture report — strategy comparison](https://github.com/lukevanin/swiftql/blob/codex/216-research-explicit-versioned-schema-migrations/Documentation/Architecture/VersionedSchemaMigrations.md) |
| Define versions, fingerprints, ordering, transactions, recovery, transforms, and dialect limits | Report sections on identity/history, execution, recovery, data transforms, and dialect capability |
| Prototype a nontrivial SQLite table rebuild | [Executable prototype tests](https://github.com/lukevanin/swiftql/blob/codex/216-research-explicit-versioned-schema-migrations/Tests/SQLTests/SchemaMigrationArchitecturePrototypeTests.swift) |
| Preserve real data, constraints, indexes, and target fingerprint | v1→v2 teams/members rebuild test with row mapping, FK/CHECK/default validation, composite index, trigger, integrity checks, and final semantic fingerprint |
| Cover interruption/idempotency/safe rejection | Tests for transactional interruption rollback, constraint failure rollback, reapplication, unexpected live objects, definition drift, ambiguous rename/codec change, and unsupported dialect |
| Convert accepted follow-up work to issues | #276, #277, #278, #279, #280, and #281 |
| Record the accepted release boundary | `ROADMAP.md` and milestone v2.5; implementation issues #276–#281 assigned to milestone 11 |

## Validation

- `swift test --filter SchemaMigrationArchitecturePrototypeTests` — 5 tests passed
- `swift test --skip-build --quiet` — 598 tests passed, 0 failures
- `swift test --filter SQLDocumentationCatalogTests` — 7 tests passed, 0 failures after the roadmap update
- `git diff --cached --check` — clean before commit
- Environment: Apple Swift 6.3.2; SQLite 3.51.0

## Key decisions

- SwiftQL should execute only an explicit migration registry, never an inferred live/model diff.
- History records exact migration identity, definition fingerprint, and before/after catalog fingerprints in the same transaction as schema/data changes.
- SQLite rebuilds follow create → copy → validate → drop → rename → recreate, with foreign-key enforcement restored after the transaction and checked before commit.
- Applications already using GRDB or another runner get a single-owner mode: that runner owns order/journal/transaction while SwiftQL supplies frozen operations and validation.
- Rollback means transaction rollback before commit; after release, recovery is restore-from-backup or a new forward migration.
- Public migration support targets v2.5, after the existing v2.1–v2.4 adapter and backend milestones.

## Scope and concerns

- This is research plus test-only prototype code. It intentionally does not add the public API proposed by #139 or change #215 bootstrap behavior.
- The prototype fingerprint uses a narrow test hash/canonicalizer; production work must use deterministic semantic serialization and a durable hash.
- Crash/power-loss, disk exhaustion, lock contention, large on-disk tables, views, virtual tables, STRICT tables, and non-SQLite lowering remain follow-up validation.
- No screenshots are attached because the acceptance evidence is database state, schema metadata, row values, and executable tests rather than a visual UI.