### PR TITLE
Update SwiftQL agent skill for v1.3

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "[v1.3 Housekeeping] Refresh README and public documentation",
-  "issue_number": 224,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/224",
+  "task_name": "[v1.3 Housekeeping] Update the SwiftQL agent SKILL.md",
+  "issue_number": 225,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/225",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#224 - [v1.3 Housekeeping] Refresh README and public documentation",
+  "codex_session_title": "lukevanin/swiftql#225 - [v1.3 Housekeeping] Update the SwiftQL agent SKILL.md",
   "codex_session_id": "019f7a0d-c80b-7f22-b47a-e3adb614acc8",
   "codex_session_url": null,
-  "task_branch": "codex/224-refresh-readme-and-public-documentation",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/224-refresh-readme-and-public-documentation"
+  "task_branch": "codex/225-update-the-swiftql-agent-skill-md",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/225-update-the-swiftql-agent-skill-md"
 }

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftql
-description: Use when Codex works in a Swift package or Apple application that uses SwiftQL to define typed tables or results, build or modify SQLite queries, pass immutable bindings, add contextual codecs, prepare reusable static queries, integrate a database adapter, or diagnose SwiftQL execution boundaries. Follow the shipped v1.2 API on this repository's main branch; do not use this skill to teach SQL generally or to claim unshipped dialects, drivers, or concurrency features.
+description: Use when Codex works in a Swift package or Apple application that uses SwiftQL to define typed tables or results, build or modify SQLite queries, pass immutable bindings, add contextual codecs, prepare reusable static queries, integrate a database adapter, or diagnose SwiftQL execution boundaries. Use the checked-out public v1 contract; 1.2.0 remains the latest published package, while main's forthcoming v1.3 adds conformance evidence rather than new public syntax or validation APIs. Do not use this skill to teach SQL generally or claim unshipped features.
 ---
 
 # SwiftQL
@@ -19,13 +19,13 @@ checked-out package version before editing consumer code.
 - Depend directly on `SwiftQLCore` only when implementing a dialect or database
   adapter. It deliberately contains no usable GRDB connection.
 - Require Swift tools 5.9, Swift 5 language mode, iOS 16 or later, or macOS 13
-  or later. SwiftQL v1.2 supports Apple platforms, SQLite syntax, and the GRDB
-  driver only.
+  or later. Supported Swift 6 compilers still use Swift 5 mode; Swift 6 mode,
+  non-Apple platforms, non-SQLite dialects, and non-GRDB drivers are unsupported.
 - Read [the changelog](CHANGELOG.md) before choosing a package requirement.
-  Use the published `1.2.0` semantic version for v1.2 APIs. Pin a source
-  revision only when intentionally testing later changes from `main`.
+  `1.2.0` is the latest published package. Pin a source revision only when
+  intentionally testing the forthcoming v1.3 changes from `main`.
 
-## Follow the preferred application workflow
+## Prefer the high-level application workflow
 
 1. Declare stored rows with `@SQLTable` and projections with `@SQLResult`.
 2. Build a statement with `sql { schema in ... }`; obtain table references from
