### PR TITLE
Research SQLite build-time query validation

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Add live-query observation stress and rollback contract tests",
-  "issue_number": 255,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/255",
+  "task_name": "Research build-time SQLite query preparation and schema validation",
+  "issue_number": 132,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/132",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#255 - Add live-query observation stress and rollback contract tests",
+  "codex_session_title": "lukevanin/swiftql#132 - Research build-time SQLite query preparation and schema validation",
   "codex_session_id": "019f7a0d-c80b-7f22-b47a-e3adb614acc8",
   "codex_session_url": null,
-  "task_branch": "codex/255-add-live-query-observation-stress-and-rollback-contract-tests",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/255-add-live-query-observation-stress-and-rollback-contract-tests"
+  "task_branch": "codex/132-research-build-time-sqlite-query-preparation-and-schema-validation",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/132-research-build-time-sqlite-query-preparation-and-schema-validation"
 }

--- a/Documentation/Architecture/SQLiteBuildValidation.md
+++ b/Documentation/Architecture/SQLiteBuildValidation.md
@@ -1,0 +1,437 @@
+# Build-Time SQLite Query Preparation and Schema Validation
+
+## 1. Executive decision and v1.3 boundary
+
+Issue [#132](https://github.com/lukevanin/swiftql/issues/132) is a research-only
+v1.3 deliverable. The v1.3 release boundary is existing public SQLite syntax
+proven against real SQLite; it does not ship a public validator, build plugin,
+query macro, schema system, or new query-declaration API.
+
+The selected validation contract is an explicit, checked-in SQLite database
+snapshot plus a deterministic sidecar plan for static query descriptors. A
+standalone validator owns a read-only SQLite connection, prepares each query
+with `sqlite3_prepare_v3`, compares the resulting C metadata with the declared
+plan, and emits a deterministic report. Only `passed` is success. `failed` and
+`unsupported` both fail the validation gate.
+
+The prepared statement exists only while one query is inspected. It is always
+finalized and is never persisted, serialized, returned, or reused by runtime
+execution. Runtime code still prepares or obtains a cached statement on each
+physical connection.
+
+## 2. Inputs audited
+
+This decision builds on existing ownership rather than defining a parallel
+model:
+
+- [#128](https://github.com/lukevanin/swiftql/issues/128) separates query
+  construction, uncached preparation, cache lookup, binding, execution, and
+  decoding. Build validation does not remove the first physical prepare on a
+  runtime connection.
+- [#129](https://github.com/lukevanin/swiftql/issues/129) provides
+  `XLStaticQueryDescriptor`: stable definition and query identities, exact SQL,
+  dialect requirements, entity hints, canonical parameter and result layouts,
+  cardinality, and codec/storage metadata. It owns no connection or statement.
+- [#190](https://github.com/lukevanin/swiftql/issues/190) owns the canonical
+  SQLite inventory and stable feature IDs in
+  [`SQLiteConformanceInventory.json`](../../Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json).
+- [#191](https://github.com/lukevanin/swiftql/issues/191) owns the bounded
+  `c191-v1` manifest, its 141 stable cases, and runtime provenance in
+  [`COMBINATORIAL_CASES.json`](../../Conformance/SQLite/COMBINATORIAL_CASES.json).
+  Its runtime collector already records SQLite version/source ID, compile
+  options, functions, collations, module names, caller-supplied extension names,
+  and exact `sqlite_schema` evidence.
+- [#254](https://github.com/lukevanin/swiftql/issues/254) owns the immutable
+  Northwind database and its validation/access policy in
+  [`NorthwindFixture.swift`](../../Tests/SwiftQLNorthwindFixtures/NorthwindFixture.swift).
+
+The current static descriptor validates its own logical layout and codec/storage
+coherence. It does not contain a schema fingerprint or all engine capability
+requirements, and it is intentionally not made `Codable` by this research.
+
+## 3. Validation question and non-goals
+
+The question is narrow: given static SQL, declared parameter/result metadata,
+explicit capabilities, and a reproducible SQLite schema, what can the same
+SQLite parser reject before application runtime?
+
+The prototype may establish syntax resolution, statement shape, C-level bind
+and result metadata, schema identity, and engine capability evidence. It is not:
+
+- a semantic query oracle or application-query execution system;
+- a migration runner, typed DDL implementation, or schema-diff generator;
+- a replacement for catalog/table-reference validation;
+- a proof of SQLite dynamic value storage, result nullability, or codec closure
+  behavior;
+- a statement cache, bytecode format, or zero-runtime-parse design; or
+- a new owner for the #190 inventory, #191 harness, or #254 fixture.
+
+## 4. Schema-source comparison and selected contract
+
+| Candidate | Reproducibility | Current ownership | Decision for #132 |
+| --- | --- | --- | --- |
+| Checked-in SQLite snapshot | Exact bytes and native SQLite parser semantics can be pinned and reviewed. | #254 already supplies an immutable real database. | **Selected.** |
+| Ordered migrations | Reproducible only after migration ordering, engine setup, and failure policy are standardized. | Migration research and implementation are separate work. | May produce a snapshot later; not implemented here. |
+| Typed DDL | Could provide a semantic catalog and generate a snapshot, but the surface does not exist yet. | [#139](https://github.com/lukevanin/swiftql/issues/139). | Future producer only; not implemented here. |
+
+The selected snapshot is the checked-in Northwind database at upstream commit
+`865de0872e61692a49cd6069cd2df8f9ac04541e`:
+
+| Property | Pinned value |
+| --- | --- |
+| SHA-256 | `cb6f0071a264e150d3796f75c4b0643e32b2132e4e02370518b50a1eac3381d8` |
+| Byte count | `602112` |
+| Application tables / views | `13` / `17` |
+| `sqlite_schema` rows | `37` |
+| Existing #191 schema FNV-1a 64 | `e2c8fadbd38c2313` |
+
+The FNV value uses #191's ordered fields `type`, `name`, `tbl_name`, `rootpage`,
+and `COALESCE(sql, '')`. It is exact runtime provenance, not a semantic catalog
+or migration identity: root pages and raw schema SQL are deliberately included.
+
+A snapshot update is explicit: replace the artifact, update its upstream and
+license provenance, SHA, byte count, object/row sentinels, schema row count and
+FNV evidence, then review the deterministic validation-report diff. Future DDL
+or migration tooling may materialize this input, but the validator boundary
+remains a snapshot URL plus pinned identity.
+
+## 5. Prototype architecture and data flow
+
+```text
+XLStaticQueryDescriptor + deterministic sidecar plan
+                         + checked-in SQLite snapshot
+                         + explicit codec/capability availability
+                                      |
+                                      v
+                         standalone validation engine
+                         - verify snapshot identity
+                         - open one owned read-only connection
+                         - capture runtime provenance
+                         - prepare and inspect each query
+                         - finalize every statement
+                                      |
+                                      v
+                         canonical validation report
+```
+
+The validator owns its `sqlite3 *` for the full run. It does not borrow an
+application connection or GRDB pool, and no statement or connection escapes.
+Functions, collations, modules, or extensions are valid evidence only when
+registered on that exact connection. The canonical snapshot remains read-only;
+validation prepares but does not step application statements.
+
+The engine is the single source of validation behavior. A prototype CLI may
+drive it, but neither is a public v1.3 SwiftQL product or API.
+
+## 6. Static validation-plan artifact
+
+The sidecar plan fills the reproducible-build fields that do not belong in the
+frozen `XLQueryIdentity` v1 representation. Each entry records:
+
+- plan schema version, descriptor definition identity, and canonical query
+  identity;
+- exact UTF-8 SQL and dialect/version requirement;
+- logical parameter indexes, physical placeholder spellings, nullability,
+  storage identifiers, and selected codec identities;
+- result indexes, declared stable aliases where available, cardinality,
+  nullability, storage identifiers, and selected codec identities;
+- expected snapshot SHA, byte count, schema row count, and exact provenance
+  fingerprint;
+- required SQLite version, compile options, functions, collations, virtual-table
+  modules, and explicit extension identities; and
+- existing #190 feature IDs, #191 case IDs, and Northwind anchor IDs used as
+  evidence.
+
+The plan is a sidecar, not a second structural query model. Descriptor fields
+remain authoritative where they overlap. The prototype uses only existing
+canonical references in its representative positive cases; #132-specific
+negative fixtures use local query IDs rather than pretending to be conformance
+cases. Strict registry resolution for arbitrary sidecar input belongs to the
+versioned manifest contract in
+[#292](https://github.com/lukevanin/swiftql/issues/292). #132 does not mint
+another syntax family. Canonical JSON sorts entries and set-like fields and
+excludes timestamps, hostnames, process IDs, absolute paths, and elapsed times.
+
+## 7. `sqlite3_prepare_v3` probe lifecycle
+
+The probe follows SQLite's documented
+[`sqlite3_prepare_v3`](https://www.sqlite.org/c3ref/prepare.html) ownership rules:
+
+1. Verify the snapshot bytes, then open a dedicated connection with
+   `SQLITE_OPEN_READONLY`.
+2. Reject embedded NUL, keep the SQL UTF-8 buffer alive, and pass its exact byte
+   length to `sqlite3_prepare_v3` with flags `0`. `SQLITE_PREPARE_PERSISTENT` is
+   only an allocation hint and is inappropriate for this one-shot inspection.
+3. Require a non-null statement. Empty, whitespace-only, or comment-only SQL
+   produces no statement and is rejected.
+4. Follow `pzTail`. Re-prepare remaining text so whitespace/comments may be
+   exhausted; any second non-null statement is rejected as multiple SQL.
+5. Inspect bind, result, and readonly metadata only after successful prepare.
+6. Call `sqlite3_finalize` for every non-null statement on every path, then
+   close the validator-owned connection after the run.
+
+A prepared statement is tied to the connection that created it. Stock SQLite
+does not expose statement serialization; database
+[`sqlite3_serialize`](https://www.sqlite.org/c3ref/serialize.html) serializes a
+database image, not `sqlite3_stmt`. The prototype therefore makes no persisted
+statement, bytecode portability, or zero-runtime-parser claim.
+
+## 8. What can be proven
+
+On the selected connection and snapshot, the validator can prove:
+
+- the SQL is one non-empty statement accepted by the real SQLite parser;
+- referenced tables, columns, functions, and collations needed during prepare
+  resolve in that environment;
+- the C parameter index/name layout agrees with the declared layout;
+- the result-column count agrees with the descriptor and explicitly declared
+  result aliases agree where stable aliases exist;
+- explicitly declared engine capabilities are present in captured evidence;
+- the snapshot and SQLite build match recorded provenance; and
+- `sqlite3_stmt_readonly` classifies the directly prepared statement as
+  read-only or potentially writing.
+
+`sqlite3_stmt_readonly` is an engine-level direct-statement classification. It
+does not replace semantic DML-role analysis and does not prove that functions or
+virtual tables have no external side effects.
+
+### Binding introspection
+
+[`sqlite3_bind_parameter_count`](https://www.sqlite.org/c3ref/bind_parameter_count.html)
+returns the largest parameter index, not necessarily the number of distinct
+logical values; `?NNN` may create gaps. The validator must compare the complete
+physical index map rather than equating this value with `parameters.count`.
+
+[`sqlite3_bind_parameter_name`](https://www.sqlite.org/c3ref/bind_parameter_name.html)
+is one-based, includes the `:`, `@`, `$`, or `?NNN` prefix, and returns null for
+anonymous `?`. Repeated named placeholders share a physical index. Preparation
+can check this layout, but a null name cannot distinguish an anonymous `?` from
+an unused index gap introduced by `?NNN`. It also cannot prove Swift argument
+values or runtime storage without binding and stepping.
+
+### Result, codec, and capability checks
+
+`sqlite3_column_count` is authoritative for prepared result width. Column names
+are compared only when the plan declares stable `AS` aliases; SQLite does not
+promise stable names for unaliased expressions. `sqlite3_column_decltype` may be
+null for expressions and reports declared origin type rather than a runtime
+storage class.
+
+Descriptor construction already checks codec/value/storage coherence. The
+validator can additionally compare declared codec identities with an explicit
+available-codec manifest. It cannot execute or inspect codec closures.
+
+Capabilities are checked against `sqlite_version()`/`sqlite_source_id()`,
+`PRAGMA compile_options`, `function_list`, `collation_list`, and `module_list`.
+SQLite has no portable registry of arbitrary loaded-extension library names, so
+the connection owner must supply those identities explicitly. An absent or
+otherwise unavailable required capability is `unsupported`. Neither a failed
+declaration check nor an unsupported capability passes.
+
+## 9. What cannot be proven
+
+Successful preparation does not prove:
+
+- persisted or reusable statement bytecode;
+- the first runtime prepare has been eliminated;
+- result values, row counts, cardinality, ordering semantics, or application
+  behavior without execution and an independent oracle;
+- SQLite runtime storage classes for dynamically typed expressions;
+- general result nullability, especially through expressions, joins, CTEs, and
+  subqueries;
+- codec encode/decode behavior or compatibility inferred from declared SQLite
+  types;
+- table identity, catalog membership, alias/reference binding, correlated
+  scopes, or semantic DML roles; or
+- custom functions, collations, modules, or extensions that are registered only
+  on a different future runtime connection.
+
+Optional SQLite column-origin metadata also depends on
+`SQLITE_ENABLE_COLUMN_METADATA`; its absence must not be treated as successful
+structural validation.
+
+## 10. Diagnostic taxonomy and verdict rules
+
+Query diagnostics include the definition/query identity, applicable #190
+feature IDs, #191 case IDs and Northwind anchor IDs, plus a stable code and
+deterministic message. Snapshot/runtime diagnostics are report-scoped. Expected
+and observed values currently live in the message rather than separate
+structured fields. SQLite primary/extended result codes and copied
+`sqlite3_errmsg` text are present only for engine preparation failures; that raw
+wording is supporting evidence, not a stable diagnostic identity.
+
+| Area | Stable diagnostic codes |
+| --- | --- |
+| Snapshot | `schema.snapshot-sha`, `schema.byte-count`, `schema.row-count`, `schema.fingerprint` |
+| Runtime | `runtime.capture` |
+| Statement | `statement.empty`, `statement.embedded-nul`, `statement.multiple`, `sqlite.prepare.failed` |
+| Parameters | `parameter.count`, `parameter.key`, `parameter.metadata`, `parameter.syntax` |
+| Results | `result.count`, `result.name` |
+| Codecs | `codec.missing`, `codec.value-type`, `codec.dialect`, `codec.storage` |
+| Capabilities | `capability.dialect`, `capability.dialect-flags`, `capability.sqlite-version`, `capability.sqlite-json-functions`, `capability.compile-option`, `capability.function`, `capability.collation`, `capability.module`, `capability.extension`, `capability.missing` |
+
+SQLite commonly reports both syntax and schema-name resolution failures as
+`SQLITE_ERROR`. The validator does not parse error-message prose to manufacture
+a stable subtype. Labeled negative fixtures prove that both classes are
+rejected, while the primary/extended code and copied message preserve the exact
+engine evidence.
+
+Verdicts are deliberately fail-closed:
+
+- `passed`: all required evidence was captured and every check agreed.
+- `failed`: SQLite or a deterministic comparison disproved the declaration.
+- `unsupported`: a required capability or evidence source was unavailable, so
+  the validator could not prove the declaration.
+
+Only `passed` permits a successful CLI exit. A run containing `failed` or
+`unsupported` entries exits nonzero. Diagnostics are sorted by query identity,
+then stable code, with result codes and message as deterministic tie breakers.
+Raw SQLite wording remains evidence and never becomes a diagnostic code.
+
+## 11. Runtime provenance and determinism
+
+Each report records the exact SQLite version and source ID, normalized compile
+options, functions with arity/flags, collations, module names, caller-supplied
+extension names, the snapshot identity table from section 4, and normalized
+explicit codec, extension, and opaque capability identifiers in
+`environment_evidence`. That last field makes caller-supplied reasons for a pass
+auditable. This reuses the #191 provenance vocabulary instead of inventing a
+second runtime record.
+
+Two runs with the same plan, snapshot, SQLite build, and capability
+registration must produce byte-identical canonical JSON. A different SQLite
+source or capability set should produce an explicit report difference, not be
+silently normalized away. Time, duration, host, PID, and local paths belong in
+optional run logs, never the canonical validation artifact.
+
+The Northwind SHA is the authoritative byte identity. The schema FNV is useful
+exact-environment evidence but includes root pages and raw SQL, so it must not
+be used as the future semantic DDL or migration fingerprint.
+
+## 12. Standalone, plugin, and macro lifecycles
+
+| Surface | Responsibility | Decision |
+| --- | --- | --- |
+| Standalone validator | Own all schema verification, connection setup, preparation, comparison, diagnostics, and report generation. | Authoritative engine and first v1.5 implementation. |
+| SwiftPM build-tool plugin | Declare snapshot/manifest inputs and report output, then invoke the standalone tool as a build command. | Thin future wrapper; no duplicated validator logic or schema inference. |
+| `@SQLQuery` macro | Lower a declaration to the existing static descriptor model and emit/collect manifest material with declaration-site source context. | Owned by #26; must not open SQLite, load a schema, or implement semantic validation. |
+
+The standalone form is reproducible outside a compiler or IDE. The plugin may
+provide build integration after the manifest and validator are stable. A build
+command is preferable when inputs and outputs are known so SwiftPM can perform
+incremental invalidation. The macro remains constrained by the v1.x Swift 5.9
+floor and delegates database work to the external validator lifecycle.
+
+## 13. Benchmark implications
+
+The #128 benchmark contract keeps construction/rendering, uncached preparation,
+cached lookup, binding, execution, and decoding separate. Build validation may
+move query-construction mistakes earlier and a future declaration flow may
+avoid repeated SwiftQL construction, but it does not install a statement into a
+runtime connection.
+
+Each physical runtime connection still performs its first supported SQLite
+prepare and may then use its own cache. #132 records no latency, throughput,
+memory, startup, or zero-parse performance claim.
+
+## 14. Compatibility and package impact
+
+The research preserves the package's Swift 5.9 tools floor and current public
+SwiftQL/SwiftQLCore APIs. It does not change `XLQueryIdentity` v1, make
+`XLStaticQueryDescriptor` wholesale `Codable`, expose GRDB or CSQLite types in a
+public contract, or add a public product.
+
+Any research targets remain internal and use the package's existing SQLite
+dependency. A v1.5 implementation must validate a clean downstream Swift 5.9
+consumer and must not require a Swift 6-only macro or plugin feature merely to
+use the existing v1 library.
+
+## 15. Validation evidence matrix
+
+The bounded prototype reuses representative stable cases; it does not rerun or
+take ownership of all 141 #191 cases.
+
+| Evidence | Existing IDs reused | Expected validation |
+| --- | --- | --- |
+| Named binding, join, and schema resolution | `c191.v1.select.j-inner.w-named-binding`; #190 `binding.named`, `syntax.expression.current-operators`, `syntax.join.current-inner-left-cross`, `syntax.select.core`; Northwind `northwind.join.customer-order-employee-product` | One `:minimum_order_id` physical binding, one result, successful Northwind prepare. |
+| CTE and explicit two-column aliases | `c191.v1.northwind.cte-order-subtotals`; #190 `syntax.cte.recursive`, `syntax.expression.aggregate-functions`, `syntax.select.core`; Northwind `northwind.cte.order-subtotals` | Zero bindings, `orderID`/`subtotal` result layout, successful Northwind prepare. |
+| Required function capability | `c191.v1.expression.numeric-floor`; #190 `syntax.expression.numeric-comparable-functions`; requirement `function:FLOOR` | Pass when `FLOOR` is captured; non-pass when required evidence is missing. |
+| Deliberate invalid fixtures | Local test query IDs, not conformance IDs | Reject syntax, missing table/column, bind count/name, result count/alias, missing codec/capability evidence, and snapshot SHA/byte/FNV disagreement; the raw probe also rejects empty and multiple statements. |
+| Lifecycle and determinism | Existing #191 runtime-evidence conventions | Exercise every probe outcome through exactly-once finalization, reject active SQLite sidecars (including through a snapshot symlink), preserve read-only snapshot access, and produce byte-identical reports on repeated equal runs. Runner-level tests execute plan decoding, real snapshot validation, report writes, byte-identical repeated output, and the `0`/`1` verdict exit contract; the executable maps argument/usage errors to `2`. |
+
+Prototype tests verify that the representative #190/#191/Northwind IDs exist in
+their canonical sources. Exhaustive reference resolution for arbitrary
+manifests is an acceptance criterion of #292. #132-specific negative fixtures
+remain validator tests rather than new conformance inventory entries.
+
+## 16. Recommended v1.5 implementation sequence
+
+1. Freeze the sidecar manifest schema and deterministic serialization without
+   database I/O.
+2. Ship the standalone validator and prove its diagnostics against the pinned
+   Northwind snapshot and a clean downstream consumer.
+3. Add a thin SwiftPM build-tool plugin after the standalone input/output
+   contract is stable.
+4. Let #26 consume the manifest seam when query declarations are available;
+   keep macro diagnostics about Swift declarations separate from SQLite
+   validation diagnostics.
+
+Catalog semantics and future schema producers can enrich the same manifest
+later without changing the validator's snapshot boundary.
+
+## 17. Existing ownership and atomic follow-ups
+
+Existing issues retain their scope:
+
+- [#26](https://github.com/lukevanin/swiftql/issues/26) owns the `@SQLQuery`
+  declaration macro, lowering, generated handles, and declaration-site
+  diagnostics. #132 does not implement or redesign it.
+- [#139](https://github.com/lukevanin/swiftql/issues/139) owns typed,
+  dialect-aware DDL and future semantic schema metadata. #132 does not create a
+  competing DDL or fingerprint model.
+- [#214](https://github.com/lukevanin/swiftql/issues/214) owns catalog
+  membership, table/reference bindings, aliases, nullability propagation, DML
+  roles, and nested/correlated scope semantics. Preparation cannot substitute
+  for those checks.
+- #190/#191 continue to own inventory and harness identities; #254 continues to
+  own Northwind; #129 continues to own the static descriptor.
+
+Three atomic v1.5 follow-ups are recommended:
+
+1. [**#292: Define a deterministic SQLite build-validation manifest for static
+   query descriptors.**](https://github.com/lukevanin/swiftql/issues/292)
+   Specify versioned canonical JSON, query/descriptor identity,
+   parameter/result/codec layout, schema identity, capabilities, and #190/#191
+   references. No database I/O, macro implementation, or query-identity change.
+2. [**#293: Ship a standalone SQLite static-query build
+   validator.**](https://github.com/lukevanin/swiftql/issues/293) Consume the
+   manifest and snapshot, own a read-only connection, call
+   `sqlite3_prepare_v3`, produce stable fail-closed diagnostics, and validate a
+   real downstream fixture. No plugin, macro, DDL, migrations, or statement
+   persistence.
+3. [**#294: Add a SwiftPM build-tool plugin wrapper for SQLite query
+   validation.**](https://github.com/lukevanin/swiftql/issues/294) Use declared
+   inputs/outputs and invoke the standalone tool. No validation logic, schema
+   inference, or second report format in the plugin.
+
+A separate macro-integration follow-up would duplicate #26 and is not proposed.
+
+## 18. Remaining risks and limitations
+
+- A byte-exact snapshot can drift from an application's migration-produced
+  schema unless the application makes snapshot updates part of its release
+  process.
+- SQLite functions, collations, virtual-table modules, and extensions are
+  connection-local; validation is authoritative only for the recorded setup.
+- Different SQLite builds may accept different syntax or expose different
+  capabilities. Source ID and compile options therefore remain part of the
+  verdict evidence.
+- SQLite dynamic typing and optional column-origin metadata leave result
+  storage, nullability, and codec behavior for runtime/conformance tests and
+  #214's structural model.
+- Build-tool sandboxing and incremental input discovery remain v1.5 integration
+  questions; hiding inputs in a prebuild command would weaken reproducibility.
+- Snapshot FNV evidence is intentionally physical and is unsuitable as a
+  semantic migration/catalog fingerprint.
+- The research does not establish a portable prepared-statement format or
+  remove runtime per-connection preparation.

--- a/Package.swift
+++ b/Package.swift
@@ -106,6 +106,25 @@ let package = Package(
             path: "Benchmarks/Sources/SwiftQLBenchmarkCLI"
         ),
 
+        // Package-private research engine for issue #132. This deliberately
+        // remains outside the package's public products while the descriptor
+        // sidecar and build lifecycle are being evaluated.
+        .target(
+            name: "SwiftQLSQLiteBuildValidationPrototype",
+            dependencies: [
+                "SwiftQLCore",
+                .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "CSQLite", package: "GRDB.swift"),
+            ],
+            path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype"
+        ),
+
+        .executableTarget(
+            name: "SwiftQLSQLiteBuildValidationPrototypeCLI",
+            dependencies: ["SwiftQLSQLiteBuildValidationPrototype"],
+            path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototypeCLI"
+        ),
+
         // A test target used to develop the macro implementation.
         .testTarget(
             name: "SwiftQLCoreTests",
@@ -173,6 +192,20 @@ let package = Package(
             name: "SwiftQLBenchmarkTests",
             dependencies: ["SwiftQLBenchmarks"],
             path: "Benchmarks/Tests/SwiftQLBenchmarkTests"
+        ),
+
+        .testTarget(
+            name: "SwiftQLSQLiteBuildValidationPrototypeTests",
+            dependencies: [
+                "SwiftQLCore",
+                "SwiftQL",
+                "SwiftQLSQLiteBuildValidationPrototype",
+                "SwiftQLNorthwindFixtures",
+                "SwiftQLSQLiteConformanceFixtures",
+                "SwiftQLSQLiteCombinatorialSupport",
+                .product(name: "GRDB", package: "GRDB.swift"),
+            ],
+            path: "Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests"
         ),
     ]
 )

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationCLIOptions.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationCLIOptions.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+
+package struct SQLiteBuildValidationCLIOptions: Equatable, Sendable {
+    package let databaseURL: URL?
+    package let planURL: URL?
+    package let outputURL: URL?
+    package let codecIdentifiers: [String]
+    package let extensionNames: [String]
+    package let capabilityIDs: [String]
+    package let showsHelp: Bool
+
+    package static func parse(
+        arguments: [String],
+        currentDirectory: URL = URL(
+            fileURLWithPath: FileManager.default.currentDirectoryPath,
+            isDirectory: true
+        )
+    ) throws -> Self {
+        var databasePath: String?
+        var planPath: String?
+        var outputPath: String?
+        var codecIdentifiers: [String] = []
+        var extensionNames: [String] = []
+        var capabilityIDs: [String] = []
+        var showsHelp = false
+        var index = 0
+
+        func value(after option: String) throws -> String {
+            let valueIndex = index + 1
+            guard arguments.indices.contains(valueIndex) else {
+                throw SQLiteBuildValidationCLIError.missingValue(option)
+            }
+            index = valueIndex
+            let value = arguments[valueIndex]
+            guard !value.isEmpty else {
+                throw SQLiteBuildValidationCLIError.missingValue(option)
+            }
+            return value
+        }
+
+        func assignOnce(
+            _ current: inout String?,
+            option: String
+        ) throws {
+            guard current == nil else {
+                throw SQLiteBuildValidationCLIError.duplicateOption(option)
+            }
+            current = try value(after: option)
+        }
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--database":
+                try assignOnce(&databasePath, option: argument)
+            case "--plan":
+                try assignOnce(&planPath, option: argument)
+            case "--output":
+                try assignOnce(&outputPath, option: argument)
+            case "--codec":
+                codecIdentifiers.append(try value(after: argument))
+            case "--extension":
+                extensionNames.append(try value(after: argument))
+            case "--capability":
+                capabilityIDs.append(try value(after: argument))
+            case "--help", "-h":
+                showsHelp = true
+            default:
+                throw SQLiteBuildValidationCLIError.unknownOption(argument)
+            }
+            index += 1
+        }
+
+        if !showsHelp {
+            for (option, value) in [
+                ("--database", databasePath),
+                ("--plan", planPath),
+                ("--output", outputPath),
+            ] where value == nil {
+                throw SQLiteBuildValidationCLIError.requiredOption(option)
+            }
+        }
+
+        return Self(
+            databaseURL: databasePath.map {
+                resolvedURL(path: $0, currentDirectory: currentDirectory)
+            },
+            planURL: planPath.map {
+                resolvedURL(path: $0, currentDirectory: currentDirectory)
+            },
+            outputURL: outputPath.map {
+                resolvedURL(path: $0, currentDirectory: currentDirectory)
+            },
+            codecIdentifiers: sortedUnique(codecIdentifiers),
+            extensionNames: sortedUnique(extensionNames),
+            capabilityIDs: sortedUnique(capabilityIDs),
+            showsHelp: showsHelp
+        )
+    }
+
+    package static let usage = """
+        Usage: SwiftQLSQLiteBuildValidationPrototypeCLI [options]
+
+          --database <path>      Checked-in SQLite snapshot to open read-only
+          --plan <path>          Codable build-validation sidecar plan
+          --output <path>        Deterministic JSON report destination
+          --codec <identity>     Available codec identity (repeatable)
+          --extension <name>     Registered extension name (repeatable)
+          --capability <id>      Explicit caller-owned capability (repeatable)
+          --help                 Show this help
+        """
+
+    package static func preflightOutputSafety(
+        databaseURL: URL,
+        planURL: URL,
+        outputURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        let outputIdentityURL = identityURL(
+            for: outputURL,
+            fileManager: fileManager
+        )
+        let outputFileIdentity = existingFileIdentity(
+            at: outputIdentityURL,
+            fileManager: fileManager
+        )
+        let databasePaths = [
+            databaseURL.path,
+            identityURL(for: databaseURL, fileManager: fileManager).path,
+        ]
+        let protectedDatabaseSidecarPaths = Set(databasePaths.flatMap { path in
+            ["-journal", "-shm", "-wal"].map { suffix in
+                ((path + suffix) as NSString).standardizingPath
+            }
+        })
+        let outputPaths = Set([
+            (outputURL.path as NSString).standardizingPath,
+            outputIdentityURL.path,
+        ])
+        if !protectedDatabaseSidecarPaths.isDisjoint(with: outputPaths) {
+            throw SQLiteBuildValidationCLIError.outputConflictsWithDatabaseSidecar
+        }
+
+        for (option, inputURL) in [
+            ("--database", databaseURL),
+            ("--plan", planURL),
+        ] {
+            let inputIdentityURL = identityURL(
+                for: inputURL,
+                fileManager: fileManager
+            )
+            if outputIdentityURL.path == inputIdentityURL.path {
+                throw SQLiteBuildValidationCLIError.outputConflictsWithInput(option)
+            }
+
+            if let outputFileIdentity,
+               let inputFileIdentity = existingFileIdentity(
+                   at: inputIdentityURL,
+                   fileManager: fileManager
+               ),
+               outputFileIdentity == inputFileIdentity {
+                throw SQLiteBuildValidationCLIError.outputConflictsWithInput(option)
+            }
+        }
+    }
+
+    private static func resolvedURL(path: String, currentDirectory: URL) -> URL {
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path).standardizedFileURL
+        }
+        return currentDirectory.appendingPathComponent(path).standardizedFileURL
+    }
+
+    private static func sortedUnique(_ values: [String]) -> [String] {
+        Array(Set(values)).sorted()
+    }
+
+    private static func identityURL(
+        for url: URL,
+        fileManager: FileManager
+    ) -> URL {
+        var existingAncestor = url.standardizedFileURL
+        var missingComponents: [String] = []
+        while existingAncestor.path != "/",
+              !fileManager.fileExists(atPath: existingAncestor.path) {
+            missingComponents.insert(
+                existingAncestor.lastPathComponent,
+                at: 0
+            )
+            existingAncestor.deleteLastPathComponent()
+        }
+        let resolvedAncestor = existingAncestor.resolvingSymlinksInPath()
+        return missingComponents.reduce(resolvedAncestor) { partialURL, component in
+            partialURL.appendingPathComponent(component)
+        }.standardizedFileURL
+    }
+
+    private static func existingFileIdentity(
+        at url: URL,
+        fileManager: FileManager
+    ) -> ExistingFileIdentity? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let device = unsignedInteger(attributes[.systemNumber]),
+              let inode = unsignedInteger(attributes[.systemFileNumber]) else {
+            return nil
+        }
+        return ExistingFileIdentity(device: device, inode: inode)
+    }
+
+    private static func unsignedInteger(_ value: Any?) -> UInt64? {
+        (value as? NSNumber)?.uint64Value
+    }
+
+    private struct ExistingFileIdentity: Equatable {
+        let device: UInt64
+        let inode: UInt64
+    }
+}
+
+
+package enum SQLiteBuildValidationCLIError:
+    Error,
+    Equatable,
+    Sendable,
+    CustomStringConvertible
+{
+    case missingValue(String)
+    case duplicateOption(String)
+    case requiredOption(String)
+    case unknownOption(String)
+    case outputConflictsWithInput(String)
+    case outputConflictsWithDatabaseSidecar
+
+    package var description: String {
+        switch self {
+        case .missingValue(let option):
+            return "\(option) requires a nonempty value."
+        case .duplicateOption(let option):
+            return "\(option) may only be supplied once."
+        case .requiredOption(let option):
+            return "\(option) is required."
+        case .unknownOption(let option):
+            return "Unknown option \(option)."
+        case .outputConflictsWithInput(let option):
+            return "--output must not identify the same file as \(option)."
+        case .outputConflictsWithDatabaseSidecar:
+            return "--output must not use a SQLite sidecar path adjacent to --database."
+        }
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationCLIRunner.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationCLIRunner.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+
+package struct SQLiteBuildValidationCLIRunResult: Equatable, Sendable {
+    package let report: SQLiteBuildValidationReport
+
+    package var exitCode: Int32 {
+        report.overallVerdict == .passed ? 0 : 1
+    }
+}
+
+
+/// Executes the operational CLI path without terminating the process.
+///
+/// Keeping orchestration here lets tests exercise input protection, plan
+/// decoding, real SQLite validation, report writing, and the zero/nonzero
+/// verdict contract. The executable entry point remains responsible only for
+/// argument/help handling and mapping thrown usage errors to exit code 2.
+package enum SQLiteBuildValidationCLIRunner {
+    package static func run(
+        options: SQLiteBuildValidationCLIOptions
+    ) throws -> SQLiteBuildValidationCLIRunResult {
+        guard let databaseURL = options.databaseURL,
+              let planURL = options.planURL,
+              let outputURL = options.outputURL else {
+            throw SQLiteBuildValidationCLIError.requiredOption(
+                "--database, --plan, and --output"
+            )
+        }
+
+        try SQLiteBuildValidationCLIOptions.preflightOutputSafety(
+            databaseURL: databaseURL,
+            planURL: planURL,
+            outputURL: outputURL
+        )
+
+        let plan = try SQLiteBuildValidationPlan.decode(contentsOf: planURL)
+        let report = try SQLiteBuildValidator.validate(
+            plan: plan,
+            againstDatabaseAt: databaseURL,
+            environment: SQLiteBuildValidationEnvironment(
+                codecIdentifiers: options.codecIdentifiers,
+                extensionNames: options.extensionNames,
+                capabilityIDs: options.capabilityIDs
+            )
+        )
+
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try report.canonicalJSONData().write(to: outputURL, options: .atomic)
+        return SQLiteBuildValidationCLIRunResult(report: report)
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationModels.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationModels.swift
@@ -1,0 +1,645 @@
+import Foundation
+import SwiftQLCore
+
+
+package enum SQLiteBuildValidationVerdict: String, Codable, CaseIterable, Sendable {
+    case passed
+    case failed
+    case unsupported
+}
+
+
+package struct SQLiteBuildValidationSchemaInput: Codable, Equatable, Sendable {
+    package enum Kind: String, Codable, Sendable {
+        case checkedInSnapshot = "checked-in-snapshot"
+    }
+
+    package let kind: Kind
+    package let identifier: String
+    package let databaseSHA256: String
+    package let databaseByteCount: Int
+    package let schemaRowCount: Int
+    package let schemaFNV1A64: String
+
+    package init(
+        kind: Kind = .checkedInSnapshot,
+        identifier: String,
+        databaseSHA256: String,
+        databaseByteCount: Int,
+        schemaRowCount: Int,
+        schemaFNV1A64: String
+    ) {
+        self.kind = kind
+        self.identifier = identifier
+        self.databaseSHA256 = databaseSHA256.lowercased()
+        self.databaseByteCount = databaseByteCount
+        self.schemaRowCount = schemaRowCount
+        self.schemaFNV1A64 = schemaFNV1A64.lowercased()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case identifier
+        case databaseSHA256 = "database_sha256"
+        case databaseByteCount = "database_byte_count"
+        case schemaRowCount = "schema_row_count"
+        case schemaFNV1A64 = "schema_fnv1a_64"
+    }
+}
+
+
+package struct SQLiteBuildValidationCodec: Codable, Equatable, Hashable, Sendable {
+    package let keyID: String
+    package let keyVersion: UInt64
+    package let valueTypeIdentifier: String
+    package let dialectIdentifier: String
+    package let storageIdentifier: String
+
+    package init(
+        keyID: String,
+        keyVersion: UInt64,
+        valueTypeIdentifier: String,
+        dialectIdentifier: String,
+        storageIdentifier: String
+    ) {
+        self.keyID = keyID
+        self.keyVersion = keyVersion
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.dialectIdentifier = dialectIdentifier
+        self.storageIdentifier = storageIdentifier
+    }
+
+    package init(_ identity: XLValueCodecIdentity) {
+        self.init(
+            keyID: identity.key.id,
+            keyVersion: UInt64(identity.key.version),
+            valueTypeIdentifier: identity.valueTypeIdentifier.rawValue,
+            dialectIdentifier: identity.dialectIdentifier.rawValue,
+            storageIdentifier: identity.storageIdentifier.rawValue
+        )
+    }
+
+    /// Stable CLI spelling for an available codec. The sidecar retains the
+    /// structured fields; this spelling is only an invocation convenience.
+    package var stableIdentifier: String {
+        "\(keyID)@\(keyVersion)|\(valueTypeIdentifier)|\(dialectIdentifier)|\(storageIdentifier)"
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case keyID = "key_id"
+        case keyVersion = "key_version"
+        case valueTypeIdentifier = "value_type_identifier"
+        case dialectIdentifier = "dialect_identifier"
+        case storageIdentifier = "storage_identifier"
+    }
+}
+
+
+package struct SQLiteBuildValidationCapabilityRequirement:
+    Codable,
+    Equatable,
+    Hashable,
+    Sendable
+{
+    package let id: String
+
+    package init(id: String) {
+        self.id = id
+    }
+}
+
+
+package struct SQLiteBuildValidationParameter: Codable, Equatable, Sendable {
+    package enum KeyKind: String, Codable, Sendable {
+        case named
+        case indexed
+    }
+
+    package let logicalIndex: Int
+    package let physicalIndex: Int
+    package let identity: String
+    package let keyKind: KeyKind
+    package let keyName: String?
+    package let keyIndex: Int?
+    package let valueTypeIdentifier: String
+    package let valueTypeName: String
+    package let nullability: String
+    package let codec: SQLiteBuildValidationCodec?
+    package let storageIdentifier: String
+
+    package init(
+        logicalIndex: Int,
+        physicalIndex: Int,
+        identity: String,
+        keyKind: KeyKind,
+        keyName: String?,
+        keyIndex: Int?,
+        valueTypeIdentifier: String,
+        valueTypeName: String,
+        nullability: String,
+        codec: SQLiteBuildValidationCodec?,
+        storageIdentifier: String
+    ) {
+        self.logicalIndex = logicalIndex
+        self.physicalIndex = physicalIndex
+        self.identity = identity
+        self.keyKind = keyKind
+        self.keyName = keyName
+        self.keyIndex = keyIndex
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.valueTypeName = valueTypeName
+        self.nullability = nullability
+        self.codec = codec
+        self.storageIdentifier = storageIdentifier
+    }
+
+    package var expectedSQLiteName: String {
+        switch keyKind {
+        case .named:
+            return ":\(keyName ?? "")"
+        case .indexed:
+            return "?\((keyIndex ?? -1) + 1)"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case logicalIndex = "logical_index"
+        case physicalIndex = "physical_index"
+        case identity
+        case keyKind = "key_kind"
+        case keyName = "key_name"
+        case keyIndex = "key_index"
+        case valueTypeIdentifier = "value_type_identifier"
+        case valueTypeName = "value_type_name"
+        case nullability
+        case codec
+        case storageIdentifier = "storage_identifier"
+    }
+}
+
+
+package struct SQLiteBuildValidationResult: Codable, Equatable, Sendable {
+    package let index: Int
+    package let identity: String
+    package let expectedAlias: String?
+    package let valueTypeIdentifier: String
+    package let valueTypeName: String
+    package let nullability: String
+    package let codec: SQLiteBuildValidationCodec?
+    package let storageIdentifier: String
+
+    package init(
+        index: Int,
+        identity: String,
+        expectedAlias: String?,
+        valueTypeIdentifier: String,
+        valueTypeName: String,
+        nullability: String,
+        codec: SQLiteBuildValidationCodec?,
+        storageIdentifier: String
+    ) {
+        self.index = index
+        self.identity = identity
+        self.expectedAlias = expectedAlias
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.valueTypeName = valueTypeName
+        self.nullability = nullability
+        self.codec = codec
+        self.storageIdentifier = storageIdentifier
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case index
+        case identity
+        case expectedAlias = "expected_alias"
+        case valueTypeIdentifier = "value_type_identifier"
+        case valueTypeName = "value_type_name"
+        case nullability
+        case codec
+        case storageIdentifier = "storage_identifier"
+    }
+}
+
+
+package struct SQLiteBuildValidationQuery: Codable, Equatable, Sendable {
+    package let id: String
+    package let definitionIdentity: String
+    package let descriptorIdentity: String
+    package let conformanceCaseIDs: [String]
+    package let northwindAnchorCaseIDs: [String]
+    package let inventoryFeatureIDs: [String]
+    package let sql: String
+    package let dialectIdentifier: String
+    package let minimumSQLiteVersion: String?
+    package let dialectCapabilitiesRawValue: UInt64
+    package let cardinality: UInt8
+    package let parameters: [SQLiteBuildValidationParameter]
+    package let results: [SQLiteBuildValidationResult]
+    package let requiredCapabilities: [SQLiteBuildValidationCapabilityRequirement]
+
+    package init(
+        id: String,
+        definitionIdentity: String,
+        descriptorIdentity: String,
+        conformanceCaseIDs: [String] = [],
+        northwindAnchorCaseIDs: [String] = [],
+        inventoryFeatureIDs: [String] = [],
+        sql: String,
+        dialectIdentifier: String = XLSQLiteDialect.identity.rawValue,
+        minimumSQLiteVersion: String? = nil,
+        dialectCapabilitiesRawValue: UInt64 = 0,
+        cardinality: UInt8,
+        parameters: [SQLiteBuildValidationParameter] = [],
+        results: [SQLiteBuildValidationResult] = [],
+        requiredCapabilities: [SQLiteBuildValidationCapabilityRequirement] = []
+    ) {
+        self.id = id
+        self.definitionIdentity = definitionIdentity
+        self.descriptorIdentity = descriptorIdentity
+        self.conformanceCaseIDs = Self.sortedUnique(conformanceCaseIDs)
+        self.northwindAnchorCaseIDs = Self.sortedUnique(northwindAnchorCaseIDs)
+        self.inventoryFeatureIDs = Self.sortedUnique(inventoryFeatureIDs)
+        self.sql = sql
+        self.dialectIdentifier = dialectIdentifier
+        self.minimumSQLiteVersion = minimumSQLiteVersion
+        self.dialectCapabilitiesRawValue = dialectCapabilitiesRawValue
+        self.cardinality = cardinality
+        self.parameters = parameters.sorted { $0.logicalIndex < $1.logicalIndex }
+        self.results = results.sorted { $0.index < $1.index }
+        self.requiredCapabilities = Array(Set(requiredCapabilities)).sorted {
+            $0.id < $1.id
+        }
+    }
+
+    package init(
+        id: String,
+        descriptor: XLStaticQueryDescriptor,
+        resultAliases: [String?]? = nil,
+        conformanceCaseIDs: [String] = [],
+        northwindAnchorCaseIDs: [String] = [],
+        inventoryFeatureIDs: [String] = [],
+        requiredCapabilities: [String] = []
+    ) throws {
+        if let resultAliases, resultAliases.count != descriptor.results.count {
+            throw SQLiteBuildValidationModelError.resultAliasCountMismatch(
+                queryID: id,
+                expected: descriptor.results.count,
+                actual: resultAliases.count
+            )
+        }
+
+        let placeholderAnalysis = SQLiteBuildValidationPlaceholderScanner.scan(
+            descriptor.sql
+        )
+        var projectedParameters: [SQLiteBuildValidationParameter] = []
+        for parameter in descriptor.parameters.sorted(by: {
+            $0.slot.index < $1.slot.index
+        }) {
+            let keyKind: SQLiteBuildValidationParameter.KeyKind
+            let keyName: String?
+            let keyIndex: Int?
+            let physicalIndex: Int
+            switch parameter.slot.key {
+            case .named(let name):
+                keyKind = .named
+                keyName = name
+                keyIndex = nil
+                let spelling = ":\(name)"
+                guard let occurrence = placeholderAnalysis.occurrences.first(
+                    where: { $0.spelling == spelling }
+                ) else {
+                    throw SQLiteBuildValidationModelError.invalidQuery(
+                        id,
+                        "named parameter '\(spelling)' is absent from descriptor SQL"
+                    )
+                }
+                physicalIndex = occurrence.physicalIndex
+            case .indexed(let zeroBasedIndex):
+                keyKind = .indexed
+                keyName = nil
+                keyIndex = zeroBasedIndex
+                physicalIndex = zeroBasedIndex + 1
+            }
+            projectedParameters.append(SQLiteBuildValidationParameter(
+                logicalIndex: parameter.slot.index.rawValue,
+                physicalIndex: physicalIndex,
+                identity: parameter.identity.description,
+                keyKind: keyKind,
+                keyName: keyName,
+                keyIndex: keyIndex,
+                valueTypeIdentifier: parameter.slot.valueTypeIdentifier.rawValue,
+                valueTypeName: parameter.slot.valueTypeName,
+                nullability: parameter.slot.nullability.rawValue,
+                codec: parameter.slot.codecIdentity.map(SQLiteBuildValidationCodec.init),
+                storageIdentifier: parameter.storageIdentifier.rawValue
+            ))
+        }
+
+        let aliases = resultAliases
+            ?? Array<String?>(repeating: nil, count: descriptor.results.count)
+        let projectedResults = descriptor.results.slots.map { result in
+            SQLiteBuildValidationResult(
+                index: result.index.rawValue,
+                identity: result.identity.description,
+                expectedAlias: aliases[result.index.rawValue],
+                valueTypeIdentifier: result.valueTypeIdentifier.rawValue,
+                valueTypeName: result.valueTypeName,
+                nullability: result.nullability.rawValue,
+                codec: result.codecIdentity.map(SQLiteBuildValidationCodec.init),
+                storageIdentifier: result.storageIdentifier.rawValue
+            )
+        }
+
+        self.init(
+            id: id,
+            definitionIdentity: descriptor.definitionIdentity.description,
+            descriptorIdentity: descriptor.identity.description,
+            conformanceCaseIDs: conformanceCaseIDs,
+            northwindAnchorCaseIDs: northwindAnchorCaseIDs,
+            inventoryFeatureIDs: inventoryFeatureIDs,
+            sql: descriptor.sql,
+            dialectIdentifier: descriptor.dialectRequirement.identity.rawValue,
+            minimumSQLiteVersion: descriptor.dialectRequirement.minimumVersion?.description,
+            dialectCapabilitiesRawValue: descriptor.dialectRequirement.capabilities.rawValue,
+            cardinality: descriptor.cardinality.rawValue,
+            parameters: projectedParameters,
+            results: projectedResults,
+            requiredCapabilities: requiredCapabilities.map {
+                SQLiteBuildValidationCapabilityRequirement(id: $0)
+            }
+        )
+    }
+
+    package var expectedPhysicalParameterCount: Int {
+        parameters.map(\.physicalIndex).max() ?? 0
+    }
+
+    package var requiredCodecIdentifiers: [String] {
+        let codecs = parameters.compactMap(\.codec) + results.compactMap(\.codec)
+        return Array(Set(codecs.map(\.stableIdentifier))).sorted()
+    }
+
+    fileprivate func normalized() -> Self {
+        Self(
+            id: id,
+            definitionIdentity: definitionIdentity,
+            descriptorIdentity: descriptorIdentity,
+            conformanceCaseIDs: conformanceCaseIDs,
+            northwindAnchorCaseIDs: northwindAnchorCaseIDs,
+            inventoryFeatureIDs: inventoryFeatureIDs,
+            sql: sql,
+            dialectIdentifier: dialectIdentifier,
+            minimumSQLiteVersion: minimumSQLiteVersion,
+            dialectCapabilitiesRawValue: dialectCapabilitiesRawValue,
+            cardinality: cardinality,
+            parameters: parameters,
+            results: results,
+            requiredCapabilities: requiredCapabilities
+        )
+    }
+
+    private static func sortedUnique(_ values: [String]) -> [String] {
+        Array(Set(values)).sorted()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case definitionIdentity = "definition_identity"
+        case descriptorIdentity = "descriptor_identity"
+        case conformanceCaseIDs = "conformance_case_ids"
+        case northwindAnchorCaseIDs = "northwind_anchor_case_ids"
+        case inventoryFeatureIDs = "inventory_feature_ids"
+        case sql
+        case dialectIdentifier = "dialect_identifier"
+        case minimumSQLiteVersion = "minimum_sqlite_version"
+        case dialectCapabilitiesRawValue = "dialect_capabilities_raw_value"
+        case cardinality
+        case parameters
+        case results
+        case requiredCapabilities = "required_capabilities"
+    }
+}
+
+
+package struct SQLiteBuildValidationPlan: Codable, Equatable, Sendable {
+    package let schemaVersion: Int
+    package let inventoryVersion: String
+    package let schema: SQLiteBuildValidationSchemaInput
+    package let queries: [SQLiteBuildValidationQuery]
+
+    package init(
+        schemaVersion: Int = 1,
+        inventoryVersion: String,
+        schema: SQLiteBuildValidationSchemaInput,
+        queries: [SQLiteBuildValidationQuery]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.inventoryVersion = inventoryVersion
+        self.schema = schema
+        self.queries = queries.map { $0.normalized() }.sorted { $0.id < $1.id }
+    }
+
+    package static func decode(_ data: Data) throws -> Self {
+        try JSONDecoder().decode(Self.self, from: data).validating()
+    }
+
+    package static func decode(contentsOf url: URL) throws -> Self {
+        try decode(Data(contentsOf: url))
+    }
+
+    package func validating() throws -> Self {
+        guard schemaVersion == 1 else {
+            throw SQLiteBuildValidationModelError.unsupportedSchemaVersion(schemaVersion)
+        }
+        guard !inventoryVersion.isEmpty else {
+            throw SQLiteBuildValidationModelError.invalidPlan(
+                "inventory_version must not be empty"
+            )
+        }
+        guard !queries.isEmpty else {
+            throw SQLiteBuildValidationModelError.invalidPlan(
+                "queries must not be empty"
+            )
+        }
+        guard !schema.identifier.isEmpty,
+              schema.databaseByteCount > 0,
+              schema.schemaRowCount > 0,
+              Self.isLowercaseHex(schema.databaseSHA256, count: 64),
+              Self.isLowercaseHex(schema.schemaFNV1A64, count: 16) else {
+            throw SQLiteBuildValidationModelError.invalidPlan(
+                "checked-in schema identity, byte count, row count, SHA-256, and FNV-1a-64 are required"
+            )
+        }
+
+        let duplicateQueryID = Dictionary(grouping: queries, by: \.id)
+            .first { $0.value.count > 1 }?.key
+        if let duplicateQueryID {
+            throw SQLiteBuildValidationModelError.duplicateQueryID(duplicateQueryID)
+        }
+        for query in queries {
+            try Self.validate(query)
+        }
+        return Self(
+            schemaVersion: schemaVersion,
+            inventoryVersion: inventoryVersion,
+            schema: schema,
+            queries: queries
+        )
+    }
+
+    package func canonicalJSONData() throws -> Data {
+        try SQLiteBuildValidationCanonicalJSON.encode(validating())
+    }
+
+    private static func validate(_ query: SQLiteBuildValidationQuery) throws {
+        guard !query.id.isEmpty,
+              !query.definitionIdentity.isEmpty,
+              !query.descriptorIdentity.isEmpty,
+              !query.dialectIdentifier.isEmpty else {
+            throw SQLiteBuildValidationModelError.invalidQuery(
+                query.id,
+                "query and descriptor identities must not be empty"
+            )
+        }
+        guard !query.conformanceCaseIDs.contains(where: \.isEmpty),
+              !query.northwindAnchorCaseIDs.contains(where: \.isEmpty),
+              !query.inventoryFeatureIDs.contains(where: \.isEmpty),
+              !query.requiredCapabilities.contains(where: { $0.id.isEmpty }) else {
+            throw SQLiteBuildValidationModelError.invalidQuery(
+                query.id,
+                "case, feature, and capability identifiers must not be empty"
+            )
+        }
+
+        for (offset, parameter) in query.parameters.enumerated() {
+            guard parameter.logicalIndex == offset,
+                  parameter.physicalIndex > 0,
+                  !parameter.identity.isEmpty,
+                  !parameter.valueTypeIdentifier.isEmpty,
+                  !parameter.valueTypeName.isEmpty,
+                  !parameter.storageIdentifier.isEmpty else {
+                throw SQLiteBuildValidationModelError.invalidQuery(
+                    query.id,
+                    "parameter metadata must be contiguous and complete"
+                )
+            }
+            switch parameter.keyKind {
+            case .named:
+                guard let name = parameter.keyName, !name.isEmpty,
+                      parameter.keyIndex == nil else {
+                    throw SQLiteBuildValidationModelError.invalidQuery(
+                        query.id,
+                        "named parameters require key_name and no key_index"
+                    )
+                }
+            case .indexed:
+                guard parameter.keyName == nil,
+                      let index = parameter.keyIndex,
+                      index >= 0,
+                      parameter.physicalIndex == index + 1 else {
+                    throw SQLiteBuildValidationModelError.invalidQuery(
+                        query.id,
+                        "indexed parameters require a nonnegative key_index matching physical_index"
+                    )
+                }
+            }
+            try validate(parameter.codec, queryID: query.id)
+        }
+        guard Set(query.parameters.map(\.physicalIndex)).count
+                == query.parameters.count else {
+            throw SQLiteBuildValidationModelError.invalidQuery(
+                query.id,
+                "logical parameters must not share a physical SQLite slot"
+            )
+        }
+
+        for (offset, result) in query.results.enumerated() {
+            guard result.index == offset,
+                  !result.identity.isEmpty,
+                  !result.valueTypeIdentifier.isEmpty,
+                  !result.valueTypeName.isEmpty,
+                  !result.storageIdentifier.isEmpty,
+                  result.expectedAlias?.isEmpty != true else {
+                throw SQLiteBuildValidationModelError.invalidQuery(
+                    query.id,
+                    "result metadata must be contiguous and complete"
+                )
+            }
+            try validate(result.codec, queryID: query.id)
+        }
+    }
+
+    private static func validate(
+        _ codec: SQLiteBuildValidationCodec?,
+        queryID: String
+    ) throws {
+        guard let codec else {
+            return
+        }
+        guard !codec.keyID.isEmpty,
+              !codec.valueTypeIdentifier.isEmpty,
+              !codec.dialectIdentifier.isEmpty,
+              !codec.storageIdentifier.isEmpty else {
+            throw SQLiteBuildValidationModelError.invalidQuery(
+                queryID,
+                "codec metadata must be complete"
+            )
+        }
+    }
+
+    private static func isLowercaseHex(_ value: String, count: Int) -> Bool {
+        value.count == count && value.allSatisfy {
+            $0.isNumber || ("a" ... "f").contains($0)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case inventoryVersion = "inventory_version"
+        case schema
+        case queries
+    }
+}
+
+
+package enum SQLiteBuildValidationModelError:
+    Error,
+    Equatable,
+    Sendable,
+    CustomStringConvertible
+{
+    case unsupportedSchemaVersion(Int)
+    case invalidPlan(String)
+    case duplicateQueryID(String)
+    case invalidQuery(String, String)
+    case resultAliasCountMismatch(queryID: String, expected: Int, actual: Int)
+
+    package var description: String {
+        switch self {
+        case .unsupportedSchemaVersion(let version):
+            return "Unsupported build-validation sidecar schema version \(version)."
+        case .invalidPlan(let reason):
+            return "Invalid build-validation plan: \(reason)."
+        case .duplicateQueryID(let id):
+            return "Build-validation query id '\(id)' is duplicated."
+        case .invalidQuery(let id, let reason):
+            return "Invalid build-validation query '\(id)': \(reason)."
+        case .resultAliasCountMismatch(let queryID, let expected, let actual):
+            return "Build-validation query '\(queryID)' supplied \(actual) result aliases for \(expected) result slots."
+        }
+    }
+}
+
+
+enum SQLiteBuildValidationCanonicalJSON {
+    static func encode<Value: Encodable>(_ value: Value) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(value)
+        while data.last == 0x0A {
+            data.removeLast()
+        }
+        data.append(0x0A)
+        return data
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationPlaceholderScanner.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationPlaceholderScanner.swift
@@ -1,0 +1,336 @@
+import Foundation
+
+
+package struct SQLiteBuildValidationPlaceholderOccurrence:
+    Codable,
+    Equatable,
+    Sendable
+{
+    package let spelling: String
+    package let byteOffset: Int
+    package let physicalIndex: Int
+
+    package init(spelling: String, byteOffset: Int, physicalIndex: Int) {
+        self.spelling = spelling
+        self.byteOffset = byteOffset
+        self.physicalIndex = physicalIndex
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case spelling
+        case byteOffset = "byte_offset"
+        case physicalIndex = "physical_index"
+    }
+}
+
+
+package struct SQLiteBuildValidationUnsupportedPlaceholder:
+    Codable,
+    Equatable,
+    Sendable
+{
+    package let spelling: String
+    package let byteOffset: Int
+    package let reason: String
+
+    package init(spelling: String, byteOffset: Int, reason: String) {
+        self.spelling = spelling
+        self.byteOffset = byteOffset
+        self.reason = reason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case spelling
+        case byteOffset = "byte_offset"
+        case reason
+    }
+}
+
+
+/// Quote/comment-aware evidence for SwiftQL's supported placeholder spellings.
+///
+/// This is deliberately smaller than SQLite's tokenizer. It recognizes only
+/// the two forms emitted by `XLSQLiteDialect`: `:name` and one-based `?N`.
+/// Anonymous `?`, `@name`, and `$name` remain explicit unsupported evidence.
+package struct SQLiteBuildValidationPlaceholderAnalysis:
+    Codable,
+    Equatable,
+    Sendable
+{
+    package let physicalParameterCount: Int
+    package let parameters: [SQLitePreparedParameter]
+    package let occurrences: [SQLiteBuildValidationPlaceholderOccurrence]
+    package let unsupported: [SQLiteBuildValidationUnsupportedPlaceholder]
+    package let collisions: [String]
+
+    package init(
+        physicalParameterCount: Int,
+        parameters: [SQLitePreparedParameter],
+        occurrences: [SQLiteBuildValidationPlaceholderOccurrence],
+        unsupported: [SQLiteBuildValidationUnsupportedPlaceholder],
+        collisions: [String]
+    ) {
+        self.physicalParameterCount = physicalParameterCount
+        self.parameters = parameters
+        self.occurrences = occurrences
+        self.unsupported = unsupported
+        self.collisions = collisions.sorted()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case physicalParameterCount = "physical_parameter_count"
+        case parameters
+        case occurrences
+        case unsupported
+        case collisions
+    }
+}
+
+
+package enum SQLiteBuildValidationPlaceholderScanner {
+    package static func scan(
+        _ sql: String
+    ) -> SQLiteBuildValidationPlaceholderAnalysis {
+        let bytes = Array(sql.utf8)
+        var physicalNameByIndex: [Int: String] = [:]
+        var physicalIndexByNamedToken: [String: Int] = [:]
+        var largestPhysicalIndex = 0
+        var occurrences: [SQLiteBuildValidationPlaceholderOccurrence] = []
+        var unsupported: [SQLiteBuildValidationUnsupportedPlaceholder] = []
+        var collisions: [String] = []
+        var index = 0
+
+        while index < bytes.count {
+            let currentByte = bytes[index]
+            if currentByte == 0x2D, byte(at: index + 1, in: bytes) == 0x2D {
+                index = skipLineComment(startingAt: index + 2, bytes: bytes)
+                continue
+            }
+            if currentByte == 0x2F, byte(at: index + 1, in: bytes) == 0x2A {
+                index = skipBlockComment(startingAt: index + 2, bytes: bytes)
+                continue
+            }
+            if currentByte == 0x27 || currentByte == 0x22 || currentByte == 0x60 {
+                index = skipQuoted(
+                    startingAt: index + 1,
+                    delimiter: currentByte,
+                    bytes: bytes
+                )
+                continue
+            }
+            if currentByte == 0x5B {
+                index = skipBracketQuoted(startingAt: index + 1, bytes: bytes)
+                continue
+            }
+
+            if currentByte == 0x3F { // ? or ?NNN
+                let tokenEnd = consumeDigits(startingAt: index + 1, bytes: bytes)
+                guard tokenEnd > index + 1 else {
+                    unsupported.append(SQLiteBuildValidationUnsupportedPlaceholder(
+                        spelling: "?",
+                        byteOffset: index,
+                        reason: "Anonymous ? placeholders are not emitted by SwiftQL static descriptors."
+                    ))
+                    index += 1
+                    continue
+                }
+                let spelling = String(
+                    decoding: bytes[index..<tokenEnd],
+                    as: UTF8.self
+                )
+                guard let physicalIndex = Int(spelling.dropFirst()),
+                      physicalIndex > 0 else {
+                    unsupported.append(SQLiteBuildValidationUnsupportedPlaceholder(
+                        spelling: spelling,
+                        byteOffset: index,
+                        reason: "Indexed placeholders require a positive one-based SQLite index."
+                    ))
+                    index = tokenEnd
+                    continue
+                }
+                largestPhysicalIndex = max(largestPhysicalIndex, physicalIndex)
+                register(
+                    spelling: spelling,
+                    physicalIndex: physicalIndex,
+                    byteOffset: index,
+                    physicalNameByIndex: &physicalNameByIndex,
+                    occurrences: &occurrences,
+                    collisions: &collisions
+                )
+                index = tokenEnd
+                continue
+            }
+
+            if currentByte == 0x3A { // :name
+                let tokenEnd = consumeName(startingAt: index + 1, bytes: bytes)
+                guard tokenEnd > index + 1 else {
+                    index += 1
+                    continue
+                }
+                let spelling = String(
+                    decoding: bytes[index..<tokenEnd],
+                    as: UTF8.self
+                )
+                let physicalIndex: Int
+                if let existing = physicalIndexByNamedToken[spelling] {
+                    physicalIndex = existing
+                } else {
+                    physicalIndex = largestPhysicalIndex + 1
+                    largestPhysicalIndex = physicalIndex
+                    physicalIndexByNamedToken[spelling] = physicalIndex
+                }
+                register(
+                    spelling: spelling,
+                    physicalIndex: physicalIndex,
+                    byteOffset: index,
+                    physicalNameByIndex: &physicalNameByIndex,
+                    occurrences: &occurrences,
+                    collisions: &collisions
+                )
+                index = tokenEnd
+                continue
+            }
+
+            if currentByte == 0x40 || currentByte == 0x24 { // @name or $name
+                let tokenEnd = consumeName(startingAt: index + 1, bytes: bytes)
+                let end = max(index + 1, tokenEnd)
+                let spelling = String(
+                    decoding: bytes[index..<end],
+                    as: UTF8.self
+                )
+                unsupported.append(SQLiteBuildValidationUnsupportedPlaceholder(
+                    spelling: spelling,
+                    byteOffset: index,
+                    reason: "Only SwiftQL-emitted :name and ?N placeholders are supported."
+                ))
+                index = end
+                continue
+            }
+
+            index += 1
+        }
+
+        let parameters: [SQLitePreparedParameter]
+        if largestPhysicalIndex == 0 {
+            parameters = []
+        } else {
+            parameters = (1...largestPhysicalIndex).map {
+                SQLitePreparedParameter(
+                    physicalIndex: $0,
+                    name: physicalNameByIndex[$0]
+                )
+            }
+        }
+        return SQLiteBuildValidationPlaceholderAnalysis(
+            physicalParameterCount: largestPhysicalIndex,
+            parameters: parameters,
+            occurrences: occurrences,
+            unsupported: unsupported,
+            collisions: collisions
+        )
+    }
+}
+
+
+private extension SQLiteBuildValidationPlaceholderScanner {
+    static func register(
+        spelling: String,
+        physicalIndex: Int,
+        byteOffset: Int,
+        physicalNameByIndex: inout [Int: String],
+        occurrences: inout [SQLiteBuildValidationPlaceholderOccurrence],
+        collisions: inout [String]
+    ) {
+        if let existing = physicalNameByIndex[physicalIndex],
+           existing != spelling {
+            collisions.append(
+                "Physical parameter \(physicalIndex) is named by both '\(existing)' and '\(spelling)'."
+            )
+        } else {
+            physicalNameByIndex[physicalIndex] = spelling
+        }
+        occurrences.append(SQLiteBuildValidationPlaceholderOccurrence(
+            spelling: spelling,
+            byteOffset: byteOffset,
+            physicalIndex: physicalIndex
+        ))
+    }
+
+    static func byte(at index: Int, in bytes: [UInt8]) -> UInt8? {
+        bytes.indices.contains(index) ? bytes[index] : nil
+    }
+
+    static func skipLineComment(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count, bytes[index] != 0x0A, bytes[index] != 0x0D {
+            index += 1
+        }
+        return index
+    }
+
+    static func skipBlockComment(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count {
+            if bytes[index] == 0x2A, byte(at: index + 1, in: bytes) == 0x2F {
+                return index + 2
+            }
+            index += 1
+        }
+        return index
+    }
+
+    static func skipQuoted(
+        startingAt index: Int,
+        delimiter: UInt8,
+        bytes: [UInt8]
+    ) -> Int {
+        var index = index
+        while index < bytes.count {
+            guard bytes[index] == delimiter else {
+                index += 1
+                continue
+            }
+            if byte(at: index + 1, in: bytes) == delimiter {
+                index += 2
+                continue
+            }
+            return index + 1
+        }
+        return index
+    }
+
+    static func skipBracketQuoted(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count {
+            if bytes[index] == 0x5D {
+                return index + 1
+            }
+            index += 1
+        }
+        return index
+    }
+
+    static func consumeDigits(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count, (0x30...0x39).contains(bytes[index]) {
+            index += 1
+        }
+        return index
+    }
+
+    static func consumeName(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count, isNameByte(bytes[index]) {
+            index += 1
+        }
+        return index
+    }
+
+    static func isNameByte(_ byte: UInt8) -> Bool {
+        (0x30...0x39).contains(byte)
+            || (0x41...0x5A).contains(byte)
+            || byte == 0x5F
+            || (0x61...0x7A).contains(byte)
+            || byte >= 0x80
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationReport.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationReport.swift
@@ -1,0 +1,289 @@
+import Foundation
+
+
+/// Explicit caller-supplied evidence used during one validation run.
+///
+/// The encoded form is deliberately limited to stable identifiers: it does
+/// not retain paths, timestamps, process identity, or host identity. Every
+/// list is sorted and deduplicated so semantically equivalent invocations
+/// produce byte-identical canonical reports.
+package struct SQLiteBuildValidationEnvironment:
+    Codable,
+    Equatable,
+    Sendable
+{
+    package let codecIdentifiers: [String]
+    package let extensionNames: [String]
+    package let capabilityIDs: [String]
+
+    package init(
+        codecIdentifiers: [String] = [],
+        extensionNames: [String] = [],
+        capabilityIDs: [String] = []
+    ) {
+        self.codecIdentifiers = Self.sortedUnique(codecIdentifiers)
+        self.extensionNames = Self.sortedUnique(extensionNames)
+        self.capabilityIDs = Self.sortedUnique(capabilityIDs)
+    }
+
+    package init(
+        codecIdentities: [SQLiteBuildValidationCodec],
+        extensionNames: [String] = [],
+        capabilityIDs: [String] = []
+    ) {
+        self.init(
+            codecIdentifiers: codecIdentities.map(\.stableIdentifier),
+            extensionNames: extensionNames,
+            capabilityIDs: capabilityIDs
+        )
+    }
+
+    private static func sortedUnique(_ values: [String]) -> [String] {
+        Array(Set(values)).sorted()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case codecIdentifiers = "codec_identifiers"
+        case extensionNames = "extension_names"
+        case capabilityIDs = "capability_ids"
+    }
+}
+
+
+package struct SQLiteBuildValidationDiagnostic: Codable, Equatable, Sendable {
+    package enum Stage: String, Codable, CaseIterable, Sendable {
+        case schema
+        case runtime
+        case codec
+        case capability
+        case prepare
+        case parameter
+        case result
+    }
+
+    package let verdict: SQLiteBuildValidationVerdict
+    package let stage: Stage
+    package let code: String
+    package let message: String
+    package let queryID: String?
+    package let definitionIdentity: String?
+    package let descriptorIdentity: String?
+    package let conformanceCaseIDs: [String]
+    package let northwindAnchorCaseIDs: [String]
+    package let inventoryFeatureIDs: [String]
+    package let sqliteResultCode: Int32?
+    package let sqliteExtendedResultCode: Int32?
+
+    package init(
+        verdict: SQLiteBuildValidationVerdict,
+        stage: Stage,
+        code: String,
+        message: String,
+        query: SQLiteBuildValidationQuery? = nil,
+        sqliteResultCode: Int32? = nil,
+        sqliteExtendedResultCode: Int32? = nil
+    ) {
+        precondition(verdict != .passed, "A diagnostic cannot carry a passed verdict.")
+        self.verdict = verdict
+        self.stage = stage
+        self.code = code
+        self.message = message
+        self.queryID = query?.id
+        self.definitionIdentity = query?.definitionIdentity
+        self.descriptorIdentity = query?.descriptorIdentity
+        self.conformanceCaseIDs = query?.conformanceCaseIDs ?? []
+        self.northwindAnchorCaseIDs = query?.northwindAnchorCaseIDs ?? []
+        self.inventoryFeatureIDs = query?.inventoryFeatureIDs ?? []
+        self.sqliteResultCode = sqliteResultCode
+        self.sqliteExtendedResultCode = sqliteExtendedResultCode
+    }
+
+    fileprivate static func canonicalOrder(
+        _ lhs: Self,
+        _ rhs: Self
+    ) -> Bool {
+        let lhsKey = [
+            lhs.queryID ?? "",
+            lhs.code,
+            lhs.stage.rawValue,
+            String(lhs.sqliteResultCode ?? 0),
+            String(lhs.sqliteExtendedResultCode ?? 0),
+            lhs.message,
+        ]
+        let rhsKey = [
+            rhs.queryID ?? "",
+            rhs.code,
+            rhs.stage.rawValue,
+            String(rhs.sqliteResultCode ?? 0),
+            String(rhs.sqliteExtendedResultCode ?? 0),
+            rhs.message,
+        ]
+        return lhsKey.lexicographicallyPrecedes(rhsKey)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case verdict
+        case stage
+        case code
+        case message
+        case queryID = "query_id"
+        case definitionIdentity = "definition_identity"
+        case descriptorIdentity = "descriptor_identity"
+        case conformanceCaseIDs = "conformance_case_ids"
+        case northwindAnchorCaseIDs = "northwind_anchor_case_ids"
+        case inventoryFeatureIDs = "inventory_feature_ids"
+        case sqliteResultCode = "sqlite_result_code"
+        case sqliteExtendedResultCode = "sqlite_extended_result_code"
+    }
+}
+
+
+package struct SQLiteBuildValidationQueryOutcome:
+    Codable,
+    Equatable,
+    Sendable
+{
+    package let queryID: String
+    package let definitionIdentity: String
+    package let descriptorIdentity: String
+    package let conformanceCaseIDs: [String]
+    package let northwindAnchorCaseIDs: [String]
+    package let inventoryFeatureIDs: [String]
+    package let verdict: SQLiteBuildValidationVerdict
+    package let placeholderAnalysis: SQLiteBuildValidationPlaceholderAnalysis
+    package let preparedShape: SQLitePreparedStatementShape?
+    package let diagnostics: [SQLiteBuildValidationDiagnostic]
+
+    package init(
+        query: SQLiteBuildValidationQuery,
+        placeholderAnalysis: SQLiteBuildValidationPlaceholderAnalysis,
+        preparedShape: SQLitePreparedStatementShape?,
+        diagnostics: [SQLiteBuildValidationDiagnostic]
+    ) {
+        let diagnostics = diagnostics.sorted(
+            by: SQLiteBuildValidationDiagnostic.canonicalOrder
+        )
+        self.queryID = query.id
+        self.definitionIdentity = query.definitionIdentity
+        self.descriptorIdentity = query.descriptorIdentity
+        self.conformanceCaseIDs = query.conformanceCaseIDs
+        self.northwindAnchorCaseIDs = query.northwindAnchorCaseIDs
+        self.inventoryFeatureIDs = query.inventoryFeatureIDs
+        self.verdict = Self.verdict(for: diagnostics)
+        self.placeholderAnalysis = placeholderAnalysis
+        self.preparedShape = preparedShape
+        self.diagnostics = diagnostics
+    }
+
+    private static func verdict(
+        for diagnostics: [SQLiteBuildValidationDiagnostic]
+    ) -> SQLiteBuildValidationVerdict {
+        if diagnostics.contains(where: { $0.verdict == .failed }) {
+            return .failed
+        }
+        if diagnostics.contains(where: { $0.verdict == .unsupported }) {
+            return .unsupported
+        }
+        return .passed
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case queryID = "query_id"
+        case definitionIdentity = "definition_identity"
+        case descriptorIdentity = "descriptor_identity"
+        case conformanceCaseIDs = "conformance_case_ids"
+        case northwindAnchorCaseIDs = "northwind_anchor_case_ids"
+        case inventoryFeatureIDs = "inventory_feature_ids"
+        case verdict
+        case placeholderAnalysis = "placeholder_analysis"
+        case preparedShape = "prepared_shape"
+        case diagnostics
+    }
+}
+
+
+package struct SQLiteBuildValidationReport: Codable, Equatable, Sendable {
+    package let formatVersion: Int
+    package let planSchemaVersion: Int
+    package let inventoryVersion: String
+    package let schema: SQLiteBuildValidationSchemaInput
+    package let observedDatabaseByteCount: Int?
+    package let observedDatabaseSHA256: String?
+    package let runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?
+    package let environmentEvidence: SQLiteBuildValidationEnvironment
+    package let delegatedChecks: [String]
+    package let overallVerdict: SQLiteBuildValidationVerdict
+    package let diagnostics: [SQLiteBuildValidationDiagnostic]
+    package let outcomes: [SQLiteBuildValidationQueryOutcome]
+
+    package init(
+        plan: SQLiteBuildValidationPlan,
+        observedDatabaseByteCount: Int?,
+        observedDatabaseSHA256: String?,
+        runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?,
+        environmentEvidence: SQLiteBuildValidationEnvironment,
+        diagnostics: [SQLiteBuildValidationDiagnostic],
+        outcomes: [SQLiteBuildValidationQueryOutcome]
+    ) {
+        let diagnostics = diagnostics.sorted(
+            by: SQLiteBuildValidationDiagnostic.canonicalOrder
+        )
+        let outcomes = outcomes.sorted { $0.queryID < $1.queryID }
+        self.formatVersion = 1
+        self.planSchemaVersion = plan.schemaVersion
+        self.inventoryVersion = plan.inventoryVersion
+        self.schema = plan.schema
+        self.observedDatabaseByteCount = observedDatabaseByteCount
+        self.observedDatabaseSHA256 = observedDatabaseSHA256?.lowercased()
+        self.runtimeMetadata = runtimeMetadata
+        self.environmentEvidence = environmentEvidence
+        self.delegatedChecks = [
+            "#214 catalog membership and table-reference binding",
+            "#214 correlated and nested reference scopes",
+            "#214 DML target roles",
+            "#214 nullability views",
+            "#214 same-scope alias uniqueness",
+            "SQLite declared types do not prove dynamic expression storage or codec compatibility",
+        ].sorted()
+        self.overallVerdict = Self.overallVerdict(
+            diagnostics: diagnostics,
+            outcomes: outcomes
+        )
+        self.diagnostics = diagnostics
+        self.outcomes = outcomes
+    }
+
+    package func canonicalJSONData() throws -> Data {
+        try SQLiteBuildValidationCanonicalJSON.encode(self)
+    }
+
+    private static func overallVerdict(
+        diagnostics: [SQLiteBuildValidationDiagnostic],
+        outcomes: [SQLiteBuildValidationQueryOutcome]
+    ) -> SQLiteBuildValidationVerdict {
+        if diagnostics.contains(where: { $0.verdict == .failed })
+            || outcomes.contains(where: { $0.verdict == .failed }) {
+            return .failed
+        }
+        if diagnostics.contains(where: { $0.verdict == .unsupported })
+            || outcomes.contains(where: { $0.verdict == .unsupported }) {
+            return .unsupported
+        }
+        return .passed
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case formatVersion = "format_version"
+        case planSchemaVersion = "plan_schema_version"
+        case inventoryVersion = "inventory_version"
+        case schema
+        case observedDatabaseByteCount = "observed_database_byte_count"
+        case observedDatabaseSHA256 = "observed_database_sha256"
+        case runtimeMetadata = "runtime_metadata"
+        case environmentEvidence = "environment_evidence"
+        case delegatedChecks = "delegated_checks"
+        case overallVerdict = "overall_verdict"
+        case diagnostics
+        case outcomes
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationRuntime.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationRuntime.swift
@@ -1,0 +1,408 @@
+import Foundation
+import GRDB
+
+
+/// Stable process, connection-capability, and schema identity for one build
+/// validation run.
+///
+/// Every encoded list is sorted and deduplicated. No timestamp, hostname,
+/// process identifier, or database path is retained.
+package struct SQLiteBuildValidationRuntimeMetadata:
+    Codable,
+    Equatable,
+    Sendable
+{
+    package let sqliteVersion: String
+    package let sqliteSourceID: String
+    package let compileOptions: [String]
+    package let functions: [SQLiteBuildValidationRuntimeFunction]
+    package let collations: [String]
+    package let moduleNames: [String]
+    package let extensionNames: [String]
+    package let schemaRowCount: Int
+    package let schemaFNV1A64: String
+
+    package init(
+        sqliteVersion: String,
+        sqliteSourceID: String,
+        compileOptions: [String],
+        functions: [SQLiteBuildValidationRuntimeFunction],
+        collations: [String],
+        moduleNames: [String],
+        extensionNames: [String],
+        schemaRowCount: Int,
+        schemaFNV1A64: String
+    ) {
+        self.sqliteVersion = sqliteVersion
+        self.sqliteSourceID = sqliteSourceID
+        self.compileOptions = sortedUniqueRuntimeStrings(compileOptions)
+        self.functions = Array(Set(functions)).sorted(
+            by: SQLiteBuildValidationRuntimeFunction.canonicalOrder
+        )
+        self.collations = sortedUniqueRuntimeStrings(collations)
+        self.moduleNames = sortedUniqueRuntimeStrings(moduleNames)
+        self.extensionNames = sortedUniqueRuntimeStrings(extensionNames)
+        self.schemaRowCount = schemaRowCount
+        self.schemaFNV1A64 = schemaFNV1A64.lowercased()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sqliteVersion = "sqlite_version"
+        case sqliteSourceID = "sqlite_source_id"
+        case compileOptions = "compile_options"
+        case functions
+        case collations
+        case moduleNames = "module_names"
+        case extensionNames = "extension_names"
+        case schemaRowCount = "schema_row_count"
+        case schemaFNV1A64 = "schema_fnv1a_64"
+    }
+
+    /// Computed sets are for capability lookup only and are not serialized.
+    package var compileOptionCapabilities: Set<String> {
+        Set(compileOptions)
+    }
+
+    package var functionCapabilities: Set<SQLiteBuildValidationRuntimeFunction> {
+        Set(functions)
+    }
+
+    package var collationCapabilities: Set<String> {
+        Set(collations)
+    }
+
+    package var moduleCapabilities: Set<String> {
+        Set(moduleNames)
+    }
+
+    package var extensionCapabilities: Set<String> {
+        Set(extensionNames)
+    }
+
+    package func hasFunction(
+        named name: String,
+        argumentCount: Int? = nil
+    ) -> Bool {
+        let requiredName = sqliteASCIIFolded(name)
+        return functions.contains { function in
+            guard sqliteASCIIFolded(function.name) == requiredName else {
+                return false
+            }
+            guard let argumentCount else {
+                return true
+            }
+            return function.argumentCount == argumentCount
+                || function.argumentCount == -1
+        }
+    }
+
+    package func hasCollation(named name: String) -> Bool {
+        let requiredName = sqliteASCIIFolded(name)
+        return collations.contains {
+            sqliteASCIIFolded($0) == requiredName
+        }
+    }
+
+    package func hasModule(named name: String) -> Bool {
+        moduleCapabilities.contains(name)
+    }
+
+    package func hasCompileOption(_ option: String) -> Bool {
+        compileOptionCapabilities.contains(option)
+    }
+
+    package func hasExtension(named name: String) -> Bool {
+        extensionCapabilities.contains(name)
+    }
+}
+
+
+package struct SQLiteBuildValidationRuntimeFunction:
+    Codable,
+    Equatable,
+    Hashable,
+    Sendable
+{
+    package let name: String
+    package let isBuiltIn: Bool
+    package let kind: String
+    package let encoding: String
+    package let argumentCount: Int
+    package let flags: Int64
+
+    package init(
+        name: String,
+        isBuiltIn: Bool,
+        kind: String,
+        encoding: String,
+        argumentCount: Int,
+        flags: Int64
+    ) {
+        self.name = name
+        self.isBuiltIn = isBuiltIn
+        self.kind = kind
+        self.encoding = encoding
+        self.argumentCount = argumentCount
+        self.flags = flags
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case isBuiltIn = "is_built_in"
+        case kind
+        case encoding
+        case argumentCount = "argument_count"
+        case flags
+    }
+
+    fileprivate static func canonicalOrder(
+        _ lhs: SQLiteBuildValidationRuntimeFunction,
+        _ rhs: SQLiteBuildValidationRuntimeFunction
+    ) -> Bool {
+        if lhs.name != rhs.name {
+            return lhs.name < rhs.name
+        }
+        if lhs.isBuiltIn != rhs.isBuiltIn {
+            return !lhs.isBuiltIn && rhs.isBuiltIn
+        }
+        if lhs.kind != rhs.kind {
+            return lhs.kind < rhs.kind
+        }
+        if lhs.encoding != rhs.encoding {
+            return lhs.encoding < rhs.encoding
+        }
+        if lhs.argumentCount != rhs.argumentCount {
+            return lhs.argumentCount < rhs.argumentCount
+        }
+        return lhs.flags < rhs.flags
+    }
+}
+
+
+package enum SQLiteBuildValidationRuntimeError: Error, Equatable, Sendable {
+    case missingSQLiteIdentity
+}
+
+
+package enum SQLiteBuildValidationRuntime {
+    /// Captures capabilities from the same validator-owned connection used by
+    /// raw preparation. SQLite can enumerate registered functions, collations,
+    /// and virtual-table modules, but not arbitrary loaded-extension library
+    /// names. Callers must therefore supply stable extension names explicitly.
+    package static func capture(
+        from database: Database,
+        extensionNames: [String] = []
+    ) throws -> SQLiteBuildValidationRuntimeMetadata {
+        guard let identity = try Row.fetchOne(
+            database,
+            sql: """
+                SELECT
+                    sqlite_version() AS sqlite_version,
+                    sqlite_source_id() AS sqlite_source_id
+                """
+        ) else {
+            throw SQLiteBuildValidationRuntimeError.missingSQLiteIdentity
+        }
+
+        let sqliteVersion: String = identity["sqlite_version"]
+        let sqliteSourceID: String = identity["sqlite_source_id"]
+        guard !sqliteVersion.isEmpty, !sqliteSourceID.isEmpty else {
+            throw SQLiteBuildValidationRuntimeError.missingSQLiteIdentity
+        }
+
+        let compileOptions = try firstColumnStrings(
+            database,
+            pragma: "compile_options"
+        )
+        let functions = try Row.fetchAll(
+            database,
+            sql: "PRAGMA function_list"
+        ).map { row in
+            let name: String = row["name"]
+            let builtIn: Int = row["builtin"]
+            let kind: String = row["type"]
+            let encoding: String = row["enc"]
+            let argumentCount: Int = row["narg"]
+            let flags: Int64 = row["flags"]
+            return SQLiteBuildValidationRuntimeFunction(
+                name: name,
+                isBuiltIn: builtIn != 0,
+                kind: kind,
+                encoding: encoding,
+                argumentCount: argumentCount,
+                flags: flags
+            )
+        }
+        let collations = try namedPragmaEntries(
+            database,
+            pragma: "collation_list"
+        )
+        let moduleNames = try namedPragmaEntries(
+            database,
+            pragma: "module_list"
+        )
+        let schemaRows = try SQLiteBuildValidationSchemaRow.fetchAll(
+            from: database
+        )
+
+        return SQLiteBuildValidationRuntimeMetadata(
+            sqliteVersion: sqliteVersion,
+            sqliteSourceID: sqliteSourceID,
+            compileOptions: compileOptions,
+            functions: functions,
+            collations: collations,
+            moduleNames: moduleNames,
+            extensionNames: extensionNames,
+            schemaRowCount: schemaRows.count,
+            schemaFNV1A64: schemaFingerprint(rows: schemaRows)
+        )
+    }
+
+    private static func firstColumnStrings(
+        _ database: Database,
+        pragma: String
+    ) throws -> [String] {
+        try Row.fetchAll(
+            database,
+            sql: "PRAGMA \(pragma)"
+        ).map { row in
+            let value: String = row[0]
+            return value
+        }
+    }
+
+    private static func namedPragmaEntries(
+        _ database: Database,
+        pragma: String
+    ) throws -> [String] {
+        try Row.fetchAll(
+            database,
+            sql: "PRAGMA \(pragma)"
+        ).map { row in
+            let value: String = row["name"]
+            return value
+        }
+    }
+
+    private static func schemaFingerprint(
+        rows: [SQLiteBuildValidationSchemaRow]
+    ) -> String {
+        let rows = rows.sorted(
+            by: SQLiteBuildValidationSchemaRow.canonicalOrder
+        )
+        var hash = SQLiteBuildValidationFNV1A64.offsetBasis
+        for row in rows {
+            for field in row.canonicalFields {
+                SQLiteBuildValidationFNV1A64.update(
+                    &hash,
+                    withLengthPrefixed: field
+                )
+            }
+        }
+        let unpadded = String(hash, radix: 16, uppercase: false)
+        return String(repeating: "0", count: 16 - unpadded.count) + unpadded
+    }
+}
+
+
+private struct SQLiteBuildValidationSchemaRow: Equatable {
+    let type: String
+    let name: String
+    let tableName: String
+    let rootPage: Int64
+    let sql: String
+
+    var canonicalFields: [String] {
+        [type, name, tableName, String(rootPage), sql]
+    }
+
+    static func fetchAll(from database: Database) throws -> [Self] {
+        try Row.fetchAll(
+            database,
+            sql: """
+                SELECT
+                    type,
+                    name,
+                    tbl_name,
+                    rootpage,
+                    COALESCE(sql, '') AS sql
+                FROM sqlite_schema
+                ORDER BY
+                    type COLLATE BINARY,
+                    name COLLATE BINARY,
+                    tbl_name COLLATE BINARY,
+                    rootpage,
+                    sql COLLATE BINARY
+                """
+        ).map { row in
+            let type: String = row["type"]
+            let name: String = row["name"]
+            let tableName: String = row["tbl_name"]
+            let rootPage: Int64 = row["rootpage"]
+            let sql: String = row["sql"]
+            return Self(
+                type: type,
+                name: name,
+                tableName: tableName,
+                rootPage: rootPage,
+                sql: sql
+            )
+        }
+    }
+
+    static func canonicalOrder(_ lhs: Self, _ rhs: Self) -> Bool {
+        if lhs.type != rhs.type {
+            return lhs.type < rhs.type
+        }
+        if lhs.name != rhs.name {
+            return lhs.name < rhs.name
+        }
+        if lhs.tableName != rhs.tableName {
+            return lhs.tableName < rhs.tableName
+        }
+        if lhs.rootPage != rhs.rootPage {
+            return lhs.rootPage < rhs.rootPage
+        }
+        return lhs.sql < rhs.sql
+    }
+}
+
+
+private enum SQLiteBuildValidationFNV1A64 {
+    static let offsetBasis: UInt64 = 14_695_981_039_346_656_037
+    static let prime: UInt64 = 1_099_511_628_211
+
+    static func update(
+        _ hash: inout UInt64,
+        withLengthPrefixed field: String
+    ) {
+        let bytes = Array(field.utf8)
+        update(&hash, bytes: Array(String(bytes.count).utf8))
+        update(&hash, bytes: [0x3A])
+        update(&hash, bytes: bytes)
+        update(&hash, bytes: [0x0A])
+    }
+
+    private static func update(_ hash: inout UInt64, bytes: [UInt8]) {
+        for byte in bytes {
+            hash ^= UInt64(byte)
+            hash &*= prime
+        }
+    }
+}
+
+
+private func sortedUniqueRuntimeStrings(_ values: [String]) -> [String] {
+    Array(Set(values)).sorted()
+}
+
+
+/// SQLite compares function and collation names with ASCII case folding.
+private func sqliteASCIIFolded(_ value: String) -> String {
+    String(decoding: value.utf8.map { byte in
+        if byte >= 0x41, byte <= 0x5A {
+            return byte + 0x20
+        }
+        return byte
+    }, as: UTF8.self)
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationSHA256.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationSHA256.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+
+/// Small cross-platform SHA-256 used to authenticate the checked-in schema
+/// snapshot without adding CryptoKit or another package dependency.
+package enum SQLiteBuildValidationSHA256 {
+    private static let initialState: [UInt32] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+        0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ]
+
+    private static let roundConstants: [UInt32] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+        0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+        0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ]
+
+    package static func hexDigest(of data: Data) -> String {
+        let bytes = digest(Array(data))
+        let digits = Array("0123456789abcdef".utf8)
+        var encoded: [UInt8] = []
+        encoded.reserveCapacity(bytes.count * 2)
+        for byte in bytes {
+            encoded.append(digits[Int(byte >> 4)])
+            encoded.append(digits[Int(byte & 0x0f)])
+        }
+        return String(decoding: encoded, as: UTF8.self)
+    }
+
+    private static func digest(_ input: [UInt8]) -> [UInt8] {
+        var message = input
+        let bitCount = UInt64(message.count) &* 8
+        message.append(0x80)
+        while message.count % 64 != 56 {
+            message.append(0)
+        }
+        for shift in stride(from: 56, through: 0, by: -8) {
+            message.append(UInt8(truncatingIfNeeded: bitCount >> UInt64(shift)))
+        }
+
+        var state = initialState
+        var words = [UInt32](repeating: 0, count: 64)
+        for blockStart in stride(from: 0, to: message.count, by: 64) {
+            for index in 0..<16 {
+                let offset = blockStart + index * 4
+                words[index] =
+                    UInt32(message[offset]) << 24 |
+                    UInt32(message[offset + 1]) << 16 |
+                    UInt32(message[offset + 2]) << 8 |
+                    UInt32(message[offset + 3])
+            }
+            for index in 16..<64 {
+                words[index] = smallSigma1(words[index - 2])
+                    &+ words[index - 7]
+                    &+ smallSigma0(words[index - 15])
+                    &+ words[index - 16]
+            }
+
+            var a = state[0]
+            var b = state[1]
+            var c = state[2]
+            var d = state[3]
+            var e = state[4]
+            var f = state[5]
+            var g = state[6]
+            var h = state[7]
+            for index in 0..<64 {
+                let temporary1 = h
+                    &+ bigSigma1(e)
+                    &+ choose(e, f, g)
+                    &+ roundConstants[index]
+                    &+ words[index]
+                let temporary2 = bigSigma0(a) &+ majority(a, b, c)
+                h = g
+                g = f
+                f = e
+                e = d &+ temporary1
+                d = c
+                c = b
+                b = a
+                a = temporary1 &+ temporary2
+            }
+
+            state[0] &+= a
+            state[1] &+= b
+            state[2] &+= c
+            state[3] &+= d
+            state[4] &+= e
+            state[5] &+= f
+            state[6] &+= g
+            state[7] &+= h
+        }
+
+        var output: [UInt8] = []
+        output.reserveCapacity(32)
+        for word in state {
+            output.append(UInt8(truncatingIfNeeded: word >> 24))
+            output.append(UInt8(truncatingIfNeeded: word >> 16))
+            output.append(UInt8(truncatingIfNeeded: word >> 8))
+            output.append(UInt8(truncatingIfNeeded: word))
+        }
+        return output
+    }
+
+    private static func rotateRight(_ value: UInt32, by count: UInt32) -> UInt32 {
+        (value >> count) | (value << (32 - count))
+    }
+
+    private static func choose(_ x: UInt32, _ y: UInt32, _ z: UInt32) -> UInt32 {
+        (x & y) ^ (~x & z)
+    }
+
+    private static func majority(_ x: UInt32, _ y: UInt32, _ z: UInt32) -> UInt32 {
+        (x & y) ^ (x & z) ^ (y & z)
+    }
+
+    private static func bigSigma0(_ value: UInt32) -> UInt32 {
+        rotateRight(value, by: 2)
+            ^ rotateRight(value, by: 13)
+            ^ rotateRight(value, by: 22)
+    }
+
+    private static func bigSigma1(_ value: UInt32) -> UInt32 {
+        rotateRight(value, by: 6)
+            ^ rotateRight(value, by: 11)
+            ^ rotateRight(value, by: 25)
+    }
+
+    private static func smallSigma0(_ value: UInt32) -> UInt32 {
+        rotateRight(value, by: 7)
+            ^ rotateRight(value, by: 18)
+            ^ (value >> 3)
+    }
+
+    private static func smallSigma1(_ value: UInt32) -> UInt32 {
+        rotateRight(value, by: 17)
+            ^ rotateRight(value, by: 19)
+            ^ (value >> 10)
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidator.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidator.swift
@@ -1,0 +1,733 @@
+import Foundation
+import GRDB
+import SwiftQLCore
+
+
+package enum SQLiteBuildValidator {
+    package static func validate(
+        plan: SQLiteBuildValidationPlan,
+        againstDatabaseAt databaseURL: URL,
+        environment: SQLiteBuildValidationEnvironment = .init()
+    ) throws -> SQLiteBuildValidationReport {
+        let databaseURL = databaseURL.standardizedFileURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let plan = try plan.validating()
+        let resourceValues = try databaseURL.resourceValues(
+            forKeys: [.isRegularFileKey]
+        )
+        guard resourceValues.isRegularFile == true else {
+            throw SQLiteBuildValidationValidatorError.databaseIsNotARegularFile(
+                databaseURL.path
+            )
+        }
+        try requireSidecarFreeSnapshot(at: databaseURL)
+        let databaseData = try Data(
+            contentsOf: databaseURL,
+            options: .mappedIfSafe
+        )
+        let observedDatabaseSHA256 = SQLiteBuildValidationSHA256.hexDigest(
+            of: databaseData
+        )
+
+        var configuration = Configuration()
+        configuration.label = "SwiftQLSQLiteBuildValidationPrototype"
+        configuration.readonly = true
+        configuration.prepareDatabase { database in
+            try database.execute(sql: "PRAGMA query_only = ON")
+        }
+        let queue = try DatabaseQueue(
+            path: databaseURL.path,
+            configuration: configuration
+        )
+        defer { try? queue.close() }
+
+        let report = try queue.read { database in
+            try validate(
+                plan: plan,
+                in: database,
+                observedDatabaseByteCount: databaseData.count,
+                observedDatabaseSHA256: observedDatabaseSHA256,
+                environment: environment
+            )
+        }
+
+        let finalDatabaseData = try Data(
+            contentsOf: databaseURL,
+            options: .mappedIfSafe
+        )
+        let finalDatabaseSHA256 = SQLiteBuildValidationSHA256.hexDigest(
+            of: finalDatabaseData
+        )
+        try requireSidecarFreeSnapshot(at: databaseURL)
+        guard finalDatabaseData.count == databaseData.count,
+              finalDatabaseSHA256 == observedDatabaseSHA256 else {
+            throw SQLiteBuildValidationValidatorError
+                .databaseChangedDuringValidation(
+                    initialByteCount: databaseData.count,
+                    initialSHA256: observedDatabaseSHA256,
+                    finalByteCount: finalDatabaseData.count,
+                    finalSHA256: finalDatabaseSHA256
+                )
+        }
+        return report
+    }
+
+    /// Validates on a caller-supplied serialized connection. The URL overload
+    /// is the authoritative CLI path because it owns a read-only/query-only
+    /// queue. This seam exists for fixture tests and never retains `database`.
+    package static func validate(
+        plan: SQLiteBuildValidationPlan,
+        in database: Database,
+        observedDatabaseByteCount: Int? = nil,
+        observedDatabaseSHA256: String? = nil,
+        environment: SQLiteBuildValidationEnvironment = .init()
+    ) throws -> SQLiteBuildValidationReport {
+        let validatedPlan = try plan.validating()
+
+        var reportDiagnostics: [SQLiteBuildValidationDiagnostic] = []
+        if let observedDatabaseByteCount {
+            if observedDatabaseByteCount != validatedPlan.schema.databaseByteCount {
+                reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .schema,
+                    code: "schema.byte-count",
+                    message: "Schema snapshot byte count is \(observedDatabaseByteCount); expected \(validatedPlan.schema.databaseByteCount)."
+                ))
+            }
+        } else {
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .schema,
+                code: "schema.byte-count",
+                message: "Schema snapshot byte count evidence was not supplied to the caller-owned validation seam."
+            ))
+        }
+        if let observedDatabaseSHA256 {
+            if observedDatabaseSHA256.lowercased() != validatedPlan.schema.databaseSHA256 {
+                reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .schema,
+                    code: "schema.snapshot-sha",
+                    message: "Schema snapshot SHA-256 is \(observedDatabaseSHA256.lowercased()); expected \(validatedPlan.schema.databaseSHA256)."
+                ))
+            }
+        } else {
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .schema,
+                code: "schema.snapshot-sha",
+                message: "Schema snapshot SHA-256 evidence was not supplied to the caller-owned validation seam."
+            ))
+        }
+
+        let runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?
+        do {
+            runtimeMetadata = try SQLiteBuildValidationRuntime.capture(
+                from: database,
+                extensionNames: environment.extensionNames
+            )
+        } catch {
+            runtimeMetadata = nil
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .runtime,
+                code: "runtime.capture",
+                message: "SQLite runtime metadata capture failed: \(String(describing: error))."
+            ))
+        }
+
+        if let runtimeMetadata {
+            if runtimeMetadata.schemaRowCount != validatedPlan.schema.schemaRowCount {
+                reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .schema,
+                    code: "schema.row-count",
+                    message: "Schema contains \(runtimeMetadata.schemaRowCount) sqlite_schema rows; expected \(validatedPlan.schema.schemaRowCount)."
+                ))
+            }
+            if runtimeMetadata.schemaFNV1A64 != validatedPlan.schema.schemaFNV1A64 {
+                reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .schema,
+                    code: "schema.fingerprint",
+                    message: "Schema FNV-1a-64 is \(runtimeMetadata.schemaFNV1A64); expected \(validatedPlan.schema.schemaFNV1A64)."
+                ))
+            }
+        }
+
+        let outcomes = validatedPlan.queries.map { query in
+            validate(
+                query: query,
+                in: database,
+                runtimeMetadata: runtimeMetadata,
+                environment: environment
+            )
+        }
+        return SQLiteBuildValidationReport(
+            plan: validatedPlan,
+            observedDatabaseByteCount: observedDatabaseByteCount,
+            observedDatabaseSHA256: observedDatabaseSHA256,
+            runtimeMetadata: runtimeMetadata,
+            environmentEvidence: environment,
+            diagnostics: reportDiagnostics,
+            outcomes: outcomes
+        )
+    }
+}
+
+
+private extension SQLiteBuildValidator {
+    static func validate(
+        query: SQLiteBuildValidationQuery,
+        in database: Database,
+        runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?,
+        environment: SQLiteBuildValidationEnvironment
+    ) -> SQLiteBuildValidationQueryOutcome {
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        let placeholderAnalysis = SQLiteBuildValidationPlaceholderScanner.scan(
+            query.sql
+        )
+        diagnostics.append(contentsOf: placeholderDiagnostics(
+            query: query,
+            analysis: placeholderAnalysis
+        ))
+        diagnostics.append(contentsOf: dialectDiagnostics(
+            query: query,
+            runtimeMetadata: runtimeMetadata
+        ))
+        diagnostics.append(contentsOf: codecDiagnostics(
+            query: query,
+            environment: environment
+        ))
+        diagnostics.append(contentsOf: capabilityDiagnostics(
+            query: query,
+            runtimeMetadata: runtimeMetadata,
+            environment: environment
+        ))
+
+        let preparedShape: SQLitePreparedStatementShape?
+        if hasUnavailablePreparationPrerequisite(diagnostics) {
+            preparedShape = nil
+        } else {
+            do {
+                let shape = try SQLitePrepareV3Probe.prepare(
+                    sql: query.sql,
+                    in: database
+                )
+                preparedShape = shape
+                if placeholderAnalysis.unsupported.isEmpty {
+                    diagnostics.append(contentsOf: parameterDiagnostics(
+                        query: query,
+                        shape: shape,
+                        analysis: placeholderAnalysis
+                    ))
+                }
+                diagnostics.append(contentsOf: resultDiagnostics(
+                    query: query,
+                    shape: shape
+                ))
+            } catch let error as SQLitePrepareV3ProbeError {
+                preparedShape = nil
+                diagnostics.append(prepareDiagnostic(error, query: query))
+            } catch {
+                preparedShape = nil
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .prepare,
+                    code: "sqlite.prepare.failed",
+                    message: "SQLite preparation failed: \(String(describing: error)).",
+                    query: query
+                ))
+            }
+        }
+
+        return SQLiteBuildValidationQueryOutcome(
+            query: query,
+            placeholderAnalysis: placeholderAnalysis,
+            preparedShape: preparedShape,
+            diagnostics: diagnostics
+        )
+    }
+
+    static func dialectDiagnostics(
+        query: SQLiteBuildValidationQuery,
+        runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        if query.dialectIdentifier != XLSQLiteDialect.identity.rawValue {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .capability,
+                code: "capability.dialect",
+                message: "Descriptor requires dialect '\(query.dialectIdentifier)'; this prototype validates SQLite only.",
+                query: query
+            ))
+        }
+
+        if let requiredVersion = query.minimumSQLiteVersion {
+            guard let actualVersion = runtimeMetadata?.sqliteVersion else {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .unsupported,
+                    stage: .capability,
+                    code: "capability.sqlite-version",
+                    message: "SQLite \(requiredVersion) or newer is required, but runtime identity is unavailable.",
+                    query: query
+                ))
+                return diagnostics
+            }
+            if !version(actualVersion, isAtLeast: requiredVersion) {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .unsupported,
+                    stage: .capability,
+                    code: "capability.sqlite-version",
+                    message: "SQLite \(actualVersion) does not satisfy required version \(requiredVersion).",
+                    query: query
+                ))
+            }
+        }
+
+        let availableDialectCapabilities = XLSQLiteDialect
+            .standardCapabilities.rawValue
+        let unavailable = query.dialectCapabilitiesRawValue
+            & ~availableDialectCapabilities
+        if unavailable != 0 {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .capability,
+                code: "capability.dialect-flags",
+                message: "Descriptor requires unsupported dialect capability bits \(unavailable).",
+                query: query
+            ))
+        }
+        return diagnostics
+    }
+
+    static func codecDiagnostics(
+        query: SQLiteBuildValidationQuery,
+        environment: SQLiteBuildValidationEnvironment
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        struct Slot {
+            let identity: String
+            let valueTypeIdentifier: String
+            let storageIdentifier: String
+            let codec: SQLiteBuildValidationCodec
+        }
+
+        let slots = query.parameters.compactMap { parameter -> Slot? in
+            parameter.codec.map {
+                Slot(
+                    identity: parameter.identity,
+                    valueTypeIdentifier: parameter.valueTypeIdentifier,
+                    storageIdentifier: parameter.storageIdentifier,
+                    codec: $0
+                )
+            }
+        } + query.results.compactMap { result -> Slot? in
+            result.codec.map {
+                Slot(
+                    identity: result.identity,
+                    valueTypeIdentifier: result.valueTypeIdentifier,
+                    storageIdentifier: result.storageIdentifier,
+                    codec: $0
+                )
+            }
+        }
+
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        for slot in slots {
+            if slot.codec.valueTypeIdentifier != slot.valueTypeIdentifier {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .codec,
+                    code: "codec.value-type",
+                    message: "Slot '\(slot.identity)' value type '\(slot.valueTypeIdentifier)' does not match codec value type '\(slot.codec.valueTypeIdentifier)'.",
+                    query: query
+                ))
+            }
+            if slot.codec.dialectIdentifier != query.dialectIdentifier {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .codec,
+                    code: "codec.dialect",
+                    message: "Slot '\(slot.identity)' codec dialect '\(slot.codec.dialectIdentifier)' does not match query dialect '\(query.dialectIdentifier)'.",
+                    query: query
+                ))
+            }
+            if slot.codec.storageIdentifier != slot.storageIdentifier {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .codec,
+                    code: "codec.storage",
+                    message: "Slot '\(slot.identity)' storage '\(slot.storageIdentifier)' does not match codec storage '\(slot.codec.storageIdentifier)'.",
+                    query: query
+                ))
+            }
+        }
+
+        let available = Set(environment.codecIdentifiers)
+        for identifier in query.requiredCodecIdentifiers where !available.contains(identifier) {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .codec,
+                code: "codec.missing",
+                message: "Required codec '\(identifier)' was not supplied to the validator environment.",
+                query: query
+            ))
+        }
+        return diagnostics
+    }
+
+    static func capabilityDiagnostics(
+        query: SQLiteBuildValidationQuery,
+        runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?,
+        environment: SQLiteBuildValidationEnvironment
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        let explicitCapabilities = Set(environment.capabilityIDs)
+        return query.requiredCapabilities.compactMap { requirement in
+            if capability(
+                    requirement.id,
+                    isAvailableIn: runtimeMetadata
+                ) || (isOpaqueCapability(requirement.id)
+                    && explicitCapabilities.contains(requirement.id)) {
+                return nil
+            }
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .capability,
+                code: capabilityDiagnosticCode(requirement.id),
+                message: "Required capability '\(requirement.id)' is unavailable on the validator connection.",
+                query: query
+            )
+        }
+    }
+
+    static func isOpaqueCapability(_ id: String) -> Bool {
+        let foldedID = id.lowercased()
+        let observablePrefixes = [
+            "function:",
+            "collation:",
+            "compile-option:",
+            "module:",
+            "extension:",
+        ]
+        return foldedID != "sqlite-json-functions"
+            && !observablePrefixes.contains(where: foldedID.hasPrefix)
+    }
+
+    static func hasUnavailablePreparationPrerequisite(
+        _ diagnostics: [SQLiteBuildValidationDiagnostic]
+    ) -> Bool {
+        let preparationBlockingCodes = Set([
+            "capability.collation",
+            "capability.dialect",
+            "capability.dialect-flags",
+            "capability.extension",
+            "capability.function",
+            "capability.module",
+            "capability.sqlite-json-functions",
+            "capability.sqlite-version",
+        ])
+        return diagnostics.contains { diagnostic in
+            diagnostic.verdict == .unsupported
+                && preparationBlockingCodes.contains(diagnostic.code)
+        }
+    }
+
+    static func requireSidecarFreeSnapshot(at databaseURL: URL) throws {
+        for suffix in ["-journal", "-shm", "-wal"] {
+            let sidecarPath = databaseURL.path + suffix
+            guard !FileManager.default.fileExists(atPath: sidecarPath) else {
+                throw SQLiteBuildValidationValidatorError.databaseHasSidecar(
+                    sidecarPath
+                )
+            }
+        }
+    }
+
+    static func capability(
+        _ id: String,
+        isAvailableIn runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?
+    ) -> Bool {
+        guard let runtimeMetadata else {
+            return false
+        }
+        if let name = suffix(of: id, after: "function:") {
+            return runtimeMetadata.hasFunction(named: name)
+        }
+        if let name = suffix(of: id, after: "collation:") {
+            return runtimeMetadata.hasCollation(named: name)
+        }
+        if let option = suffix(of: id, after: "compile-option:") {
+            return runtimeMetadata.hasCompileOption(option)
+        }
+        if let name = suffix(of: id, after: "module:") {
+            return runtimeMetadata.hasModule(named: name)
+        }
+        if let name = suffix(of: id, after: "extension:") {
+            return runtimeMetadata.hasExtension(named: name)
+        }
+        switch id {
+        case "named-bindings", "indexed-bindings", "sqlite-core-parser",
+             "sqlite-storage-classes", "compound-select", "recursive-cte",
+             "transactions":
+            return true
+        case "sqlite-json-functions":
+            return runtimeMetadata.hasFunction(named: "JSON_VALID")
+        default:
+            return false
+        }
+    }
+
+    static func capabilityDiagnosticCode(_ id: String) -> String {
+        let foldedID = id.lowercased()
+        if foldedID.hasPrefix("function:") {
+            return "capability.function"
+        }
+        if foldedID.hasPrefix("collation:") {
+            return "capability.collation"
+        }
+        if foldedID.hasPrefix("compile-option:") {
+            return "capability.compile-option"
+        }
+        if foldedID.hasPrefix("module:") {
+            return "capability.module"
+        }
+        if foldedID.hasPrefix("extension:") {
+            return "capability.extension"
+        }
+        if foldedID == "sqlite-json-functions" {
+            return "capability.sqlite-json-functions"
+        }
+        return "capability.missing"
+    }
+
+    static func parameterDiagnostics(
+        query: SQLiteBuildValidationQuery,
+        shape: SQLitePreparedStatementShape,
+        analysis: SQLiteBuildValidationPlaceholderAnalysis
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        if shape.physicalParameterCount != query.expectedPhysicalParameterCount {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .parameter,
+                code: "parameter.count",
+                message: "SQLite exposes \(shape.physicalParameterCount) physical parameter slots; descriptor expects \(query.expectedPhysicalParameterCount).",
+                query: query
+            ))
+        }
+
+        let actualByIndex = Dictionary(
+            uniqueKeysWithValues: shape.parameters.map {
+                ($0.physicalIndex, $0.name)
+            }
+        )
+        let expectedByIndex = Dictionary(
+            uniqueKeysWithValues: query.parameters.map {
+                ($0.physicalIndex, $0.expectedSQLiteName)
+            }
+        )
+        let allIndices = Set(actualByIndex.keys).union(expectedByIndex.keys).sorted()
+        for physicalIndex in allIndices {
+            let expected = expectedByIndex[physicalIndex]
+            let actual = actualByIndex[physicalIndex] ?? nil
+            if let expected {
+                guard actual == expected else {
+                    diagnostics.append(SQLiteBuildValidationDiagnostic(
+                        verdict: .failed,
+                        stage: .parameter,
+                        code: "parameter.key",
+                        message: "Physical parameter \(physicalIndex) is '\(actual ?? "anonymous/implicit")'; descriptor expects '\(expected)'.",
+                        query: query
+                    ))
+                    continue
+                }
+            } else if let actual {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .parameter,
+                    code: "parameter.key",
+                    message: "Physical parameter \(physicalIndex) unexpectedly exposes key '\(actual)'.",
+                    query: query
+                ))
+            }
+        }
+
+        if analysis.unsupported.isEmpty {
+            if analysis.physicalParameterCount != shape.physicalParameterCount
+                || analysis.parameters != shape.parameters {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .parameter,
+                    code: "parameter.metadata",
+                    message: "Lexical placeholder evidence does not match SQLite's physical parameter table.",
+                    query: query
+                ))
+            }
+        }
+        return diagnostics
+    }
+
+    static func placeholderDiagnostics(
+        query: SQLiteBuildValidationQuery,
+        analysis: SQLiteBuildValidationPlaceholderAnalysis
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        let unsupported = analysis.unsupported.map { placeholder in
+            SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .parameter,
+                code: "parameter.syntax",
+                message: "Unsupported placeholder '\(placeholder.spelling)' at UTF-8 byte offset \(placeholder.byteOffset): \(placeholder.reason)",
+                query: query
+            )
+        }
+        let collisions = analysis.collisions.map { collision in
+            SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .parameter,
+                code: "parameter.key",
+                message: collision,
+                query: query
+            )
+        }
+        return unsupported + collisions
+    }
+
+    static func resultDiagnostics(
+        query: SQLiteBuildValidationQuery,
+        shape: SQLitePreparedStatementShape
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        if shape.columns.count != query.results.count {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .result,
+                code: "result.count",
+                message: "SQLite exposes \(shape.columns.count) result columns; descriptor expects \(query.results.count).",
+                query: query
+            ))
+        }
+
+        let actualByIndex = Dictionary(
+            uniqueKeysWithValues: shape.columns.map { ($0.index, $0) }
+        )
+        for result in query.results {
+            guard let expectedAlias = result.expectedAlias,
+                  let column = actualByIndex[result.index],
+                  column.name != expectedAlias else {
+                continue
+            }
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .result,
+                code: "result.name",
+                message: "Result column \(result.index) is named '\(column.name)'; descriptor expects explicit alias '\(expectedAlias)'.",
+                query: query
+            ))
+        }
+        return diagnostics
+    }
+
+    static func prepareDiagnostic(
+        _ error: SQLitePrepareV3ProbeError,
+        query: SQLiteBuildValidationQuery
+    ) -> SQLiteBuildValidationDiagnostic {
+        switch error {
+        case .emptyStatement:
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .prepare,
+                code: "statement.empty",
+                message: "SQL contains no preparable SQLite statement.",
+                query: query
+            )
+        case .embeddedNUL:
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .prepare,
+                code: "statement.embedded-nul",
+                message: "SQL contains an embedded NUL byte.",
+                query: query
+            )
+        case .multipleStatements:
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .prepare,
+                code: "statement.multiple",
+                message: "SQL contains more than one preparable SQLite statement.",
+                query: query
+            )
+        case .sqlitePrepare(let resultCode, let extendedResultCode, let message):
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .prepare,
+                code: "sqlite.prepare.failed",
+                message: message,
+                query: query,
+                sqliteResultCode: resultCode,
+                sqliteExtendedResultCode: extendedResultCode
+            )
+        }
+    }
+
+    static func suffix(of value: String, after prefix: String) -> String? {
+        guard value.hasPrefix(prefix) else {
+            return nil
+        }
+        let suffix = String(value.dropFirst(prefix.count))
+        return suffix.isEmpty ? nil : suffix
+    }
+
+    static func version(_ actual: String, isAtLeast required: String) -> Bool {
+        guard let actual = versionComponents(actual),
+              let required = versionComponents(required) else {
+            return false
+        }
+        return actual.lexicographicallyPrecedes(required) == false
+    }
+
+    static func versionComponents(_ value: String) -> [Int]? {
+        let components = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard !components.isEmpty,
+              components.count <= 3,
+              components.allSatisfy({ Int($0) != nil }) else {
+            return nil
+        }
+        return components.map { Int($0)! }
+            + Array(repeating: 0, count: 3 - components.count)
+    }
+}
+
+
+package enum SQLiteBuildValidationValidatorError:
+    Error,
+    Equatable,
+    Sendable,
+    CustomStringConvertible
+{
+    case databaseIsNotARegularFile(String)
+    case databaseHasSidecar(String)
+    case databaseChangedDuringValidation(
+        initialByteCount: Int,
+        initialSHA256: String,
+        finalByteCount: Int,
+        finalSHA256: String
+    )
+
+    package var description: String {
+        switch self {
+        case .databaseIsNotARegularFile(let path):
+            return "Build-validation database is not a regular file: \(path)"
+        case .databaseHasSidecar(let path):
+            return "Build-validation snapshot has an adjacent SQLite sidecar and is not immutable: \(path)"
+        case .databaseChangedDuringValidation(
+            let initialByteCount,
+            let initialSHA256,
+            let finalByteCount,
+            let finalSHA256
+        ):
+            return "Build-validation snapshot changed during validation: initial byte count \(initialByteCount), SHA-256 \(initialSHA256); final byte count \(finalByteCount), SHA-256 \(finalSHA256)."
+        }
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLitePrepareV3Probe.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLitePrepareV3Probe.swift
@@ -1,0 +1,311 @@
+import CSQLite
+import Foundation
+import GRDB
+
+
+/// One entry in SQLite's one-based physical parameter table.
+///
+/// `name` preserves SQLite's leading sigil (`:`, `@`, `$`, or `?`). A `nil`
+/// name is intentionally ambiguous at this layer: SQLite does not distinguish
+/// an unused `?NNN` gap from an anonymous `?` through its statement metadata
+/// API. The validator reconciles this table with SwiftQL's logical layout.
+package struct SQLitePreparedParameter: Codable, Equatable, Sendable {
+    package let physicalIndex: Int
+    package let name: String?
+
+    package init(physicalIndex: Int, name: String?) {
+        self.physicalIndex = physicalIndex
+        self.name = name
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case physicalIndex = "physical_index"
+        case name
+    }
+}
+
+
+/// Metadata SQLite exposes for one zero-based result column at prepare time.
+///
+/// A missing `declaredType` is expected for expressions, aggregates, literals,
+/// and other results that do not map directly to a declared schema column. It
+/// is evidence only and must not be treated as a storage, codec, or nullability
+/// proof.
+package struct SQLitePreparedColumn: Codable, Equatable, Sendable {
+    package let index: Int
+    package let name: String
+    package let declaredType: String?
+
+    package init(index: Int, name: String, declaredType: String?) {
+        self.index = index
+        self.name = name
+        self.declaredType = declaredType
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case index
+        case name
+        case declaredType = "declared_type"
+    }
+}
+
+
+/// The connection-bound shape SQLite reports for one prepared statement.
+package struct SQLitePreparedStatementShape: Codable, Equatable, Sendable {
+    /// SQLite's largest physical parameter index, including any `?NNN` gaps.
+    package let physicalParameterCount: Int
+
+    /// One entry for every index in `1...physicalParameterCount`.
+    package let parameters: [SQLitePreparedParameter]
+
+    package let columns: [SQLitePreparedColumn]
+
+    /// Raw `sqlite3_stmt_readonly` evidence. This does not classify SwiftQL's
+    /// semantic command/query role.
+    package let isReadOnly: Bool
+
+    package init(
+        physicalParameterCount: Int,
+        parameters: [SQLitePreparedParameter],
+        columns: [SQLitePreparedColumn],
+        isReadOnly: Bool
+    ) {
+        self.physicalParameterCount = physicalParameterCount
+        self.parameters = parameters
+        self.columns = columns
+        self.isReadOnly = isReadOnly
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case physicalParameterCount = "physical_parameter_count"
+        case parameters
+        case columns
+        case isReadOnly = "is_read_only"
+    }
+}
+
+
+/// Stable preparation failures that the higher-level validator maps into its
+/// deterministic report model.
+package enum SQLitePrepareV3ProbeError: Error, Equatable, Sendable {
+    case emptyStatement
+    case embeddedNUL
+    case multipleStatements
+    case sqlitePrepare(
+        resultCode: Int32,
+        extendedResultCode: Int32,
+        message: String
+    )
+}
+
+
+/// Extracts SQLite statement metadata without executing the statement.
+///
+/// This API is package-visible so it can only be reached through the research
+/// validator. It must be called inside the `read` closure of a validator-owned
+/// `DatabaseQueue`, never against an application's long-lived pool. Raw C
+/// preparation bypasses GRDB's internal statement-authorizer reset and must not
+/// escape the serialized connection closure. Returned values contain copied
+/// Swift strings only; no SQLite pointer survives this call.
+package enum SQLitePrepareV3Probe {
+    package static func prepare(
+        sql: String,
+        in database: Database
+    ) throws -> SQLitePreparedStatementShape {
+        guard !sql.utf8.contains(0) else {
+            throw SQLitePrepareV3ProbeError.embeddedNUL
+        }
+        guard let connection = database.sqliteConnection else {
+            throw syntheticPrepareFailure(
+                resultCode: SQLITE_MISUSE,
+                message: "The validator-owned SQLite connection is unavailable."
+            )
+        }
+
+        return try sql.utf8CString.withUnsafeBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                throw SQLitePrepareV3ProbeError.emptyStatement
+            }
+
+            // `utf8CString` includes one trailing NUL byte. Supplying an exact
+            // byte count keeps tail offsets deterministic and avoids allowing
+            // embedded NUL to silently truncate the validated statement.
+            let sqlByteCount = buffer.count - 1
+            guard sqlByteCount <= Int(CInt.max) else {
+                throw syntheticPrepareFailure(
+                    resultCode: SQLITE_TOOBIG,
+                    message: "SQL UTF-8 byte count \(sqlByteCount) exceeds Int32.max."
+                )
+            }
+
+            let endAddress = baseAddress.advanced(by: sqlByteCount)
+            var cursor = baseAddress
+            var preparedShape: SQLitePreparedStatementShape?
+
+            while cursor < endAddress {
+                var statement: OpaquePointer?
+                var tail: UnsafePointer<CChar>?
+                let remainingByteCount = cursor.distance(to: endAddress)
+                let resultCode = sqlite3_prepare_v3(
+                    connection,
+                    cursor,
+                    CInt(remainingByteCount),
+                    0,
+                    &statement,
+                    &tail
+                )
+
+                guard resultCode == SQLITE_OK else {
+                    // SQLite owns these pointers. Copy the diagnostic before
+                    // finalization or any subsequent SQLite call can replace it.
+                    let extendedResultCode = sqlite3_extended_errcode(connection)
+                    let message = copiedString(sqlite3_errmsg(connection))
+                        ?? "sqlite3_prepare_v3 failed without an error message."
+                    if let statement {
+                        _ = sqlite3_finalize(statement)
+                    }
+                    throw SQLitePrepareV3ProbeError.sqlitePrepare(
+                        resultCode: resultCode,
+                        extendedResultCode: extendedResultCode,
+                        message: message
+                    )
+                }
+
+                guard let tail,
+                      tail > cursor,
+                      tail <= endAddress else {
+                    if let statement {
+                        _ = sqlite3_finalize(statement)
+                    }
+                    throw syntheticPrepareFailure(
+                        resultCode: SQLITE_MISUSE,
+                        message: "sqlite3_prepare_v3 returned an invalid or non-advancing tail pointer."
+                    )
+                }
+
+                if let statement {
+                    let shape = try inspectAndFinalize(
+                        statement,
+                        connection: connection
+                    )
+                    guard preparedShape == nil else {
+                        throw SQLitePrepareV3ProbeError.multipleStatements
+                    }
+                    preparedShape = shape
+                }
+
+                cursor = tail
+            }
+
+            guard let preparedShape else {
+                throw SQLitePrepareV3ProbeError.emptyStatement
+            }
+            return preparedShape
+        }
+    }
+
+    /// Copies every SQLite-owned string and finalizes `statement` exactly once,
+    /// whether inspection succeeds or fails.
+    private static func inspectAndFinalize(
+        _ statement: OpaquePointer,
+        connection: OpaquePointer
+    ) throws -> SQLitePreparedStatementShape {
+        let inspection: Result<SQLitePreparedStatementShape, SQLitePrepareV3ProbeError>
+        do {
+            inspection = .success(try inspect(statement, connection: connection))
+        } catch let error as SQLitePrepareV3ProbeError {
+            inspection = .failure(error)
+        } catch {
+            inspection = .failure(syntheticPrepareFailure(
+                resultCode: SQLITE_ERROR,
+                message: "Unexpected statement metadata inspection failure."
+            ))
+        }
+
+        let finalizeResultCode = sqlite3_finalize(statement)
+        switch inspection {
+        case .failure(let error):
+            throw error
+        case .success(let shape):
+            guard finalizeResultCode == SQLITE_OK else {
+                let extendedResultCode = sqlite3_extended_errcode(connection)
+                let message = copiedString(sqlite3_errmsg(connection))
+                    ?? "sqlite3_finalize failed without an error message."
+                throw SQLitePrepareV3ProbeError.sqlitePrepare(
+                    resultCode: finalizeResultCode,
+                    extendedResultCode: extendedResultCode,
+                    message: message
+                )
+            }
+            return shape
+        }
+    }
+
+    private static func inspect(
+        _ statement: OpaquePointer,
+        connection: OpaquePointer
+    ) throws -> SQLitePreparedStatementShape {
+        let physicalParameterCount = Int(
+            sqlite3_bind_parameter_count(statement)
+        )
+        var parameters: [SQLitePreparedParameter] = []
+        parameters.reserveCapacity(physicalParameterCount)
+        if physicalParameterCount > 0 {
+            for physicalIndex in 1...physicalParameterCount {
+                parameters.append(SQLitePreparedParameter(
+                    physicalIndex: physicalIndex,
+                    name: copiedString(sqlite3_bind_parameter_name(
+                        statement,
+                        CInt(physicalIndex)
+                    ))
+                ))
+            }
+        }
+
+        let columnCount = Int(sqlite3_column_count(statement))
+        var columns: [SQLitePreparedColumn] = []
+        columns.reserveCapacity(columnCount)
+        for index in 0..<columnCount {
+            let sqliteIndex = CInt(index)
+            guard let name = copiedString(
+                sqlite3_column_name(statement, sqliteIndex)
+            ) else {
+                throw syntheticPrepareFailure(
+                    resultCode: SQLITE_NOMEM,
+                    message: "SQLite returned no name for result column \(index)."
+                )
+            }
+            columns.append(SQLitePreparedColumn(
+                index: index,
+                name: name,
+                declaredType: copiedString(
+                    sqlite3_column_decltype(statement, sqliteIndex)
+                )
+            ))
+        }
+
+        return SQLitePreparedStatementShape(
+            physicalParameterCount: physicalParameterCount,
+            parameters: parameters,
+            columns: columns,
+            isReadOnly: sqlite3_stmt_readonly(statement) != 0
+        )
+    }
+
+    private static func copiedString(
+        _ value: UnsafePointer<CChar>?
+    ) -> String? {
+        value.map(String.init(cString:))
+    }
+
+    private static func syntheticPrepareFailure(
+        resultCode: Int32,
+        message: String
+    ) -> SQLitePrepareV3ProbeError {
+        .sqlitePrepare(
+            resultCode: resultCode,
+            extendedResultCode: resultCode,
+            message: message
+        )
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototypeCLI/main.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototypeCLI/main.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftQLSQLiteBuildValidationPrototype
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+
+private func writeStandardError(_ message: String) {
+    guard let data = "\(message)\n".data(using: .utf8) else {
+        return
+    }
+    FileHandle.standardError.write(data)
+}
+
+
+do {
+    let options = try SQLiteBuildValidationCLIOptions.parse(
+        arguments: Array(CommandLine.arguments.dropFirst())
+    )
+    if options.showsHelp {
+        print(SQLiteBuildValidationCLIOptions.usage)
+        exit(EXIT_SUCCESS)
+    }
+
+    let result = try SQLiteBuildValidationCLIRunner.run(options: options)
+    exit(result.exitCode)
+} catch {
+    writeStandardError(String(describing: error))
+    writeStandardError(SQLiteBuildValidationCLIOptions.usage)
+    exit(2)
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationCLIOptionsTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationCLIOptionsTests.swift
@@ -1,0 +1,342 @@
+import Foundation
+import XCTest
+
+@testable import SwiftQLSQLiteBuildValidationPrototype
+
+
+final class SQLiteBuildValidationCLIOptionsTests: XCTestCase {
+    func testParsesRequiredPathsAndCanonicalizesRepeatableValues() throws {
+        let currentDirectory = URL(
+            fileURLWithPath: "/tmp/swiftql-build-validation-options",
+            isDirectory: true
+        )
+        let options = try SQLiteBuildValidationCLIOptions.parse(
+            arguments: [
+                "--database", "fixtures/northwind.db",
+                "--plan", "input/plan.json",
+                "--output", "/tmp/report.json",
+                "--codec", "z-codec",
+                "--codec", "a-codec",
+                "--codec", "z-codec",
+                "--extension", "json1",
+                "--extension", "json1",
+                "--capability", "custom:z",
+                "--capability", "custom:a",
+            ],
+            currentDirectory: currentDirectory
+        )
+
+        XCTAssertEqual(
+            options.databaseURL,
+            currentDirectory
+                .appendingPathComponent("fixtures/northwind.db")
+                .standardizedFileURL
+        )
+        XCTAssertEqual(
+            options.planURL,
+            currentDirectory
+                .appendingPathComponent("input/plan.json")
+                .standardizedFileURL
+        )
+        XCTAssertEqual(
+            options.outputURL,
+            URL(fileURLWithPath: "/tmp/report.json").standardizedFileURL
+        )
+        XCTAssertEqual(options.codecIdentifiers, ["a-codec", "z-codec"])
+        XCTAssertEqual(options.extensionNames, ["json1"])
+        XCTAssertEqual(options.capabilityIDs, ["custom:a", "custom:z"])
+        XCTAssertFalse(options.showsHelp)
+    }
+
+    func testHelpDoesNotRequireOperationalArguments() throws {
+        for argument in ["--help", "-h"] {
+            let options = try SQLiteBuildValidationCLIOptions.parse(
+                arguments: [argument]
+            )
+            XCTAssertTrue(options.showsHelp)
+            XCTAssertNil(options.databaseURL)
+            XCTAssertNil(options.planURL)
+            XCTAssertNil(options.outputURL)
+        }
+        XCTAssertTrue(SQLiteBuildValidationCLIOptions.usage.contains("--database"))
+        XCTAssertTrue(SQLiteBuildValidationCLIOptions.usage.contains("--codec"))
+    }
+
+    func testRejectsMissingDuplicateRequiredAndUnknownOptions() throws {
+        assertCLIError(
+            arguments: ["--database"],
+            expected: .missingValue("--database")
+        )
+        assertCLIError(
+            arguments: [
+                "--database", "first.db",
+                "--database", "second.db",
+                "--plan", "plan.json",
+                "--output", "report.json",
+            ],
+            expected: .duplicateOption("--database")
+        )
+        assertCLIError(
+            arguments: [],
+            expected: .requiredOption("--database")
+        )
+        assertCLIError(
+            arguments: ["--unknown"],
+            expected: .unknownOption("--unknown")
+        )
+    }
+
+    func testPreflightRejectsStandardizedDatabaseAndPlanEquality() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cases: [([String], SQLiteBuildValidationCLIError)] = [
+            (
+                [
+                    "--database", "inputs/../database.sqlite",
+                    "--plan", "plan.json",
+                    "--output", "./database.sqlite",
+                ],
+                .outputConflictsWithInput("--database")
+            ),
+            (
+                [
+                    "--database", "database.sqlite",
+                    "--plan", "inputs/../plan.json",
+                    "--output", "./plan.json",
+                ],
+                .outputConflictsWithInput("--plan")
+            ),
+        ]
+
+        for (arguments, expected) in cases {
+            let options = try SQLiteBuildValidationCLIOptions.parse(
+                arguments: arguments,
+                currentDirectory: directory
+            )
+            assertOutputPreflightError(options: options, expected: expected)
+        }
+    }
+
+    func testPreflightRejectsSymlinkAliasesAndSymlinkedParents() throws {
+        let fileManager = FileManager.default
+        let directory = try makeTemporaryDirectory()
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let realDirectory = directory.appendingPathComponent(
+            "real",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(
+            at: realDirectory,
+            withIntermediateDirectories: true
+        )
+        let databaseURL = realDirectory.appendingPathComponent("database.sqlite")
+        let planURL = realDirectory.appendingPathComponent("plan.json")
+        try Data("database".utf8).write(to: databaseURL)
+        try Data("plan".utf8).write(to: planURL)
+
+        let databaseAliasURL = directory.appendingPathComponent("database-alias")
+        try fileManager.createSymbolicLink(
+            at: databaseAliasURL,
+            withDestinationURL: databaseURL
+        )
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationCLIOptions.preflightOutputSafety(
+                databaseURL: databaseURL,
+                planURL: planURL,
+                outputURL: databaseAliasURL
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationCLIError,
+                .outputConflictsWithInput("--database")
+            )
+        }
+
+        let parentAliasURL = directory.appendingPathComponent("parent-alias")
+        try fileManager.createSymbolicLink(
+            at: parentAliasURL,
+            withDestinationURL: realDirectory
+        )
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationCLIOptions.preflightOutputSafety(
+                databaseURL: databaseURL,
+                planURL: planURL,
+                outputURL: parentAliasURL.appendingPathComponent("database.sqlite")
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationCLIError,
+                .outputConflictsWithInput("--database")
+            )
+        }
+    }
+
+    func testPreflightRejectsExistingHardLinkIdentity() throws {
+        let fileManager = FileManager.default
+        let directory = try makeTemporaryDirectory()
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let databaseURL = directory.appendingPathComponent("database.sqlite")
+        let planURL = directory.appendingPathComponent("plan.json")
+        let outputURL = directory.appendingPathComponent("report.json")
+        try Data("database".utf8).write(to: databaseURL)
+        try Data("plan".utf8).write(to: planURL)
+        try fileManager.linkItem(at: databaseURL, to: outputURL)
+
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationCLIOptions.preflightOutputSafety(
+                databaseURL: databaseURL,
+                planURL: planURL,
+                outputURL: outputURL
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationCLIError,
+                .outputConflictsWithInput("--database")
+            )
+        }
+    }
+
+    func testPreflightRejectsDatabaseSidecarOutputPaths() throws {
+        let fileManager = FileManager.default
+        let directory = try makeTemporaryDirectory()
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let realDirectory = directory.appendingPathComponent(
+            "real",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(
+            at: realDirectory,
+            withIntermediateDirectories: true
+        )
+        let databaseURL = realDirectory.appendingPathComponent("database.sqlite")
+        let planURL = realDirectory.appendingPathComponent("plan.json")
+        try Data("database".utf8).write(to: databaseURL)
+        try Data("plan".utf8).write(to: planURL)
+
+        let parentAliasURL = directory.appendingPathComponent("parent-alias")
+        try fileManager.createSymbolicLink(
+            at: parentAliasURL,
+            withDestinationURL: realDirectory
+        )
+        let databaseAliasURL = directory.appendingPathComponent("database-alias")
+        try fileManager.createSymbolicLink(
+            at: databaseAliasURL,
+            withDestinationURL: databaseURL
+        )
+        for suffix in ["-journal", "-shm", "-wal"] {
+            let cases = [
+                (
+                    databaseURL,
+                    parentAliasURL.appendingPathComponent(
+                        "database.sqlite\(suffix)"
+                    )
+                ),
+                (
+                    databaseAliasURL,
+                    URL(fileURLWithPath: databaseAliasURL.path + suffix)
+                ),
+            ]
+            for (inputURL, outputURL) in cases {
+                XCTAssertThrowsError(
+                    try SQLiteBuildValidationCLIOptions.preflightOutputSafety(
+                        databaseURL: inputURL,
+                        planURL: planURL,
+                        outputURL: outputURL
+                    ),
+                    "Expected \(outputURL.path) to be protected for \(inputURL.path)"
+                ) { error in
+                    XCTAssertEqual(
+                        error as? SQLiteBuildValidationCLIError,
+                        .outputConflictsWithDatabaseSidecar
+                    )
+                }
+            }
+        }
+    }
+
+    func testPreflightAllowsNewOutputBesideInputs() throws {
+        let fileManager = FileManager.default
+        let directory = try makeTemporaryDirectory()
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let databaseURL = directory.appendingPathComponent("database.sqlite")
+        let planURL = directory.appendingPathComponent("plan.json")
+        let outputURL = directory.appendingPathComponent("report.json")
+        try Data("database".utf8).write(to: databaseURL)
+        try Data("plan".utf8).write(to: planURL)
+
+        XCTAssertNoThrow(
+            try SQLiteBuildValidationCLIOptions.preflightOutputSafety(
+                databaseURL: databaseURL,
+                planURL: planURL,
+                outputURL: outputURL
+            )
+        )
+    }
+
+    private func assertCLIError(
+        arguments: [String],
+        expected: SQLiteBuildValidationCLIError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationCLIOptions.parse(arguments: arguments),
+            file: file,
+            line: line
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationCLIError,
+                expected,
+                file: file,
+                line: line
+            )
+            XCTAssertFalse(expected.description.isEmpty, file: file, line: line)
+        }
+    }
+
+    private func assertOutputPreflightError(
+        options: SQLiteBuildValidationCLIOptions,
+        expected: SQLiteBuildValidationCLIError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let databaseURL = options.databaseURL,
+              let planURL = options.planURL,
+              let outputURL = options.outputURL else {
+            return XCTFail("Expected operational URLs", file: file, line: line)
+        }
+
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationCLIOptions.preflightOutputSafety(
+                databaseURL: databaseURL,
+                planURL: planURL,
+                outputURL: outputURL
+            ),
+            file: file,
+            line: line
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationCLIError,
+                expected,
+                file: file,
+                line: line
+            )
+            XCTAssertFalse(expected.description.isEmpty, file: file, line: line)
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true
+        )
+        return url
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationCLIRunnerTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationCLIRunnerTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import SwiftQLCore
+import XCTest
+
+@testable import SwiftQLSQLiteBuildValidationPrototype
+
+
+final class SQLiteBuildValidationCLIRunnerTests: XCTestCase {
+    private typealias Support = SQLiteBuildValidationTestSupport
+
+    func testRunnerWritesByteIdenticalPassingReportsAndReturnsZero() throws {
+        try Support.withValidatorOwnedNorthwindURL { databaseURL in
+            let directory = databaseURL.deletingLastPathComponent()
+            let planURL = directory.appendingPathComponent("plan.json")
+            let firstOutputURL = directory.appendingPathComponent("report-1.json")
+            let secondOutputURL = directory.appendingPathComponent("report-2.json")
+            let plan = Support.plan(queries: [Support.query(
+                id: "cli.northwind.customer-count",
+                inventoryFeatureIDs: ["syntax.select.core"],
+                sql: "SELECT COUNT(*) AS value FROM Customers",
+                cardinality: XLQueryCardinality.exactlyOne.rawValue
+            )])
+            try plan.canonicalJSONData().write(to: planURL)
+
+            let first = try SQLiteBuildValidationCLIRunner.run(options: options(
+                databaseURL: databaseURL,
+                planURL: planURL,
+                outputURL: firstOutputURL
+            ))
+            let second = try SQLiteBuildValidationCLIRunner.run(options: options(
+                databaseURL: databaseURL,
+                planURL: planURL,
+                outputURL: secondOutputURL
+            ))
+
+            XCTAssertEqual(first.exitCode, 0)
+            XCTAssertEqual(second.exitCode, 0)
+            XCTAssertEqual(first.report.overallVerdict, .passed)
+            XCTAssertEqual(second.report, first.report)
+            XCTAssertEqual(
+                try Data(contentsOf: firstOutputURL),
+                try Data(contentsOf: secondOutputURL)
+            )
+            XCTAssertEqual(
+                try Data(contentsOf: firstOutputURL),
+                try first.report.canonicalJSONData()
+            )
+        }
+    }
+
+    func testRunnerWritesFailedReportAndReturnsOne() throws {
+        try Support.withValidatorOwnedNorthwindURL { databaseURL in
+            let directory = databaseURL.deletingLastPathComponent()
+            let planURL = directory.appendingPathComponent("invalid-plan.json")
+            let outputURL = directory.appendingPathComponent("failed-report.json")
+            let plan = Support.plan(queries: [Support.query(
+                id: "cli.invalid.missing-table",
+                inventoryFeatureIDs: ["syntax.select.core"],
+                sql: "SELECT value FROM definitely_missing_table"
+            )])
+            try plan.canonicalJSONData().write(to: planURL)
+
+            let result = try SQLiteBuildValidationCLIRunner.run(options: options(
+                databaseURL: databaseURL,
+                planURL: planURL,
+                outputURL: outputURL
+            ))
+
+            XCTAssertEqual(result.exitCode, 1)
+            XCTAssertEqual(result.report.overallVerdict, .failed)
+            XCTAssertTrue(result.report.outcomes[0].diagnostics.contains {
+                $0.code == "sqlite.prepare.failed" && $0.verdict == .failed
+            })
+            XCTAssertEqual(
+                try Data(contentsOf: outputURL),
+                try result.report.canonicalJSONData()
+            )
+        }
+    }
+
+    private func options(
+        databaseURL: URL,
+        planURL: URL,
+        outputURL: URL
+    ) throws -> SQLiteBuildValidationCLIOptions {
+        try SQLiteBuildValidationCLIOptions.parse(arguments: [
+            "--database", databaseURL.path,
+            "--plan", planURL.path,
+            "--output", outputURL.path,
+        ])
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationCapabilityAuditTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationCapabilityAuditTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import GRDB
+import XCTest
+
+@testable import SwiftQLSQLiteBuildValidationPrototype
+
+
+final class SQLiteBuildValidationCapabilityAuditTests: XCTestCase {
+    private typealias Support = SQLiteBuildValidationTestSupport
+
+    func testObservableFunctionCapabilityCannotBeSpoofedByGenericEvidence() throws {
+        let capabilityID = "function:definitely_missing"
+        let report = try validate(
+            query: Support.query(
+                id: "capability.function-spoof",
+                requiredCapabilities: [capabilityID]
+            ),
+            environment: SQLiteBuildValidationEnvironment(
+                capabilityIDs: [capabilityID]
+            )
+        )
+
+        let outcome = try XCTUnwrap(report.outcomes.first)
+        XCTAssertEqual(report.overallVerdict, .unsupported)
+        XCTAssertEqual(outcome.verdict, .unsupported)
+        XCTAssertNil(outcome.preparedShape)
+        XCTAssertTrue(outcome.diagnostics.contains {
+            $0.code == "capability.function" && $0.verdict == .unsupported
+        })
+    }
+
+    func testOpaqueCustomCapabilityCanBeSuppliedExplicitly() throws {
+        let capabilityID = "custom:opaque-audit-capability"
+        let report = try validate(
+            query: Support.query(
+                id: "capability.opaque-explicit",
+                requiredCapabilities: [capabilityID]
+            ),
+            environment: SQLiteBuildValidationEnvironment(
+                capabilityIDs: [capabilityID]
+            )
+        )
+
+        let outcome = try XCTUnwrap(report.outcomes.first)
+        XCTAssertEqual(report.overallVerdict, .passed)
+        XCTAssertEqual(outcome.verdict, .passed)
+        XCTAssertNotNil(outcome.preparedShape)
+        XCTAssertEqual(outcome.diagnostics, [])
+    }
+
+    func testCanonicalReportIncludesNormalizedExplicitEnvironmentEvidence() throws {
+        let plan = Support.plan()
+        let environment = SQLiteBuildValidationEnvironment(
+            codecIdentifiers: ["codec:z", "codec:a", "codec:z"],
+            extensionNames: ["extension:z", "extension:a", "extension:z"],
+            capabilityIDs: ["custom:z", "custom:a", "custom:z"]
+        )
+        let reorderedEnvironment = SQLiteBuildValidationEnvironment(
+            codecIdentifiers: ["codec:a", "codec:z"],
+            extensionNames: ["extension:a", "extension:z"],
+            capabilityIDs: ["custom:a", "custom:z"]
+        )
+
+        try Support.withReadOnlyNorthwindDatabase { database in
+            let report = try validate(
+                plan: plan,
+                in: database,
+                environment: environment
+            )
+            let canonicalData = try report.canonicalJSONData()
+            let reorderedData = try validate(
+                plan: plan,
+                in: database,
+                environment: reorderedEnvironment
+            ).canonicalJSONData()
+
+            XCTAssertEqual(
+                report.environmentEvidence.codecIdentifiers,
+                ["codec:a", "codec:z"]
+            )
+            XCTAssertEqual(
+                report.environmentEvidence.extensionNames,
+                ["extension:a", "extension:z"]
+            )
+            XCTAssertEqual(
+                report.environmentEvidence.capabilityIDs,
+                ["custom:a", "custom:z"]
+            )
+            XCTAssertEqual(canonicalData, reorderedData)
+
+            let changedCodecData = try validate(
+                plan: plan,
+                in: database,
+                environment: SQLiteBuildValidationEnvironment(
+                    codecIdentifiers: ["codec:different"],
+                    extensionNames: environment.extensionNames,
+                    capabilityIDs: environment.capabilityIDs
+                )
+            ).canonicalJSONData()
+            let changedExtensionData = try validate(
+                plan: plan,
+                in: database,
+                environment: SQLiteBuildValidationEnvironment(
+                    codecIdentifiers: environment.codecIdentifiers,
+                    extensionNames: ["extension:different"],
+                    capabilityIDs: environment.capabilityIDs
+                )
+            ).canonicalJSONData()
+            let changedCapabilityData = try validate(
+                plan: plan,
+                in: database,
+                environment: SQLiteBuildValidationEnvironment(
+                    codecIdentifiers: environment.codecIdentifiers,
+                    extensionNames: environment.extensionNames,
+                    capabilityIDs: ["custom:different"]
+                )
+            ).canonicalJSONData()
+
+            XCTAssertNotEqual(canonicalData, changedCodecData)
+            XCTAssertNotEqual(canonicalData, changedExtensionData)
+            XCTAssertNotEqual(canonicalData, changedCapabilityData)
+        }
+    }
+
+    func testInvokedMissingFunctionRemainsUnsupportedWithoutPreparationFailure() throws {
+        let report = try validate(query: Support.query(
+            id: "capability.invoked-missing-function",
+            sql: "SELECT definitely_missing() AS value",
+            requiredCapabilities: ["function:definitely_missing"]
+        ))
+
+        let outcome = try XCTUnwrap(report.outcomes.first)
+        XCTAssertEqual(report.overallVerdict, .unsupported)
+        XCTAssertEqual(outcome.verdict, .unsupported)
+        XCTAssertNil(outcome.preparedShape)
+        XCTAssertTrue(outcome.diagnostics.contains {
+            $0.code == "capability.function" && $0.verdict == .unsupported
+        })
+        XCTAssertFalse(outcome.diagnostics.contains {
+            $0.code == "sqlite.prepare.failed" || $0.stage == .prepare
+        })
+    }
+
+    func testMissingCodecDoesNotMaskIndependentMissingTableFailure() throws {
+        let codec = Support.codec()
+        let report = try validate(query: Support.query(
+            id: "codec.missing-with-missing-table",
+            sql: "SELECT value FROM definitely_missing_table",
+            results: [Support.result(
+                valueTypeIdentifier: codec.valueTypeIdentifier,
+                valueTypeName: "Tests.Token",
+                codec: codec,
+                storageIdentifier: codec.storageIdentifier
+            )]
+        ))
+
+        let outcome = try XCTUnwrap(report.outcomes.first)
+        XCTAssertEqual(report.overallVerdict, .failed)
+        XCTAssertEqual(outcome.verdict, .failed)
+        XCTAssertNil(outcome.preparedShape)
+        XCTAssertTrue(outcome.diagnostics.contains {
+            $0.code == "codec.missing" && $0.verdict == .unsupported
+        })
+        XCTAssertTrue(outcome.diagnostics.contains {
+            $0.code == "sqlite.prepare.failed" && $0.verdict == .failed
+        })
+    }
+
+    func testMissingOpaqueCapabilityDoesNotMaskIndependentSyntaxFailure() throws {
+        let report = try validate(query: Support.query(
+            id: "capability.missing-opaque-with-invalid-sql",
+            sql: "SELEC 1 AS value",
+            requiredCapabilities: ["custom:missing-audit-capability"]
+        ))
+
+        let outcome = try XCTUnwrap(report.outcomes.first)
+        XCTAssertEqual(report.overallVerdict, .failed)
+        XCTAssertEqual(outcome.verdict, .failed)
+        XCTAssertNil(outcome.preparedShape)
+        XCTAssertTrue(outcome.diagnostics.contains {
+            $0.code == "capability.missing" && $0.verdict == .unsupported
+        })
+        XCTAssertTrue(outcome.diagnostics.contains {
+            $0.code == "sqlite.prepare.failed" && $0.verdict == .failed
+        })
+    }
+
+    func testUnsupportedPlaceholderSyntaxDoesNotProduceDerivedParameterFailures() throws {
+        let queries = [
+            Support.query(id: "placeholder.anonymous", sql: "SELECT ? AS value"),
+            Support.query(id: "placeholder.at", sql: "SELECT @value AS value"),
+            Support.query(id: "placeholder.dollar", sql: "SELECT $value AS value"),
+        ]
+        let report = try validate(plan: Support.plan(queries: queries))
+
+        XCTAssertEqual(report.overallVerdict, .unsupported)
+        for outcome in report.outcomes {
+            XCTAssertEqual(outcome.verdict, .unsupported, outcome.queryID)
+            XCTAssertNotNil(outcome.preparedShape, outcome.queryID)
+            XCTAssertTrue(outcome.diagnostics.contains {
+                $0.code == "parameter.syntax" && $0.verdict == .unsupported
+            }, outcome.queryID)
+            XCTAssertFalse(outcome.diagnostics.contains {
+                $0.stage == .parameter && $0.verdict == .failed
+            }, outcome.queryID)
+        }
+    }
+
+    func testURLValidationRejectsAdjacentRollbackJournal() throws {
+        try Support.withValidatorOwnedNorthwindURL { databaseURL in
+            let journalURL = URL(fileURLWithPath: databaseURL.path + "-journal")
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: journalURL.path,
+                contents: Data("audit".utf8)
+            ))
+
+            XCTAssertThrowsError(
+                try SQLiteBuildValidator.validate(
+                    plan: Support.plan(),
+                    againstDatabaseAt: databaseURL
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? SQLiteBuildValidationValidatorError,
+                    .databaseHasSidecar(journalURL.path)
+                )
+            }
+        }
+    }
+
+    private func validate(
+        query: SQLiteBuildValidationQuery,
+        environment: SQLiteBuildValidationEnvironment = .init()
+    ) throws -> SQLiteBuildValidationReport {
+        try validate(
+            plan: Support.plan(queries: [query]),
+            environment: environment
+        )
+    }
+
+    private func validate(
+        plan: SQLiteBuildValidationPlan,
+        environment: SQLiteBuildValidationEnvironment = .init()
+    ) throws -> SQLiteBuildValidationReport {
+        try Support.withReadOnlyNorthwindDatabase { database in
+            try validate(
+                plan: plan,
+                in: database,
+                environment: environment
+            )
+        }
+    }
+
+    private func validate(
+        plan: SQLiteBuildValidationPlan,
+        in database: Database,
+        environment: SQLiteBuildValidationEnvironment
+    ) throws -> SQLiteBuildValidationReport {
+        try SQLiteBuildValidator.validate(
+            plan: plan,
+            in: database,
+            observedDatabaseByteCount: Support.northwindSchemaByteCount,
+            observedDatabaseSHA256: Support.northwindSchemaSHA256,
+            environment: environment
+        )
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationModelTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationModelTests.swift
@@ -1,0 +1,418 @@
+import Foundation
+import SwiftQLCore
+import XCTest
+
+@testable import SwiftQLSQLiteBuildValidationPrototype
+
+
+final class SQLiteBuildValidationModelTests: XCTestCase {
+    typealias Support = SQLiteBuildValidationTestSupport
+
+    func testPlanCanonicalizesOrderingRoundTripsAndEndsWithOneNewline() throws {
+        let later = Support.query(
+            id: "z-later",
+            conformanceCaseIDs: [
+                "c191.v1.select.j-inner.w-named-binding",
+                "c191.v1.northwind.cte-order-subtotals",
+                "c191.v1.select.j-inner.w-named-binding",
+            ],
+            inventoryFeatureIDs: [
+                "syntax.select.core",
+                "binding.named",
+                "syntax.select.core",
+            ],
+            requiredCapabilities: [
+                "function:FLOOR",
+                "function:ABS",
+                "function:FLOOR",
+            ]
+        )
+        let earlier = Support.query(id: "a-earlier")
+        let plan = Support.plan(queries: [later, earlier])
+
+        let validated = try plan.validating()
+        XCTAssertEqual(validated.queries.map(\.id), ["a-earlier", "z-later"])
+        XCTAssertEqual(
+            validated.queries[1].conformanceCaseIDs,
+            [
+                "c191.v1.northwind.cte-order-subtotals",
+                "c191.v1.select.j-inner.w-named-binding",
+            ]
+        )
+        XCTAssertEqual(
+            validated.queries[1].inventoryFeatureIDs,
+            ["binding.named", "syntax.select.core"]
+        )
+        XCTAssertEqual(
+            validated.queries[1].requiredCapabilities.map(\.id),
+            ["function:ABS", "function:FLOOR"]
+        )
+
+        let data = try validated.canonicalJSONData()
+        XCTAssertEqual(data.last, 0x0A)
+        XCTAssertNotEqual(data.dropLast().last, 0x0A)
+        XCTAssertEqual(try SQLiteBuildValidationPlan.decode(data), validated)
+        XCTAssertEqual(
+            try SQLiteBuildValidationPlan.decode(data).canonicalJSONData(),
+            data
+        )
+
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+        let earlierRange = try XCTUnwrap(json.range(of: "a-earlier"))
+        let laterRange = try XCTUnwrap(json.range(of: "z-later"))
+        XCTAssertLessThan(earlierRange.lowerBound, laterRange.lowerBound)
+        XCTAssertTrue(json.contains("\"schema_version\" : 1"))
+        XCTAssertFalse(json.contains("timestamp"))
+        XCTAssertFalse(json.contains("hostname"))
+    }
+
+    func testPlanRejectsInvalidSchemaVersionIdentityAndDuplicateQueryIDs() throws {
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationPlan(
+                schemaVersion: 2,
+                inventoryVersion: "1.3.0",
+                schema: Support.schema(),
+                queries: []
+            ).validating()
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationModelError,
+                .unsupportedSchemaVersion(2)
+            )
+        }
+
+        XCTAssertThrowsError(
+            try Support.plan(
+                schema: Support.schema(databaseSHA256: String(repeating: "g", count: 64))
+            ).validating()
+        ) { error in
+            guard case .invalidPlan(let reason) =
+                error as? SQLiteBuildValidationModelError else {
+                return XCTFail("Expected invalid plan, received \(error)")
+            }
+            XCTAssertTrue(reason.contains("SHA-256"))
+        }
+
+        let duplicate = Support.query(id: "duplicate")
+        XCTAssertThrowsError(
+            try Support.plan(queries: [duplicate, duplicate]).validating()
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationModelError,
+                .duplicateQueryID("duplicate")
+            )
+        }
+    }
+
+    func testPlanRejectsParameterGapsPhysicalCollisionsAndMalformedKeys() throws {
+        let logicalGap = Support.parameter(logicalIndex: 1)
+        assertInvalidQuery(
+            Support.query(parameters: [logicalGap]),
+            contains: "contiguous"
+        )
+
+        let first = Support.parameter(
+            logicalIndex: 0,
+            physicalIndex: 1,
+            identity: "parameter/first",
+            keyName: "first"
+        )
+        let collision = Support.parameter(
+            logicalIndex: 1,
+            physicalIndex: 1,
+            identity: "parameter/second",
+            keyName: "second"
+        )
+        assertInvalidQuery(
+            Support.query(parameters: [first, collision]),
+            contains: "must not share"
+        )
+
+        let malformedIndexed = Support.parameter(
+            logicalIndex: 0,
+            physicalIndex: 3,
+            keyKind: .indexed,
+            keyName: nil,
+            keyIndex: 0
+        )
+        assertInvalidQuery(
+            Support.query(parameters: [malformedIndexed]),
+            contains: "matching physical_index"
+        )
+
+        let malformedNamed = Support.parameter(
+            keyKind: .named,
+            keyName: nil,
+            keyIndex: 0
+        )
+        assertInvalidQuery(
+            Support.query(parameters: [malformedNamed]),
+            contains: "named parameters"
+        )
+    }
+
+    func testPlanRejectsResultGapsEmptyAliasesAndIncompleteCodecs() throws {
+        assertInvalidQuery(
+            Support.query(results: [Support.result(index: 1)]),
+            contains: "result metadata"
+        )
+        assertInvalidQuery(
+            Support.query(results: [Support.result(expectedAlias: "")]),
+            contains: "result metadata"
+        )
+
+        let incompleteCodec = Support.codec(keyID: "")
+        assertInvalidQuery(
+            Support.query(results: [Support.result(codec: incompleteCodec)]),
+            contains: "codec metadata"
+        )
+    }
+
+    func testDescriptorProjectionPreservesStableIdentityPhysicalSlotsAndCodec() throws {
+        let descriptorCodec = makeDescriptorCodec()
+        let descriptor = try makeMixedDescriptor(codec: descriptorCodec)
+
+        let projected = try SQLiteBuildValidationQuery(
+            id: "projection.mixed-bindings",
+            descriptor: descriptor,
+            resultAliases: ["indexed_value", "token"],
+            conformanceCaseIDs: [
+                "c191.v1.select.j-inner.w-named-binding",
+                "c191.v1.northwind.cte-order-subtotals",
+                "c191.v1.select.j-inner.w-named-binding",
+            ],
+            inventoryFeatureIDs: ["binding.named", "binding.indexed"],
+            requiredCapabilities: ["function:JSON_VALID", "function:ABS"]
+        )
+        let repeated = try SQLiteBuildValidationQuery(
+            id: "projection.mixed-bindings",
+            descriptor: descriptor,
+            resultAliases: ["indexed_value", "token"],
+            conformanceCaseIDs: [
+                "c191.v1.northwind.cte-order-subtotals",
+                "c191.v1.select.j-inner.w-named-binding",
+            ],
+            inventoryFeatureIDs: ["binding.indexed", "binding.named"],
+            requiredCapabilities: ["function:ABS", "function:JSON_VALID"]
+        )
+
+        XCTAssertEqual(projected, repeated)
+        XCTAssertEqual(
+            projected.definitionIdentity,
+            "tests/build-validation/projection@1"
+        )
+        XCTAssertEqual(projected.descriptorIdentity, descriptor.identity.description)
+        XCTAssertEqual(projected.sql, "SELECT ?5 AS indexed_value, :token AS token")
+        XCTAssertEqual(projected.parameters.map(\.logicalIndex), [0, 1])
+        XCTAssertEqual(projected.parameters.map(\.physicalIndex), [5, 6])
+        XCTAssertEqual(projected.expectedPhysicalParameterCount, 6)
+        XCTAssertEqual(projected.parameters[0].expectedSQLiteName, "?5")
+        XCTAssertEqual(projected.parameters[1].expectedSQLiteName, ":token")
+        XCTAssertNil(projected.parameters[0].codec)
+        XCTAssertEqual(
+            projected.parameters[1].codec,
+            SQLiteBuildValidationCodec(descriptorCodec)
+        )
+        XCTAssertEqual(projected.results.map(\.expectedAlias), ["indexed_value", "token"])
+        XCTAssertEqual(
+            projected.results[1].codec,
+            SQLiteBuildValidationCodec(descriptorCodec)
+        )
+        XCTAssertEqual(
+            projected.requiredCodecIdentifiers,
+            [SQLiteBuildValidationCodec(descriptorCodec).stableIdentifier]
+        )
+        XCTAssertEqual(projected.conformanceCaseIDs, [
+            "c191.v1.northwind.cte-order-subtotals",
+            "c191.v1.select.j-inner.w-named-binding",
+        ])
+        XCTAssertEqual(
+            projected.requiredCapabilities.map(\.id),
+            ["function:ABS", "function:JSON_VALID"]
+        )
+    }
+
+    func testDescriptorProjectionRejectsAliasCountMismatch() throws {
+        let descriptor = try makeMixedDescriptor(codec: makeDescriptorCodec())
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationQuery(
+                id: "projection.alias-mismatch",
+                descriptor: descriptor,
+                resultAliases: ["only-one"]
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationModelError,
+                .resultAliasCountMismatch(
+                    queryID: "projection.alias-mismatch",
+                    expected: 2,
+                    actual: 1
+                )
+            )
+        }
+    }
+
+    func testDescriptorProjectionUsesSQLTokenOrderForNamedPhysicalSlots() throws {
+        let descriptor = try makeMixedDescriptor(
+            codec: makeDescriptorCodec(),
+            sql: "SELECT :token AS indexed_value, ?5 AS token"
+        )
+
+        let projected = try SQLiteBuildValidationQuery(
+            id: "projection.sql-token-order",
+            descriptor: descriptor
+        )
+
+        XCTAssertEqual(projected.parameters.map(\.logicalIndex), [0, 1])
+        XCTAssertEqual(projected.parameters.map(\.physicalIndex), [5, 1])
+        XCTAssertEqual(projected.parameters.map(\.expectedSQLiteName), ["?5", ":token"])
+        XCTAssertEqual(projected.expectedPhysicalParameterCount, 5)
+    }
+
+    func testDescriptorProjectionRejectsNamedParameterAbsentFromSQL() throws {
+        let descriptor = try makeMixedDescriptor(
+            codec: makeDescriptorCodec(),
+            sql: "SELECT ?5 AS indexed_value, 1 AS token"
+        )
+
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationQuery(
+                id: "projection.missing-named-parameter",
+                descriptor: descriptor
+            )
+        ) { error in
+            guard case .invalidQuery(let queryID, let reason) =
+                    error as? SQLiteBuildValidationModelError else {
+                return XCTFail("Expected invalid query, received \(error)")
+            }
+            XCTAssertEqual(queryID, "projection.missing-named-parameter")
+            XCTAssertTrue(reason.contains(":token"))
+        }
+    }
+
+    private func assertInvalidQuery(
+        _ query: SQLiteBuildValidationQuery,
+        contains expectedReason: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(
+            try Support.plan(queries: [query]).validating(),
+            file: file,
+            line: line
+        ) { error in
+            guard case .invalidQuery(_, let reason) =
+                error as? SQLiteBuildValidationModelError else {
+                return XCTFail(
+                    "Expected invalid query, received \(error)",
+                    file: file,
+                    line: line
+                )
+            }
+            XCTAssertTrue(
+                reason.contains(expectedReason),
+                "Expected '\(reason)' to contain '\(expectedReason)'",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    private func makeDescriptorCodec() -> XLValueCodecIdentity {
+        XLValueCodecIdentity(
+            key: XLValueCodecKey(id: "tests.codec.token", version: 7),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "tests.token"),
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "text")
+        )
+    }
+
+    private func makeMixedDescriptor(
+        codec: XLValueCodecIdentity,
+        sql: String = "SELECT ?5 AS indexed_value, :token AS token"
+    ) throws -> XLStaticQueryDescriptor {
+        let indexed = XLParameterSlot(
+            index: XLLogicalParameterIndex(0),
+            key: .indexed(4),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: "Swift.Int",
+            nullability: .required,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath(["parameter", "indexed"])
+            )
+        )
+        let named = XLParameterSlot(
+            index: XLLogicalParameterIndex(1),
+            key: .named("token"),
+            valueTypeIdentifier: codec.valueTypeIdentifier,
+            valueTypeName: "Tests.Token",
+            nullability: .nullable,
+            codecIdentity: codec,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath(["parameter", "token"])
+            )
+        )
+        let integerStorage = XLValueStorageIdentifier(rawValue: "integer")
+        let textStorage = XLValueStorageIdentifier(rawValue: "text")
+
+        return try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "build-validation", "projection"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: sql,
+                dialectRequirement: XLDialectRequirement(
+                    identity: XLSQLiteDialect.identity,
+                    minimumVersion: XLDialectVersion(3, 38, 0),
+                    capabilities: [.namedBindings, .indexedBindings]
+                ),
+                parameterLayout: try XLParameterLayout(slots: [named, indexed])
+            ),
+            parameters: [
+                XLStaticQueryParameterMetadata(
+                    identity: try XLQuerySlotIdentity(path: ["parameter", "token"]),
+                    slot: named,
+                    storageIdentifier: textStorage
+                ),
+                XLStaticQueryParameterMetadata(
+                    identity: try XLQuerySlotIdentity(path: ["parameter", "indexed"]),
+                    slot: indexed,
+                    storageIdentifier: integerStorage
+                ),
+            ],
+            results: try XLStaticQueryResultMetadata(slots: [
+                XLStaticQueryResultSlot(
+                    index: XLLogicalResultIndex(0),
+                    identity: try XLQuerySlotIdentity(path: ["result", "indexed"]),
+                    valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+                    valueTypeName: "Swift.Int",
+                    nullability: .required,
+                    codecIdentity: nil,
+                    storageIdentifier: integerStorage,
+                    codingContext: XLValueCodingContext(
+                        site: .result,
+                        path: XLValueCodingPath(["result", "indexed"])
+                    )
+                ),
+                XLStaticQueryResultSlot(
+                    index: XLLogicalResultIndex(1),
+                    identity: try XLQuerySlotIdentity(path: ["result", "token"]),
+                    valueTypeIdentifier: codec.valueTypeIdentifier,
+                    valueTypeName: "Tests.Token",
+                    nullability: .nullable,
+                    codecIdentity: codec,
+                    storageIdentifier: textStorage,
+                    codingContext: XLValueCodingContext(
+                        site: .result,
+                        path: XLValueCodingPath(["result", "token"])
+                    )
+                ),
+            ]),
+            cardinality: .exactlyOne
+        )
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationPlaceholderScannerTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationPlaceholderScannerTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+@testable import SwiftQLSQLiteBuildValidationPrototype
+
+
+final class SQLiteBuildValidationPlaceholderScannerTests: XCTestCase {
+    func testRecognizesNamedIndexedGapsAndRepeatedNamesWhileIgnoringQuotedText() {
+        let analysis = SQLiteBuildValidationPlaceholderScanner.scan(
+            """
+            SELECT ?3, :later, :later, ?1,
+                   ':string', "?:identifier", `:quoted`, [?:bracket]
+            -- :line_comment ?8
+            /* :block_comment ?9 */
+            """
+        )
+
+        XCTAssertEqual(analysis.physicalParameterCount, 4)
+        XCTAssertEqual(analysis.parameters, [
+            SQLitePreparedParameter(physicalIndex: 1, name: "?1"),
+            SQLitePreparedParameter(physicalIndex: 2, name: nil),
+            SQLitePreparedParameter(physicalIndex: 3, name: "?3"),
+            SQLitePreparedParameter(physicalIndex: 4, name: ":later"),
+        ])
+        XCTAssertEqual(
+            analysis.occurrences.map(\.spelling),
+            ["?3", ":later", ":later", "?1"]
+        )
+        XCTAssertEqual(
+            analysis.occurrences.map(\.physicalIndex),
+            [3, 4, 4, 1]
+        )
+        XCTAssertEqual(analysis.unsupported, [])
+        XCTAssertEqual(analysis.collisions, [])
+    }
+
+    func testRecordsCollisionsAndUnsupportedPlaceholderSpellings() {
+        let analysis = SQLiteBuildValidationPlaceholderScanner.scan(
+            "SELECT :first, ?1, ?, @other, $cash, ?0"
+        )
+
+        XCTAssertEqual(analysis.physicalParameterCount, 1)
+        XCTAssertEqual(
+            analysis.collisions,
+            ["Physical parameter 1 is named by both ':first' and '?1'."]
+        )
+        XCTAssertEqual(
+            analysis.unsupported.map(\.spelling),
+            ["?", "@other", "$cash", "?0"]
+        )
+        XCTAssertTrue(analysis.unsupported.allSatisfy { !$0.reason.isEmpty })
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationTestSupport.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidationTestSupport.swift
@@ -1,0 +1,184 @@
+import Foundation
+import GRDB
+import SwiftQLCore
+import SwiftQLNorthwindFixtures
+
+@testable import SwiftQLSQLiteBuildValidationPrototype
+
+
+enum SQLiteBuildValidationTestSupport {
+    static let northwindSchemaSHA256 =
+        "cb6f0071a264e150d3796f75c4b0643e32b2132e4e02370518b50a1eac3381d8"
+    static let northwindSchemaByteCount = 602_112
+    static let northwindSchemaRowCount = 37
+    static let northwindSchemaFNV1A64 = "e2c8fadbd38c2313"
+
+    static func schema(
+        databaseSHA256: String = northwindSchemaSHA256,
+        databaseByteCount: Int = northwindSchemaByteCount,
+        schemaRowCount: Int = northwindSchemaRowCount,
+        schemaFNV1A64: String = northwindSchemaFNV1A64
+    ) -> SQLiteBuildValidationSchemaInput {
+        SQLiteBuildValidationSchemaInput(
+            identifier: "northwind.issue-254",
+            databaseSHA256: databaseSHA256,
+            databaseByteCount: databaseByteCount,
+            schemaRowCount: schemaRowCount,
+            schemaFNV1A64: schemaFNV1A64
+        )
+    }
+
+    static func codec(
+        keyID: String = "tests.codec.token",
+        keyVersion: UInt64 = 7,
+        valueTypeIdentifier: String = "tests.token",
+        dialectIdentifier: String = XLSQLiteDialect.identity.rawValue,
+        storageIdentifier: String = "text"
+    ) -> SQLiteBuildValidationCodec {
+        SQLiteBuildValidationCodec(
+            keyID: keyID,
+            keyVersion: keyVersion,
+            valueTypeIdentifier: valueTypeIdentifier,
+            dialectIdentifier: dialectIdentifier,
+            storageIdentifier: storageIdentifier
+        )
+    }
+
+    static func parameter(
+        logicalIndex: Int = 0,
+        physicalIndex: Int = 1,
+        identity: String = "parameter/value",
+        keyKind: SQLiteBuildValidationParameter.KeyKind = .named,
+        keyName: String? = "value",
+        keyIndex: Int? = nil,
+        valueTypeIdentifier: String = "swift.int",
+        valueTypeName: String = "Swift.Int",
+        nullability: String = "required",
+        codec: SQLiteBuildValidationCodec? = nil,
+        storageIdentifier: String = "integer"
+    ) -> SQLiteBuildValidationParameter {
+        SQLiteBuildValidationParameter(
+            logicalIndex: logicalIndex,
+            physicalIndex: physicalIndex,
+            identity: identity,
+            keyKind: keyKind,
+            keyName: keyName,
+            keyIndex: keyIndex,
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codec: codec,
+            storageIdentifier: storageIdentifier
+        )
+    }
+
+    static func result(
+        index: Int = 0,
+        identity: String = "result/value",
+        expectedAlias: String? = "value",
+        valueTypeIdentifier: String = "swift.int",
+        valueTypeName: String = "Swift.Int",
+        nullability: String = "required",
+        codec: SQLiteBuildValidationCodec? = nil,
+        storageIdentifier: String = "integer"
+    ) -> SQLiteBuildValidationResult {
+        SQLiteBuildValidationResult(
+            index: index,
+            identity: identity,
+            expectedAlias: expectedAlias,
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codec: codec,
+            storageIdentifier: storageIdentifier
+        )
+    }
+
+    static func query(
+        id: String = "tests.query",
+        definitionIdentity: String? = nil,
+        descriptorIdentity: String? = nil,
+        conformanceCaseIDs: [String] = [],
+        inventoryFeatureIDs: [String] = [],
+        northwindAnchorCaseIDs: [String] = [],
+        sql: String = "SELECT 1 AS value",
+        cardinality: UInt8 = XLQueryCardinality.exactlyOne.rawValue,
+        parameters: [SQLiteBuildValidationParameter] = [],
+        results: [SQLiteBuildValidationResult] = [result()],
+        requiredCapabilities: [String] = []
+    ) -> SQLiteBuildValidationQuery {
+        SQLiteBuildValidationQuery(
+            id: id,
+            definitionIdentity: definitionIdentity ?? "tests/\(id)@1",
+            descriptorIdentity: descriptorIdentity ?? "swiftql-query-v1-\(id)",
+            conformanceCaseIDs: conformanceCaseIDs,
+            northwindAnchorCaseIDs: northwindAnchorCaseIDs,
+            inventoryFeatureIDs: inventoryFeatureIDs,
+            sql: sql,
+            cardinality: cardinality,
+            parameters: parameters,
+            results: results,
+            requiredCapabilities: requiredCapabilities.map {
+                SQLiteBuildValidationCapabilityRequirement(id: $0)
+            }
+        )
+    }
+
+    static func plan(
+        schema: SQLiteBuildValidationSchemaInput = schema(),
+        inventoryVersion: String = "1.3.0",
+        queries: [SQLiteBuildValidationQuery] = [query()]
+    ) -> SQLiteBuildValidationPlan {
+        SQLiteBuildValidationPlan(
+            inventoryVersion: inventoryVersion,
+            schema: schema,
+            queries: queries
+        )
+    }
+
+    static func withNorthwindURL<Result>(
+        _ body: (URL) throws -> Result
+    ) throws -> Result {
+        try NorthwindFixture.withTemporaryCopy { copy in
+            try body(copy.url)
+        }
+    }
+
+    /// Places an untouched canonical snapshot at a second unique path inside
+    /// the fixture's temporary directory. The fixture pool never opens this
+    /// path, so the validator owns its complete connection lifecycle and no
+    /// WAL/SHM sidecars exist before validation begins.
+    static func withValidatorOwnedNorthwindURL<Result>(
+        _ body: (URL) throws -> Result
+    ) throws -> Result {
+        try NorthwindFixture.withTemporaryCopy { copy in
+            let canonicalPool = try NorthwindFixture.validatedReadOnlyPool()
+            defer { try? canonicalPool.close() }
+
+            let sourceURL = URL(fileURLWithPath: canonicalPool.path)
+            let validatorURL = copy.url.deletingLastPathComponent()
+                .appendingPathComponent("validator-owned-northwind.db")
+            try FileManager.default.copyItem(at: sourceURL, to: validatorURL)
+            return try body(validatorURL)
+        }
+    }
+
+    static func withReadOnlyNorthwindDatabase<Result>(
+        _ body: (Database) throws -> Result
+    ) throws -> Result {
+        try withNorthwindURL { url in
+            var configuration = Configuration()
+            configuration.label = "SwiftQLSQLiteBuildValidationPrototypeTests.raw-probe"
+            configuration.readonly = true
+            configuration.prepareDatabase { database in
+                try database.execute(sql: "PRAGMA query_only = ON")
+            }
+            let queue = try DatabaseQueue(
+                path: url.path,
+                configuration: configuration
+            )
+            defer { try? queue.close() }
+            return try queue.read(body)
+        }
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidatorIntegrationTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLiteBuildValidatorIntegrationTests.swift
@@ -1,0 +1,551 @@
+import Foundation
+import SwiftQLCore
+import SwiftQLNorthwindFixtures
+import SwiftQLSQLiteCombinatorialSupport
+import XCTest
+
+@testable import SwiftQLSQLiteBuildValidationPrototype
+
+
+final class SQLiteBuildValidatorIntegrationTests: XCTestCase {
+    typealias Support = SQLiteBuildValidationTestSupport
+
+    func testRepresentativeIssue191CasesAndFeatureReferencesPass() throws {
+        let manifest = try SQLiteCombinatorialSuite.makeManifest()
+        let named = try manifestCase(
+            "c191.v1.select.j-inner.w-named-binding",
+            in: manifest
+        )
+        let cte = try manifestCase(
+            "c191.v1.northwind.cte-order-subtotals",
+            in: manifest
+        )
+        let floor = try manifestCase(
+            "c191.v1.expression.numeric-floor",
+            in: manifest
+        )
+
+        XCTAssertEqual(named.inventoryFeatureIDs, [
+            "binding.named",
+            "syntax.expression.current-operators",
+            "syntax.join.current-inner-left-cross",
+            "syntax.select.core",
+        ])
+        XCTAssertEqual(
+            named.northwindAnchorCaseIDs,
+            ["northwind.join.customer-order-employee-product"]
+        )
+        XCTAssertEqual(cte.inventoryFeatureIDs, [
+            "syntax.cte.recursive",
+            "syntax.expression.aggregate-functions",
+            "syntax.select.core",
+        ])
+        XCTAssertEqual(
+            cte.northwindAnchorCaseIDs,
+            ["northwind.cte.order-subtotals"]
+        )
+        XCTAssertEqual(
+            floor.inventoryFeatureIDs,
+            ["syntax.expression.numeric-comparable-functions"]
+        )
+        XCTAssertEqual(floor.requiredCapabilities, ["function:FLOOR"])
+
+        let queries = [
+            Support.query(
+                id: named.id,
+                conformanceCaseIDs: [named.id],
+                inventoryFeatureIDs: named.inventoryFeatureIDs,
+                northwindAnchorCaseIDs: named.northwindAnchorCaseIDs ?? [],
+                sql: named.renderedSQL,
+                cardinality: XLQueryCardinality.many.rawValue,
+                parameters: [Support.parameter(
+                    identity: "parameter/minimum-order-id",
+                    keyName: "minimum_order_id"
+                )],
+                results: [Support.result(
+                    identity: "result/order-id",
+                    expectedAlias: nil
+                )],
+                requiredCapabilities: named.requiredCapabilities
+            ),
+            Support.query(
+                id: cte.id,
+                conformanceCaseIDs: [cte.id],
+                inventoryFeatureIDs: cte.inventoryFeatureIDs,
+                northwindAnchorCaseIDs: cte.northwindAnchorCaseIDs ?? [],
+                sql: cte.renderedSQL,
+                cardinality: XLQueryCardinality.many.rawValue,
+                results: [
+                    Support.result(
+                        index: 0,
+                        identity: "result/order-id",
+                        expectedAlias: "orderID"
+                    ),
+                    Support.result(
+                        index: 1,
+                        identity: "result/subtotal",
+                        expectedAlias: "subtotal",
+                        valueTypeIdentifier: "swift.double",
+                        valueTypeName: "Swift.Double",
+                        storageIdentifier: "real"
+                    ),
+                ],
+                requiredCapabilities: cte.requiredCapabilities
+            ),
+            Support.query(
+                id: floor.id,
+                conformanceCaseIDs: [floor.id],
+                inventoryFeatureIDs: floor.inventoryFeatureIDs,
+                northwindAnchorCaseIDs: floor.northwindAnchorCaseIDs ?? [],
+                sql: floor.renderedSQL,
+                parameters: [Support.parameter(
+                    identity: "parameter/real-value",
+                    keyName: "real_value",
+                    valueTypeIdentifier: "swift.double",
+                    valueTypeName: "Swift.Double",
+                    storageIdentifier: "real"
+                )],
+                results: [Support.result(
+                    identity: "result/floor",
+                    expectedAlias: nil,
+                    valueTypeIdentifier: "swift.double",
+                    valueTypeName: "Swift.Double",
+                    storageIdentifier: "real"
+                )],
+                requiredCapabilities: floor.requiredCapabilities
+            ),
+        ]
+        let plan = Support.plan(
+            inventoryVersion: manifest.inventoryVersion,
+            queries: queries
+        )
+
+        let report = try validateOnOwnedNorthwindURL(plan: plan)
+        XCTAssertEqual(report.overallVerdict, .passed)
+        XCTAssertEqual(report.diagnostics, [])
+        XCTAssertEqual(
+            report.outcomes.map(\.queryID),
+            queries.map(\.id).sorted()
+        )
+        XCTAssertTrue(report.outcomes.allSatisfy { outcome in
+            outcome.verdict == .passed && outcome.diagnostics.isEmpty
+        })
+        for query in queries {
+            let outcome = try XCTUnwrap(
+                report.outcomes.first { $0.queryID == query.id }
+            )
+            XCTAssertEqual(outcome.conformanceCaseIDs, query.conformanceCaseIDs)
+            XCTAssertEqual(outcome.inventoryFeatureIDs, query.inventoryFeatureIDs)
+            XCTAssertEqual(
+                outcome.northwindAnchorCaseIDs,
+                query.northwindAnchorCaseIDs
+            )
+            XCTAssertNotNil(outcome.preparedShape)
+        }
+    }
+
+    func testSyntaxMissingTableAndMissingColumnFailWithStableDescriptorAndFeatureReferences() throws {
+        let queries = [
+            Support.query(
+                id: "invalid.syntax",
+                inventoryFeatureIDs: ["syntax.select.core"],
+                sql: "SELECT FROM"
+            ),
+            Support.query(
+                id: "invalid.table",
+                inventoryFeatureIDs: ["syntax.select.core"],
+                sql: "SELECT * FROM definitely_missing_table"
+            ),
+            Support.query(
+                id: "invalid.column",
+                inventoryFeatureIDs: ["syntax.select.core"],
+                sql: "SELECT definitely_missing_column FROM Customers"
+            ),
+        ]
+
+        let report = try validateOnOwnedNorthwindURL(
+            plan: Support.plan(queries: queries)
+        )
+        XCTAssertEqual(report.overallVerdict, .failed)
+        XCTAssertEqual(report.outcomes.count, 3)
+        for query in queries {
+            let outcome = try XCTUnwrap(
+                report.outcomes.first { $0.queryID == query.id }
+            )
+            XCTAssertEqual(outcome.verdict, .failed)
+            XCTAssertNil(outcome.preparedShape)
+            let diagnostic = try XCTUnwrap(
+                outcome.diagnostics.first { $0.code == "sqlite.prepare.failed" }
+            )
+            XCTAssertEqual(diagnostic.queryID, query.id)
+            XCTAssertEqual(
+                diagnostic.definitionIdentity,
+                query.definitionIdentity
+            )
+            XCTAssertEqual(
+                diagnostic.descriptorIdentity,
+                query.descriptorIdentity
+            )
+            XCTAssertEqual(
+                diagnostic.conformanceCaseIDs,
+                query.conformanceCaseIDs
+            )
+            XCTAssertEqual(
+                diagnostic.inventoryFeatureIDs,
+                query.inventoryFeatureIDs
+            )
+            XCTAssertNotNil(diagnostic.sqliteResultCode)
+            XCTAssertNotNil(diagnostic.sqliteExtendedResultCode)
+            XCTAssertFalse(diagnostic.message.isEmpty)
+        }
+    }
+
+    func testIndexedGapPassesCollisionFailsAndAnonymousIsExplicitlyUnsupported() throws {
+        let indexedGap = Support.query(
+            id: "binding.indexed-gap",
+            sql: "SELECT ?3 AS value",
+            parameters: [Support.parameter(
+                physicalIndex: 3,
+                keyKind: .indexed,
+                keyName: nil,
+                keyIndex: 2
+            )]
+        )
+        let collision = Support.query(
+            id: "binding.collision",
+            sql: "SELECT :first AS first, ?1 AS duplicate",
+            parameters: [Support.parameter(
+                identity: "parameter/first",
+                keyName: "first"
+            )],
+            results: [
+                Support.result(identity: "result/first", expectedAlias: "first"),
+                Support.result(
+                    index: 1,
+                    identity: "result/duplicate",
+                    expectedAlias: "duplicate"
+                ),
+            ]
+        )
+        let anonymous = Support.query(
+            id: "binding.anonymous",
+            sql: "SELECT ? AS value",
+            parameters: [Support.parameter(
+                keyKind: .indexed,
+                keyName: nil,
+                keyIndex: 0
+            )]
+        )
+
+        let report = try validateOnOwnedNorthwindURL(
+            plan: Support.plan(queries: [anonymous, collision, indexedGap])
+        )
+        XCTAssertEqual(report.overallVerdict, .failed)
+        XCTAssertEqual(
+            try outcome("binding.indexed-gap", in: report).verdict,
+            .passed
+        )
+        XCTAssertTrue(
+            try outcome("binding.collision", in: report).diagnostics.contains {
+                $0.code == "parameter.key" && $0.verdict == .failed
+            }
+        )
+        let anonymousOutcome = try outcome("binding.anonymous", in: report)
+        XCTAssertEqual(anonymousOutcome.verdict, .unsupported)
+        XCTAssertTrue(anonymousOutcome.diagnostics.contains {
+            $0.code == "parameter.syntax" && $0.verdict == .unsupported
+        })
+        XCTAssertFalse(anonymousOutcome.diagnostics.contains {
+            $0.stage == .parameter && $0.verdict == .failed
+        })
+    }
+
+    func testResultCountAndExplicitAliasMismatchesFail() throws {
+        let count = Support.query(
+            id: "result.count-mismatch",
+            results: [
+                Support.result(index: 0),
+                Support.result(index: 1, identity: "result/extra", expectedAlias: "extra"),
+            ]
+        )
+        let alias = Support.query(
+            id: "result.alias-mismatch",
+            results: [Support.result(expectedAlias: "not_value")]
+        )
+
+        let report = try validateOnOwnedNorthwindURL(
+            plan: Support.plan(queries: [count, alias])
+        )
+        XCTAssertEqual(report.overallVerdict, .failed)
+        XCTAssertTrue(
+            try outcome(count.id, in: report).diagnostics.contains {
+                $0.code == "result.count"
+            }
+        )
+        XCTAssertTrue(
+            try outcome(alias.id, in: report).diagnostics.contains {
+                $0.code == "result.name"
+            }
+        )
+    }
+
+    func testMissingCodecAndExtensionCapabilityAreUnsupportedAndExplicitInputsPass() throws {
+        let codec = Support.codec()
+        let query = Support.query(
+            id: "requirements.codec-extension",
+            sql: "SELECT :value AS value",
+            parameters: [Support.parameter(
+                valueTypeIdentifier: codec.valueTypeIdentifier,
+                valueTypeName: "Tests.Token",
+                codec: codec,
+                storageIdentifier: codec.storageIdentifier
+            )],
+            results: [Support.result(
+                valueTypeIdentifier: codec.valueTypeIdentifier,
+                valueTypeName: "Tests.Token",
+                codec: codec,
+                storageIdentifier: codec.storageIdentifier
+            )],
+            requiredCapabilities: ["extension:tests-required-extension"]
+        )
+        let plan = Support.plan(queries: [query])
+
+        let missing = try validateOnOwnedNorthwindURL(plan: plan)
+        XCTAssertEqual(missing.overallVerdict, .unsupported)
+        let missingOutcome = try XCTUnwrap(missing.outcomes.first)
+        XCTAssertEqual(missingOutcome.verdict, .unsupported)
+        XCTAssertEqual(
+            Set(missingOutcome.diagnostics.map(\.code)),
+            ["codec.missing", "capability.extension"]
+        )
+        XCTAssertTrue(missingOutcome.diagnostics.allSatisfy {
+            $0.verdict == .unsupported
+        })
+
+        let supplied = try validateOnOwnedNorthwindURL(
+            plan: plan,
+            environment: SQLiteBuildValidationEnvironment(
+                codecIdentities: [codec],
+                extensionNames: ["tests-required-extension"]
+            )
+        )
+        XCTAssertEqual(supplied.overallVerdict, .passed)
+        XCTAssertEqual(try XCTUnwrap(supplied.outcomes.first).diagnostics, [])
+    }
+
+    func testSchemaSHAByteCountAndFNVDisagreementsFailClosed() throws {
+        let cases: [(SQLiteBuildValidationSchemaInput, String)] = [
+            (
+                Support.schema(
+                    databaseSHA256: String(repeating: "0", count: 64)
+                ),
+                "schema.snapshot-sha"
+            ),
+            (
+                Support.schema(
+                    databaseByteCount: Support.northwindSchemaByteCount + 1
+                ),
+                "schema.byte-count"
+            ),
+            (
+                Support.schema(
+                    schemaFNV1A64: String(repeating: "0", count: 16)
+                ),
+                "schema.fingerprint"
+            ),
+        ]
+
+        try Support.withValidatorOwnedNorthwindURL { url in
+            for (schema, code) in cases {
+                let report = try SQLiteBuildValidator.validate(
+                    plan: Support.plan(schema: schema),
+                    againstDatabaseAt: url
+                )
+                XCTAssertEqual(report.overallVerdict, .failed)
+                let diagnostic = try XCTUnwrap(
+                    report.diagnostics.first { $0.code == code }
+                )
+                XCTAssertEqual(diagnostic.stage, .schema)
+                XCTAssertEqual(diagnostic.verdict, .failed)
+            }
+        }
+    }
+
+    func testRuntimeMetadataMatchesIssue191CollectorOnSameConnection() throws {
+        try Support.withReadOnlyNorthwindDatabase { database in
+            let extensionNames = ["tests.extension.z", "tests.extension.a"]
+            let prototype = try SQLiteBuildValidationRuntime.capture(
+                from: database,
+                extensionNames: extensionNames
+            )
+            let issue191 = try SQLiteRuntimeMetadata.capture(
+                from: database,
+                extensionNames: extensionNames
+            )
+
+            XCTAssertEqual(prototype.sqliteVersion, issue191.sqliteVersion)
+            XCTAssertEqual(prototype.sqliteSourceID, issue191.sqliteSourceID)
+            XCTAssertEqual(prototype.compileOptions, issue191.compileOptions)
+            XCTAssertEqual(prototype.collations, issue191.collations)
+            XCTAssertEqual(prototype.moduleNames, issue191.moduleNames)
+            XCTAssertEqual(prototype.extensionNames, issue191.extensionNames)
+            XCTAssertEqual(prototype.schemaRowCount, issue191.schemaRowCount)
+            XCTAssertEqual(prototype.schemaFNV1A64, issue191.schemaFNV1A64)
+            XCTAssertEqual(prototype.schemaRowCount, Support.northwindSchemaRowCount)
+            XCTAssertEqual(prototype.schemaFNV1A64, Support.northwindSchemaFNV1A64)
+            XCTAssertEqual(
+                prototype.functions.map(prototypeFunctionSignature),
+                issue191.functions.map(issue191FunctionSignature)
+            )
+        }
+    }
+
+    func testDifferentCopiedPathsProduceByteIdenticalCanonicalReports() throws {
+        let plan = Support.plan(queries: [
+            Support.query(id: "z-query"),
+            Support.query(id: "a-query"),
+        ])
+
+        let first = try canonicalReportFromFreshCopy(plan: plan)
+        let second = try canonicalReportFromFreshCopy(plan: plan)
+
+        XCTAssertNotEqual(first.path, second.path)
+        XCTAssertEqual(first.data, second.data)
+        XCTAssertEqual(first.data.last, 0x0A)
+        XCTAssertNotEqual(first.data.dropLast().last, 0x0A)
+        let decoded = try JSONDecoder().decode(
+            SQLiteBuildValidationReport.self,
+            from: first.data
+        )
+        XCTAssertEqual(decoded.overallVerdict, .passed)
+        XCTAssertEqual(decoded.outcomes.map(\.queryID), ["a-query", "z-query"])
+        XCTAssertEqual(
+            decoded.observedDatabaseSHA256,
+            Support.northwindSchemaSHA256
+        )
+    }
+
+    func testURLOverloadRejectsOpenFixtureSidecars() throws {
+        try Support.withNorthwindURL { url in
+            XCTAssertThrowsError(
+                try SQLiteBuildValidator.validate(
+                    plan: Support.plan(),
+                    againstDatabaseAt: url
+                )
+            ) { error in
+                guard case .databaseHasSidecar(let path) =
+                    error as? SQLiteBuildValidationValidatorError else {
+                    return XCTFail("Expected database sidecar rejection, received \(error)")
+                }
+                XCTAssertTrue(path.hasSuffix("-wal") || path.hasSuffix("-shm"))
+            }
+        }
+    }
+
+    func testURLOverloadRejectsSidecarAdjacentToSymlinkTarget() throws {
+        try Support.withValidatorOwnedNorthwindURL { databaseURL in
+            let databaseAliasURL = databaseURL.deletingLastPathComponent()
+                .appendingPathComponent("database-alias.sqlite")
+            try FileManager.default.createSymbolicLink(
+                at: databaseAliasURL,
+                withDestinationURL: databaseURL
+            )
+            let journalURL = URL(fileURLWithPath: databaseURL.path + "-journal")
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: journalURL.path,
+                contents: Data("audit".utf8)
+            ))
+
+            XCTAssertThrowsError(
+                try SQLiteBuildValidator.validate(
+                    plan: Support.plan(),
+                    againstDatabaseAt: databaseAliasURL
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? SQLiteBuildValidationValidatorError,
+                    .databaseHasSidecar(journalURL.path)
+                )
+            }
+        }
+    }
+
+    private func validateOnOwnedNorthwindURL(
+        plan: SQLiteBuildValidationPlan,
+        environment: SQLiteBuildValidationEnvironment = .init()
+    ) throws -> SQLiteBuildValidationReport {
+        try Support.withValidatorOwnedNorthwindURL { url in
+            try SQLiteBuildValidator.validate(
+                plan: plan,
+                againstDatabaseAt: url,
+                environment: environment
+            )
+        }
+    }
+
+    private func canonicalReportFromFreshCopy(
+        plan: SQLiteBuildValidationPlan
+    ) throws -> (path: String, data: Data) {
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let report = try SQLiteBuildValidator.validate(
+                plan: plan,
+                againstDatabaseAt: url
+            )
+            return (url.path, try report.canonicalJSONData())
+        }
+    }
+
+    private func outcome(
+        _ queryID: String,
+        in report: SQLiteBuildValidationReport,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> SQLiteBuildValidationQueryOutcome {
+        try XCTUnwrap(
+            report.outcomes.first { $0.queryID == queryID },
+            "Missing outcome for \(queryID)",
+            file: file,
+            line: line
+        )
+    }
+
+    private func manifestCase(
+        _ id: String,
+        in manifest: SQLiteCombinatorialManifest,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> SQLiteCombinatorialCase {
+        try XCTUnwrap(
+            manifest.cases.first { $0.id == id },
+            "Missing #191 case \(id)",
+            file: file,
+            line: line
+        )
+    }
+
+    private func prototypeFunctionSignature(
+        _ function: SQLiteBuildValidationRuntimeFunction
+    ) -> String {
+        [
+            function.name,
+            function.isBuiltIn ? "1" : "0",
+            function.kind,
+            function.encoding,
+            String(function.argumentCount),
+            String(function.flags),
+        ].joined(separator: "|")
+    }
+
+    private func issue191FunctionSignature(
+        _ function: SQLiteRuntimeFunction
+    ) -> String {
+        [
+            function.name,
+            function.isBuiltIn ? "1" : "0",
+            function.kind,
+            function.encoding,
+            String(function.argumentCount),
+            String(function.flags),
+        ].joined(separator: "|")
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLitePrepareV3ProbeTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests/SQLitePrepareV3ProbeTests.swift
@@ -1,0 +1,151 @@
+import CSQLite
+import GRDB
+import XCTest
+
+@testable import SwiftQLSQLiteBuildValidationPrototype
+
+
+final class SQLitePrepareV3ProbeTests: XCTestCase {
+    typealias Support = SQLiteBuildValidationTestSupport
+
+    func testEmptyCommentSingleTrailingCommentAndMultipleStatementTails() throws {
+        try Support.withReadOnlyNorthwindDatabase { database in
+            assertProbeError(sql: "", expected: .emptyStatement, database: database)
+            assertProbeError(
+                sql: "-- comment only\n/* and another comment */",
+                expected: .emptyStatement,
+                database: database
+            )
+
+            let single = try SQLitePrepareV3Probe.prepare(
+                sql: "SELECT 1 AS one",
+                in: database
+            )
+            XCTAssertEqual(single.physicalParameterCount, 0)
+            XCTAssertEqual(single.parameters, [])
+            XCTAssertEqual(
+                single.columns,
+                [SQLitePreparedColumn(index: 0, name: "one", declaredType: nil)]
+            )
+            XCTAssertTrue(single.isReadOnly)
+
+            let trailingComment = try SQLitePrepareV3Probe.prepare(
+                sql: "SELECT 1 AS one; -- accepted trailing comment\n/* done */",
+                in: database
+            )
+            XCTAssertEqual(trailingComment, single)
+
+            assertProbeError(
+                sql: "SELECT 1; SELECT 2",
+                expected: .multipleStatements,
+                database: database
+            )
+        }
+    }
+
+    func testInvalidTailSyntaxMissingTableAndMissingColumnPreserveSQLiteFailure() throws {
+        try Support.withReadOnlyNorthwindDatabase { database in
+            for sql in [
+                "SELECT 1; SELECT FROM",
+                "SELECT FROM",
+                "SELECT * FROM definitely_missing_table",
+                "SELECT definitely_missing_column FROM Customers",
+            ] {
+                XCTAssertThrowsError(
+                    try SQLitePrepareV3Probe.prepare(sql: sql, in: database)
+                ) { error in
+                    guard case .sqlitePrepare(
+                        let resultCode,
+                        let extendedResultCode,
+                        let message
+                    ) = error as? SQLitePrepareV3ProbeError else {
+                        return XCTFail(
+                            "Expected SQLite preparation failure for \(sql), received \(error)"
+                        )
+                    }
+                    XCTAssertEqual(resultCode, SQLITE_ERROR)
+                    XCTAssertNotEqual(extendedResultCode, SQLITE_OK)
+                    XCTAssertFalse(message.isEmpty)
+                }
+            }
+        }
+    }
+
+    func testEmbeddedNULIsRejectedBeforeSQLiteCanTruncateIt() throws {
+        try Support.withReadOnlyNorthwindDatabase { database in
+            assertProbeError(
+                sql: "SELECT 1\0; SELECT 2",
+                expected: .embeddedNUL,
+                database: database
+            )
+        }
+    }
+
+    func testBindingMetadataIncludesHighestIndexGapsRepeatedNamesAndAnonymousAmbiguity() throws {
+        try Support.withReadOnlyNorthwindDatabase { database in
+            let shape = try SQLitePrepareV3Probe.prepare(
+                sql: "SELECT :name, ?3, :name, @other, $cash",
+                in: database
+            )
+            XCTAssertEqual(shape.physicalParameterCount, 5)
+            XCTAssertEqual(shape.parameters, [
+                SQLitePreparedParameter(physicalIndex: 1, name: ":name"),
+                SQLitePreparedParameter(physicalIndex: 2, name: nil),
+                SQLitePreparedParameter(physicalIndex: 3, name: "?3"),
+                SQLitePreparedParameter(physicalIndex: 4, name: "@other"),
+                SQLitePreparedParameter(physicalIndex: 5, name: "$cash"),
+            ])
+            XCTAssertEqual(shape.columns.count, 5)
+
+            let anonymous = try SQLitePrepareV3Probe.prepare(
+                sql: "SELECT ?, ?",
+                in: database
+            )
+            XCTAssertEqual(anonymous.physicalParameterCount, 2)
+            XCTAssertEqual(anonymous.parameters.map(\.name), [nil, nil])
+        }
+    }
+
+    func testNorthwindResultAliasesCountAndDeclaredTypeEvidence() throws {
+        try Support.withReadOnlyNorthwindDatabase { database in
+            let shape = try SQLitePrepareV3Probe.prepare(
+                sql: """
+                    SELECT CustomerID AS customer_id,
+                           CompanyName AS company_name,
+                           LENGTH(CompanyName) AS company_name_length
+                    FROM Customers
+                    """,
+                in: database
+            )
+
+            XCTAssertEqual(shape.columns.count, 3)
+            XCTAssertEqual(
+                shape.columns.map(\.name),
+                ["customer_id", "company_name", "company_name_length"]
+            )
+            XCTAssertEqual(shape.columns.map(\.declaredType), ["TEXT", "TEXT", nil])
+            XCTAssertTrue(shape.isReadOnly)
+        }
+    }
+
+    private func assertProbeError(
+        sql: String,
+        expected: SQLitePrepareV3ProbeError,
+        database: GRDB.Database,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(
+            try SQLitePrepareV3Probe.prepare(sql: sql, in: database),
+            file: file,
+            line: line
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLitePrepareV3ProbeError,
+                expected,
+                file: file,
+                line: line
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #132

## Summary

- document the reproducible checked-in-snapshot contract and the limits of public SQLite preparation
- add a package-private research validator and CLI around direct `sqlite3_prepare_v3`
- pin snapshot/runtime provenance, descriptor bindings/results, codec and capability evidence, and deterministic fail-closed diagnostics
- protect the read-only/query-only validator path from active sidecars and unsafe report aliases
- reuse canonical #190/#191/Northwind identities and split accepted v1.5 implementation into #292, #293, and #294

This is research-only: it adds no public product or SwiftQL API.

## Validation

- `xcrun swift test --filter SwiftQLSQLiteBuildValidationPrototypeTests` — 43 tests, 0 failures
- `xcrun swift test` — 687 tests, 0 failures
- actual CLI twice against the pinned Northwind snapshot — exit 0; byte-identical reports, SHA-256 `8055e3b1a8a39af07e6571add6d1f83ffe9a4e6ac69041220c116e6424ed9885`
- SwiftQLCore boundary — PASS
- SQLite inventory tool — 28 tests, report current
- first-party warnings gate — clean
- complete strict-concurrency gate — clean
- downstream Swift 5 client — `SWIFTQL_DOWNSTREAM_SWIFT5_CLIENT ok`
- independent final review — no actionable findings