### PR TITLE
Refresh v1.3 public documentation

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Research build-time SQLite query preparation and schema validation",
-  "issue_number": 132,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/132",
+  "task_name": "[v1.3 Housekeeping] Refresh README and public documentation",
+  "issue_number": 224,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/224",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#132 - Research build-time SQLite query preparation and schema validation",
+  "codex_session_title": "lukevanin/swiftql#224 - [v1.3 Housekeeping] Refresh README and public documentation",
   "codex_session_id": "019f7a0d-c80b-7f22-b47a-e3adb614acc8",
   "codex_session_url": null,
-  "task_branch": "codex/132-research-build-time-sqlite-query-preparation-and-schema-validation",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/132-research-build-time-sqlite-query-preparation-and-schema-validation"
+  "task_branch": "codex/224-refresh-readme-and-public-documentation",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/224-refresh-readme-and-public-documentation"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [1.3.0] - Unreleased
+
+### Added
+
+- Added the #190 canonical SQLite conformance inventory and deterministic
+  generated report. It records 101 public-surface feature records: 82
+  supported, 7 partial, 3 capability-gated, 1 intentionally unsupported, and
+  8 unimplemented. Of the 98 evidence records, 66 exercise real SQLite and
+  cite one captured SQLite 3.51.0 environment.
+- Added the #191 bounded combinatorial SQLite corpus with 141 stable generated
+  cases across joins, subqueries, common table expressions, grouping,
+  bindings, and related interactions, plus a deliberately broken-renderer
+  negative control. Deterministic manifests and runtime provenance keep the
+  exercised combinations reviewable without presenting them as exhaustive
+  SQL coverage.
+- Added the #254 immutable Northwind SQLite snapshot and 18 stable correctness
+  scenarios for realistic joins, aggregates, subqueries, compound queries,
+  common table expressions, decoding, CRUD, and rollback behavior.
+- Added the #255 live-query observation stress suite with 12 stable cases for
+  concurrent writes, invalidation, delivery, cancellation, transient-busy
+  retries, and database isolation.
+- Added the #132 research prototype for deterministic build-time preparation
+  of static query descriptors against the checked-in Northwind snapshot. The
+  prototype owns a read-only validation connection, finalizes every prepared
+  statement, and emits a reproducible report; it is internal research, not a
+  public validator, build plugin, macro, schema system, or v1.3 API.
+
+### Migration
+
+No migration is required for v1.3. The milestone adds conformance evidence,
+correctness and stress coverage, internal research artifacts, and refreshed
+documentation while preserving the v1.2 public source and runtime contracts.
+
 ## [1.2.0] - 2026-07-19
 
 ### Added

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,7 +6,7 @@ series currently listed by Swift Package Index: Swift 6.0 through Swift 6.3.
 All Swift 6 compilers run the package in Swift 5 language mode; SwiftQL does not
 opt into Swift 6 language mode.
 
-## v1.2 public products and runtime boundaries
+## v1.3 public products and runtime boundaries
 
 The package supports iOS 16 or later and macOS 13 or later. Its public products
 have separate responsibilities:
@@ -28,7 +28,8 @@ pass. The exact resolved versions and loaded SQLite source ID are CI evidence,
 not a promise that every future dependency version in those ranges is already
 supported.
 
-In v1.2, an `XLStaticQueryDescriptor` and `XLInvocationBindings` are immutable,
+The reusable-query ownership model introduced in v1.2 remains unchanged in
+v1.3. An `XLStaticQueryDescriptor` and `XLInvocationBindings` are immutable,
 database-independent values. A raw `GRDBPreparedStaticQuery` or
 `GRDBPreparedInvocation` is `Sendable` and database-bound without owning a
 connection-bound statement. The high-level `XLRequest` facade and
@@ -40,7 +41,7 @@ not only implementation details.
 SwiftQL currently ships only a SQLite dialect and a GRDB database driver. The
 core protocols are extension seams, not claims that another dialect, driver,
 Linux runtime, nested transaction/savepoint API, asynchronous cursor, or
-Swift 6 language mode is supported in v1.2.
+Swift 6 language mode is supported in v1.3.
 
 ## SQLite conformance inventory
 
@@ -51,11 +52,48 @@ The report is evidence for SwiftQL's existing public SQLite subset; it is not a
 claim of complete SQLite grammar coverage. The inventory remains the source of
 truth, while the report is its readable generated view.
 