@@ -80,12 +80,15 @@ func fetchSkillPeople(
 }
 ```
 
+Lower-level boundaries include `SwiftQLCore`, validated driver helpers, raw-value
+prepared handles, and direct GRDB; use them only for the specialized needs below.
+
 Use `sqlCreate` only for basic table creation. It does not add declared SQLite
 type names, primary keys, uniqueness, foreign keys, indexes, or migrations, and
 it never upgrades an existing table. Keep production schema evolution in an
 explicit application-owned migration system.
 
-## Use the v1.2 reusable-query boundary deliberately
+## Use the v1.2 reusable-query boundary retained in v1.3
 
 Choose a static query when the definition needs durable identity, explicit
 parameter and result metadata, cardinality, registration before a database is
@@ -104,7 +107,7 @@ opened, or a raw-value handle that can cross tasks.
   descriptor cardinality.
 - Use macro-generated static row layouts for contextual-only properties or
   typed static decoding. The raw `GRDBPreparedStaticQuery` is `Sendable`; the
-  closure-backed typed layout wrapper remains task-local in v1.2.
+  closure-backed typed layout wrapper remains task-local in v1.3.
 
 Read the canonical [static-query guide](https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/)
 for descriptor construction, captures, cardinality, preparation, and typed
@@ -140,16 +143,36 @@ and [prepared execution boundaries](https://lukevanin.github.io/swiftql/document
 for the exact selection order, structured errors, row lifetime, and driver
 contracts.
 
+## Report v1.3 support from canonical evidence
+
+- Treat the versioned [inventory](Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json) as
+  the source of truth and its [report](Conformance/SQLite/REPORT.md) as a generated
+  view; use the [compatibility guide](COMPATIBILITY.md#sqlite-conformance-inventory)
+  to interpret it. It records 101 feature records: 82 supported, 7 partial,
+  3 capability-gated, 1 intentionally unsupported, and 8 unimplemented.
+- Keep those five statuses distinct. Bind every claim to the feature's recorded
+  SQLite version, source ID, compile options, capabilities, evidence, and
+  rationale before claiming support.
+- Of the 98 evidence records, 66 exercise real SQLite against one captured
+  environment, SQLite 3.51.0. Evidence is reusable, so evidence and feature
+  counts do not map one to one; never turn this into an exhaustive-SQL claim.
+- #191 contributes 141 generated positive cases plus a separate broken-renderer
+  negative control; #254 contributes 18 Northwind scenarios; #255 contributes
+  12 observation-stress cases. These strengthen evidence without adding syntax.
+- #132 remains package-private research. It ships no public validator, build
+  plugin, query macro, schema system, or new v1.3 API. It neither persists
+  prepared statements nor removes runtime preparation on a physical connection.
+
 ## Keep transactions and migrations explicit
 
-- Do not invent a high-level `GRDBDatabase.transaction` API. The shipped v1.2
+- Do not invent a high-level `GRDBDatabase.transaction` API. The shipped v1
   transaction contract is the lower-level driver's synchronous
   `withValidatedTransaction` helper.
 - Use only the pinned connection inside its transaction body. Do not re-enter
   the root pool. A returned body commits; a thrown body rolls back and preserves
   the body error.
 - Do not claim nested transactions, savepoints, task-cancellation hooks, or a
-  separate single-connection GRDB capability in v1.2.
+  separate single-connection GRDB capability in v1.3.
 - Treat migrations as application or driver work. `sqlCreate` is not a
   migration engine.
 
@@ -182,6 +205,7 @@ subject of the task.
 
 ```sh
 swift test --filter SQLSkillDocumentationTests
+python3 scripts/ci/sqlite-conformance-inventory.py check
 scripts/ci/check-downstream-swift5-client.sh committed
 swift test
 ./make-docs.sh docs

--- a/Tests/SQLTests/SQLSkillDocumentationTests.swift
+++ b/Tests/SQLTests/SQLSkillDocumentationTests.swift
@@ -50,11 +50,110 @@ final class SQLSkillDocumentationTests: XCTestCase {
             "`sqlCreate` is not a migration engine",
             "SwiftQL exposes no general raw-fragment API",
             "`XLRequest` across tasks; it is not `Sendable`",
+            "checked-out public v1 contract",
+            "forthcoming v1.3 adds conformance evidence rather than new public syntax or validation APIs",
+            "`1.2.0` is the latest published package",
+            "Keep those five statuses distinct",
+            "recorded SQLite version, source ID, compile options, capabilities",
+            "#132 remains package-private research",
+            "neither persists prepared statements nor removes runtime preparation",
             "Swift 5.9 and Swift 6.0-6.3 evidence",
         ] {
             XCTAssertTrue(
                 normalizedContents.contains(required),
                 "SKILL.md is missing '\(required)'."
+            )
+        }
+    }
+
+    func testV13GuidanceMatchesCanonicalConformanceInventory() throws {
+        let inventory = try JSONDecoder().decode(
+            SkillConformanceInventory.self,
+            from: Data(
+                contentsOf: repositoryRootURL().appendingPathComponent(
+                    "Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json"
+                )
+            )
+        )
+        let combinatorialManifest = try JSONDecoder().decode(
+            SkillCombinatorialManifest.self,
+            from: Data(
+                contentsOf: repositoryRootURL().appendingPathComponent(
+                    "Conformance/SQLite/COMBINATORIAL_CASES.json"
+                )
+            )
+        )
+        let statusCounts = Dictionary(
+            grouping: inventory.features,
+            by: \.status
+        ).mapValues(\.count)
+        let realSQLiteEvidenceCount = inventory.evidence.filter {
+            $0.realSQLite
+        }.count
+        let environmentCountText = inventory.sqliteEnvironments.count == 1
+            ? "one"
+            : String(inventory.sqliteEnvironments.count)
+        let environmentNoun = inventory.sqliteEnvironments.count == 1
+            ? "environment"
+            : "environments"
+        let sqliteVersions = Set(
+            inventory.sqliteEnvironments.map(\.sqliteVersion)
+        ).sorted().joined(separator: ", ")
+        let supportedCount = statusCounts["supported", default: 0]
+        let partialCount = statusCounts["partial", default: 0]
+        let capabilityGatedCount = statusCounts[
+            "capability-gated",
+            default: 0
+        ]
+        let intentionallyUnsupportedCount = statusCounts[
+            "intentionally-unsupported",
+            default: 0
+        ]
+        let unimplementedCount = statusCounts["unimplemented", default: 0]
+        let combinatorialSuite = try XCTUnwrap(
+            inventory.suites.first { $0.issue == 191 }
+        )
+        let northwindSuite = try XCTUnwrap(
+            inventory.suites.first { $0.issue == 254 }
+        )
+        let observationSuite = try XCTUnwrap(
+            inventory.suites.first { $0.issue == 255 }
+        )
+        let normalizedContents = normalizedWhitespace(try skillContents())
+
+        XCTAssertEqual(
+            statusCounts.values.reduce(0, +),
+            inventory.features.count,
+            "Every inventory feature must contribute to the skill's status totals."
+        )
+        for suite in [combinatorialSuite, northwindSuite, observationSuite] {
+            XCTAssertEqual(suite.status, "completed")
+        }
+        XCTAssertTrue(
+            combinatorialSuite.evidenceIDs.contains(
+                "evidence.combinatorial.broken-renderer.sqlite"
+            )
+        )
+        for required in [
+            "It records \(inventory.features.count) feature records: "
+                + "\(supportedCount) supported, \(partialCount) partial, "
+                + "\(capabilityGatedCount) capability-gated, "
+                + "\(intentionallyUnsupportedCount) intentionally unsupported, "
+                + "and \(unimplementedCount) unimplemented.",
+            "Of the \(inventory.evidence.count) evidence records, "
+                + "\(realSQLiteEvidenceCount) exercise real SQLite against "
+                + "\(environmentCountText) captured \(environmentNoun), SQLite "
+                + "\(sqliteVersions).",
+            "Evidence is reusable, so evidence and feature counts do not map one to one",
+            "#191 contributes \(combinatorialManifest.cases.count) generated positive cases "
+                + "plus a separate broken-renderer negative control; #254 contributes "
+                + "\(northwindSuite.caseIDs.count) Northwind scenarios; #255 contributes "
+                + "\(observationSuite.caseIDs.count) observation-stress cases.",
+            "It ships no public validator, build plugin, query macro, schema system, or new v1.3 API. It neither persists prepared statements nor removes runtime preparation on a physical connection.",
+        ] {
+            XCTAssertTrue(
+                normalizedContents.contains(required),
+                "SKILL.md is stale against the canonical inventory phrase '\(required)'."
             )
         }
     }