-An inventory entry is counted as supported only when it links to successful
-preparation by a real SQLite engine whose version and source ID are recorded.
-Capability-gated, syntax-gated, adapter/API-gated, intentionally unsupported,
-and intentionally out-of-scope entries remain visible with their requirements
-or rationale, but are excluded from supported totals.
+The v1.3 inventory contains 101 feature records and 98 evidence records. Its
+support-status totals are exact and mutually exclusive:
+
+| Support status | Features |
+| --- | ---: |
+| Supported | 82 |
+| Partial | 7 |
+| Capability-gated | 3 |
+| Intentionally unsupported | 1 |
+| Unimplemented | 8 |
+
+Of those 98 evidence records, 66 exercise real SQLite and
+cite one captured environment, SQLite 3.51.0. An inventory entry is counted in
+the 82 supported features only when it links to successful preparation by a
+real SQLite engine whose version and source ID are recorded. Partial,
+capability-gated, intentionally unsupported, and unimplemented entries remain
+visible with their evidence, requirements, or rationale, but are excluded
+from the supported total. Evidence records are reusable proofs, so the count
+of 98 is not intended to match the feature count one for one.
+
+The v1.3 work has distinct ownership and claims:
+
+- [#190](https://github.com/lukevanin/swiftql/issues/190) owns the canonical
+  feature taxonomy, status decisions, evidence references, generated report,
+  and the totals above.
+- [#191](https://github.com/lukevanin/swiftql/issues/191) supplies a bounded,
+  deterministic 141-case combinatorial manifest for joins, subqueries, common
+  table expressions, grouping, bindings, and related interactions, plus a
+  deliberately broken-renderer negative control. It contributes real-SQLite
+  evidence to the inventory without claiming exhaustive SQL combinations.
+- [#254](https://github.com/lukevanin/swiftql/issues/254) supplies the pinned
+  Northwind SQLite snapshot and 18 stable correctness scenarios over realistic
+  joins, aggregates, subqueries, compound queries, common table expressions,
+  decoding, CRUD, and rollback behavior.
+- [#255](https://github.com/lukevanin/swiftql/issues/255) supplies 12 stable
+  observation-stress cases and their evidence for concurrent writes,
+  invalidation, delivery, cancellation, retries, and database isolation.
+- [#132](https://github.com/lukevanin/swiftql/issues/132) is research only. Its
+  internal prototype prepares static descriptors against the checked-in
+  Northwind snapshot and emits a deterministic validation report. It ships no
+  public validator, build plugin, macro, schema system, or new v1.3 API, and it
+  does not expand the supported inventory total.
 
 From the repository root, reproduce the validation and confirm that the report
 matches the canonical inventory with:
@@ -111,8 +149,9 @@ Each pinned Apple support point runs two independent dependency modes:
   removes the exported lockfile, resolves from the manifest's declared ranges,
   and reports the resulting versions. It never modifies the checkout.
 
-All four pinned support cells and all three additional Swift-series cells build
-every first-party target and run the complete test suite. No cell is
+All four pinned support cells and all three additional Swift-series cells form
+seven release-blocking compiler cells. Every cell builds every first-party
+target and runs the complete test suite. No cell is
 conditional, allowed to fail, or represented by a skipped job. The workflow
 does not share build caches across compilers or resolution modes.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ for.
 
 <!-- test: XLDocumentationTests.testDocumentationREADME -->
 ```swift
+import Foundation
 import SwiftQL
 
 @SQLTable
@@ -50,6 +51,13 @@ struct Person {
     var age: Int
 }
 
+let databaseURL = FileManager.default.temporaryDirectory
+    .appendingPathComponent(UUID().uuidString)
+    .appendingPathExtension("sqlite")
+let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+try database.makeRequest(with: sqlCreate(Person.self)).execute()
+
 let query = sql { schema in
     let person = schema.table(Person.self)
     Select(person)
@@ -57,6 +65,11 @@ let query = sql { schema in
     Where(person.name == "Fred")
 }
 ```
+
+The temporary file keeps this example self-contained. In an application, use
+your durable database URL and reuse one `GRDBDatabase` for that path. The basic
+`sqlCreate` call uses `CREATE TABLE IF NOT EXISTS`; it creates this first table
+but does not migrate an existing schema when `Person` changes.
 
 That Swift expression emits recognizable SQLite:
 
@@ -126,14 +139,15 @@ their SQL meaning.
 - **Your domain.** Extend SQLite with Swift enums, custom value types, and
   type-safe custom SQL functions.
 
-## The v1.2 reusable-query boundary
+## Reusable queries and the v1.3 evidence boundary
 
-SwiftQL v1.2 separates the reusable SQL contract from each database invocation.
-An `XLStaticQueryDescriptor` contains rendered SQL, dialect requirements,
-parameter and result layouts, stable identity, and cardinality; it contains no
-database, connection, statement, or runtime value. Prepare that descriptor
-against a `GRDBDatabase`, then create a fresh `XLInvocationBindings` value for
-every call. Invocation values never become identifiers or SQL grammar tokens.
+The reusable-query contract introduced in SwiftQL v1.2 remains the runtime
+boundary for v1.3. An `XLStaticQueryDescriptor` contains rendered SQL, dialect
+requirements, parameter and result layouts, stable identity, and cardinality;
+it contains no database, connection, statement, or runtime value. Prepare that
+descriptor against a `GRDBDatabase`, then create a fresh
+`XLInvocationBindings` value for every call. Invocation values never become
+identifiers or SQL grammar tokens.
 
 The products have distinct roles:
 
@@ -151,6 +165,16 @@ raw-value invocation matters. See the
 [prepared-statement boundaries](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/),
 and [contextual-codec migration](https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/)
 for the complete contracts and current limitations.
+
+SwiftQL v1.3 adds evidence around that public surface rather than claiming
+complete SQLite grammar coverage. The canonical inventory records 101 features:
+82 supported, 7 partial, 3 capability-gated, 1 intentionally unsupported, and
+8 unimplemented. Of its 98 evidence records, 66 exercise real SQLite and
+cite one recorded SQLite 3.51.0 environment. See
+[SQLite conformance](COMPATIBILITY.md#sqlite-conformance-inventory) for what
+those counts prove, how the #191 combinatorial cases, #254 Northwind corpus,
+and #255 observation stress suite contribute evidence, and why the #132
+build-validation prototype remains research rather than a public v1.3 API.
 
 ## SQL-shaped, not ORM-shaped
 
@@ -177,9 +201,9 @@ file:
 ```
 
 `1.2.0` is the latest published package. The examples above use APIs retained
-by v1.2, and the v1.2 static-query surface is available from that semantic
-version. Pin a source revision only when intentionally testing later changes
-from `main`.
+by v1.2 and the forthcoming v1.3, and the static-query surface is available
+from version 1.2.0. Pin a source revision only when intentionally testing
+unreleased v1.3 changes from `main`.
 
 ### Xcode
 
@@ -199,8 +223,8 @@ For project guarantees and direction:
   toolchains and reproducible CI matrix.
 - [SQLite conformance](COMPATIBILITY.md#sqlite-conformance-inventory) records
   the evidence boundary for SwiftQL's currently supported public subset.
-- [Changelog](CHANGELOG.md) records released behavior and v1.2 migration
-  guidance.
+- [Changelog](CHANGELOG.md) records released behavior and the unreleased v1.3
+  evidence milestone.
 - [Performance benchmarks](BENCHMARKS.md) measure query construction,
   preparation, caching, binding, execution, and decoding.
 - [First-party source coverage](Coverage/README.md) preserves the reproducible

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,36 +1,41 @@
 # Releasing SwiftQL
 
 SwiftQL releases use `vMAJOR.MINOR.PATCH` tags beginning with `v1.1.0`. This
-guide uses the `v1.2.0` release as its concrete example. The historical
-`1.0.0` tag and release are intentionally unchanged.
+guide uses the forthcoming `v1.3.0` release as its concrete example. At the
+time this guide was refreshed, `v1.2.0` remained the latest published package;
+the historical `1.0.0` tag and release are intentionally unchanged.
 
 The [Verified release workflow](.github/workflows/release.yml) treats a tag as
 an untrusted request. It publishes only after it has proved that the exact tag
-commit is still reachable from `main`, run the complete Swift compatibility
+commit is still reachable from `main`, run the seven-cell Swift compatibility
 matrix, and built the exact commit's validated DocC artifact.
 
 ## Before a release
 
-1. Merge every retained v1.2 issue, complete audit issue #223, and close
-   milestone 6 with no open issues. Verify the live milestone rather than a
-   local planning file. The checked-in
-   [v1.2 release-readiness audit](Documentation/ReleaseAudits/v1.2.md) records
-   the pre-tag verdict and evidence:
+1. Merge every retained v1.3 issue, complete audit issue #226, and close
+   milestone 8 with no open issues. Verify the live milestone rather than a
+   local planning file. Audit issue
+   [#226](https://github.com/lukevanin/swiftql/issues/226) must produce the
+   checked-in v1.3 release-readiness audit and record the pre-tag verdict and
+   evidence:
 
    ```sh
-   gh api repos/lukevanin/swiftql/milestones/6 |
+   gh api repos/lukevanin/swiftql/milestones/8 |
      jq -e '
-       .title == "v1.2" and
+       .title == "v1.3" and
        .state == "closed" and
        .open_issues == 0'
    ```
 
    `scripts/ci/check-release-readiness.sh` retains the historical one-time
    server-side gate for `v1.1.0` and deliberately skips later versions. It is
-   not proof of v1.2 milestone readiness; preserve the command output and #223
-   audit evidence in the v1.2 release issue.
+   not proof of v1.3 milestone readiness; preserve the command output and #226
+   audit evidence in the v1.3 release issue.
 2. Confirm the latest `main` runs of **Swift compatibility** and
-   **Documentation** pass. Verify the deployed documentation provenance names
+   **Documentation** pass. The compatibility run must contain all seven
+   release-blocking compiler cells: committed and clean resolution for each of
+   the pinned Swift 5.9 and Swift 6.0 support points, plus clean resolution for
+   Swift 6.1, 6.2, and 6.3. Verify the deployed documentation provenance names
    that `main` commit.
 3. Run `scripts/ci/test-release-workflow.sh` locally. This exercises the tag,
    reachability, packaging, dry-run, partial-draft, rerun, and conflict paths
@@ -114,7 +119,7 @@ matrix, and built the exact commit's validated DocC artifact.
    between the workflow's last tag check and release publication. Do not prove
    the rule with a disposable `v...` tag: the rule intentionally prevents that
    tag from being deleted. Its first end-to-end proof was the historical
-   `v1.1.0` tag; verify that the same rule remains active before `v1.2.0`.
+   `v1.1.0` tag; verify that the same rule remains active before `v1.3.0`.
 7. Record the exact remote commit. Do not release from an unpushed local commit.
 
 ```sh
@@ -131,11 +136,11 @@ They can never enter the write-capable publication job.
 
 Run these one at a time after the release workflow has landed on `main`:
 
-- `release-test/v1.2.999` at `origin/main` must pass through the dry-run job and
+- `release-test/v1.3.999` at `origin/main` must pass through the dry-run job and
   create no GitHub Release.
 - `release-test/not-semver` must fail tag validation before compiler or
   documentation jobs start.
-- A valid test tag such as `release-test/v1.2.998` on a temporary commit that is
+- A valid test tag such as `release-test/v1.3.998` on a temporary commit that is
   not reachable from `main` must fail the reachability gate.
 
 After recording the workflow URLs and confirming that no release was created,
@@ -148,18 +153,19 @@ Create one annotated tag at the recorded `origin/main` commit and push only
 that tag:
 
 ```sh
-git tag -a v1.2.0 "$release_sha" -m "SwiftQL v1.2.0"
-git push origin refs/tags/v1.2.0
+git tag -a v1.3.0 "$release_sha" -m "SwiftQL v1.3.0"
+git push origin refs/tags/v1.3.0
 ```
 
 The release workflow:
 
 1. validates and peels the event SHA and tag ref;
 2. proves the commit is reachable from current `origin/main`;
-3. invokes the reusable four-lane compatibility workflow;
+3. invokes the reusable compatibility workflow and requires all seven compiler
+   cells;
 4. invokes the reusable documentation workflow without deploying Pages;
-5. packages the Pages tar as `swiftql-docc-v1.2.0.tar.gz` and creates
-   `swiftql-release-v1.2.0.json` plus `SHA256SUMS`;
+5. packages the Pages tar as `swiftql-docc-v1.3.0.tar.gz` and creates
+   `swiftql-release-v1.3.0.json` plus `SHA256SUMS`;
 6. creates a draft GitHub Release with generated notes and an exact commit/run
    marker;
 7. uploads and verifies all three assets, then immediately refetches and
@@ -181,25 +187,26 @@ Do not close the release issue when its workflow PR merges. After the tag run
 succeeds, independently verify:
 
 - the run event, ref, and head SHA match the release tag and recorded commit;
-- all four compatibility lanes and the documentation build passed;
+- all seven compatibility cells and the documentation build passed;
 - the tag still peels to that commit and remains reachable from `main`;
 - the release is published, is not a prerelease, and its generated notes contain
   the exact commit marker;
 - the release API reports `immutable: true`, and the production tag ruleset is
   still active;
 - GitHub verifies the immutable release attestation with
-  `gh release verify v1.2.0 --repo lukevanin/swiftql`, and each downloaded asset
-  passes `gh release verify-asset v1.2.0 PATH --repo lukevanin/swiftql`;
+  `gh release verify v1.3.0 --repo lukevanin/swiftql`, and each downloaded asset
+  passes `gh release verify-asset v1.3.0 PATH --repo lukevanin/swiftql`;
 - the release has exactly the DocC archive, manifest, and checksum assets;
 - API asset digests match `SHA256SUMS`, and the manifest maps the tag to the
   exact commit and workflow run; and
-- the historical `1.0.0` tag and release are unchanged.
+- the historical `1.0.0` tag and release and the published `v1.2.0` release are
+  unchanged.
 
-For `v1.2.0`, #223 is the pre-tag milestone audit, not proof that a release was
-published. Before tagging, create or identify one dedicated v1.2 release issue
+For `v1.3.0`, #226 is the pre-tag milestone audit, not proof that a release was
+published. Before tagging, create or identify one dedicated v1.3 release issue
 outside the closed milestone. Post the tag-run, release, asset, attestation, and
 ruleset evidence there; close it only after every check above passes. Re-fetch
-the issue to confirm closure. Do not reopen #223 or the v1.2 milestone merely to
+the issue to confirm closure. Do not reopen #226 or the v1.3 milestone merely to
 store post-tag evidence.
 
 ## Recovery

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -25,6 +25,14 @@ supported in v1.2, and its static-query and contextual-codec APIs are available
 from version 1.2.0 or later. Pin a source revision only when intentionally
 testing later changes from `main`.
 
+The repository's v1.3 work validates the existing SQLite surface against
+recorded real-engine, Northwind, and stress evidence; it does not replace the
+published 1.2.0 package with a new public syntax or validation API. In
+particular, issue [#132](https://github.com/lukevanin/swiftql/issues/132) is a
+research-only schema-snapshot preparation prototype. Applications still own
+their schema lifecycle and perform physical preparation on the runtime
+connection that executes each statement.
+
 Then add `SwiftQL` to the dependencies of your target and import the module in
 files that use it. The package requires Swift tools 5.9 and targets iOS 16 or
 later and macOS 13 or later. The supported compiler configurations are listed

--- a/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
@@ -23,6 +23,24 @@ registry of query definitions. The raw `GRDBPreparedStaticQuery` handle is
 `Sendable`; the closure-backed typed row layout and its prepared wrapper are
 currently task-local.
 
+### Build-validation research boundary
+
+A static descriptor contains the stable SQL and parameter/result metadata that
+future build validation can consume, but it does not validate a schema by
+itself. The v1.3 research for issue
+[#132](https://github.com/lukevanin/swiftql/issues/132) pairs descriptors with
+an explicit sidecar plan and a pinned SQLite snapshot, then uses a private
+prototype to prepare and inspect each statement on a validator-owned read-only
+connection. The prototype is conformance evidence, not a public SwiftQL
+product or API.
+
+Successful prototype validation applies only to the recorded snapshot, SQLite
+build, and registered capabilities. It does not prove result values,
+cardinality, dynamic storage classes, codec behavior, or application semantics.
+The inspected statement is finalized immediately; runtime execution still
+prepares or retrieves a cached physical statement on its own connection. A
+standalone validator and SwiftPM plugin remain separate v1.5 follow-up work.
+
 ## Construct a descriptor
 
 First render a statement and convert its validated encoding into an

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -79,6 +79,28 @@ database-bound and not `Sendable`; prepared raw static-query handles are
 Use <doc:CustomTypes> when one Swift type needs contextual or multiple SQLite
 representations.
 
+## v1.3 conformance evidence
+
+The v1.3 source-tree milestone validates SwiftQL's existing public SQLite
+surface rather than adding another syntax layer. Its versioned inventory,
+generated report, bounded combinatorial cases, pinned Northwind corpus, and
+observation stress contracts exercise rendering, real SQLite preparation, and
+behavior. Evidence is tied to the recorded SQLite version, source ID, compile
+options, and available capabilities; it is not a claim of complete SQLite
+grammar coverage. See the repository's
+[compatibility matrix](https://github.com/lukevanin/swiftql/blob/main/COMPATIBILITY.md)
+and
+[conformance report](https://github.com/lukevanin/swiftql/blob/main/Conformance/SQLite/REPORT.md)
+for the canonical scope and current evidence.
+
+Issue [#132](https://github.com/lukevanin/swiftql/issues/132) is research only.
+Its internal prototype prepares static SQL against a pinned, read-only schema
+snapshot and emits deterministic diagnostics, but v1.3 does not ship a public
+validator, build plugin, query macro, schema system, or new query-declaration
+API. It neither persists prepared statements nor removes runtime preparation
+on each physical connection. Version 1.2.0 remains the latest published
+package.
+
 ## When to use SwiftQL
 
 SwiftQL provides a safer way to write SQL to interact with an SQLite database, 

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -16,6 +16,40 @@ private struct DocumentationTestReference {
 }
 
 
+private struct DocumentationConformanceInventory: Decodable {
+
+    struct Feature: Decodable {
+        let status: String
+    }
+
+    struct Evidence: Decodable {
+        let realSQLite: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case realSQLite = "real_sqlite"
+        }
+    }
+
+    struct SQLiteEnvironment: Decodable {
+        let sqliteVersion: String
+
+        enum CodingKeys: String, CodingKey {
+            case sqliteVersion = "sqlite_version"
+        }
+    }
+
+    let features: [Feature]
+    let evidence: [Evidence]
+    let sqliteEnvironments: [SQLiteEnvironment]
+
+    enum CodingKeys: String, CodingKey {
+        case features
+        case evidence
+        case sqliteEnvironments = "sqlite_environments"
+    }
+}
+
+
 private let documentationTests = [
     DocumentationTestReference(
         "XLDocumentationTests.testDocumentationREADME",
@@ -249,53 +283,139 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         }
     }
 
-    func testV12PublicDocumentsShareReleaseAndBoundaryContract() throws {
+    func testV13PublicDocumentsShareReleaseAndBoundaryContract() throws {
         let repositoryRoot = repositoryRootURL()
+        let inventory = try JSONDecoder().decode(
+            DocumentationConformanceInventory.self,
+            from: Data(
+                contentsOf: repositoryRoot.appendingPathComponent(
+                    "Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json"
+                )
+            )
+        )
+        let statusCounts = Dictionary(
+            grouping: inventory.features,
+            by: \.status
+        ).mapValues(\.count)
+        let realSQLiteEvidenceCount = inventory.evidence.count(where: \.realSQLite)
+        let environmentCount = inventory.sqliteEnvironments.count
+        let environmentCountText = environmentCount == 1
+            ? "one"
+            : String(environmentCount)
+        let environmentNoun = environmentCount == 1
+            ? "environment"
+            : "environments"
+        let sqliteVersions = Set(
+            inventory.sqliteEnvironments.map(\.sqliteVersion)
+        ).sorted().joined(separator: ", ")
+        let supportedCount = statusCounts["supported", default: 0]
+        let partialCount = statusCounts["partial", default: 0]
+        let capabilityGatedCount = statusCounts["capability-gated", default: 0]
+        let intentionallyUnsupportedCount = statusCounts[
+            "intentionally-unsupported",
+            default: 0
+        ]
+        let unimplementedCount = statusCounts["unimplemented", default: 0]
+        XCTAssertEqual(
+            statusCounts.values.reduce(0, +),
+            inventory.features.count,
+            "Every inventory feature must contribute to the documented status totals."
+        )
+
         let requiredPhrasesByPath = [
             "README.md": [
-                "## The v1.2 reusable-query boundary",
+                "## Reusable queries and the v1.3 evidence boundary",
                 "An `XLStaticQueryDescriptor` contains rendered SQL",
-                "fresh `XLInvocationBindings` value",
-                "every call. Invocation values never become identifiers",
+                "then create a fresh",
+                "`XLInvocationBindings` value for every call.",
+                "Invocation values never become",
                 "`SwiftQLCore` exposes GRDB-free",
+                "build-validation prototype remains research rather than a public v1.3 API",
                 "`1.2.0` is the latest published package",
             ],
             "COMPATIBILITY.md": [
-                "## v1.2 public products and runtime boundaries",
+                "## v1.3 public products and runtime boundaries",
                 "iOS 16 or later and macOS 13 or later",
                 "SwiftSyntax 509.0.0, GRDB 6.29.3",
                 "The high-level `XLRequest` facade",
                 "only a SQLite dialect and a GRDB database driver",
-                "all twelve source articles",
+                "seven release-blocking compiler cells",
+                "It ships no",
+                "public validator, build plugin, macro, schema system, or new v1.3 API",
             ],
             "CHANGELOG.md": [
+                "## [1.3.0] - Unreleased",
+                "141 stable generated",
+                "deliberately broken-renderer",
+                "internal research, not a",
+                "No migration is required for v1.3",
                 "## [1.2.0] - 2026-07-19",
-                "Added the GRDB-free `SwiftQLCore` product",
-                "Added immutable `XLStaticQueryDescriptor` definitions",
-                "GRDB result rows are stepped and decoded incrementally",
-                "Existing `makeRequest(with:)`",
             ],
             "RELEASING.md": [
-                "complete audit issue #223",
-                ".title == \"v1.2\"",
-                "not proof of v1.2 milestone readiness",
-                "uses the `v1.2.0` release as its concrete example",
-                "dedicated v1.2 release issue",
+                "uses the forthcoming `v1.3.0` release as its concrete example",
+                "`v1.2.0` remained the latest published package",
+                "complete audit issue #226",
+                "milestone 8 with no open issues",
+                ".title == \"v1.3\"",
+                "not proof of v1.3 milestone readiness",
+                "must contain all seven",
+                "release-blocking compiler cells",
+                "dedicated v1.3 release issue",
             ],
             "Sources/SwiftQL/SwiftQL.docc/SwiftQL.md": [
-                "## v1.2 boundaries",
+                "## v1.3 conformance evidence",
                 "database-independent query definitions",
                 "`SwiftQLCore` contains the GRDB-free",
                 "The current `XLRequest` facade is",
+                "not a claim of complete SQLite",
+                "v1.3 does not ship a public",
+                "validator, build plugin, query macro, schema system",
+                "Version 1.2.0 remains the latest published",
             ],
             "Sources/SwiftQL/SwiftQL.docc/GettingStarted.md": [
                 "Version 1.2.0 is the published package",
                 "This guide's basic request path remains",
                 "from version 1.2.0 or later",
+                "research-only schema-snapshot preparation prototype",
+                "perform physical preparation on the runtime",
+            ],
+            "Sources/SwiftQL/SwiftQL.docc/StaticQueries.md": [
+                "### Build-validation research boundary",
+                "not a public SwiftQL",
+                "product or API",
+                "runtime execution still",
+                "prepares or retrieves a cached physical statement",
             ],
             "scripts/ci/check-docc-output.sh": [
                 "realvalues|Real Values",
                 "staticqueries|Static queries",
+            ],
+        ]
+        let inventoryPhrasesByPath = [
+            "README.md": [
+                "The canonical inventory records \(inventory.features.count) features",
+                "\(supportedCount) supported, \(partialCount) partial, \(capabilityGatedCount) capability-gated",
+                "\(intentionallyUnsupportedCount) intentionally unsupported, and",
+                "\(unimplementedCount) unimplemented",
+                "Of its \(inventory.evidence.count) evidence records, \(realSQLiteEvidenceCount) exercise real SQLite",
+                "cite \(environmentCountText) recorded SQLite \(sqliteVersions) \(environmentNoun)",
+            ],
+            "COMPATIBILITY.md": [
+                "The v1.3 inventory contains \(inventory.features.count) feature records and \(inventory.evidence.count) evidence records",
+                "| Supported | \(supportedCount) |",
+                "| Partial | \(partialCount) |",
+                "| Capability-gated | \(capabilityGatedCount) |",
+                "| Intentionally unsupported | \(intentionallyUnsupportedCount) |",
+                "| Unimplemented | \(unimplementedCount) |",
+                "Of those \(inventory.evidence.count) evidence records, \(realSQLiteEvidenceCount) exercise real SQLite",
+                "cite \(environmentCountText) captured \(environmentNoun), SQLite \(sqliteVersions)",
+            ],
+            "CHANGELOG.md": [
+                "\(inventory.features.count) public-surface feature records: \(supportedCount)",
+                "supported, \(partialCount) partial, \(capabilityGatedCount) capability-gated, \(intentionallyUnsupportedCount) intentionally unsupported, and",
+                "\(unimplementedCount) unimplemented",
+                "Of the \(inventory.evidence.count) evidence records, \(realSQLiteEvidenceCount) exercise real SQLite",
+                "cite \(environmentCountText) captured SQLite \(sqliteVersions) \(environmentNoun)",
             ],
         ]
 
@@ -307,7 +427,19 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             for phrase in requiredPhrases {
                 XCTAssertTrue(
                     contents.contains(phrase),
-                    "\(path) is missing the v1.2 contract phrase '\(phrase)'."
+                    "\(path) is missing the v1.3 contract phrase '\(phrase)'."
+                )
+            }
+        }
+        for (path, inventoryPhrases) in inventoryPhrasesByPath {
+            let contents = try String(
+                contentsOf: repositoryRoot.appendingPathComponent(path),
+                encoding: .utf8
+            )
+            for phrase in inventoryPhrases {
+                XCTAssertTrue(
+                    contents.contains(phrase),
+                    "\(path) is stale against the canonical inventory phrase '\(phrase)'."
                 )
             }
         }
@@ -319,7 +451,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         let firstReleaseHeading = changelog
             .components(separatedBy: .newlines)
             .first(where: { $0.hasPrefix("## [") })
-        XCTAssertEqual(firstReleaseHeading, "## [1.2.0] - 2026-07-19")
+        XCTAssertEqual(firstReleaseHeading, "## [1.3.0] - Unreleased")
     }
 
     func testREADMERepositoryLinksResolveWithExactCase() throws {

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -297,7 +297,9 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             grouping: inventory.features,
             by: \.status
         ).mapValues(\.count)
-        let realSQLiteEvidenceCount = inventory.evidence.count(where: \.realSQLite)
+        let realSQLiteEvidenceCount = inventory.evidence.filter {
+            $0.realSQLite
+        }.count
         let environmentCount = inventory.sqliteEnvironments.count
         let environmentCountText = environmentCount == 1
             ? "one"

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1072,25 +1072,40 @@ final class XLDocumentationTests: XCTestCase {
 extension XLDocumentationTests {
 
     func testDocumentationREADME() throws {
-        let query = sql { schema in
-            let person = schema.table(Person.self)
-            Select(person)
-            From(person)
-            Where(person.name == "Fred")
-        }
-
-        XCTAssertEqual(
-            encoder.makeSQL(query).sql,
-            "SELECT t0.id AS id, t0.occupationId AS occupationId, t0.name AS name, t0.age AS age FROM Person AS t0 WHERE (t0.name == 'Fred')"
+        let databaseDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: databaseDirectory,
+            withIntermediateDirectories: false
         )
+        defer { try? FileManager.default.removeItem(at: databaseDirectory) }
+        let databaseURL = databaseDirectory.appendingPathComponent("readme.sqlite")
 
-        let request = database.makeRequest(with: query)
+        do {
+            let database = try GRDBDatabase(url: databaseURL, logger: nil)
 
-        let people: [Person] = try request.fetchAll()
-        let firstPerson: Person? = try request.fetchOne()
+            try database.makeRequest(with: sqlCreate(Person.self)).execute()
 
-        XCTAssertTrue(people.isEmpty)
-        XCTAssertNil(firstPerson)
+            let query = sql { schema in
+                let person = schema.table(Person.self)
+                Select(person)
+                From(person)
+                Where(person.name == "Fred")
+            }
+
+            XCTAssertEqual(
+                encoder.makeSQL(query).sql,
+                "SELECT t0.id AS id, t0.occupationId AS occupationId, t0.name AS name, t0.age AS age FROM Person AS t0 WHERE (t0.name == 'Fred')"
+            )
+
+            let request = database.makeRequest(with: query)
+
+            let people: [Person] = try request.fetchAll()
+            let firstPerson: Person? = try request.fetchOne()
+
+            XCTAssertTrue(people.isEmpty)
+            XCTAssertNil(firstPerson)
+        }
     }
 
     func testDocumentationQuickStart() throws {


### PR DESCRIPTION
Closes #224

## Summary

- make the README quick start self-contained with an executable database and schema lifecycle
- align README, compatibility, changelog, DocC, and release guidance with the v1.3 milestone evidence
- distinguish the 141 generated combinatorial cases from the separate negative control
- state the exact inventory boundary: 101 features, 98 evidence records, and 66 real-SQLite records tied to the captured SQLite 3.51.0 environment
- keep #132 explicitly research-only with no public validator, plugin, macro, schema system, or v1.3 API
- derive documentation assertions from the canonical inventory and clean up temporary README-test databases

## Local validation

- `xcrun swift test`: 687 tests, 0 failures
- `xcrun swift test --filter XLDocumentationTests`: 33 tests, 0 failures
- `./make-docs.sh /private/tmp/swiftql-224-docs-20260719-2149`: warnings-as-errors build and output check passed
- `python3 scripts/ci/sqlite-conformance-inventory.py check`: current
- `scripts/ci/test-release-workflow.sh`: passed
- `scripts/ci/check-first-party-warnings.sh`: clean
- `scripts/ci/check-strict-concurrency.sh`: clean
- `python3 scripts/ci/check-core-contract-boundary.py`: passed
- `scripts/ci/check-downstream-swift5-client.sh committed`: passed
- `git diff --check`: passed

An independent final review found two test-quality issues; both were fixed and re-reviewed before this PR was opened.