@@ -89,7 +188,13 @@ final class SQLSkillDocumentationTests: XCTestCase {
         let root = repositoryRootURL()
         let contents = try skillContents()
 
-        for path in ["README.md", "CHANGELOG.md", "COMPATIBILITY.md"] {
+        for path in [
+            "README.md",
+            "CHANGELOG.md",
+            "COMPATIBILITY.md",
+            "Conformance/SQLite/REPORT.md",
+            "Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json",
+        ] {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(path).path))
             XCTAssertTrue(contents.contains("](\(path))"), "SKILL.md must link \(path).")
         }
@@ -100,12 +205,18 @@ final class SQLSkillDocumentationTests: XCTestCase {
         ] {
             XCTAssertTrue(contents.contains(canonicalURL))
         }
+        XCTAssertTrue(
+            contents.contains(
+                "](COMPATIBILITY.md#sqlite-conformance-inventory)"
+            )
+        )
 
         let shell = try text(between: "```sh\n", and: "\n```", in: contents)
         XCTAssertEqual(
             shell.components(separatedBy: .newlines),
             [
                 "swift test --filter SQLSkillDocumentationTests",
+                "python3 scripts/ci/sqlite-conformance-inventory.py check",
                 "scripts/ci/check-downstream-swift5-client.sh committed",
                 "swift test",
                 "./make-docs.sh docs",
@@ -149,4 +260,64 @@ final class SQLSkillDocumentationTests: XCTestCase {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
     }
+}
+
+
+private struct SkillConformanceInventory: Decodable {
+
+    struct Feature: Decodable {
+        let status: String
+    }
+
+    struct Evidence: Decodable {
+        let realSQLite: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case realSQLite = "real_sqlite"
+        }
+    }
+
+    struct SQLiteEnvironment: Decodable {
+        let sqliteVersion: String
+
+        enum CodingKeys: String, CodingKey {
+            case sqliteVersion = "sqlite_version"
+        }
+    }
+
+    struct Suite: Decodable {
+        let issue: Int
+        let status: String
+        let caseIDs: [String]
+        let evidenceIDs: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case issue
+            case status
+            case caseIDs = "case_ids"
+            case evidenceIDs = "evidence_ids"
+        }
+    }
+
+    let features: [Feature]
+    let evidence: [Evidence]
+    let sqliteEnvironments: [SQLiteEnvironment]
+    let suites: [Suite]
+
+    enum CodingKeys: String, CodingKey {
+        case features
+        case evidence
+        case sqliteEnvironments = "sqlite_environments"
+        case suites
+    }
+}
+
+
+private struct SkillCombinatorialManifest: Decodable {
+
+    struct Case: Decodable {
+        let id: String
+    }
+
+    let cases: [Case]
 }


### PR DESCRIPTION
## Summary

- update the repository-shipped SwiftQL Codex skill for the forthcoming v1.3 evidence milestone while preserving `1.2.0` as the latest published package
- distinguish the preferred application workflow from adapter, transaction, cross-task, and direct-GRDB boundaries
- document the canonical conformance statuses, environment/capability boundary, bounded #191/#254/#255 evidence, and #132 research-only limitations
- strengthen the skill contract tests so inventory totals and all three corpus sizes are derived from canonical checked-in artifacts

## Validation

- `swift test --filter SQLSkillDocumentationTests` — 4/4 passed
- `python3 scripts/ci/sqlite-conformance-inventory.py check` — report current
- `scripts/ci/check-downstream-swift5-client.sh committed` — passed
- `swift test` — 688/688 passed
- `./make-docs.sh /private/tmp/swiftql-225-docs-20260719-2256` — warnings-as-errors and output verification passed
- `scripts/ci/check-first-party-warnings.sh` — clean
- `scripts/ci/check-strict-concurrency.sh` — clean
- independent final review — no remaining P1–P3 findings

Closes #225