### PR TITLE
Replace retiring Swift 5.9 CI runner

### DIFF
--- a/.codex/task.json
+++ b/.codex/task.json
@@ -1,11 +1,11 @@
 {
-  "task_name": "Release SwiftQL v1.3.0",
-  "issue_number": 298,
-  "issue_url": "https://github.com/lukevanin/swiftql/issues/298",
+  "task_name": "Move Swift 5.9 CI off retiring hosted macOS 14 runners",
+  "issue_number": 164,
+  "issue_url": "https://github.com/lukevanin/swiftql/issues/164",
   "workspace_repo": "lukevanin/swiftql",
-  "codex_session_title": "lukevanin/swiftql#298 - Release SwiftQL v1.3.0",
-  "codex_session_id": "019f7a0d-c80b-7f22-b47a-e3adb614acc8",
+  "codex_session_title": "lukevanin/swiftql#164 - Move Swift 5.9 CI off macOS 14",
+  "codex_session_id": "019f7f4b-cec3-77c2-97d9-5741d2cfe48e",
   "codex_session_url": null,
-  "task_branch": "codex/298-release-swiftql-v1-3-0",
-  "task_worktree_path": "/private/tmp/swiftql-worktrees/298-release-swiftql-v1-3-0"
+  "task_branch": "codex/164-move-swift-5-9-ci-off-retiring-hosted-macos-14-runners",
+  "task_worktree_path": "/private/tmp/swiftql-worktrees/164-move-swift-5-9-ci-off-retiring-hosted-macos-14-runners"
 }

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -345,9 +345,28 @@ jobs:
 
       - name: Install exact Swift 5.9.2 toolchain
         if: ${{ matrix.swift_command_mode == 'path' }}
-        uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
-        with:
-          swift-version: "5.9.2"
+        env:
+          SWIFT_TOOLCHAIN_URL: https://download.swift.org/swift-5.9.2-release/xcode/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-osx.pkg
+          SWIFT_TOOLCHAIN_SHA256: 68951c313b4b559878fc5be27e460c877f98d14e161f755220b063123919e896
+        run: |
+          set -euo pipefail
+          package="$RUNNER_TEMP/swift-5.9.2-RELEASE-osx.pkg"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --retry 3 --silent --show-error \
+            --output "$package" "$SWIFT_TOOLCHAIN_URL"
+          printf '%s  %s\n' "$SWIFT_TOOLCHAIN_SHA256" "$package" |
+            shasum -a 256 --check
+
+          signature_report="$(pkgutil --check-signature "$package")"
+          printf '%s\n' "$signature_report"
+          grep -Fq 'Developer ID Installer: Swift Open Source (V9AUD2URP3)' \
+            <<< "$signature_report"
+
+          installer -pkg "$package" -target CurrentUserHomeDirectory
+          toolchain_bin="$HOME/Library/Developer/Toolchains/swift-5.9.2-RELEASE.xctoolchain/usr/bin"
+          test -x "$toolchain_bin/swift"
+          test -x "$toolchain_bin/swiftc"
+          printf '%s\n' "$toolchain_bin" >> "$GITHUB_PATH"
 
       - name: Validate and report compiler environment
         env:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -282,31 +282,40 @@ jobs:
       matrix:
         include:
           - name: Swift 5.9 / committed resolution
-            runner: macos-15-intel
-            developer_dir: /Applications/Xcode_16.2.app/Contents/Developer
-            xcode_version: "16.2"
-            xcode_build: 16C5032a
+            runner: ubuntu-22.04
+            platform: linux
+            developer_dir: ""
+            xcode_version: ""
+            xcode_build: ""
             swift_series: "5.9"
             swift_version: "5.9.2"
             swift_command_mode: path
-            sdk_version: "15.2"
-            image_os: macos15
+            sdk_version: ""
+            image_os: ubuntu22
             architecture: x86_64
+            os_id: ubuntu
+            os_version_id: "22.04"
+            target_triple: x86_64-unknown-linux-gnu
             resolution: committed
           - name: Swift 5.9 / clean resolution
-            runner: macos-15-intel
-            developer_dir: /Applications/Xcode_16.2.app/Contents/Developer
-            xcode_version: "16.2"
-            xcode_build: 16C5032a
+            runner: ubuntu-22.04
+            platform: linux
+            developer_dir: ""
+            xcode_version: ""
+            xcode_build: ""
             swift_series: "5.9"
             swift_version: "5.9.2"
             swift_command_mode: path
-            sdk_version: "15.2"
-            image_os: macos15
+            sdk_version: ""
+            image_os: ubuntu22
             architecture: x86_64
+            os_id: ubuntu
+            os_version_id: "22.04"
+            target_triple: x86_64-unknown-linux-gnu
             resolution: clean
           - name: Swift 6.0 / committed resolution
             runner: macos-15
+            platform: macos
             developer_dir: /Applications/Xcode_16.2.app/Contents/Developer
             xcode_version: "16.2"
             xcode_build: 16C5032a
@@ -316,9 +325,13 @@ jobs:
             sdk_version: "15.2"
             image_os: macos15
             architecture: arm64
+            os_id: ""
+            os_version_id: ""
+            target_triple: ""
             resolution: committed
           - name: Swift 6.0 / clean resolution
             runner: macos-15
+            platform: macos
             developer_dir: /Applications/Xcode_16.2.app/Contents/Developer
             xcode_version: "16.2"
             xcode_build: 16C5032a
@@ -328,6 +341,9 @@ jobs:
             sdk_version: "15.2"
             image_os: macos15
             architecture: arm64
+            os_id: ""
+            os_version_id: ""
+            target_triple: ""
             resolution: clean
 
     env:
@@ -344,34 +360,16 @@ jobs:
         run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - name: Install exact Swift 5.9.2 toolchain
-        if: ${{ matrix.swift_command_mode == 'path' }}
-        env:
-          SWIFT_TOOLCHAIN_URL: https://download.swift.org/swift-5.9.2-release/xcode/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-osx.pkg
-          SWIFT_TOOLCHAIN_SHA256: 68951c313b4b559878fc5be27e460c877f98d14e161f755220b063123919e896
-        run: |
-          set -euo pipefail
-          package="$RUNNER_TEMP/swift-5.9.2-RELEASE-osx.pkg"
-          curl --fail --location --proto '=https' --tlsv1.2 \
-            --retry 3 --silent --show-error \
-            --output "$package" "$SWIFT_TOOLCHAIN_URL"
-          printf '%s  %s\n' "$SWIFT_TOOLCHAIN_SHA256" "$package" |
-            shasum -a 256 --check
-
-          signature_report="$(pkgutil --check-signature "$package")"
-          printf '%s\n' "$signature_report"
-          grep -Fq 'Developer ID Installer: Swift Open Source (V9AUD2URP3)' \
-            <<< "$signature_report"
-
-          installer -pkg "$package" -target CurrentUserHomeDirectory
-          toolchain_bin="$HOME/Library/Developer/Toolchains/swift-5.9.2-RELEASE.xctoolchain/usr/bin"
-          test -x "$toolchain_bin/swift"
-          test -x "$toolchain_bin/swiftc"
-          printf '%s\n' "$toolchain_bin" >> "$GITHUB_PATH"
+        if: ${{ matrix.platform == 'linux' }}
+        uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+        with:
+          swift-version: "5.9.2"
 
       - name: Validate and report compiler environment
         env:
           EXPECTED_XCODE_VERSION: ${{ matrix.xcode_version }}
           EXPECTED_XCODE_BUILD: ${{ matrix.xcode_build }}
+          EXPECTED_PLATFORM: ${{ matrix.platform }}
           EXPECTED_SWIFT_SERIES: ${{ matrix.swift_series }}
           EXPECTED_SWIFT_VERSION: ${{ matrix.swift_version }}
           EXPECTED_SWIFT_COMMAND_MODE: ${{ matrix.swift_command_mode }}
@@ -379,6 +377,9 @@ jobs:
           EXPECTED_DEVELOPER_DIR: ${{ matrix.developer_dir }}
           EXPECTED_IMAGE_OS: ${{ matrix.image_os }}
           EXPECTED_ARCHITECTURE: ${{ matrix.architecture }}
+          EXPECTED_OS_ID: ${{ matrix.os_id }}
+          EXPECTED_OS_VERSION_ID: ${{ matrix.os_version_id }}
+          EXPECTED_TARGET_TRIPLE: ${{ matrix.target_triple }}
         run: scripts/ci/check-compatibility-environment.sh
 
       - name: Prepare ${{ matrix.resolution }} dependency resolution

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -499,6 +499,10 @@ jobs:
           printf 'CPATH=%s\n' "$sqlite_prefix/include" >> "$GITHUB_ENV"
           printf 'LIBRARY_PATH=%s\n' "$sqlite_prefix/lib" >> "$GITHUB_ENV"
           printf 'LD_LIBRARY_PATH=%s\n' "$sqlite_prefix/lib" >> "$GITHUB_ENV"
+          printf 'SWIFTQL_SQLITE_INCLUDE_DIR=%s\n' \
+            "$sqlite_prefix/include" >> "$GITHUB_ENV"
+          printf 'SWIFTQL_SQLITE_LIBRARY_DIR=%s\n' \
+            "$sqlite_prefix/lib" >> "$GITHUB_ENV"
 
           # GRDB 6.29.3 assumes Linux SQLite exports optional snapshot symbols.
           # The pinned amalgamation intentionally does not enable that optional
@@ -511,7 +515,7 @@ jobs:
             'if [[ "${1:-}" == "-modulewrap" ]]; then' \
             '  exec "$SWIFTQL_REAL_SWIFT_FRONTEND" "$@"' \
             'fi' \
-            'exec "$SWIFTQL_REAL_SWIFTC" -DGRDBCUSTOMSQLITE "$@"' \
+            'exec "$SWIFTQL_REAL_SWIFTC" -DGRDBCUSTOMSQLITE -Xcc -I -Xcc "$SWIFTQL_SQLITE_INCLUDE_DIR" -L "$SWIFTQL_SQLITE_LIBRARY_DIR" "$@"' \
             > "$compiler_wrapper"
           chmod 755 "$compiler_wrapper"
           printf 'SWIFTQL_REAL_SWIFTC=%s\n' "$toolchain_bin/swiftc" \

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run source coverage reporting fixtures
         run: python3 scripts/ci/test-source-coverage-report.py
 
+      - name: Run Swift compatibility workflow fixtures
+        run: python3 scripts/ci/test-swift-compatibility-workflow.py
+
       - name: Validate SQLite conformance inventory
         run: |
           python3 scripts/ci/test-sqlite-conformance-inventory.py
@@ -279,20 +282,28 @@ jobs:
       matrix:
         include:
           - name: Swift 5.9 / committed resolution
-            runner: macos-14
-            developer_dir: /Applications/Xcode_15.2.app/Contents/Developer
-            xcode_version: "15.2"
-            xcode_build: 15C500b
+            runner: macos-15
+            developer_dir: /Applications/Xcode_16.2.app/Contents/Developer
+            xcode_version: "16.2"
+            xcode_build: 16C5032a
             swift_series: "5.9"
-            sdk_version: "14.2"
+            swift_version: "5.9.2"
+            swift_command_mode: path
+            sdk_version: "15.2"
+            image_os: macos15
+            architecture: arm64
             resolution: committed
           - name: Swift 5.9 / clean resolution
-            runner: macos-14
-            developer_dir: /Applications/Xcode_15.2.app/Contents/Developer
-            xcode_version: "15.2"
-            xcode_build: 15C500b
+            runner: macos-15
+            developer_dir: /Applications/Xcode_16.2.app/Contents/Developer
+            xcode_version: "16.2"
+            xcode_build: 16C5032a
             swift_series: "5.9"
-            sdk_version: "14.2"
+            swift_version: "5.9.2"
+            swift_command_mode: path
+            sdk_version: "15.2"
+            image_os: macos15
+            architecture: arm64
             resolution: clean
           - name: Swift 6.0 / committed resolution
             runner: macos-15
@@ -300,7 +311,11 @@ jobs:
             xcode_version: "16.2"
             xcode_build: 16C5032a
             swift_series: "6.0"
+            swift_version: ""
+            swift_command_mode: xcrun
             sdk_version: "15.2"
+            image_os: macos15
+            architecture: arm64
             resolution: committed
           - name: Swift 6.0 / clean resolution
             runner: macos-15
@@ -308,7 +323,11 @@ jobs:
             xcode_version: "16.2"
             xcode_build: 16C5032a
             swift_series: "6.0"
+            swift_version: ""
+            swift_command_mode: xcrun
             sdk_version: "15.2"
+            image_os: macos15
+            architecture: arm64
             resolution: clean
 
     env:
@@ -324,13 +343,23 @@ jobs:
       - name: Verify exact source commit
         run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
+      - name: Install exact Swift 5.9.2 toolchain
+        if: ${{ matrix.swift_command_mode == 'path' }}
+        uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+        with:
+          swift-version: "5.9.2"
+
       - name: Validate and report compiler environment
         env:
           EXPECTED_XCODE_VERSION: ${{ matrix.xcode_version }}
           EXPECTED_XCODE_BUILD: ${{ matrix.xcode_build }}
           EXPECTED_SWIFT_SERIES: ${{ matrix.swift_series }}
+          EXPECTED_SWIFT_VERSION: ${{ matrix.swift_version }}
+          EXPECTED_SWIFT_COMMAND_MODE: ${{ matrix.swift_command_mode }}
           EXPECTED_SDK_VERSION: ${{ matrix.sdk_version }}
           EXPECTED_DEVELOPER_DIR: ${{ matrix.developer_dir }}
+          EXPECTED_IMAGE_OS: ${{ matrix.image_os }}
+          EXPECTED_ARCHITECTURE: ${{ matrix.architecture }}
         run: scripts/ci/check-compatibility-environment.sh
 
       - name: Prepare ${{ matrix.resolution }} dependency resolution
@@ -357,7 +386,7 @@ jobs:
         run: |
           set -euo pipefail
           cd "$SWIFTQL_SOURCE"
-          xcrun swift package resolve
+          swift package resolve
           scripts/ci/report-resolved-dependencies.sh
           if [[ "$RESOLUTION_MODE" == "committed" ]]; then
             git diff --exit-code -- Package.resolved
@@ -388,7 +417,7 @@ jobs:
         run: |
           set -euo pipefail
           cd "$SWIFTQL_SOURCE"
-          xcrun swift test --filter XLCompatibilityReportTests 2>&1 |
+          swift test --filter XLCompatibilityReportTests 2>&1 |
             tee "$RUNNER_TEMP/swift-test-build.log"
           runtime_markers="$(
             grep -c 'SWIFTQL_SQLITE_RUNTIME ' "$RUNNER_TEMP/swift-test-build.log" ||
@@ -404,7 +433,7 @@ jobs:
           set -euo pipefail
           cd "$SWIFTQL_SOURCE"
           benchmark_report="$RUNNER_TEMP/swiftql-benchmark.json"
-          xcrun swift run --skip-build swiftql-benchmark \
+          swift run --skip-build swiftql-benchmark \
             --warmups 0 \
             --samples 1 \
             --output "$benchmark_report" 2>&1 | \
@@ -439,7 +468,7 @@ jobs:
             mkdir -p "$determinism_directory"
             SWIFTQL_COMBINATORIAL_MANIFEST_PATH="$determinism_directory/manifest.json" \
             SWIFTQL_COMBINATORIAL_SUMMARY_PATH="$determinism_directory/summary.md" \
-              xcrun swift test --skip-build \
+              swift test --skip-build \
                 --filter SQLiteCombinatorialConformanceTests/testGeneratedManifestIsDeterministicAndMatchesCheckedInArtifacts \
                 2>&1 | tee "$determinism_directory/test.log"
             test -s "$determinism_directory/manifest.json"
@@ -455,7 +484,7 @@ jobs:
             tee "$output_directory/determinism-result.txt"
 
           set +e
-          xcrun swift test --skip-build \
+          swift test --skip-build \
             --filter SQLiteCombinatorialConformanceTests 2>&1 | \
             tee "$output_directory/test.log"
           test_status="${PIPESTATUS[0]}"
@@ -602,7 +631,7 @@ jobs:
         run: |
           set -euo pipefail
           cd "$SWIFTQL_SOURCE"
-          xcrun swift test --skip-build -v
+          swift test --skip-build -v
 
       - name: Check complete strict concurrency
         if: ${{ matrix.swift_series == '6.0' }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -296,6 +296,7 @@ jobs:
             os_id: ubuntu
             os_version_id: "22.04"
             target_triple: x86_64-unknown-linux-gnu
+            sqlite_version: "3.53.3"
             resolution: committed
           - name: Swift 5.9 / clean resolution
             runner: ubuntu-22.04
@@ -312,6 +313,7 @@ jobs:
             os_id: ubuntu
             os_version_id: "22.04"
             target_triple: x86_64-unknown-linux-gnu
+            sqlite_version: "3.53.3"
             resolution: clean
           - name: Swift 6.0 / committed resolution
             runner: macos-15
@@ -328,6 +330,7 @@ jobs:
             os_id: ""
             os_version_id: ""
             target_triple: ""
+            sqlite_version: ""
             resolution: committed
           - name: Swift 6.0 / clean resolution
             runner: macos-15
@@ -344,6 +347,7 @@ jobs:
             os_id: ""
             os_version_id: ""
             target_triple: ""
+            sqlite_version: ""
             resolution: clean
 
     env:
@@ -359,7 +363,7 @@ jobs:
       - name: Verify exact source commit
         run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
-      - name: Install exact Swift 5.9.2 toolchain
+      - name: Install exact Swift 5.9.2 toolchain and SQLite 3.53.3
         if: ${{ matrix.platform == 'linux' }}
         env:
           SWIFT_TOOLCHAIN_URL: https://download.swift.org/swift-5.9.2-release/ubuntu2204/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-ubuntu22.04.tar.gz
@@ -368,6 +372,8 @@ jobs:
           SWIFT_SIGNING_KEYS_URL: https://www.swift.org/keys/all-keys.asc
           SWIFT_SIGNING_KEY_FALLBACK_URL: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xA62AE125BBBFBB96A6E042EC925CC1CCED3D1561
           SWIFT_SIGNING_FINGERPRINT: A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+          SQLITE_AMALGAMATION_URL: https://www.sqlite.org/2026/sqlite-amalgamation-3530300.zip
+          SQLITE_AMALGAMATION_SHA3_256: d45c688a8cb23f68611a894a756a12d7eb6ab6e9e2468ca70adbeab3808b5ab9
         run: |
           set -euo pipefail
           archive="$RUNNER_TEMP/swift-5.9.2-RELEASE-ubuntu22.04.tar.gz"
@@ -391,6 +397,32 @@ jobs:
                 return 0
               fi
               printf 'Downloaded bytes for %s failed SHA-256 verification (attempt %s/3)\n' \
+                "$url" "$attempt" >&2
+              sleep 1
+            done
+            return 1
+          }
+
+          download_verified_sha3() {
+            local url="$1"
+            local output="$2"
+            local expected_sha3_256="$3"
+            local actual_sha3_256
+            local attempt
+
+            for attempt in 1 2 3; do
+              curl --fail --location --proto '=https' --tlsv1.2 \
+                --retry 3 --silent --show-error \
+                --output "$output" "$url"
+              actual_sha3_256="$(
+                openssl dgst -sha3-256 "$output" | awk '{ print $NF }'
+              )"
+              if [[ "$actual_sha3_256" == "$expected_sha3_256" ]]; then
+                printf 'Verified %s at SHA3-256 %s\n' \
+                  "$url" "$expected_sha3_256"
+                return 0
+              fi
+              printf 'Downloaded bytes for %s failed SHA3-256 verification (attempt %s/3)\n' \
                 "$url" "$attempt" >&2
               sleep 1
             done
@@ -438,9 +470,39 @@ jobs:
           test -x "$toolchain_bin/swift-frontend"
           printf '%s\n' "$toolchain_bin" >> "$GITHUB_PATH"
 
-          # GRDB 6.29.3 assumes Linux libsqlite exports snapshot functions.
-          # Ubuntu 22.04's libsqlite omits those optional symbols, so compile
-          # GRDB's documented custom-SQLite path against the detected runtime.
+          # Ubuntu 22.04's SQLite 3.37 predates the UNIXEPOCH function in
+          # SwiftQL's real-SQLite conformance corpus. Build the exact official
+          # amalgamation so every required public expression is executed rather
+          # than skipped or weakened for the Linux compatibility environment.
+          sqlite_archive="$RUNNER_TEMP/sqlite-amalgamation-3530300.zip"
+          sqlite_source="$RUNNER_TEMP/sqlite-amalgamation-3530300"
+          sqlite_prefix="$RUNNER_TEMP/sqlite-3.53.3"
+          download_verified_sha3 \
+            "$SQLITE_AMALGAMATION_URL" \
+            "$sqlite_archive" \
+            "$SQLITE_AMALGAMATION_SHA3_256"
+          unzip -q "$sqlite_archive" -d "$RUNNER_TEMP"
+          test -f "$sqlite_source/sqlite3.c"
+          test -f "$sqlite_source/sqlite3.h"
+          mkdir -p "$sqlite_prefix/include" "$sqlite_prefix/lib"
+          cp "$sqlite_source/sqlite3.h" "$sqlite_source/sqlite3ext.h" \
+            "$sqlite_prefix/include/"
+          cc -O2 -fPIC \
+            -DSQLITE_THREADSAFE=1 \
+            -DSQLITE_ENABLE_COLUMN_METADATA \
+            -DSQLITE_ENABLE_FTS5 \
+            -DSQLITE_ENABLE_MATH_FUNCTIONS \
+            -shared "$sqlite_source/sqlite3.c" \
+            -o "$sqlite_prefix/lib/libsqlite3.so" \
+            -ldl -lm -lpthread
+          test -s "$sqlite_prefix/lib/libsqlite3.so"
+          printf 'CPATH=%s\n' "$sqlite_prefix/include" >> "$GITHUB_ENV"
+          printf 'LIBRARY_PATH=%s\n' "$sqlite_prefix/lib" >> "$GITHUB_ENV"
+          printf 'LD_LIBRARY_PATH=%s\n' "$sqlite_prefix/lib" >> "$GITHUB_ENV"
+
+          # GRDB 6.29.3 assumes Linux SQLite exports optional snapshot symbols.
+          # The pinned amalgamation intentionally does not enable that optional
+          # API, so compile GRDB's documented custom-SQLite path.
           # Keep the override beside swiftc so SwiftPM derives the matching
           # toolchain lib directory when it loads libIndexStore for discovery.
           compiler_wrapper="$toolchain_bin/swiftql-swiftc"
@@ -527,6 +589,8 @@ jobs:
           scripts/ci/check-query-clause-ordering-type-safety.sh
 
       - name: Report SQLite runtime through GRDB
+        env:
+          EXPECTED_SQLITE_VERSION: ${{ matrix.sqlite_version }}
         run: |
           set -euo pipefail
           cd "$SWIFTQL_SOURCE"
@@ -538,6 +602,13 @@ jobs:
           )"
           if [[ "$runtime_markers" -ne 1 ]]; then
             echo "error: expected one SQLite runtime marker; found $runtime_markers" >&2
+            exit 1
+          fi
+          if [[ -n "$EXPECTED_SQLITE_VERSION" ]] && \
+              ! grep -Fq \
+                "SWIFTQL_SQLITE_RUNTIME sqlite_version=$EXPECTED_SQLITE_VERSION " \
+                "$RUNNER_TEMP/swift-test-build.log"; then
+            echo "error: expected SQLite $EXPECTED_SQLITE_VERSION runtime marker" >&2
             exit 1
           fi
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -282,7 +282,7 @@ jobs:
       matrix:
         include:
           - name: Swift 5.9 / committed resolution
-            runner: macos-15
+            runner: macos-15-intel
             developer_dir: /Applications/Xcode_16.2.app/Contents/Developer
             xcode_version: "16.2"
             xcode_build: 16C5032a
@@ -291,10 +291,10 @@ jobs:
             swift_command_mode: path
             sdk_version: "15.2"
             image_os: macos15
-            architecture: arm64
+            architecture: x86_64
             resolution: committed
           - name: Swift 5.9 / clean resolution
-            runner: macos-15
+            runner: macos-15-intel
             developer_dir: /Applications/Xcode_16.2.app/Contents/Developer
             xcode_version: "16.2"
             xcode_build: 16C5032a
@@ -303,7 +303,7 @@ jobs:
             swift_command_mode: path
             sdk_version: "15.2"
             image_os: macos15
-            architecture: arm64
+            architecture: x86_64
             resolution: clean
           - name: Swift 6.0 / committed resolution
             runner: macos-15

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -441,7 +441,9 @@ jobs:
           # GRDB 6.29.3 assumes Linux libsqlite exports snapshot functions.
           # Ubuntu 22.04's libsqlite omits those optional symbols, so compile
           # GRDB's documented custom-SQLite path against the detected runtime.
-          compiler_wrapper="$RUNNER_TEMP/swiftql-swiftc"
+          # Keep the override beside swiftc so SwiftPM derives the matching
+          # toolchain lib directory when it loads libIndexStore for discovery.
+          compiler_wrapper="$toolchain_bin/swiftql-swiftc"
           printf '%s\n' \
             '#!/bin/bash' \
             'if [[ "${1:-}" == "-modulewrap" ]]; then' \

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -361,9 +361,43 @@ jobs:
 
       - name: Install exact Swift 5.9.2 toolchain
         if: ${{ matrix.platform == 'linux' }}
-        uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
-        with:
-          swift-version: "5.9.2"
+        env:
+          SWIFT_TOOLCHAIN_URL: https://download.swift.org/swift-5.9.2-release/ubuntu2204/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-ubuntu22.04.tar.gz
+          SWIFT_TOOLCHAIN_SIGNATURE_URL: https://download.swift.org/swift-5.9.2-release/ubuntu2204/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-ubuntu22.04.tar.gz.sig
+          SWIFT_SIGNING_KEYS_URL: https://www.swift.org/keys/all-keys.asc
+          SWIFT_SIGNING_FINGERPRINT: A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/swift-5.9.2-RELEASE-ubuntu22.04.tar.gz"
+          signature="$archive.sig"
+          signing_keys="$RUNNER_TEMP/swift-signing-keys.asc"
+          keyring_directory="$RUNNER_TEMP/swift-signing-keyring"
+
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --retry 3 --silent --show-error \
+            --output "$archive" "$SWIFT_TOOLCHAIN_URL"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --retry 3 --silent --show-error \
+            --output "$signature" "$SWIFT_TOOLCHAIN_SIGNATURE_URL"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --retry 3 --silent --show-error \
+            --output "$signing_keys" "$SWIFT_SIGNING_KEYS_URL"
+
+          mkdir -m 700 "$keyring_directory"
+          gpg --batch --homedir "$keyring_directory" --import "$signing_keys"
+          signature_status="$(
+            gpg --batch --homedir "$keyring_directory" --status-fd 1 \
+              --verify "$signature" "$archive" 2>&1
+          )"
+          printf '%s\n' "$signature_status"
+          grep -Fq "[GNUPG:] VALIDSIG $SWIFT_SIGNING_FINGERPRINT " \
+            <<< "$signature_status"
+
+          tar -xzf "$archive" -C "$RUNNER_TEMP"
+          toolchain_bin="$RUNNER_TEMP/swift-5.9.2-RELEASE-ubuntu22.04/usr/bin"
+          test -x "$toolchain_bin/swift"
+          test -x "$toolchain_bin/swiftc"
+          printf '%s\n' "$toolchain_bin" >> "$GITHUB_PATH"
 
       - name: Validate and report compiler environment
         env:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -366,7 +366,7 @@ jobs:
           SWIFT_TOOLCHAIN_SIGNATURE_URL: https://download.swift.org/swift-5.9.2-release/ubuntu2204/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-ubuntu22.04.tar.gz.sig
           SWIFT_TOOLCHAIN_SIGNATURE_SHA256: 325657c10c0a917cb0126aaf2ce0fe1c72bb9bf14657a89f82330839003959ed
           SWIFT_SIGNING_KEYS_URL: https://www.swift.org/keys/all-keys.asc
-          SWIFT_SIGNING_KEYS_SHA256: 07c0c26f4a96a2eafbeebcfbd1c128a1c4dcf840f9e71f0886ff291921f4ad8f
+          SWIFT_SIGNING_KEY_FALLBACK_URL: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xA62AE125BBBFBB96A6E042EC925CC1CCED3D1561
           SWIFT_SIGNING_FINGERPRINT: A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
         run: |
           set -euo pipefail
@@ -404,13 +404,25 @@ jobs:
             "$SWIFT_TOOLCHAIN_SIGNATURE_URL" \
             "$signature" \
             "$SWIFT_TOOLCHAIN_SIGNATURE_SHA256"
-          download_verified \
-            "$SWIFT_SIGNING_KEYS_URL" \
-            "$signing_keys" \
-            "$SWIFT_SIGNING_KEYS_SHA256"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --retry 3 --silent --show-error \
+            --output "$signing_keys" "$SWIFT_SIGNING_KEYS_URL"
 
           mkdir -m 700 "$keyring_directory"
-          gpg --batch --homedir "$keyring_directory" --import "$signing_keys"
+          if ! gpg --batch --homedir "$keyring_directory" \
+              --import "$signing_keys"; then
+            printf 'Swift.org key bundle was not importable; using pinned-fingerprint fallback\n' >&2
+            curl --fail --location --proto '=https' --tlsv1.2 \
+              --retry 3 --silent --show-error \
+              --output "$signing_keys" "$SWIFT_SIGNING_KEY_FALLBACK_URL"
+            gpg --batch --homedir "$keyring_directory" --import "$signing_keys"
+          fi
+          imported_fingerprints="$(
+            gpg --batch --homedir "$keyring_directory" --with-colons \
+              --fingerprint "$SWIFT_SIGNING_FINGERPRINT"
+          )"
+          grep -Fq "fpr:::::::::$SWIFT_SIGNING_FINGERPRINT:" \
+            <<< "$imported_fingerprints"
           signature_status="$(
             gpg --batch --homedir "$keyring_directory" --status-fd 1 \
               --verify "$signature" "$archive" 2>&1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -364,7 +364,9 @@ jobs:
         env:
           SWIFT_TOOLCHAIN_URL: https://download.swift.org/swift-5.9.2-release/ubuntu2204/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-ubuntu22.04.tar.gz
           SWIFT_TOOLCHAIN_SIGNATURE_URL: https://download.swift.org/swift-5.9.2-release/ubuntu2204/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-ubuntu22.04.tar.gz.sig
+          SWIFT_TOOLCHAIN_SIGNATURE_SHA256: 325657c10c0a917cb0126aaf2ce0fe1c72bb9bf14657a89f82330839003959ed
           SWIFT_SIGNING_KEYS_URL: https://www.swift.org/keys/all-keys.asc
+          SWIFT_SIGNING_KEYS_SHA256: 07c0c26f4a96a2eafbeebcfbd1c128a1c4dcf840f9e71f0886ff291921f4ad8f
           SWIFT_SIGNING_FINGERPRINT: A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
         run: |
           set -euo pipefail
@@ -373,15 +375,39 @@ jobs:
           signing_keys="$RUNNER_TEMP/swift-signing-keys.asc"
           keyring_directory="$RUNNER_TEMP/swift-signing-keyring"
 
+          download_verified() {
+            local url="$1"
+            local output="$2"
+            local expected_sha256="$3"
+            local attempt
+
+            for attempt in 1 2 3; do
+              curl --fail --location --proto '=https' --tlsv1.2 \
+                --retry 3 --silent --show-error \
+                --output "$output" "$url"
+              if printf '%s  %s\n' "$expected_sha256" "$output" | \
+                  sha256sum --check --status; then
+                printf 'Verified %s at SHA-256 %s\n' "$url" "$expected_sha256"
+                return 0
+              fi
+              printf 'Downloaded bytes for %s failed SHA-256 verification (attempt %s/3)\n' \
+                "$url" "$attempt" >&2
+              sleep 1
+            done
+            return 1
+          }
+
           curl --fail --location --proto '=https' --tlsv1.2 \
             --retry 3 --silent --show-error \
             --output "$archive" "$SWIFT_TOOLCHAIN_URL"
-          curl --fail --location --proto '=https' --tlsv1.2 \
-            --retry 3 --silent --show-error \
-            --output "$signature" "$SWIFT_TOOLCHAIN_SIGNATURE_URL"
-          curl --fail --location --proto '=https' --tlsv1.2 \
-            --retry 3 --silent --show-error \
-            --output "$signing_keys" "$SWIFT_SIGNING_KEYS_URL"
+          download_verified \
+            "$SWIFT_TOOLCHAIN_SIGNATURE_URL" \
+            "$signature" \
+            "$SWIFT_TOOLCHAIN_SIGNATURE_SHA256"
+          download_verified \
+            "$SWIFT_SIGNING_KEYS_URL" \
+            "$signing_keys" \
+            "$SWIFT_SIGNING_KEYS_SHA256"
 
           mkdir -m 700 "$keyring_directory"
           gpg --batch --homedir "$keyring_directory" --import "$signing_keys"
@@ -398,6 +424,19 @@ jobs:
           test -x "$toolchain_bin/swift"
           test -x "$toolchain_bin/swiftc"
           printf '%s\n' "$toolchain_bin" >> "$GITHUB_PATH"
+
+          # GRDB 6.29.3 assumes Linux libsqlite exports snapshot functions.
+          # Ubuntu 22.04's libsqlite omits those optional symbols, so compile
+          # GRDB's documented custom-SQLite path against the detected runtime.
+          compiler_wrapper="$RUNNER_TEMP/swiftql-swiftc"
+          printf '%s\n' \
+            '#!/bin/bash' \
+            'exec "$SWIFTQL_REAL_SWIFTC" -DGRDBCUSTOMSQLITE "$@"' \
+            > "$compiler_wrapper"
+          chmod 755 "$compiler_wrapper"
+          printf 'SWIFTQL_REAL_SWIFTC=%s\n' "$toolchain_bin/swiftc" \
+            >> "$GITHUB_ENV"
+          printf 'SWIFT_EXEC=%s\n' "$compiler_wrapper" >> "$GITHUB_ENV"
 
       - name: Validate and report compiler environment
         env:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -492,10 +492,15 @@ jobs:
             -DSQLITE_ENABLE_COLUMN_METADATA \
             -DSQLITE_ENABLE_FTS5 \
             -DSQLITE_ENABLE_MATH_FUNCTIONS \
+            -DSQLITE_ENABLE_SNAPSHOT \
             -shared "$sqlite_source/sqlite3.c" \
             -o "$sqlite_prefix/lib/libsqlite3.so" \
             -ldl -lm -lpthread
           test -s "$sqlite_prefix/lib/libsqlite3.so"
+          sqlite_symbols="$RUNNER_TEMP/sqlite-3.53.3-symbols.txt"
+          nm -D --defined-only "$sqlite_prefix/lib/libsqlite3.so" \
+            > "$sqlite_symbols"
+          grep -Eq ' [[:alpha:]] sqlite3_snapshot_get$' "$sqlite_symbols"
           printf 'CPATH=%s\n' "$sqlite_prefix/include" >> "$GITHUB_ENV"
           printf 'LIBRARY_PATH=%s\n' "$sqlite_prefix/lib" >> "$GITHUB_ENV"
           printf 'LD_LIBRARY_PATH=%s\n' "$sqlite_prefix/lib" >> "$GITHUB_ENV"
@@ -504,9 +509,10 @@ jobs:
           printf 'SWIFTQL_SQLITE_LIBRARY_DIR=%s\n' \
             "$sqlite_prefix/lib" >> "$GITHUB_ENV"
 
-          # GRDB 6.29.3 assumes Linux SQLite exports optional snapshot symbols.
-          # The pinned amalgamation intentionally does not enable that optional
-          # API, so compile GRDB's documented custom-SQLite path.
+          # Keep GRDB on its documented custom-SQLite path while exposing the
+          # snapshot capability compiled into the pinned library. DatabasePool
+          # observations use that capability to avoid an unconditional second
+          # startup fetch when the database has not changed.
           # Keep the override beside swiftc so SwiftPM derives the matching
           # toolchain lib directory when it loads libIndexStore for discovery.
           compiler_wrapper="$toolchain_bin/swiftql-swiftc"
@@ -515,7 +521,7 @@ jobs:
             'if [[ "${1:-}" == "-modulewrap" ]]; then' \
             '  exec "$SWIFTQL_REAL_SWIFT_FRONTEND" "$@"' \
             'fi' \
-            'exec "$SWIFTQL_REAL_SWIFTC" -DGRDBCUSTOMSQLITE -Xcc -I -Xcc "$SWIFTQL_SQLITE_INCLUDE_DIR" -L "$SWIFTQL_SQLITE_LIBRARY_DIR" "$@"' \
+            'exec "$SWIFTQL_REAL_SWIFTC" -DGRDBCUSTOMSQLITE -DSQLITE_ENABLE_SNAPSHOT -Xcc -I -Xcc "$SWIFTQL_SQLITE_INCLUDE_DIR" -L "$SWIFTQL_SQLITE_LIBRARY_DIR" "$@"' \
             > "$compiler_wrapper"
           chmod 755 "$compiler_wrapper"
           printf 'SWIFTQL_REAL_SWIFTC=%s\n' "$toolchain_bin/swiftc" \

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -435,6 +435,7 @@ jobs:
           toolchain_bin="$RUNNER_TEMP/swift-5.9.2-RELEASE-ubuntu22.04/usr/bin"
           test -x "$toolchain_bin/swift"
           test -x "$toolchain_bin/swiftc"
+          test -x "$toolchain_bin/swift-frontend"
           printf '%s\n' "$toolchain_bin" >> "$GITHUB_PATH"
 
           # GRDB 6.29.3 assumes Linux libsqlite exports snapshot functions.
@@ -443,11 +444,16 @@ jobs:
           compiler_wrapper="$RUNNER_TEMP/swiftql-swiftc"
           printf '%s\n' \
             '#!/bin/bash' \
+            'if [[ "${1:-}" == "-modulewrap" ]]; then' \
+            '  exec "$SWIFTQL_REAL_SWIFT_FRONTEND" "$@"' \
+            'fi' \
             'exec "$SWIFTQL_REAL_SWIFTC" -DGRDBCUSTOMSQLITE "$@"' \
             > "$compiler_wrapper"
           chmod 755 "$compiler_wrapper"
           printf 'SWIFTQL_REAL_SWIFTC=%s\n' "$toolchain_bin/swiftc" \
             >> "$GITHUB_ENV"
+          printf 'SWIFTQL_REAL_SWIFT_FRONTEND=%s\n' \
+            "$toolchain_bin/swift-frontend" >> "$GITHUB_ENV"
           printf 'SWIFT_EXEC=%s\n' "$compiler_wrapper" >> "$GITHUB_ENV"
 
       - name: Validate and report compiler environment

--- a/Benchmarks/Sources/SwiftQLBenchmarkCLI/main.swift
+++ b/Benchmarks/Sources/SwiftQLBenchmarkCLI/main.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 import Foundation
 import SwiftQLBenchmarks
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -115,13 +115,16 @@ python3 scripts/ci/sqlite-conformance-inventory.py check
 The Swift 5.9 cells use GitHub's maintained Ubuntu 22.04 image and install the
 exact official Swift 5.9.2 Ubuntu 22.04 archive from Swift.org. CI verifies its
 detached signature against Swift's pinned signing-key fingerprint before
-extracting it. The signature and signing-key bundle bytes also have pinned
-SHA-256 digests with bounded download retries. SwiftQL uses Apple's Combine on
-Apple platforms and the exact OpenCombine 0.14.0 dependency on Linux. A small
-GRDB observation bridge preserves positive-demand startup, independent
-subscriber state, error delivery, and cancellation. The same publisher,
-retry-policy, codec, SQLite, macro, benchmark, and full-suite tests execute on
-Linux; the lane does not remove or skip the live-query surface.
+extracting it. The detached signature bytes also have a pinned SHA-256 digest
+with bounded download retries. The signing key comes from Swift.org's published
+bundle, with Swift's documented Ubuntu keyserver as an exact-fingerprint
+fallback; the imported full fingerprint is checked before signature
+verification. SwiftQL uses Apple's Combine on Apple platforms and the exact
+OpenCombine 0.14.0 dependency on Linux. A small GRDB observation bridge
+preserves positive-demand startup, independent subscriber state, error
+delivery, and cancellation. The same publisher, retry-policy, codec, SQLite,
+macro, benchmark, and full-suite tests execute on Linux; the lane does not
+remove or skip the live-query surface.
 
 Every cell verifies the compiler series, runner OS family, architecture, and
 target metadata, then reports the runner image version, dependency graph, and
@@ -385,15 +388,19 @@ The Swift 5.9 cells no longer use the hosted `macos-14` image that GitHub will
 retire on 2 November 2026. They use maintained `ubuntu-22.04` runners and
 install exact Swift 5.9.2 independently of Xcode. The archive and detached
 signature use immutable release URLs, and signature verification requires the
-pinned Swift project key fingerprint. The signature and key-bundle SHA-256
-digests reject wrong or transient response bodies before GPG runs. The download
-receives no repository secret or persistent runner access. Each job runs on a
-fresh GitHub-hosted VM with read-only contents permission.
+pinned Swift project key fingerprint. The detached-signature SHA-256 rejects a
+wrong or transient response body before GPG runs. The Swift.org signing-key
+bundle is allowed to evolve for revocations and key rotation; if it is not
+importable, the job retrieves only the pinned fingerprint from Swift's
+documented Ubuntu keyserver and verifies that fingerprint before use. The
+download receives no repository secret or persistent runner access. Each job
+runs on a fresh GitHub-hosted VM with read-only contents permission.
 
-Repository maintainers own the Swift.org release URLs, signature and key-bundle
-digests, signing-key fingerprint, OpenCombine pin, GRDB Linux compiler define,
-and environment pins. Review them when GitHub changes the Ubuntu 22.04 image,
-Swift publishes a signing-key revocation, or the GRDB/SQLite dependency changes.
+Repository maintainers own the Swift.org release URLs, signature digest,
+signing-key fingerprint and fallback, OpenCombine pin, GRDB Linux compiler
+define, and environment pins. Review them when GitHub changes the Ubuntu 22.04
+image, Swift publishes a signing-key revocation, or the GRDB/SQLite dependency
+changes.
 A missing or invalid download, signature, compiler, distribution, runner-family,
 architecture, target-triple, dependency, link, or OpenCombine bridge is a hard
 failure. Do not skip the lane or advance it to Swift 6 as recovery. If the exact

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -109,7 +109,7 @@ python3 scripts/ci/sqlite-conformance-inventory.py check
 
 | Support point | GitHub runner | Platform toolchain | Swift | Runtime surface |
 | --- | --- | --- | --- | --- |
-| Swift 5.9 | `ubuntu-22.04` | official Swift 5.9.2 Linux | 5.9.2 | GRDB + OpenCombine |
+| Swift 5.9 | `ubuntu-22.04` | official Swift 5.9.2 Linux | 5.9.2 | GRDB + OpenCombine + SQLite 3.53.3 |
 | Swift 6.0 | `macos-15` | Xcode 16.2 (`16C5032a`) | 6.0 series | macOS 15.2 SDK + Combine |
 
 The Swift 5.9 cells use GitHub's maintained Ubuntu 22.04 image and install the
@@ -126,6 +126,15 @@ delivery, and cancellation. The same publisher, retry-policy, codec, SQLite,
 macro, benchmark, and full-suite tests execute on Linux; the lane does not
 remove or skip the live-query surface.
 
+Ubuntu 22.04's system SQLite 3.37 predates `UNIXEPOCH`, which is a required
+capability in SwiftQL's real-SQLite conformance corpus. The Linux cells
+therefore compile and link the official SQLite 3.53.3 amalgamation from an
+immutable SQLite.org release URL. CI verifies SQLite's published SHA3-256
+before extraction, enables the FTS5, math-function, and column-metadata
+surfaces used by the package, and fails unless GRDB reports exact SQLite
+3.53.3. Required SQL capabilities remain executable instead of being skipped
+for the older runner library.
+
 Every cell verifies the compiler series, runner OS family, architecture, and
 target metadata, then reports the runner image version, dependency graph, and
 SQLite runtime. Linux additionally verifies exact Swift 5.9.2, Ubuntu 22.04,
@@ -134,13 +143,14 @@ Xcode version, build, and SDK. Toolchain or image drift therefore fails instead
 of silently redefining support.
 
 GRDB 6.29.3's Swift 5.9 Linux condition assumes the linked SQLite exports its
-optional snapshot symbols, while Ubuntu 22.04's system library omits them. The
-Linux cells consistently define GRDB's documented `GRDBCUSTOMSQLITE` build path
-through SwiftPM's compiler override. This removes only the unavailable snapshot
-API branch. The override delegates SwiftPM's module-wrapping phase directly to
-the matching `swift-frontend` and remains next to the selected compiler so
-SwiftPM loads that toolchain's index-store runtime. The runtime capability
-report and full tests remain authoritative for the linked system SQLite surface.
+optional snapshot symbols. The pinned amalgamation intentionally leaves that
+optional API disabled, so the Linux cells consistently define GRDB's documented
+`GRDBCUSTOMSQLITE` build path through SwiftPM's compiler override. This removes
+only the unavailable snapshot API branch. The override delegates SwiftPM's
+module-wrapping phase directly to the matching `swift-frontend` and remains next
+to the selected compiler so SwiftPM loads that toolchain's index-store runtime.
+The exact-version runtime probe, capability report, and full tests remain
+authoritative for the pinned SQLite surface.
 
 ## Swift 6 series coverage
 
@@ -193,8 +203,10 @@ command-line tool.
 ## Reproducing a cell
 
 On Ubuntu 22.04 x86_64, install exact Swift 5.9.2 so its `swift` and `swiftc`
-executables lead `PATH`, then run the environment check with the values from
-[`.github/workflows/swift.yml`](.github/workflows/swift.yml):
+executables lead `PATH`. Build official SQLite 3.53.3 with the exact URL,
+published SHA3-256, compiler flags, and library/include environment from
+[`.github/workflows/swift.yml`](.github/workflows/swift.yml), then run the
+environment check with the workflow values:
 
 ```sh
 EXPECTED_PLATFORM=linux \
@@ -399,13 +411,14 @@ download receives no repository secret or persistent runner access. Each job
 runs on a fresh GitHub-hosted VM with read-only contents permission.
 
 Repository maintainers own the Swift.org release URLs, signature digest,
-signing-key fingerprint and fallback, OpenCombine pin, GRDB Linux compiler
-define, and environment pins. Review them when GitHub changes the Ubuntu 22.04
-image, Swift publishes a signing-key revocation, or the GRDB/SQLite dependency
-changes.
+signing-key fingerprint and fallback, SQLite.org amalgamation URL and published
+SHA3-256, OpenCombine pin, GRDB Linux compiler define, and environment pins.
+Review them when GitHub changes the Ubuntu 22.04 image, Swift publishes a
+signing-key revocation, SQLite publishes a security update, or the GRDB/SQLite
+dependency changes.
 A missing or invalid download, signature, compiler, distribution, runner-family,
-architecture, target-triple, dependency, link, or OpenCombine bridge is a hard
-failure. Do not skip the lane or advance it to Swift 6 as recovery. If the exact
-toolchain can no longer run on the hosted image, move the same full-suite checks
-to a digest-pinned official Swift 5.9.2 container or another maintained provider
-before removing this strategy.
+architecture, target-triple, SQLite digest/version, dependency, link, or
+OpenCombine bridge is a hard failure. Do not skip the lane or advance it to
+Swift 6 as recovery. If the exact toolchain can no longer run on the hosted
+image, move the same full-suite checks to a digest-pinned official Swift 5.9.2
+container or another maintained provider before removing this strategy.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Compiler compatibility
 
-SwiftQL 1.x keeps `swift-tools-version: 5.9`. CI retains two pinned Apple
+SwiftQL 1.x keeps `swift-tools-version: 5.9`. CI retains two pinned compiler
 support points and also runs the complete package test suite with every Swift
 series currently listed by Swift Package Index: Swift 6.0 through Swift 6.3.
 All Swift 6 compilers run the package in Swift 5 language mode; SwiftQL does not
@@ -21,8 +21,10 @@ have separate responsibilities:
 - `swiftql-benchmark` is a repository performance diagnostic executable, not an
   application runtime dependency or a database adapter.
 
-The manifest's dependency lower bounds are SwiftSyntax 509.0.0, GRDB 6.29.3,
-and the Swift-DocC plugin 1.0.0. Committed-resolution jobs prove the checked-in
+The manifest's dependency bounds are SwiftSyntax 509.0.0, GRDB 6.29.3 or later,
+Swift-DocC plugin 1.0.0 or later, and exact OpenCombine 0.14.0. SwiftSyntax also
+retains its existing compatible-from-509.0.0 manifest range.
+Committed-resolution jobs prove the checked-in
 graph; clean-resolution jobs prove that the declared ranges still resolve and
 pass. The exact resolved versions and loaded SQLite source ID are CI evidence,
 not a promise that every future dependency version in those ranges is already
@@ -38,10 +40,11 @@ lease a different connection and prepare or cache a physical GRDB statement on
 that connection. These ownership rules are part of the supported API contract,
 not only implementation details.
 
-SwiftQL currently ships only a SQLite dialect and a GRDB database driver. The
-core protocols are extension seams, not claims that another dialect, driver,
-Linux runtime, nested transaction/savepoint API, asynchronous cursor, or
-Swift 6 language mode is supported in v1.3.
+SwiftQL currently ships only a SQLite dialect and a GRDB database driver. Apple
+platforms use Combine; Linux uses OpenCombine for the same request-publisher
+surface. The core protocols are extension seams, not claims that another
+dialect, driver, nested transaction/savepoint API, asynchronous cursor, or
+Swift 6 language mode is supported.
 
 ## SQLite conformance inventory
 
@@ -102,27 +105,26 @@ matches the canonical inventory with:
 python3 scripts/ci/sqlite-conformance-inventory.py check
 ```
 
-## Pinned Apple support points
+## Pinned compiler support points
 
-| Support point | GitHub runner | Xcode | Swift | macOS SDK |
+| Support point | GitHub runner | Platform toolchain | Swift | Runtime surface |
 | --- | --- | --- | --- | --- |
-| Swift 5.9 | `macos-15-intel` | 16.2 (`16C5032a`) | 5.9.2 standalone | 15.2 |
-| Swift 6.0 | `macos-15` | 16.2 (`16C5032a`) | 6.0 series | 15.2 |
+| Swift 5.9 | `ubuntu-22.04` | official Swift 5.9.2 Linux | 5.9.2 | GRDB + OpenCombine |
+| Swift 6.0 | `macos-15` | Xcode 16.2 (`16C5032a`) | 6.0 series | macOS 15.2 SDK + Combine |
 
-The Swift 5.9 cells use GitHub's maintained Intel macOS 15 image and install the
-exact Swift 5.9.2 release package from Swift.org. The workflow pins the official
-download URL and SHA-256, requires Swift.org's Apple-issued installer identity,
-and checks both installed compiler executables. Xcode 16.2 supplies the pinned
-macOS 15.2 SDK and Apple Combine framework, but it does not supply the compiler:
-the environment gate requires `swift` to resolve from `PATH`, rejects the
-`/usr/bin/swift` Xcode dispatcher, and verifies the exact 5.9.2 version. The
-Swift 6.0 cells continue to select Xcode's compiler with `xcrun`.
+The Swift 5.9 cells use GitHub's maintained Ubuntu 22.04 image and install exact
+Swift 5.9.2 with a commit-pinned setup action. SwiftQL uses Apple's Combine on
+Apple platforms and the exact OpenCombine 0.14.0 dependency on Linux. A small
+GRDB observation bridge preserves positive-demand startup, independent
+subscriber state, error delivery, and cancellation. The same publisher,
+retry-policy, codec, SQLite, macro, benchmark, and full-suite tests execute on
+Linux; the lane does not remove or skip the live-query surface.
 
-Every cell verifies the exact Xcode version and build, compiler series, SDK,
-runner OS family, and architecture, then reports the compiler target metadata,
-OS version, runner image version, dependency graph, and SQLite runtime. An
-image update that removes Xcode 16.2, changes its SDK, changes architecture, or
-causes the standalone toolchain selection to fall back therefore fails instead
+Every cell verifies the compiler series, runner OS family, architecture, and
+target metadata, then reports the runner image version, dependency graph, and
+SQLite runtime. Linux additionally verifies exact Swift 5.9.2, Ubuntu 22.04,
+and the `x86_64-unknown-linux-gnu` target. macOS additionally verifies the exact
+Xcode version, build, and SDK. Toolchain or image drift therefore fails instead
 of silently redefining support.
 
 ## Swift 6 series coverage
@@ -141,9 +143,9 @@ series and SDK, resolves dependencies without either committed lockfile, runs
 the first-party warning gate, executes the SQLite runtime probe, and runs the
 complete test suite.
 
-SwiftQL imports Apple Combine and supports Apple platforms, so the compiler
-series lanes use Apple SDKs. Linux Swift toolchains do not ship Combine and are
-not presented as supported-platform evidence.
+Apple builds continue to expose Apple's Combine types without source or ABI
+changes. Linux builds import matching OpenCombine types and exercise the same
+typed publisher contracts through real GRDB observations.
 
 The compatibility test target contains a compile-time `#if swift(>=6.0)`
 failure. Because `swift()` tests the active language mode, every Swift 6.0–6.3
@@ -151,7 +153,7 @@ job proves that SwiftQL remains in Swift 5 language mode.
 
 ## Dependency resolution
 
-Each pinned Apple support point runs two independent dependency modes:
+Each pinned compiler support point runs two independent dependency modes:
 
 - **Committed resolution** uses the checked-in `Package.resolved` and fails if
   resolution changes it.
@@ -175,19 +177,20 @@ command-line tool.
 
 ## Reproducing a cell
 
-Install the exact Swift 5.9.2 release toolchain so its `swift` and `swiftc`
-executables lead `PATH`, select the same Xcode, and run the environment check
-with the values from [`.github/workflows/swift.yml`](.github/workflows/swift.yml):
+On Ubuntu 22.04 x86_64, install exact Swift 5.9.2 so its `swift` and `swiftc`
+executables lead `PATH`, then run the environment check with the values from
+[`.github/workflows/swift.yml`](.github/workflows/swift.yml):
 
 ```sh
-export DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer
-EXPECTED_XCODE_VERSION=16.2 \
-EXPECTED_XCODE_BUILD=16C5032a \
+EXPECTED_PLATFORM=linux \
 EXPECTED_SWIFT_SERIES=5.9 \
 EXPECTED_SWIFT_VERSION=5.9.2 \
 EXPECTED_SWIFT_COMMAND_MODE=path \
-EXPECTED_SDK_VERSION=15.2 \
-EXPECTED_DEVELOPER_DIR="$DEVELOPER_DIR" \
+EXPECTED_IMAGE_OS=ubuntu22 \
+EXPECTED_ARCHITECTURE=x86_64 \
+EXPECTED_OS_ID=ubuntu \
+EXPECTED_OS_VERSION_ID=22.04 \
+EXPECTED_TARGET_TRIPLE=x86_64-unknown-linux-gnu \
 scripts/ci/check-compatibility-environment.sh
 
 swift package resolve
@@ -355,9 +358,10 @@ warnings in separate, searchable sections for every applicable cell:
 - Complete strict-concurrency warnings are release blockers in the pinned Swift
   6.0 cells; `check-strict-concurrency.sh` enforces that boundary after the
   standard build and tests.
-- Verbose builds on both pinned Apple support points currently emit
+- Verbose builds on both pinned compiler support points currently emit
   dependency-prefixed manifest compiler command lines for `swift-docc-plugin`,
-  `grdb.swift`, `swift-syntax`, and `swift-docc-symbolkit`. They are recorded
+  `grdb.swift`, `swift-syntax`, `OpenCombine`, and `swift-docc-symbolkit`. They
+  are recorded
   separately under the gate's dependency-warning section. The structurally
   identified root `Package.swift` compiler invocation is reported as
   build-system output rather than a source warning. Exact resolved versions are
@@ -368,18 +372,17 @@ The matrix suppresses neither category.
 ## Swift 5.9 runner maintenance and recovery
 
 The Swift 5.9 cells no longer use the hosted `macos-14` image that GitHub will
-retire on 2 November 2026. They use maintained `macos-15-intel` runners, which
-GitHub currently supports through August 2027, and install Swift 5.9.2
-independently of Xcode. The official package is pinned by SHA-256 and verified
-against the `Developer ID Installer: Swift Open Source (V9AUD2URP3)` identity
-before installation. The download and installer need no repository token,
-secret, or persistent runner access. Each job runs on a fresh GitHub-hosted VM.
+retire on 2 November 2026. They use maintained `ubuntu-22.04` runners and
+install exact Swift 5.9.2 independently of Xcode. The setup action is pinned to
+an immutable commit and receives no repository secret or persistent runner
+access. Each job runs on a fresh GitHub-hosted VM with read-only contents
+permission.
 
-Repository maintainers own the package SHA-256 and environment pins. Review them
-when GitHub changes the `macos-15-intel` image or Swift.org republishes the
-release artifact. A missing download, checksum/signature failure, Xcode/SDK
-drift, unexpected runner family/architecture, or compiler fallback is a hard
-failure. Do not skip the lane or advance it to Swift 6 as recovery. If the exact
-toolchain can no longer run on GitHub-hosted macOS, move the same checks to a
-maintained macOS runner or immutable provider with verified Swift 5.9.2 and an
-Apple SDK that passes the complete suite before removing this strategy.
+Repository maintainers own the action SHA, OpenCombine pin, and environment
+pins. Review them when GitHub changes the Ubuntu 22.04 image or the setup action
+publishes a security or availability update. A missing download, compiler,
+distribution, runner-family, architecture, target-triple, dependency, or
+OpenCombine bridge failure is a hard failure. Do not skip the lane or advance
+it to Swift 6 as recovery. If the exact toolchain can no longer run on the
+hosted image, move the same full-suite checks to a digest-pinned official Swift
+5.9.2 container or another maintained provider before removing this strategy.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -110,9 +110,10 @@ python3 scripts/ci/sqlite-conformance-inventory.py check
 | Swift 6.0 | `macos-15` | 16.2 (`16C5032a`) | 6.0 series | 15.2 |
 
 The Swift 5.9 cells use GitHub's maintained Intel macOS 15 image and install the
-exact Swift 5.9.2 release toolchain with the commit-pinned
-`swift-actions/setup-swift` action. Xcode 16.2 supplies the pinned macOS 15.2
-SDK and Apple Combine framework, but it does not supply the compiler:
+exact Swift 5.9.2 release package from Swift.org. The workflow pins the official
+download URL and SHA-256, requires Swift.org's Apple-issued installer identity,
+and checks both installed compiler executables. Xcode 16.2 supplies the pinned
+macOS 15.2 SDK and Apple Combine framework, but it does not supply the compiler:
 the environment gate requires `swift` to resolve from `PATH`, rejects the
 `/usr/bin/swift` Xcode dispatcher, and verifies the exact 5.9.2 version. The
 Swift 6.0 cells continue to select Xcode's compiler with `xcrun`.
@@ -369,15 +370,14 @@ The matrix suppresses neither category.
 The Swift 5.9 cells no longer use the hosted `macos-14` image that GitHub will
 retire on 2 November 2026. They use maintained `macos-15-intel` runners, which
 GitHub currently supports through August 2027, and install Swift 5.9.2
-independently of Xcode. The setup action is pinned to an immutable
-commit, requests an exact compiler patch release, verifies the downloaded
-toolchain, and needs no repository secret or persistent runner access. Each job
-runs on a fresh GitHub-hosted VM; the action receives only the default
-read-only repository token boundary used by the workflow.
+independently of Xcode. The official package is pinned by SHA-256 and verified
+against the `Developer ID Installer: Swift Open Source (V9AUD2URP3)` identity
+before installation. The download and installer need no repository token,
+secret, or persistent runner access. Each job runs on a fresh GitHub-hosted VM.
 
-Repository maintainers own the action SHA and environment pins. Review them
-when GitHub changes the `macos-15-intel` image or when the setup action publishes a
-security or availability update. A missing download, action failure, Xcode/SDK
+Repository maintainers own the package SHA-256 and environment pins. Review them
+when GitHub changes the `macos-15-intel` image or Swift.org republishes the
+release artifact. A missing download, checksum/signature failure, Xcode/SDK
 drift, unexpected runner family/architecture, or compiler fallback is a hard
 failure. Do not skip the lane or advance it to Swift 6 as recovery. If the exact
 toolchain can no longer run on GitHub-hosted macOS, move the same checks to a

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -137,8 +137,9 @@ GRDB 6.29.3's Swift 5.9 Linux condition assumes the linked SQLite exports its
 optional snapshot symbols, while Ubuntu 22.04's system library omits them. The
 Linux cells consistently define GRDB's documented `GRDBCUSTOMSQLITE` build path
 through SwiftPM's compiler override. This removes only the unavailable snapshot
-API branch; the runtime capability report and full tests remain authoritative
-for the linked system SQLite surface.
+API branch. The override delegates SwiftPM's module-wrapping phase directly to
+the matching `swift-frontend`; the runtime capability report and full tests
+remain authoritative for the linked system SQLite surface.
 
 ## Swift 6 series coverage
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -138,8 +138,9 @@ optional snapshot symbols, while Ubuntu 22.04's system library omits them. The
 Linux cells consistently define GRDB's documented `GRDBCUSTOMSQLITE` build path
 through SwiftPM's compiler override. This removes only the unavailable snapshot
 API branch. The override delegates SwiftPM's module-wrapping phase directly to
-the matching `swift-frontend`; the runtime capability report and full tests
-remain authoritative for the linked system SQLite surface.
+the matching `swift-frontend` and remains next to the selected compiler so
+SwiftPM loads that toolchain's index-store runtime. The runtime capability
+report and full tests remain authoritative for the linked system SQLite surface.
 
 ## Swift 6 series coverage
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -112,13 +112,15 @@ python3 scripts/ci/sqlite-conformance-inventory.py check
 | Swift 5.9 | `ubuntu-22.04` | official Swift 5.9.2 Linux | 5.9.2 | GRDB + OpenCombine |
 | Swift 6.0 | `macos-15` | Xcode 16.2 (`16C5032a`) | 6.0 series | macOS 15.2 SDK + Combine |
 
-The Swift 5.9 cells use GitHub's maintained Ubuntu 22.04 image and install exact
-Swift 5.9.2 with a commit-pinned setup action. SwiftQL uses Apple's Combine on
-Apple platforms and the exact OpenCombine 0.14.0 dependency on Linux. A small
-GRDB observation bridge preserves positive-demand startup, independent
-subscriber state, error delivery, and cancellation. The same publisher,
-retry-policy, codec, SQLite, macro, benchmark, and full-suite tests execute on
-Linux; the lane does not remove or skip the live-query surface.
+The Swift 5.9 cells use GitHub's maintained Ubuntu 22.04 image and install the
+exact official Swift 5.9.2 Ubuntu 22.04 archive from Swift.org. CI verifies its
+detached signature against Swift's pinned signing-key fingerprint before
+extracting it. SwiftQL uses Apple's Combine on Apple platforms and the exact
+OpenCombine 0.14.0 dependency on Linux. A small GRDB observation bridge
+preserves positive-demand startup, independent subscriber state, error
+delivery, and cancellation. The same publisher, retry-policy, codec, SQLite,
+macro, benchmark, and full-suite tests execute on Linux; the lane does not
+remove or skip the live-query surface.
 
 Every cell verifies the compiler series, runner OS family, architecture, and
 target metadata, then reports the runner image version, dependency graph, and
@@ -373,16 +375,18 @@ The matrix suppresses neither category.
 
 The Swift 5.9 cells no longer use the hosted `macos-14` image that GitHub will
 retire on 2 November 2026. They use maintained `ubuntu-22.04` runners and
-install exact Swift 5.9.2 independently of Xcode. The setup action is pinned to
-an immutable commit and receives no repository secret or persistent runner
-access. Each job runs on a fresh GitHub-hosted VM with read-only contents
-permission.
+install exact Swift 5.9.2 independently of Xcode. The archive and detached
+signature use immutable release URLs, and signature verification requires the
+pinned Swift project key fingerprint. The download receives no repository
+secret or persistent runner access. Each job runs on a fresh GitHub-hosted VM
+with read-only contents permission.
 
-Repository maintainers own the action SHA, OpenCombine pin, and environment
-pins. Review them when GitHub changes the Ubuntu 22.04 image or the setup action
-publishes a security or availability update. A missing download, compiler,
-distribution, runner-family, architecture, target-triple, dependency, or
-OpenCombine bridge failure is a hard failure. Do not skip the lane or advance
-it to Swift 6 as recovery. If the exact toolchain can no longer run on the
-hosted image, move the same full-suite checks to a digest-pinned official Swift
-5.9.2 container or another maintained provider before removing this strategy.
+Repository maintainers own the Swift.org release URLs, signing-key fingerprint,
+OpenCombine pin, and environment pins. Review them when GitHub changes the
+Ubuntu 22.04 image or Swift publishes a signing-key revocation. A missing or
+invalid download, signature, compiler, distribution, runner-family,
+architecture, target-triple, dependency, or OpenCombine bridge is a hard
+failure. Do not skip the lane or advance it to Swift 6 as recovery. If the exact
+toolchain can no longer run on the hosted image, move the same full-suite checks
+to a digest-pinned official Swift 5.9.2 container or another maintained provider
+before removing this strategy.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -106,12 +106,13 @@ python3 scripts/ci/sqlite-conformance-inventory.py check
 
 | Support point | GitHub runner | Xcode | Swift | macOS SDK |
 | --- | --- | --- | --- | --- |
-| Swift 5.9 | `macos-15` | 16.2 (`16C5032a`) | 5.9.2 standalone | 15.2 |
+| Swift 5.9 | `macos-15-intel` | 16.2 (`16C5032a`) | 5.9.2 standalone | 15.2 |
 | Swift 6.0 | `macos-15` | 16.2 (`16C5032a`) | 6.0 series | 15.2 |
 
-The Swift 5.9 cells install the exact Swift 5.9.2 release toolchain with the
-commit-pinned `swift-actions/setup-swift` action. Xcode 16.2 supplies the pinned
-macOS 15.2 SDK and Apple Combine framework, but it does not supply the compiler:
+The Swift 5.9 cells use GitHub's maintained Intel macOS 15 image and install the
+exact Swift 5.9.2 release toolchain with the commit-pinned
+`swift-actions/setup-swift` action. Xcode 16.2 supplies the pinned macOS 15.2
+SDK and Apple Combine framework, but it does not supply the compiler:
 the environment gate requires `swift` to resolve from `PATH`, rejects the
 `/usr/bin/swift` Xcode dispatcher, and verifies the exact 5.9.2 version. The
 Swift 6.0 cells continue to select Xcode's compiler with `xcrun`.
@@ -366,15 +367,16 @@ The matrix suppresses neither category.
 ## Swift 5.9 runner maintenance and recovery
 
 The Swift 5.9 cells no longer use the hosted `macos-14` image that GitHub will
-retire on 2 November 2026. They use maintained `macos-15` runners and install
-Swift 5.9.2 independently of Xcode. The setup action is pinned to an immutable
+retire on 2 November 2026. They use maintained `macos-15-intel` runners, which
+GitHub currently supports through August 2027, and install Swift 5.9.2
+independently of Xcode. The setup action is pinned to an immutable
 commit, requests an exact compiler patch release, verifies the downloaded
 toolchain, and needs no repository secret or persistent runner access. Each job
 runs on a fresh GitHub-hosted VM; the action receives only the default
 read-only repository token boundary used by the workflow.
 
 Repository maintainers own the action SHA and environment pins. Review them
-when GitHub changes the `macos-15` image or when the setup action publishes a
+when GitHub changes the `macos-15-intel` image or when the setup action publishes a
 security or availability update. A missing download, action failure, Xcode/SDK
 drift, unexpected runner family/architecture, or compiler fallback is a hard
 failure. Do not skip the lane or advance it to Swift 6 as recovery. If the exact

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -106,14 +106,22 @@ python3 scripts/ci/sqlite-conformance-inventory.py check
 
 | Support point | GitHub runner | Xcode | Swift | macOS SDK |
 | --- | --- | --- | --- | --- |
-| Swift 5.9 | `macos-14` | 15.2 (`15C500b`) | 5.9 series | 14.2 |
+| Swift 5.9 | `macos-15` | 16.2 (`16C5032a`) | 5.9.2 standalone | 15.2 |
 | Swift 6.0 | `macos-15` | 16.2 (`16C5032a`) | 6.0 series | 15.2 |
 
-The workflow selects Xcode with an exact `DEVELOPER_DIR`, verifies the Xcode
-version and build number, verifies the compiler family and SDK, and reports the
-complete compiler, OS, runner image, and architecture details. A runner image
-update that removes or changes a selected toolchain therefore fails instead of
-silently redefining support.
+The Swift 5.9 cells install the exact Swift 5.9.2 release toolchain with the
+commit-pinned `swift-actions/setup-swift` action. Xcode 16.2 supplies the pinned
+macOS 15.2 SDK and Apple Combine framework, but it does not supply the compiler:
+the environment gate requires `swift` to resolve from `PATH`, rejects the
+`/usr/bin/swift` Xcode dispatcher, and verifies the exact 5.9.2 version. The
+Swift 6.0 cells continue to select Xcode's compiler with `xcrun`.
+
+Every cell verifies the exact Xcode version and build, compiler series, SDK,
+runner OS family, and architecture, then reports the compiler target metadata,
+OS version, runner image version, dependency graph, and SQLite runtime. An
+image update that removes Xcode 16.2, changes its SDK, changes architecture, or
+causes the standalone toolchain selection to fall back therefore fails instead
+of silently redefining support.
 
 ## Swift 6 series coverage
 
@@ -165,23 +173,26 @@ command-line tool.
 
 ## Reproducing a cell
 
-Select the same Xcode and run the environment check with the values from
-[`.github/workflows/swift.yml`](.github/workflows/swift.yml):
+Install the exact Swift 5.9.2 release toolchain so its `swift` and `swiftc`
+executables lead `PATH`, select the same Xcode, and run the environment check
+with the values from [`.github/workflows/swift.yml`](.github/workflows/swift.yml):
 
 ```sh
-export DEVELOPER_DIR=/Applications/Xcode_15.2.app/Contents/Developer
-EXPECTED_XCODE_VERSION=15.2 \
-EXPECTED_XCODE_BUILD=15C500b \
+export DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer
+EXPECTED_XCODE_VERSION=16.2 \
+EXPECTED_XCODE_BUILD=16C5032a \
 EXPECTED_SWIFT_SERIES=5.9 \
-EXPECTED_SDK_VERSION=14.2 \
+EXPECTED_SWIFT_VERSION=5.9.2 \
+EXPECTED_SWIFT_COMMAND_MODE=path \
+EXPECTED_SDK_VERSION=15.2 \
 EXPECTED_DEVELOPER_DIR="$DEVELOPER_DIR" \
 scripts/ci/check-compatibility-environment.sh
 
-xcrun swift package resolve
+swift package resolve
 scripts/ci/report-resolved-dependencies.sh
 scripts/ci/check-first-party-warnings.sh
-xcrun swift test --filter XLCompatibilityReportTests
-xcrun swift test --skip-build -v
+swift test --filter XLCompatibilityReportTests
+swift test --skip-build -v
 ```
 
 To reproduce clean resolution without modifying the checkout:
@@ -192,11 +203,11 @@ git archive --format=tar HEAD | tar -xf - -C "$clean_source"
 rm "$clean_source/Package.resolved"
 cd "$clean_source"
 
-xcrun swift package resolve
+swift package resolve
 scripts/ci/report-resolved-dependencies.sh
 scripts/ci/check-first-party-warnings.sh
-xcrun swift test --filter XLCompatibilityReportTests
-xcrun swift test --skip-build -v
+swift test --filter XLCompatibilityReportTests
+swift test --skip-build -v
 ```
 
 The workflow is the canonical executable specification for both procedures.
@@ -352,11 +363,21 @@ warnings in separate, searchable sections for every applicable cell:
 
 The matrix suppresses neither category.
 
-## Hosted runner lifetime
+## Swift 5.9 runner maintenance and recovery
 
-GitHub has announced that hosted `macos-14` runners will be retired on
-2 November 2026. Later hosted macOS images do not include Xcode 15, so replacing
-the real Swift 5.9 lane requires a maintained self-hosted environment or another
-pinned toolchain strategy. [#164](https://github.com/lukevanin/swiftql/issues/164)
-tracks that migration; the Swift 5.9 gate must not be removed or advanced
-silently.
+The Swift 5.9 cells no longer use the hosted `macos-14` image that GitHub will
+retire on 2 November 2026. They use maintained `macos-15` runners and install
+Swift 5.9.2 independently of Xcode. The setup action is pinned to an immutable
+commit, requests an exact compiler patch release, verifies the downloaded
+toolchain, and needs no repository secret or persistent runner access. Each job
+runs on a fresh GitHub-hosted VM; the action receives only the default
+read-only repository token boundary used by the workflow.
+
+Repository maintainers own the action SHA and environment pins. Review them
+when GitHub changes the `macos-15` image or when the setup action publishes a
+security or availability update. A missing download, action failure, Xcode/SDK
+drift, unexpected runner family/architecture, or compiler fallback is a hard
+failure. Do not skip the lane or advance it to Swift 6 as recovery. If the exact
+toolchain can no longer run on GitHub-hosted macOS, move the same checks to a
+maintained macOS runner or immutable provider with verified Swift 5.9.2 and an
+Apple SDK that passes the complete suite before removing this strategy.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -115,12 +115,13 @@ python3 scripts/ci/sqlite-conformance-inventory.py check
 The Swift 5.9 cells use GitHub's maintained Ubuntu 22.04 image and install the
 exact official Swift 5.9.2 Ubuntu 22.04 archive from Swift.org. CI verifies its
 detached signature against Swift's pinned signing-key fingerprint before
-extracting it. SwiftQL uses Apple's Combine on Apple platforms and the exact
-OpenCombine 0.14.0 dependency on Linux. A small GRDB observation bridge
-preserves positive-demand startup, independent subscriber state, error
-delivery, and cancellation. The same publisher, retry-policy, codec, SQLite,
-macro, benchmark, and full-suite tests execute on Linux; the lane does not
-remove or skip the live-query surface.
+extracting it. The signature and signing-key bundle bytes also have pinned
+SHA-256 digests with bounded download retries. SwiftQL uses Apple's Combine on
+Apple platforms and the exact OpenCombine 0.14.0 dependency on Linux. A small
+GRDB observation bridge preserves positive-demand startup, independent
+subscriber state, error delivery, and cancellation. The same publisher,
+retry-policy, codec, SQLite, macro, benchmark, and full-suite tests execute on
+Linux; the lane does not remove or skip the live-query surface.
 
 Every cell verifies the compiler series, runner OS family, architecture, and
 target metadata, then reports the runner image version, dependency graph, and
@@ -128,6 +129,13 @@ SQLite runtime. Linux additionally verifies exact Swift 5.9.2, Ubuntu 22.04,
 and the `x86_64-unknown-linux-gnu` target. macOS additionally verifies the exact
 Xcode version, build, and SDK. Toolchain or image drift therefore fails instead
 of silently redefining support.
+
+GRDB 6.29.3's Swift 5.9 Linux condition assumes the linked SQLite exports its
+optional snapshot symbols, while Ubuntu 22.04's system library omits them. The
+Linux cells consistently define GRDB's documented `GRDBCUSTOMSQLITE` build path
+through SwiftPM's compiler override. This removes only the unavailable snapshot
+API branch; the runtime capability report and full tests remain authoritative
+for the linked system SQLite surface.
 
 ## Swift 6 series coverage
 
@@ -377,15 +385,17 @@ The Swift 5.9 cells no longer use the hosted `macos-14` image that GitHub will
 retire on 2 November 2026. They use maintained `ubuntu-22.04` runners and
 install exact Swift 5.9.2 independently of Xcode. The archive and detached
 signature use immutable release URLs, and signature verification requires the
-pinned Swift project key fingerprint. The download receives no repository
-secret or persistent runner access. Each job runs on a fresh GitHub-hosted VM
-with read-only contents permission.
+pinned Swift project key fingerprint. The signature and key-bundle SHA-256
+digests reject wrong or transient response bodies before GPG runs. The download
+receives no repository secret or persistent runner access. Each job runs on a
+fresh GitHub-hosted VM with read-only contents permission.
 
-Repository maintainers own the Swift.org release URLs, signing-key fingerprint,
-OpenCombine pin, and environment pins. Review them when GitHub changes the
-Ubuntu 22.04 image or Swift publishes a signing-key revocation. A missing or
-invalid download, signature, compiler, distribution, runner-family,
-architecture, target-triple, dependency, or OpenCombine bridge is a hard
+Repository maintainers own the Swift.org release URLs, signature and key-bundle
+digests, signing-key fingerprint, OpenCombine pin, GRDB Linux compiler define,
+and environment pins. Review them when GitHub changes the Ubuntu 22.04 image,
+Swift publishes a signing-key revocation, or the GRDB/SQLite dependency changes.
+A missing or invalid download, signature, compiler, distribution, runner-family,
+architecture, target-triple, dependency, link, or OpenCombine bridge is a hard
 failure. Do not skip the lane or advance it to Swift 6 as recovery. If the exact
 toolchain can no longer run on the hosted image, move the same full-suite checks
 to a digest-pinned official Swift 5.9.2 container or another maintained provider

--- a/IntegrationTests/Swift5Client/Package.resolved
+++ b/IntegrationTests/Swift5Client/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "opencombine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OpenCombine/OpenCombine.git",
+      "state" : {
+        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+        "version" : "0.14.0"
+      }
+    },
+    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin.git",

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "opencombine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OpenCombine/OpenCombine.git",
+      "state" : {
+        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+        "version" : "0.14.0"
+      }
+    },
+    {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin.git",

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
         .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.29.3"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
+        .package(url: "https://github.com/OpenCombine/OpenCombine.git", exact: "0.14.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -86,6 +87,9 @@ let package = Package(
                 "SwiftQLCore",
                 "SQLMacros",
                 .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "OpenCombine", package: "OpenCombine"),
+                .product(name: "OpenCombineDispatch", package: "OpenCombine"),
+                .product(name: "OpenCombineFoundation", package: "OpenCombine"),
             ]
         ),
 
@@ -155,6 +159,9 @@ let package = Package(
                 "SwiftQLNorthwindFixtures",
                 "SwiftQLSQLiteConformanceFixtures",
                 .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "OpenCombine", package: "OpenCombine"),
+                .product(name: "OpenCombineDispatch", package: "OpenCombine"),
+                .product(name: "OpenCombineFoundation", package: "OpenCombine"),
             ]
         ),
 
@@ -166,6 +173,7 @@ let package = Package(
                 "SwiftQL",
                 "SwiftQLSQLiteConformanceFixtures",
                 .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "OpenCombine", package: "OpenCombine"),
             ]
         ),
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@
 <p align="center">
   <a href="https://github.com/lukevanin/swiftql/actions/workflows/swift.yml?query=branch%3Amain"><img alt="Build and CI status" src="https://img.shields.io/github/actions/workflow/status/lukevanin/swiftql/swift.yml?branch=main&amp;label=build%20%26%20CI"></a>
   <a href="https://github.com/lukevanin/swiftql/actions/workflows/documentation.yml?query=branch%3Amain"><img alt="Documentation status" src="https://img.shields.io/github/actions/workflow/status/lukevanin/swiftql/documentation.yml?branch=main&amp;label=documentation"></a>
-  <a href="COMPATIBILITY.md#pinned-apple-support-points"><img alt="Swift 5.9 CI" src="https://img.shields.io/badge/Swift-5.9-F05138?logo=swift&amp;logoColor=white"></a>
+  <a href="COMPATIBILITY.md#pinned-compiler-support-points"><img alt="Swift 5.9 CI" src="https://img.shields.io/badge/Swift-5.9-F05138?logo=swift&amp;logoColor=white"></a>
   <a href="COMPATIBILITY.md#swift-6-series-coverage"><img alt="Swift 6.0 CI" src="https://img.shields.io/badge/Swift-6.0-F05138?logo=swift&amp;logoColor=white"></a>
   <a href="COMPATIBILITY.md#swift-6-series-coverage"><img alt="Swift 6.1 CI" src="https://img.shields.io/badge/Swift-6.1-F05138?logo=swift&amp;logoColor=white"></a>
   <a href="COMPATIBILITY.md#swift-6-series-coverage"><img alt="Swift 6.2 CI" src="https://img.shields.io/badge/Swift-6.2-F05138?logo=swift&amp;logoColor=white"></a>
   <a href="COMPATIBILITY.md#swift-6-series-coverage"><img alt="Swift 6.3 CI" src="https://img.shields.io/badge/Swift-6.3-F05138?logo=swift&amp;logoColor=white"></a>
-  <a href="Package.swift"><img alt="Supported platforms: iOS 16 or later and macOS 13 or later" src="https://img.shields.io/badge/platforms-iOS%2016%2B%20%7C%20macOS%2013%2B-lightgrey"></a>
+  <a href="COMPATIBILITY.md#pinned-compiler-support-points"><img alt="Supported platforms: iOS 16 or later, macOS 13 or later, and Linux" src="https://img.shields.io/badge/platforms-iOS%2016%2B%20%7C%20macOS%2013%2B%20%7C%20Linux-lightgrey"></a>
   <a href="https://swiftpackageindex.com/lukevanin/swiftql"><img alt="Swift Package Index Swift version compatibility" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Flukevanin%2Fswiftql%2Fbadge%3Ftype%3Dswift-versions"></a>
   <a href="https://github.com/lukevanin/swiftql/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/lukevanin/swiftql?sort=semver"></a>
   <a href="LICENSE.md"><img alt="MIT license" src="https://img.shields.io/github/license/lukevanin/swiftql"></a>

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationCLIOptions.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationCLIOptions.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 
-package struct SQLiteBuildValidationCLIOptions: Equatable, Sendable {
+// Swift 5.9's Linux Foundation predates URL's Sendable annotation. Options are
+// immutable values, and newer Foundation versions declare URL Sendable.
+package struct SQLiteBuildValidationCLIOptions: Equatable, @unchecked Sendable {
     package let databaseURL: URL?
     package let planURL: URL?
     package let outputURL: URL?

--- a/Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift
+++ b/Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift
@@ -1,4 +1,9 @@
+#if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+import OpenCombineDispatch
+#endif
 import Dispatch
 import Foundation
 import GRDB

--- a/Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift
+++ b/Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift
@@ -39,7 +39,7 @@ struct GRDBOpenCombineValuePublisher<Output>: Publisher {
 private final class GRDBOpenCombineValueSubscription<Downstream>: Subscription
 where Downstream: Subscriber, Downstream.Failure == Error {
 
-    private typealias Start = (
+    fileprivate typealias Start = (
         @escaping (Error) -> Void,
         @escaping (Downstream.Input) -> Void
     ) -> AnyDatabaseCancellable
@@ -57,7 +57,7 @@ where Downstream: Subscriber, Downstream.Failure == Error {
     private var cancellable: AnyDatabaseCancellable?
     private var state: State
 
-    init(start: @escaping Start, downstream: Downstream) {
+    fileprivate init(start: @escaping Start, downstream: Downstream) {
         state = .waiting(start: start, downstream: downstream)
     }
 

--- a/Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift
+++ b/Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift
@@ -1,0 +1,154 @@
+#if !canImport(Combine)
+import Foundation
+import GRDB
+import OpenCombine
+
+
+/// OpenCombine bridge for GRDB value observations on non-Apple platforms.
+///
+/// GRDB's native publisher is compiled only when Apple's Combine module is
+/// available. This bridge preserves the same demand-driven lifecycle: the
+/// SQLite observation does not start until positive demand arrives, and every
+/// subscriber owns an independent observation and cancellation token.
+struct GRDBOpenCombineValuePublisher<Output>: Publisher {
+
+    typealias Failure = Error
+
+    typealias Start = (
+        @escaping (Error) -> Void,
+        @escaping (Output) -> Void
+    ) -> AnyDatabaseCancellable
+
+    private let start: Start
+
+    init(start: @escaping Start) {
+        self.start = start
+    }
+
+    func receive<S>(subscriber: S)
+    where S: Subscriber, S.Input == Output, S.Failure == Error {
+        let subscription = GRDBOpenCombineValueSubscription(
+            start: start,
+            downstream: subscriber
+        )
+        subscriber.receive(subscription: subscription)
+    }
+}
+
+
+private final class GRDBOpenCombineValueSubscription<Downstream>: Subscription
+where Downstream: Subscriber, Downstream.Failure == Error {
+
+    private typealias Start = (
+        @escaping (Error) -> Void,
+        @escaping (Downstream.Input) -> Void
+    ) -> AnyDatabaseCancellable
+
+    private enum State {
+        case waiting(start: Start, downstream: Downstream)
+        case observing(
+            downstream: Downstream,
+            remainingDemand: Subscribers.Demand
+        )
+        case finished
+    }
+
+    private let lock = NSRecursiveLock()
+    private var cancellable: AnyDatabaseCancellable?
+    private var state: State
+
+    init(start: @escaping Start, downstream: Downstream) {
+        state = .waiting(start: start, downstream: downstream)
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        var cancellableToCancel: AnyDatabaseCancellable?
+
+        lock.lock()
+        switch state {
+        case let .waiting(start, downstream):
+            guard demand > .none else {
+                lock.unlock()
+                return
+            }
+
+            state = .observing(
+                downstream: downstream,
+                remainingDemand: demand
+            )
+            let startedCancellable = start(
+                { [weak self] error in
+                    self?.receiveCompletion(.failure(error))
+                },
+                { [weak self] value in
+                    self?.receive(value)
+                }
+            )
+
+            switch state {
+            case .observing:
+                cancellable = startedCancellable
+            case .finished:
+                cancellableToCancel = startedCancellable
+            case .waiting:
+                preconditionFailure("observation returned to waiting state")
+            }
+
+        case let .observing(downstream, remainingDemand):
+            state = .observing(
+                downstream: downstream,
+                remainingDemand: remainingDemand + demand
+            )
+
+        case .finished:
+            break
+        }
+        lock.unlock()
+
+        cancellableToCancel?.cancel()
+    }
+
+    func cancel() {
+        lock.lock()
+        let cancellableToCancel = cancellable
+        cancellable = nil
+        state = .finished
+        lock.unlock()
+
+        cancellableToCancel?.cancel()
+    }
+
+    private func receive(_ value: Downstream.Input) {
+        lock.lock()
+        guard case let .observing(downstream, remainingDemand) = state,
+              remainingDemand > .none else {
+            lock.unlock()
+            return
+        }
+
+        let additionalDemand = downstream.receive(value)
+        if case let .observing(currentDownstream, currentDemand) = state {
+            state = .observing(
+                downstream: currentDownstream,
+                remainingDemand: currentDemand + additionalDemand - 1
+            )
+        }
+        lock.unlock()
+    }
+
+    private func receiveCompletion(
+        _ completion: Subscribers.Completion<Error>
+    ) {
+        lock.lock()
+        guard case let .observing(downstream, _) = state else {
+            lock.unlock()
+            return
+        }
+        cancellable = nil
+        state = .finished
+        lock.unlock()
+
+        downstream.receive(completion: completion)
+    }
+}
+#endif

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -661,7 +661,10 @@ public struct GRDBDatabaseBuilder {
     /// Creates the configured database and its connection pool.
     public func build() throws -> GRDBDatabase {
         try GRDBDatabase(
-            databasePool: try DatabasePool(path: url.path(percentEncoded: false), configuration: configuration),
+            databasePool: try DatabasePool(
+                path: url.path,
+                configuration: configuration
+            ),
             codingConfiguration: codingConfiguration,
             formatter: formatter,
             logger: logger,
@@ -743,7 +746,7 @@ public struct GRDBDatabase: XLDatabase {
     ) throws {
         try self.init(
             databasePool: try DatabasePool(
-                path: url.path(percentEncoded: false),
+                path: url.path,
                 configuration: configuration
             ),
             codingConfiguration: codingConfiguration,

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -6,9 +6,12 @@
 //
 
 import Foundation
-import OSLog
 import GRDB
+#if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+#endif
 
 
 struct GRDBRowAdapter: XLColumnReader {
@@ -366,10 +369,23 @@ struct GRDBRequest<Row>: XLRequest {
     
     private func publisher<T>(fetch: @escaping (Database) throws -> T) -> AnyPublisher<T, Error> {
         let makeSource = {
+#if canImport(Combine)
             ValueObservation
                 .tracking(fetch)
                 .publisher(in: executor.driver.databasePool)
                 .eraseToAnyPublisher()
+#else
+            GRDBOpenCombineValuePublisher { onError, onChange in
+                ValueObservation
+                    .tracking(fetch)
+                    .start(
+                        in: executor.driver.databasePool,
+                        onError: onError,
+                        onChange: onChange
+                    )
+            }
+            .eraseToAnyPublisher()
+#endif
         }
 
         switch liveQueryRetryPolicy {

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -6,7 +6,12 @@
 //
 
 import Foundation
+#if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+import OpenCombineFoundation
+#endif
 
 
 extension Notification.Name {

--- a/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
@@ -471,7 +471,7 @@ struct SQLDate: XLCustomType, XLComparable, Equatable {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-        formatter.timeZone = .gmt
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter
     }()
 

--- a/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
@@ -1,6 +1,6 @@
 # Live Queries
 
-Use Combine publishers to observe query results as a database changes.
+Use Combine-compatible publishers to observe query results as a database changes.
 
 ## Overview
 
@@ -9,7 +9,11 @@ With the GRDB adapter, each subscriber's first positive demand starts a GRDB val
 begins a fresh database fetch. The observation then tracks the database region that the query
 actually reads.
 
-### Combine
+Apple platforms use Combine. Linux uses OpenCombine 0.14.0 and preserves the
+same demand-driven GRDB observation, error, and cancellation contracts. Import
+`Combine` or `OpenCombine` for the platform where the client is built.
+
+### Combine-compatible publishers
 
 Use `publish()` to observe all rows returned by a request:
 

--- a/Tests/SQLTests/GRDBLiveQueryRetryTests.swift
+++ b/Tests/SQLTests/GRDBLiveQueryRetryTests.swift
@@ -804,13 +804,13 @@ final class XLGRDBLiveQueryRetryTests: XCTestCase {
         initialValue: Int? = 1
     ) throws -> IntegrationFixture {
         let directoryURL = FileManager.default.temporaryDirectory
-            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
             at: directoryURL,
             withIntermediateDirectories: true
         )
         let databaseURL = directoryURL
-            .appending(path: "retry.sqlite", directoryHint: .notDirectory)
+            .appendingPathComponent("retry.sqlite", isDirectory: false)
         let functionState = InjectedBusyFunctionState(behavior: busyBehavior)
         var configuration = Configuration()
         configuration.prepareDatabase { database in
@@ -827,7 +827,7 @@ final class XLGRDBLiveQueryRetryTests: XCTestCase {
         let database: GRDBDatabase
         if let retryScheduler {
             let databasePool = try DatabasePool(
-                path: databaseURL.path(percentEncoded: false),
+                path: databaseURL.path,
                 configuration: configuration
             )
             database = try GRDBDatabase(

--- a/Tests/SQLTests/GRDBLiveQueryRetryTests.swift
+++ b/Tests/SQLTests/GRDBLiveQueryRetryTests.swift
@@ -1,4 +1,9 @@
+#if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+import OpenCombineDispatch
+#endif
 import Foundation
 import GRDB
 import XCTest

--- a/Tests/SQLTests/SQLColumnReadErrorTests.swift
+++ b/Tests/SQLTests/SQLColumnReadErrorTests.swift
@@ -75,12 +75,15 @@ final class XLColumnReadErrorTests: XCTestCase {
         logger = ColumnReadTestLogger()
         streamStepProbe = ColumnReadStreamStepProbe()
         databaseDirectoryURL = FileManager.default.temporaryDirectory
-            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
             at: databaseDirectoryURL,
             withIntermediateDirectories: true
         )
-        let fileURL = databaseDirectoryURL.appending(path: "database.sqlite", directoryHint: .notDirectory)
+        let fileURL = databaseDirectoryURL.appendingPathComponent(
+            "database.sqlite",
+            isDirectory: false
+        )
         var configuration = Configuration()
         let streamStepProbe = try XCTUnwrap(streamStepProbe)
         configuration.prepareDatabase { database in

--- a/Tests/SQLTests/SQLColumnReadErrorTests.swift
+++ b/Tests/SQLTests/SQLColumnReadErrorTests.swift
@@ -1,5 +1,9 @@
 import Foundation
+#if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+#endif
 import GRDB
 import XCTest
 @testable import SwiftQL

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -552,7 +552,9 @@ final class XLDocumentationTests: XCTestCase {
     override func setUp() {
         let directory = FileManager.default.temporaryDirectory
         let filename = UUID().uuidString
-        let fileURL = directory.appending(path: filename, directoryHint: .notDirectory).appendingPathExtension("sqlite")
+        let fileURL = directory
+            .appendingPathComponent(filename, isDirectory: false)
+            .appendingPathExtension("sqlite")
         print("Connecting to database \(fileURL.path)")
         //        databasePool = try! DatabasePool(path: fileURL.path)
         //        database = try! GRDBDatabase(

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -136,7 +136,7 @@ struct SQLDate: XLCustomType, XLComparable, Equatable {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-        formatter.timeZone = .gmt
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter
     }()
 
@@ -403,7 +403,7 @@ extension Date: XLCustomType, XLComparable {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-        formatter.timeZone = .gmt
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         return formatter
     }()
     

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -6,7 +6,11 @@
 //
 
 import Foundation
+#if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+#endif
 import XCTest
 import GRDB
 import SwiftQL

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -28,7 +28,9 @@ final class XLExecutionTests: XCTestCase {
         )
         let directory = FileManager.default.temporaryDirectory
         let filename = UUID().uuidString
-        let fileURL = directory.appending(path: filename, directoryHint: .notDirectory).appendingPathExtension("sqlite")
+        let fileURL = directory
+            .appendingPathComponent(filename, isDirectory: false)
+            .appendingPathExtension("sqlite")
         print("Connecting to database \(fileURL.path)")
         encoder = XLiteEncoder(formatter: formatter)
         databasePool = try! DatabasePool(path: fileURL.path)

--- a/Tests/SQLTests/SQLPublisherTests.swift
+++ b/Tests/SQLTests/SQLPublisherTests.swift
@@ -6,7 +6,11 @@
 //
 
 import Foundation
+#if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+#endif
 import XCTest
 import GRDB
 import SwiftQL

--- a/Tests/SQLTests/SQLPublisherTests.swift
+++ b/Tests/SQLTests/SQLPublisherTests.swift
@@ -244,12 +244,15 @@ final class XLPublisherTests: XCTestCase {
             identifierFormattingOptions: .mysqlCompatible
         )
         databaseDirectoryURL = FileManager.default.temporaryDirectory
-            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
             at: databaseDirectoryURL,
             withIntermediateDirectories: true
         )
-        let fileURL = databaseDirectoryURL.appending(path: "primary.sqlite", directoryHint: .notDirectory)
+        let fileURL = databaseDirectoryURL.appendingPathComponent(
+            "primary.sqlite",
+            isDirectory: false
+        )
         databasePool = try DatabasePool(path: fileURL.path)
         logger = RecordingLogger()
         database = try GRDBDatabase(databasePool: databasePool, formatter: formatter, logger: logger)
@@ -791,7 +794,7 @@ final class XLPublisherTests: XCTestCase {
             )
         }
         let blockingURL = databaseDirectoryURL
-            .appending(path: "blocking.sqlite", directoryHint: .notDirectory)
+            .appendingPathComponent("blocking.sqlite", isDirectory: false)
         let blockingPool = try DatabasePool(
             path: blockingURL.path,
             configuration: configuration
@@ -849,7 +852,10 @@ final class XLPublisherTests: XCTestCase {
 
     func testDistinctDatabasePoolsDoNotCrossTrigger() throws {
         try createTestTable()
-        let secondaryURL = databaseDirectoryURL.appending(path: "secondary.sqlite", directoryHint: .notDirectory)
+        let secondaryURL = databaseDirectoryURL.appendingPathComponent(
+            "secondary.sqlite",
+            isDirectory: false
+        )
         let secondaryPool = try DatabasePool(path: secondaryURL.path)
         let unrelatedSecondaryPool = try DatabasePool(path: secondaryURL.path)
         let secondaryDatabase = try GRDBDatabase(

--- a/Tests/SQLTests/SQLRequestCompatibilityTests.swift
+++ b/Tests/SQLTests/SQLRequestCompatibilityTests.swift
@@ -1,4 +1,8 @@
+#if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+#endif
 import Foundation
 import GRDB
 import SwiftQL

--- a/Tests/SwiftQLCodecIntegrationTests/InvocationBindingsGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/InvocationBindingsGRDBTests.swift
@@ -1,5 +1,9 @@
 import Foundation
+#if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+#endif
 import GRDB
 import XCTest
 @testable import SwiftQL

--- a/Tests/SwiftQLNorthwindFixtures/NorthwindFixture.swift
+++ b/Tests/SwiftQLNorthwindFixtures/NorthwindFixture.swift
@@ -29,7 +29,9 @@ public struct NorthwindFixtureMetadata: Equatable, Sendable {
 }
 
 
-public struct NorthwindFixtureValidation: Equatable, Sendable {
+// Swift 5.9's Linux Foundation predates URL's Sendable annotation. This value
+// is immutable, and newer Foundation versions declare the same URL value safe.
+public struct NorthwindFixtureValidation: Equatable, @unchecked Sendable {
     let databaseURL: URL
     public let databaseSHA256: String
     public let databaseByteCount: Int

--- a/Tests/SwiftQLNorthwindFixtures/PortableSHA256.swift
+++ b/Tests/SwiftQLNorthwindFixtures/PortableSHA256.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// A small SHA-256 implementation used only to authenticate checked-in test
 /// resources without adding a platform-specific framework or package dependency.
-enum PortableSHA256 {
+public enum PortableSHA256 {
 
     private static let initialState: [UInt32] = [
         0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
@@ -29,7 +29,7 @@ enum PortableSHA256 {
         0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
     ]
 
-    static func hexDigest(of data: Data) -> String {
+    public static func hexDigest(of data: Data) -> String {
         let bytes = digest(Array(data))
         let digits = Array("0123456789abcdef".utf8)
         var encoded: [UInt8] = []

--- a/Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift
+++ b/Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import GRDB
 import SwiftQL
@@ -846,7 +845,7 @@ private extension SQLiteCombinatorialConformanceTests {
     }
 
     func sha256Hex(_ data: Data) -> String {
-        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        PortableSHA256.hexDigest(of: data)
     }
 }
 

--- a/scripts/ci/check-bitwise-not-type-safety.sh
+++ b/scripts/ci/check-bitwise-not-type-safety.sh
@@ -24,8 +24,8 @@ build_arguments=(
 
 # Make the gate independently runnable while remaining an incremental no-op
 # immediately after the compatibility matrix's warning-clean build.
-xcrun swift build "${build_arguments[@]}" --target SwiftQL
-bin_path="$(xcrun swift build "${build_arguments[@]}" --show-bin-path)"
+swift build "${build_arguments[@]}" --target SwiftQL
+bin_path="$(swift build "${build_arguments[@]}" --show-bin-path)"
 csqlite_module_map="$scratch_path/checkouts/GRDB.swift/Sources/CSQLite/module.modulemap"
 
 module_search_paths=()
@@ -53,7 +53,7 @@ if [[ ! -f "$csqlite_module_map" ]]; then
 fi
 
 compiler=(
-    xcrun swiftc
+    swiftc
     -typecheck
     -swift-version 5
     -Xcc "-fmodule-map-file=$csqlite_module_map"

--- a/scripts/ci/check-compatibility-environment.sh
+++ b/scripts/ci/check-compatibility-environment.sh
@@ -2,12 +2,9 @@
 
 set -euo pipefail
 
-: "${EXPECTED_XCODE_VERSION:?Set EXPECTED_XCODE_VERSION}"
-: "${EXPECTED_XCODE_BUILD:?Set EXPECTED_XCODE_BUILD}"
 : "${EXPECTED_SWIFT_SERIES:?Set EXPECTED_SWIFT_SERIES}"
-: "${EXPECTED_SDK_VERSION:?Set EXPECTED_SDK_VERSION}"
-: "${EXPECTED_DEVELOPER_DIR:?Set EXPECTED_DEVELOPER_DIR}"
 
+expected_platform="${EXPECTED_PLATFORM:-macos}"
 expected_swift_command_mode="${EXPECTED_SWIFT_COMMAND_MODE:-xcrun}"
 
 fail() {
@@ -18,9 +15,6 @@ fail() {
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repository_root"
 
-xcode_output="$(xcodebuild -version)"
-xcode_version="$(printf '%s\n' "$xcode_output" | sed -n '1s/^Xcode //p')"
-xcode_build="$(printf '%s\n' "$xcode_output" | sed -n '2s/^Build version //p')"
 case "$expected_swift_command_mode" in
     xcrun)
         swift_output="$(xcrun swift --version 2>&1)"
@@ -29,44 +23,79 @@ case "$expected_swift_command_mode" in
     path)
         swift_output="$(swift --version 2>&1)"
         swift_executable="$(command -v swift)"
-        [[ "$swift_executable" != "/usr/bin/swift" ]] ||
+        [[ "$expected_platform" != "macos" || "$swift_executable" != "/usr/bin/swift" ]] ||
             fail "PATH Swift unexpectedly resolved to the Xcode dispatcher"
         ;;
     *)
         fail "unsupported EXPECTED_SWIFT_COMMAND_MODE: $expected_swift_command_mode"
         ;;
 esac
-sdk_version="$(xcrun --sdk macosx --show-sdk-version)"
 tools_version="$(swift package tools-version)"
+target_info="$(swiftc -print-target-info)"
 
-printf '%s\n' "Selected developer directory: ${DEVELOPER_DIR:-<unset>}"
-printf '%s\n' "$xcode_output"
 printf '%s\n' "$swift_output"
-printf 'macOS SDK: %s\n' "$sdk_version"
-printf 'macOS SDK path: %s\n' "$(xcrun --sdk macosx --show-sdk-path)"
 printf 'Swift package tools version: %s\n' "$tools_version"
 printf 'Swift executable: %s\n' "$swift_executable"
 printf 'Swift command mode: %s\n' "$expected_swift_command_mode"
+printf 'Compatibility platform: %s\n' "$expected_platform"
 printf 'Swift target information:\n'
-swiftc -print-target-info
-printf 'System xcode-select path: %s\n' "$(xcode-select -p)"
+printf '%s\n' "$target_info"
 printf 'Architecture: %s\n' "$(uname -m)"
 printf 'Runner ImageOS: %s\n' "${ImageOS:-<not reported>}"
 printf 'Runner ImageVersion: %s\n' "${ImageVersion:-<not reported>}"
-sw_vers
 
-[[ "${DEVELOPER_DIR:-}" == "$EXPECTED_DEVELOPER_DIR" ]] ||
-    fail "DEVELOPER_DIR is '${DEVELOPER_DIR:-<unset>}'; expected '$EXPECTED_DEVELOPER_DIR'"
-[[ -d "$EXPECTED_DEVELOPER_DIR" ]] ||
-    fail "expected Xcode developer directory does not exist: $EXPECTED_DEVELOPER_DIR"
-if [[ "$expected_swift_command_mode" == "xcrun" ]]; then
-    [[ "$swift_executable" == "$EXPECTED_DEVELOPER_DIR"/Toolchains/*/usr/bin/swift ]] ||
-        fail "xcrun selected Swift outside the expected Xcode: $swift_executable"
-fi
-[[ "$xcode_version" == "$EXPECTED_XCODE_VERSION" ]] ||
-    fail "Xcode version is '$xcode_version'; expected '$EXPECTED_XCODE_VERSION'"
-[[ "$xcode_build" == "$EXPECTED_XCODE_BUILD" ]] ||
-    fail "Xcode build is '$xcode_build'; expected '$EXPECTED_XCODE_BUILD'"
+case "$expected_platform" in
+    macos)
+        : "${EXPECTED_XCODE_VERSION:?Set EXPECTED_XCODE_VERSION}"
+        : "${EXPECTED_XCODE_BUILD:?Set EXPECTED_XCODE_BUILD}"
+        : "${EXPECTED_SDK_VERSION:?Set EXPECTED_SDK_VERSION}"
+        : "${EXPECTED_DEVELOPER_DIR:?Set EXPECTED_DEVELOPER_DIR}"
+
+        xcode_output="$(xcodebuild -version)"
+        xcode_version="$(printf '%s\n' "$xcode_output" | sed -n '1s/^Xcode //p')"
+        xcode_build="$(printf '%s\n' "$xcode_output" | sed -n '2s/^Build version //p')"
+        sdk_version="$(xcrun --sdk macosx --show-sdk-version)"
+
+        printf '%s\n' "Selected developer directory: ${DEVELOPER_DIR:-<unset>}"
+        printf '%s\n' "$xcode_output"
+        printf 'macOS SDK: %s\n' "$sdk_version"
+        printf 'macOS SDK path: %s\n' "$(xcrun --sdk macosx --show-sdk-path)"
+        printf 'System xcode-select path: %s\n' "$(xcode-select -p)"
+        sw_vers
+
+        [[ "${DEVELOPER_DIR:-}" == "$EXPECTED_DEVELOPER_DIR" ]] ||
+            fail "DEVELOPER_DIR is '${DEVELOPER_DIR:-<unset>}'; expected '$EXPECTED_DEVELOPER_DIR'"
+        [[ -d "$EXPECTED_DEVELOPER_DIR" ]] ||
+            fail "expected Xcode developer directory does not exist: $EXPECTED_DEVELOPER_DIR"
+        if [[ "$expected_swift_command_mode" == "xcrun" ]]; then
+            [[ "$swift_executable" == "$EXPECTED_DEVELOPER_DIR"/Toolchains/*/usr/bin/swift ]] ||
+                fail "xcrun selected Swift outside the expected Xcode: $swift_executable"
+        fi
+        [[ "$xcode_version" == "$EXPECTED_XCODE_VERSION" ]] ||
+            fail "Xcode version is '$xcode_version'; expected '$EXPECTED_XCODE_VERSION'"
+        [[ "$xcode_build" == "$EXPECTED_XCODE_BUILD" ]] ||
+            fail "Xcode build is '$xcode_build'; expected '$EXPECTED_XCODE_BUILD'"
+        [[ "$sdk_version" == "$EXPECTED_SDK_VERSION" ]] ||
+            fail "macOS SDK is '$sdk_version'; expected '$EXPECTED_SDK_VERSION'"
+        ;;
+    linux)
+        : "${EXPECTED_OS_ID:?Set EXPECTED_OS_ID}"
+        : "${EXPECTED_OS_VERSION_ID:?Set EXPECTED_OS_VERSION_ID}"
+        os_release_file="${EXPECTED_OS_RELEASE_FILE:-/etc/os-release}"
+        [[ -r "$os_release_file" ]] || fail "$os_release_file is not readable"
+        # shellcheck source=/dev/null
+        source "$os_release_file"
+        printf 'Linux distribution: %s %s\n' "${ID:-<unset>}" "${VERSION_ID:-<unset>}"
+        [[ "${ID:-}" == "$EXPECTED_OS_ID" ]] ||
+            fail "Linux ID is '${ID:-<unset>}'; expected '$EXPECTED_OS_ID'"
+        [[ "${VERSION_ID:-}" == "$EXPECTED_OS_VERSION_ID" ]] ||
+            fail "Linux VERSION_ID is '${VERSION_ID:-<unset>}'; expected '$EXPECTED_OS_VERSION_ID'"
+        ;;
+    *)
+        fail "unsupported EXPECTED_PLATFORM: $expected_platform"
+        ;;
+esac
+
 [[ "$swift_output" == *"Apple Swift version $EXPECTED_SWIFT_SERIES"* ]] ||
     [[ "$swift_output" == *"Swift version $EXPECTED_SWIFT_SERIES"* ]] ||
     fail "Swift compiler is not in the expected $EXPECTED_SWIFT_SERIES series"
@@ -74,10 +103,14 @@ if [[ -n "${EXPECTED_SWIFT_VERSION:-}" ]]; then
     [[ "$swift_output" == *"Swift version $EXPECTED_SWIFT_VERSION"* ]] ||
         fail "Swift compiler is not exactly version $EXPECTED_SWIFT_VERSION"
 fi
-[[ "$sdk_version" == "$EXPECTED_SDK_VERSION" ]] ||
-    fail "macOS SDK is '$sdk_version'; expected '$EXPECTED_SDK_VERSION'"
 [[ "$tools_version" == "5.9.0" ]] ||
     fail "package tools version is '$tools_version'; expected '5.9.0'"
+if [[ -n "${EXPECTED_TARGET_TRIPLE:-}" ]]; then
+    [[ "$target_info" == *"\"triple\" : \"$EXPECTED_TARGET_TRIPLE\""* ]] ||
+        [[ "$target_info" == *"\"triple\": \"$EXPECTED_TARGET_TRIPLE\""* ]] ||
+        [[ "$target_info" == *"\"triple\":\"$EXPECTED_TARGET_TRIPLE\""* ]] ||
+        fail "Swift target triple is not '$EXPECTED_TARGET_TRIPLE'"
+fi
 if [[ -n "${EXPECTED_IMAGE_OS:-}" ]]; then
     [[ "${ImageOS:-}" == "$EXPECTED_IMAGE_OS" ]] ||
         fail "ImageOS is '${ImageOS:-<unset>}'; expected '$EXPECTED_IMAGE_OS'"

--- a/scripts/ci/check-compatibility-environment.sh
+++ b/scripts/ci/check-compatibility-environment.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 : "${EXPECTED_SDK_VERSION:?Set EXPECTED_SDK_VERSION}"
 : "${EXPECTED_DEVELOPER_DIR:?Set EXPECTED_DEVELOPER_DIR}"
 
+expected_swift_command_mode="${EXPECTED_SWIFT_COMMAND_MODE:-xcrun}"
+
 fail() {
     printf 'error: %s\n' "$*" >&2
     exit 1
@@ -19,9 +21,23 @@ cd "$repository_root"
 xcode_output="$(xcodebuild -version)"
 xcode_version="$(printf '%s\n' "$xcode_output" | sed -n '1s/^Xcode //p')"
 xcode_build="$(printf '%s\n' "$xcode_output" | sed -n '2s/^Build version //p')"
-swift_output="$(xcrun swift --version 2>&1)"
+case "$expected_swift_command_mode" in
+    xcrun)
+        swift_output="$(xcrun swift --version 2>&1)"
+        swift_executable="$(xcrun --find swift)"
+        ;;
+    path)
+        swift_output="$(swift --version 2>&1)"
+        swift_executable="$(command -v swift)"
+        [[ "$swift_executable" != "/usr/bin/swift" ]] ||
+            fail "PATH Swift unexpectedly resolved to the Xcode dispatcher"
+        ;;
+    *)
+        fail "unsupported EXPECTED_SWIFT_COMMAND_MODE: $expected_swift_command_mode"
+        ;;
+esac
 sdk_version="$(xcrun --sdk macosx --show-sdk-version)"
-tools_version="$(xcrun swift package tools-version)"
+tools_version="$(swift package tools-version)"
 
 printf '%s\n' "Selected developer directory: ${DEVELOPER_DIR:-<unset>}"
 printf '%s\n' "$xcode_output"
@@ -29,8 +45,10 @@ printf '%s\n' "$swift_output"
 printf 'macOS SDK: %s\n' "$sdk_version"
 printf 'macOS SDK path: %s\n' "$(xcrun --sdk macosx --show-sdk-path)"
 printf 'Swift package tools version: %s\n' "$tools_version"
-swift_executable="$(xcrun --find swift)"
 printf 'Swift executable: %s\n' "$swift_executable"
+printf 'Swift command mode: %s\n' "$expected_swift_command_mode"
+printf 'Swift target information:\n'
+swiftc -print-target-info
 printf 'System xcode-select path: %s\n' "$(xcode-select -p)"
 printf 'Architecture: %s\n' "$(uname -m)"
 printf 'Runner ImageOS: %s\n' "${ImageOS:-<not reported>}"
@@ -41,15 +59,30 @@ sw_vers
     fail "DEVELOPER_DIR is '${DEVELOPER_DIR:-<unset>}'; expected '$EXPECTED_DEVELOPER_DIR'"
 [[ -d "$EXPECTED_DEVELOPER_DIR" ]] ||
     fail "expected Xcode developer directory does not exist: $EXPECTED_DEVELOPER_DIR"
-[[ "$swift_executable" == "$EXPECTED_DEVELOPER_DIR"/Toolchains/*/usr/bin/swift ]] ||
-    fail "xcrun selected Swift outside the expected Xcode: $swift_executable"
+if [[ "$expected_swift_command_mode" == "xcrun" ]]; then
+    [[ "$swift_executable" == "$EXPECTED_DEVELOPER_DIR"/Toolchains/*/usr/bin/swift ]] ||
+        fail "xcrun selected Swift outside the expected Xcode: $swift_executable"
+fi
 [[ "$xcode_version" == "$EXPECTED_XCODE_VERSION" ]] ||
     fail "Xcode version is '$xcode_version'; expected '$EXPECTED_XCODE_VERSION'"
 [[ "$xcode_build" == "$EXPECTED_XCODE_BUILD" ]] ||
     fail "Xcode build is '$xcode_build'; expected '$EXPECTED_XCODE_BUILD'"
 [[ "$swift_output" == *"Apple Swift version $EXPECTED_SWIFT_SERIES"* ]] ||
+    [[ "$swift_output" == *"Swift version $EXPECTED_SWIFT_SERIES"* ]] ||
     fail "Swift compiler is not in the expected $EXPECTED_SWIFT_SERIES series"
+if [[ -n "${EXPECTED_SWIFT_VERSION:-}" ]]; then
+    [[ "$swift_output" == *"Swift version $EXPECTED_SWIFT_VERSION"* ]] ||
+        fail "Swift compiler is not exactly version $EXPECTED_SWIFT_VERSION"
+fi
 [[ "$sdk_version" == "$EXPECTED_SDK_VERSION" ]] ||
     fail "macOS SDK is '$sdk_version'; expected '$EXPECTED_SDK_VERSION'"
 [[ "$tools_version" == "5.9.0" ]] ||
     fail "package tools version is '$tools_version'; expected '5.9.0'"
+if [[ -n "${EXPECTED_IMAGE_OS:-}" ]]; then
+    [[ "${ImageOS:-}" == "$EXPECTED_IMAGE_OS" ]] ||
+        fail "ImageOS is '${ImageOS:-<unset>}'; expected '$EXPECTED_IMAGE_OS'"
+fi
+if [[ -n "${EXPECTED_ARCHITECTURE:-}" ]]; then
+    [[ "$(uname -m)" == "$EXPECTED_ARCHITECTURE" ]] ||
+        fail "architecture is '$(uname -m)'; expected '$EXPECTED_ARCHITECTURE'"
+fi

--- a/scripts/ci/check-first-party-warnings.sh
+++ b/scripts/ci/check-first-party-warnings.sh
@@ -29,8 +29,8 @@ main() {
     # A clean --build-tests build covers every first-party product and test
     # target and prevents an incremental no-op from hiding diagnostics.
     cd "$source_root"
-    xcrun swift package --scratch-path "$scratch_root" clean
-    xcrun swift build --scratch-path "$scratch_root" --build-tests -v \
+    swift package --scratch-path "$scratch_root" clean
+    swift build --scratch-path "$scratch_root" --build-tests -v \
         2>&1 | tee "$build_log"
 
     if [[ ! -s "$build_log" ]]; then

--- a/scripts/ci/check-query-clause-ordering-type-safety.sh
+++ b/scripts/ci/check-query-clause-ordering-type-safety.sh
@@ -29,8 +29,8 @@ build_arguments=(
 
 # Make the gate independently runnable while remaining an incremental no-op
 # immediately after the compatibility matrix's warning-clean build.
-xcrun swift build "${build_arguments[@]}" --target SwiftQL
-bin_path="$(xcrun swift build "${build_arguments[@]}" --show-bin-path)"
+swift build "${build_arguments[@]}" --target SwiftQL
+bin_path="$(swift build "${build_arguments[@]}" --show-bin-path)"
 csqlite_module_map="$scratch_path/checkouts/GRDB.swift/Sources/CSQLite/module.modulemap"
 
 module_search_paths=()
@@ -58,7 +58,7 @@ if [[ ! -f "$csqlite_module_map" ]]; then
 fi
 
 compiler=(
-    xcrun swiftc
+    swiftc
     -typecheck
     -swift-version 5
     -Xcc "-fmodule-map-file=$csqlite_module_map"

--- a/scripts/ci/compiler-diagnostics-lib.sh
+++ b/scripts/ci/compiler-diagnostics-lib.sh
@@ -42,7 +42,7 @@ swiftql_diagnostic_source_path() {
 
     source_path="${BASH_REMATCH[1]}"
     case "$source_path" in
-        /*|Sources/*|Tests/*|Benchmarks/*|Package.swift)
+        /*|Sources/*|Tests/*|Benchmarks/*|Research/*|Package.swift)
             ;;
         *" /"*)
             # Macro-origin notes are rendered with a tree prefix before the
@@ -71,6 +71,10 @@ swiftql_is_dependency_warning() {
                 ;;
         esac
     else
+        if [[ "$warning" == *" -primary-file $scratch_root/checkouts/"* ]] || \
+            [[ "$warning" == *" -primary-file $source_root/.build/checkouts/"* ]]; then
+            return 0
+        fi
         case "$warning" in
             "warning: 'grdb.swift':"*|"warning: 'swift-syntax':"*|\
             "warning: 'swift-docc-plugin':"*|\
@@ -115,8 +119,9 @@ swiftql_is_first_party_warning() {
 
     case "$source_path" in
         "$source_root"/Sources/*|"$source_root"/Tests/*|\
-        "$source_root"/Benchmarks/*|"$source_root"/Package.swift|\
-        Sources/*|Tests/*|Benchmarks/*|Package.swift)
+        "$source_root"/Benchmarks/*|"$source_root"/Research/*|\
+        "$source_root"/Package.swift|Sources/*|Tests/*|Benchmarks/*|\
+        Research/*|Package.swift)
             return 0
             ;;
     esac
@@ -135,7 +140,7 @@ swiftql_is_first_party_macro_origin() {
 
     case "$source_path" in
         "$source_root"/Sources/*|"$source_root"/Tests/*|\
-        "$source_root"/Benchmarks/*)
+        "$source_root"/Benchmarks/*|"$source_root"/Research/*)
             return 0
             ;;
     esac
@@ -407,6 +412,15 @@ swiftql_run_diagnostic_classifier_self_tests() {
         return 1
     fi
 
+    fixture="$source_root/Research/Fixture/Sources/Fixture.swift:1:1: warning: simulated research-target diagnostic"
+    if ! swiftql_self_test_rejected_warning \
+        "$self_test_log" "$source_root" "$scratch_root" "$output_prefix" \
+        "$fixture" "FIRST_PARTY_WARNINGS" \
+        "a first-party research-target warning"; then
+        rm -f "$self_test_log"
+        return 1
+    fi
+
     fixture="$source_root/Sources/SwiftQL/Fixture.swift:1:1: warning: referenced $scratch_root/checkouts/Dependency"
     if ! swiftql_self_test_rejected_warning \
         "$self_test_log" "$source_root" "$scratch_root" "$output_prefix" \
@@ -491,6 +505,17 @@ swiftql_run_diagnostic_classifier_self_tests() {
     if ! swiftql_self_test_accepted_warning \
         "$self_test_log" "$source_root" "$scratch_root" "$output_prefix" \
         "$fixture" "DEPENDENCY_WARNINGS" "a dependency warning"; then
+        rm -f "$self_test_log"
+        return 1
+    fi
+
+    fixture="warning: 'opencombine': /tool/swift-frontend"
+    fixture+=" -primary-file $scratch_root/checkouts/OpenCombine/Package.swift"
+    fixture+=" -package-description-version 5.5.0 -module-name main -o /tmp/Package.o"
+    if ! swiftql_self_test_accepted_warning \
+        "$self_test_log" "$source_root" "$scratch_root" "$output_prefix" \
+        "$fixture" "DEPENDENCY_WARNINGS" \
+        "a dependency-manifest build warning"; then
         rm -f "$self_test_log"
         return 1
     fi

--- a/scripts/ci/report-resolved-dependencies.sh
+++ b/scripts/ci/report-resolved-dependencies.sh
@@ -12,7 +12,7 @@ cd "$repository_root"
 
 [[ -f Package.resolved ]] || fail "Package.resolved was not produced"
 
-swift_package=(xcrun swift package)
+swift_package=(swift package)
 if [[ -n "${SWIFTQL_SCRATCH_PATH:-}" ]]; then
     swift_package+=(--scratch-path "$SWIFTQL_SCRATCH_PATH")
 fi

--- a/scripts/ci/source-coverage-config.json
+++ b/scripts/ci/source-coverage-config.json
@@ -10,6 +10,7 @@
       "name": "SwiftQL",
       "source_root": "Sources/SwiftQL",
       "allowed_uninstrumented_sources": [
+        "Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift",
         "Sources/SwiftQL/SQL.swift",
         "Sources/SwiftQL/SQLScalarResult.swift",
         "Sources/SwiftQL/SwiftQLCore.swift"

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -36,6 +36,7 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertEqual(matrix.count("image_os: macos15"), 2)
         self.assertEqual(matrix.count("architecture: x86_64"), 2)
         self.assertEqual(matrix.count("architecture: arm64"), 2)
+        self.assertEqual(matrix.count('sqlite_version: "3.53.3"'), 2)
 
         self.assertNotIn("swift-actions/setup-swift", compatibility)
         self.assertIn(
@@ -64,6 +65,22 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertIn("sha256sum --check --status", compatibility)
         self.assertIn("gpg --batch", compatibility)
         self.assertIn("[GNUPG:] VALIDSIG", compatibility)
+        self.assertIn(
+            "https://www.sqlite.org/2026/sqlite-amalgamation-3530300.zip",
+            compatibility,
+        )
+        self.assertIn(
+            "SQLITE_AMALGAMATION_SHA3_256: "
+            "d45c688a8cb23f68611a894a756a12d7eb6ab6e9e2468ca70adbeab3808b5ab9",
+            compatibility,
+        )
+        self.assertIn("openssl dgst -sha3-256", compatibility)
+        self.assertIn("-DSQLITE_ENABLE_FTS5", compatibility)
+        self.assertIn("-DSQLITE_ENABLE_MATH_FUNCTIONS", compatibility)
+        self.assertIn("libsqlite3.so", compatibility)
+        self.assertIn("CPATH=", compatibility)
+        self.assertIn("LIBRARY_PATH=", compatibility)
+        self.assertIn("LD_LIBRARY_PATH=", compatibility)
         self.assertIn("-DGRDBCUSTOMSQLITE", compatibility)
         self.assertIn("SWIFT_EXEC=", compatibility)
         self.assertIn(
@@ -84,6 +101,14 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertIn("EXPECTED_IMAGE_OS: ${{ matrix.image_os }}", compatibility)
         self.assertIn(
             "EXPECTED_ARCHITECTURE: ${{ matrix.architecture }}", compatibility
+        )
+        self.assertIn(
+            "EXPECTED_SQLITE_VERSION: ${{ matrix.sqlite_version }}",
+            compatibility,
+        )
+        self.assertIn(
+            "SWIFTQL_SQLITE_RUNTIME sqlite_version=$EXPECTED_SQLITE_VERSION ",
+            compatibility,
         )
 
     def test_linux_surface_uses_opencombine_without_conditional_exclusion(self) -> None:

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -66,6 +66,8 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertIn("[GNUPG:] VALIDSIG", compatibility)
         self.assertIn("-DGRDBCUSTOMSQLITE", compatibility)
         self.assertIn("SWIFT_EXEC=", compatibility)
+        self.assertIn("SWIFTQL_REAL_SWIFT_FRONTEND=", compatibility)
+        self.assertIn('"-modulewrap"', compatibility)
         self.assertIn("os_id: ubuntu", matrix)
         self.assertIn('os_version_id: "22.04"', matrix)
         self.assertIn("target_triple: x86_64-unknown-linux-gnu", matrix)

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -81,6 +81,13 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertIn("CPATH=", compatibility)
         self.assertIn("LIBRARY_PATH=", compatibility)
         self.assertIn("LD_LIBRARY_PATH=", compatibility)
+        self.assertIn("SWIFTQL_SQLITE_INCLUDE_DIR=", compatibility)
+        self.assertIn("SWIFTQL_SQLITE_LIBRARY_DIR=", compatibility)
+        self.assertIn(
+            '-Xcc -I -Xcc "$SWIFTQL_SQLITE_INCLUDE_DIR" '
+            '-L "$SWIFTQL_SQLITE_LIBRARY_DIR"',
+            compatibility,
+        )
         self.assertIn("-DGRDBCUSTOMSQLITE", compatibility)
         self.assertIn("SWIFT_EXEC=", compatibility)
         self.assertIn(

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -34,15 +34,24 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertEqual(matrix.count("architecture: x86_64"), 2)
         self.assertEqual(matrix.count("architecture: arm64"), 2)
 
-        action = (
-            "swift-actions/setup-swift@"
-            "65540b95f51493d65f5e59e97dcef9629ddf11bf"
-        )
-        self.assertEqual(compatibility.count(action), 1)
+        self.assertNotIn("swift-actions/setup-swift", compatibility)
         self.assertIn(
             "if: ${{ matrix.swift_command_mode == 'path' }}", compatibility
         )
-        self.assertIn('swift-version: "5.9.2"', compatibility)
+        self.assertIn(
+            "https://download.swift.org/swift-5.9.2-release/xcode/"
+            "swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-osx.pkg",
+            compatibility,
+        )
+        self.assertIn(
+            "68951c313b4b559878fc5be27e460c877f98d14e161f755220b063123919e896",
+            compatibility,
+        )
+        self.assertIn("shasum -a 256 --check", compatibility)
+        self.assertIn(
+            "Developer ID Installer: Swift Open Source (V9AUD2URP3)",
+            compatibility,
+        )
         self.assertIn(
             "EXPECTED_SWIFT_VERSION: ${{ matrix.swift_version }}", compatibility
         )

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -54,15 +54,12 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
             compatibility,
         )
         self.assertIn(
-            "SWIFT_SIGNING_KEYS_SHA256: "
-            "07c0c26f4a96a2eafbeebcfbd1c128a1c4dcf840f9e71f0886ff291921f4ad8f",
-            compatibility,
-        )
-        self.assertIn(
             "SWIFT_SIGNING_FINGERPRINT: "
             "A62AE125BBBFBB96A6E042EC925CC1CCED3D1561",
             compatibility,
         )
+        self.assertIn("https://keyserver.ubuntu.com/pks/lookup", compatibility)
+        self.assertIn("pinned-fingerprint fallback", compatibility)
         self.assertIn("download_verified()", compatibility)
         self.assertIn("sha256sum --check --status", compatibility)
         self.assertIn("gpg --batch", compatibility)

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -49,12 +49,26 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         )
         self.assertIn("SWIFT_TOOLCHAIN_SIGNATURE_URL", compatibility)
         self.assertIn(
+            "SWIFT_TOOLCHAIN_SIGNATURE_SHA256: "
+            "325657c10c0a917cb0126aaf2ce0fe1c72bb9bf14657a89f82330839003959ed",
+            compatibility,
+        )
+        self.assertIn(
+            "SWIFT_SIGNING_KEYS_SHA256: "
+            "07c0c26f4a96a2eafbeebcfbd1c128a1c4dcf840f9e71f0886ff291921f4ad8f",
+            compatibility,
+        )
+        self.assertIn(
             "SWIFT_SIGNING_FINGERPRINT: "
             "A62AE125BBBFBB96A6E042EC925CC1CCED3D1561",
             compatibility,
         )
+        self.assertIn("download_verified()", compatibility)
+        self.assertIn("sha256sum --check --status", compatibility)
         self.assertIn("gpg --batch", compatibility)
         self.assertIn("[GNUPG:] VALIDSIG", compatibility)
+        self.assertIn("-DGRDBCUSTOMSQLITE", compatibility)
+        self.assertIn("SWIFT_EXEC=", compatibility)
         self.assertIn("os_id: ubuntu", matrix)
         self.assertIn('os_version_id: "22.04"', matrix)
         self.assertIn("target_triple: x86_64-unknown-linux-gnu", matrix)

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -130,6 +130,10 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         coverage_config = (
             ROOT / "scripts/ci/source-coverage-config.json"
         ).read_text(encoding="utf-8")
+        root_lockfile = (ROOT / "Package.resolved").read_bytes()
+        downstream_lockfile = (
+            ROOT / "IntegrationTests/Swift5Client/Package.resolved"
+        ).read_bytes()
 
         self.assertIn(
             '.package(url: "https://github.com/OpenCombine/OpenCombine.git", '
@@ -143,6 +147,7 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
             '"Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift"',
             coverage_config,
         )
+        self.assertEqual(downstream_lockfile, root_lockfile)
 
     def test_swift59_linux_surface_avoids_newer_foundation_url_apis(self) -> None:
         swift_sources = list((ROOT / "Sources").rglob("*.swift"))

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -77,13 +77,17 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertIn("openssl dgst -sha3-256", compatibility)
         self.assertIn("-DSQLITE_ENABLE_FTS5", compatibility)
         self.assertIn("-DSQLITE_ENABLE_MATH_FUNCTIONS", compatibility)
+        self.assertEqual(compatibility.count("-DSQLITE_ENABLE_SNAPSHOT"), 2)
         self.assertIn("libsqlite3.so", compatibility)
+        self.assertIn("nm -D --defined-only", compatibility)
+        self.assertIn("sqlite3_snapshot_get", compatibility)
         self.assertIn("CPATH=", compatibility)
         self.assertIn("LIBRARY_PATH=", compatibility)
         self.assertIn("LD_LIBRARY_PATH=", compatibility)
         self.assertIn("SWIFTQL_SQLITE_INCLUDE_DIR=", compatibility)
         self.assertIn("SWIFTQL_SQLITE_LIBRARY_DIR=", compatibility)
         self.assertIn(
+            '-DSQLITE_ENABLE_SNAPSHOT '
             '-Xcc -I -Xcc "$SWIFTQL_SQLITE_INCLUDE_DIR" '
             '-L "$SWIFTQL_SQLITE_LIBRARY_DIR"',
             compatibility,

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -107,6 +107,13 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
 
         self.assertNotIn(".path(percentEncoded:", source)
         self.assertNotIn(".appending(path:", source)
+        self.assertNotIn("formatter.timeZone = .gmt", source)
+
+        benchmark_cli = (
+            ROOT / "Benchmarks/Sources/SwiftQLBenchmarkCLI/main.swift"
+        ).read_text(encoding="utf-8")
+        self.assertIn("#if canImport(Darwin)", benchmark_cli)
+        self.assertIn("#elseif canImport(Glibc)", benchmark_cli)
 
     def test_compatibility_commands_use_selected_path_toolchain(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -66,6 +66,9 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertIn("[GNUPG:] VALIDSIG", compatibility)
         self.assertIn("-DGRDBCUSTOMSQLITE", compatibility)
         self.assertIn("SWIFT_EXEC=", compatibility)
+        self.assertIn(
+            'compiler_wrapper="$toolchain_bin/swiftql-swiftc"', compatibility
+        )
         self.assertIn("SWIFTQL_REAL_SWIFT_FRONTEND=", compatibility)
         self.assertIn('"-modulewrap"', compatibility)
         self.assertIn("os_id: ubuntu", matrix)

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -19,7 +19,7 @@ ENVIRONMENT_CHECK = ROOT / "scripts/ci/check-compatibility-environment.sh"
 
 
 class SwiftCompatibilityWorkflowTests(unittest.TestCase):
-    def test_swift59_cells_use_exact_toolchain_on_macos15(self) -> None:
+    def test_swift59_cells_use_exact_toolchain_on_ubuntu22(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         compatibility = workflow.split("\n  compatibility:\n", maxsplit=1)[1]
         matrix = compatibility.split("\n    env:\n", maxsplit=1)[0]
@@ -28,30 +28,27 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertEqual(matrix.count('swift_series: "5.9"'), 2)
         self.assertEqual(matrix.count('swift_version: "5.9.2"'), 2)
         self.assertEqual(matrix.count("swift_command_mode: path"), 2)
-        self.assertEqual(matrix.count("runner: macos-15-intel"), 2)
+        self.assertEqual(matrix.count("runner: ubuntu-22.04"), 2)
         self.assertEqual(matrix.count("\n            runner: macos-15\n"), 2)
-        self.assertEqual(matrix.count("image_os: macos15"), 4)
+        self.assertEqual(matrix.count("platform: linux"), 2)
+        self.assertEqual(matrix.count("platform: macos"), 2)
+        self.assertEqual(matrix.count("image_os: ubuntu22"), 2)
+        self.assertEqual(matrix.count("image_os: macos15"), 2)
         self.assertEqual(matrix.count("architecture: x86_64"), 2)
         self.assertEqual(matrix.count("architecture: arm64"), 2)
 
-        self.assertNotIn("swift-actions/setup-swift", compatibility)
-        self.assertIn(
-            "if: ${{ matrix.swift_command_mode == 'path' }}", compatibility
+        action = (
+            "swift-actions/setup-swift@"
+            "65540b95f51493d65f5e59e97dcef9629ddf11bf"
         )
+        self.assertEqual(compatibility.count(action), 1)
         self.assertIn(
-            "https://download.swift.org/swift-5.9.2-release/xcode/"
-            "swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-osx.pkg",
-            compatibility,
+            "if: ${{ matrix.platform == 'linux' }}", compatibility
         )
-        self.assertIn(
-            "68951c313b4b559878fc5be27e460c877f98d14e161f755220b063123919e896",
-            compatibility,
-        )
-        self.assertIn("shasum -a 256 --check", compatibility)
-        self.assertIn(
-            "Developer ID Installer: Swift Open Source (V9AUD2URP3)",
-            compatibility,
-        )
+        self.assertIn('swift-version: "5.9.2"', compatibility)
+        self.assertIn("os_id: ubuntu", matrix)
+        self.assertIn('os_version_id: "22.04"', matrix)
+        self.assertIn("target_triple: x86_64-unknown-linux-gnu", matrix)
         self.assertIn(
             "EXPECTED_SWIFT_VERSION: ${{ matrix.swift_version }}", compatibility
         )
@@ -63,6 +60,21 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertIn(
             "EXPECTED_ARCHITECTURE: ${{ matrix.architecture }}", compatibility
         )
+
+    def test_linux_surface_uses_opencombine_without_conditional_exclusion(self) -> None:
+        manifest = (ROOT / "Package.swift").read_text(encoding="utf-8")
+        bridge = (
+            ROOT / "Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            '.package(url: "https://github.com/OpenCombine/OpenCombine.git", '
+            'exact: "0.14.0")',
+            manifest,
+        )
+        self.assertIn("case waiting", bridge)
+        self.assertIn("remainingDemand", bridge)
+        self.assertNotIn("XCTSkip", bridge)
 
     def test_compatibility_commands_use_selected_path_toolchain(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
@@ -188,6 +200,64 @@ class CompatibilityEnvironmentTests(unittest.TestCase):
             check=False,
         )
 
+    def run_linux_check(self, **overrides: str) -> subprocess.CompletedProcess[str]:
+        os_release = self.root / "os-release"
+        os_release.write_text('ID=ubuntu\nVERSION_ID="22.04"\n', encoding="utf-8")
+        self.install_command(
+            "swift",
+            """
+            #!/bin/sh
+            if [ "$*" = "package tools-version" ]; then
+              printf '5.9.0\n'
+            else
+              printf 'Swift version 5.9.2 (swift-5.9.2-RELEASE)\n'
+              printf 'Target: x86_64-unknown-linux-gnu\n'
+            fi
+            """,
+        )
+        self.install_command(
+            "swiftc",
+            """
+            #!/bin/sh
+            printf '{"target": {"triple": "x86_64-unknown-linux-gnu"}}\n'
+            """,
+        )
+        self.install_command(
+            "uname",
+            """
+            #!/bin/sh
+            printf 'x86_64\n'
+            """,
+        )
+
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PATH": f"{self.bin}:/usr/bin:/bin",
+                "EXPECTED_PLATFORM": "linux",
+                "EXPECTED_SWIFT_SERIES": "5.9",
+                "EXPECTED_SWIFT_VERSION": "5.9.2",
+                "EXPECTED_SWIFT_COMMAND_MODE": "path",
+                "EXPECTED_IMAGE_OS": "ubuntu22",
+                "EXPECTED_ARCHITECTURE": "x86_64",
+                "EXPECTED_OS_ID": "ubuntu",
+                "EXPECTED_OS_VERSION_ID": "22.04",
+                "EXPECTED_OS_RELEASE_FILE": str(os_release),
+                "EXPECTED_TARGET_TRIPLE": "x86_64-unknown-linux-gnu",
+                "ImageOS": "ubuntu22",
+                "ImageVersion": "fixture.1",
+            }
+        )
+        environment.update(overrides)
+        return subprocess.run(
+            ["/bin/bash", str(ENVIRONMENT_CHECK)],
+            cwd=ROOT,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
     def test_exact_path_toolchain_environment_passes(self) -> None:
         result = self.run_check()
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -209,6 +279,17 @@ class CompatibilityEnvironmentTests(unittest.TestCase):
         result = self.run_check(EXPECTED_ARCHITECTURE="x86_64")
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("architecture is 'arm64'; expected 'x86_64'", result.stderr)
+
+    def test_exact_linux_environment_passes(self) -> None:
+        result = self.run_linux_check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Compatibility platform: linux", result.stdout)
+        self.assertIn("Linux distribution: ubuntu 22.04", result.stdout)
+
+    def test_linux_distribution_drift_fails_closed(self) -> None:
+        result = self.run_linux_check(EXPECTED_OS_VERSION_ID="24.04")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("VERSION_ID is '22.04'; expected '24.04'", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -28,9 +28,11 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertEqual(matrix.count('swift_series: "5.9"'), 2)
         self.assertEqual(matrix.count('swift_version: "5.9.2"'), 2)
         self.assertEqual(matrix.count("swift_command_mode: path"), 2)
-        self.assertEqual(matrix.count("runner: macos-15"), 4)
+        self.assertEqual(matrix.count("runner: macos-15-intel"), 2)
+        self.assertEqual(matrix.count("\n            runner: macos-15\n"), 2)
         self.assertEqual(matrix.count("image_os: macos15"), 4)
-        self.assertEqual(matrix.count("architecture: arm64"), 4)
+        self.assertEqual(matrix.count("architecture: x86_64"), 2)
+        self.assertEqual(matrix.count("architecture: arm64"), 2)
 
         action = (
             "swift-actions/setup-swift@"

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -37,15 +37,24 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertEqual(matrix.count("architecture: x86_64"), 2)
         self.assertEqual(matrix.count("architecture: arm64"), 2)
 
-        action = (
-            "swift-actions/setup-swift@"
-            "65540b95f51493d65f5e59e97dcef9629ddf11bf"
-        )
-        self.assertEqual(compatibility.count(action), 1)
+        self.assertNotIn("swift-actions/setup-swift", compatibility)
         self.assertIn(
             "if: ${{ matrix.platform == 'linux' }}", compatibility
         )
-        self.assertIn('swift-version: "5.9.2"', compatibility)
+        self.assertIn(
+            "https://download.swift.org/swift-5.9.2-release/ubuntu2204/"
+            "swift-5.9.2-RELEASE/"
+            "swift-5.9.2-RELEASE-ubuntu22.04.tar.gz",
+            compatibility,
+        )
+        self.assertIn("SWIFT_TOOLCHAIN_SIGNATURE_URL", compatibility)
+        self.assertIn(
+            "SWIFT_SIGNING_FINGERPRINT: "
+            "A62AE125BBBFBB96A6E042EC925CC1CCED3D1561",
+            compatibility,
+        )
+        self.assertIn("gpg --batch", compatibility)
+        self.assertIn("[GNUPG:] VALIDSIG", compatibility)
         self.assertIn("os_id: ubuntu", matrix)
         self.assertIn('os_version_id: "22.04"', matrix)
         self.assertIn("target_triple: x86_64-unknown-linux-gnu", matrix)

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -108,6 +108,7 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertNotIn(".path(percentEncoded:", source)
         self.assertNotIn(".appending(path:", source)
         self.assertNotIn("formatter.timeZone = .gmt", source)
+        self.assertNotIn("import CryptoKit", source)
 
         benchmark_cli = (
             ROOT / "Benchmarks/Sources/SwiftQLBenchmarkCLI/main.swift"

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+
+"""Fail-closed fixtures for the pinned Swift compatibility workflow."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/swift.yml"
+ENVIRONMENT_CHECK = ROOT / "scripts/ci/check-compatibility-environment.sh"
+
+
+class SwiftCompatibilityWorkflowTests(unittest.TestCase):
+    def test_swift59_cells_use_exact_toolchain_on_macos15(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        compatibility = workflow.split("\n  compatibility:\n", maxsplit=1)[1]
+        matrix = compatibility.split("\n    env:\n", maxsplit=1)[0]
+
+        self.assertNotIn("runner: macos-14", matrix)
+        self.assertEqual(matrix.count('swift_series: "5.9"'), 2)
+        self.assertEqual(matrix.count('swift_version: "5.9.2"'), 2)
+        self.assertEqual(matrix.count("swift_command_mode: path"), 2)
+        self.assertEqual(matrix.count("runner: macos-15"), 4)
+        self.assertEqual(matrix.count("image_os: macos15"), 4)
+        self.assertEqual(matrix.count("architecture: arm64"), 4)
+
+        action = (
+            "swift-actions/setup-swift@"
+            "65540b95f51493d65f5e59e97dcef9629ddf11bf"
+        )
+        self.assertEqual(compatibility.count(action), 1)
+        self.assertIn(
+            "if: ${{ matrix.swift_command_mode == 'path' }}", compatibility
+        )
+        self.assertIn('swift-version: "5.9.2"', compatibility)
+        self.assertIn(
+            "EXPECTED_SWIFT_VERSION: ${{ matrix.swift_version }}", compatibility
+        )
+        self.assertIn(
+            "EXPECTED_SWIFT_COMMAND_MODE: ${{ matrix.swift_command_mode }}",
+            compatibility,
+        )
+        self.assertIn("EXPECTED_IMAGE_OS: ${{ matrix.image_os }}", compatibility)
+        self.assertIn(
+            "EXPECTED_ARCHITECTURE: ${{ matrix.architecture }}", compatibility
+        )
+
+    def test_compatibility_commands_use_selected_path_toolchain(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        compatibility = workflow.split("\n  compatibility:\n", maxsplit=1)[1]
+
+        for command in (
+            "swift package resolve",
+            "swift test --filter XLCompatibilityReportTests",
+            "swift run --skip-build swiftql-benchmark",
+            "swift test --skip-build -v",
+        ):
+            self.assertIn(command, compatibility)
+        self.assertNotIn("xcrun swift package resolve", compatibility)
+        self.assertNotIn("xcrun swift run --skip-build swiftql-benchmark", compatibility)
+
+
+class CompatibilityEnvironmentTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory(
+            prefix="swiftql-compatibility-environment."
+        )
+        self.root = Path(self.temporary_directory.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.developer_dir = self.root / "Xcode_16.2.app/Contents/Developer"
+        self.developer_dir.mkdir(parents=True)
+        self.install_fake_commands(swift_version="5.9.2")
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def install_command(self, name: str, source: str) -> None:
+        path = self.bin / name
+        path.write_text(textwrap.dedent(source).lstrip(), encoding="utf-8")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def install_fake_commands(self, swift_version: str) -> None:
+        self.install_command(
+            "xcodebuild",
+            """
+            #!/bin/sh
+            printf 'Xcode 16.2\nBuild version 16C5032a\n'
+            """,
+        )
+        self.install_command(
+            "xcrun",
+            """
+            #!/bin/sh
+            case "$*" in
+              "--sdk macosx --show-sdk-version") printf '15.2\n' ;;
+              "--sdk macosx --show-sdk-path") printf '/fake/MacOSX15.2.sdk\n' ;;
+              *) printf 'unexpected xcrun arguments: %s\n' "$*" >&2; exit 64 ;;
+            esac
+            """,
+        )
+        self.install_command(
+            "swift",
+            f"""
+            #!/bin/sh
+            if [ "$*" = "package tools-version" ]; then
+              printf '5.9.0\n'
+            else
+              printf 'Swift version {swift_version} (swift-{swift_version}-RELEASE)\n'
+              printf 'Target: arm64-apple-macosx15.0\n'
+            fi
+            """,
+        )
+        self.install_command(
+            "swiftc",
+            """
+            #!/bin/sh
+            printf '{"target":{"triple":"arm64-apple-macosx15.0"}}\n'
+            """,
+        )
+        self.install_command(
+            "xcode-select",
+            f"""
+            #!/bin/sh
+            printf '%s\n' '{self.developer_dir}'
+            """,
+        )
+        self.install_command(
+            "uname",
+            """
+            #!/bin/sh
+            printf 'arm64\n'
+            """,
+        )
+        self.install_command(
+            "sw_vers",
+            """
+            #!/bin/sh
+            printf 'ProductName:\tmacOS\nProductVersion:\t15.7\nBuildVersion:\t24G207\n'
+            """,
+        )
+
+    def run_check(self, **overrides: str) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PATH": f"{self.bin}:/usr/bin:/bin",
+                "DEVELOPER_DIR": str(self.developer_dir),
+                "EXPECTED_XCODE_VERSION": "16.2",
+                "EXPECTED_XCODE_BUILD": "16C5032a",
+                "EXPECTED_SWIFT_SERIES": "5.9",
+                "EXPECTED_SWIFT_VERSION": "5.9.2",
+                "EXPECTED_SWIFT_COMMAND_MODE": "path",
+                "EXPECTED_SDK_VERSION": "15.2",
+                "EXPECTED_DEVELOPER_DIR": str(self.developer_dir),
+                "EXPECTED_IMAGE_OS": "macos15",
+                "EXPECTED_ARCHITECTURE": "arm64",
+                "ImageOS": "macos15",
+                "ImageVersion": "fixture.1",
+            }
+        )
+        environment.update(overrides)
+        return subprocess.run(
+            ["/bin/bash", str(ENVIRONMENT_CHECK)],
+            cwd=ROOT,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_exact_path_toolchain_environment_passes(self) -> None:
+        result = self.run_check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Swift command mode: path", result.stdout)
+        self.assertIn("Swift version 5.9.2", result.stdout)
+
+    def test_patch_drift_fails_closed(self) -> None:
+        self.install_fake_commands(swift_version="5.9.1")
+        result = self.run_check()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not exactly version 5.9.2", result.stderr)
+
+    def test_runner_family_drift_fails_closed(self) -> None:
+        result = self.run_check(ImageOS="macos16")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ImageOS is 'macos16'; expected 'macos15'", result.stderr)
+
+    def test_architecture_drift_fails_closed(self) -> None:
+        result = self.run_check(EXPECTED_ARCHITECTURE="x86_64")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("architecture is 'arm64'; expected 'x86_64'", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -127,6 +127,9 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         bridge = (
             ROOT / "Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift"
         ).read_text(encoding="utf-8")
+        coverage_config = (
+            ROOT / "scripts/ci/source-coverage-config.json"
+        ).read_text(encoding="utf-8")
 
         self.assertIn(
             '.package(url: "https://github.com/OpenCombine/OpenCombine.git", '
@@ -136,6 +139,10 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertIn("case waiting", bridge)
         self.assertIn("remainingDemand", bridge)
         self.assertNotIn("XCTSkip", bridge)
+        self.assertIn(
+            '"Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift"',
+            coverage_config,
+        )
 
     def test_swift59_linux_surface_avoids_newer_foundation_url_apis(self) -> None:
         swift_sources = list((ROOT / "Sources").rglob("*.swift"))

--- a/scripts/ci/test-swift-compatibility-workflow.py
+++ b/scripts/ci/test-swift-compatibility-workflow.py
@@ -98,6 +98,16 @@ class SwiftCompatibilityWorkflowTests(unittest.TestCase):
         self.assertIn("remainingDemand", bridge)
         self.assertNotIn("XCTSkip", bridge)
 
+    def test_swift59_linux_surface_avoids_newer_foundation_url_apis(self) -> None:
+        swift_sources = list((ROOT / "Sources").rglob("*.swift"))
+        swift_sources.extend((ROOT / "Tests").rglob("*.swift"))
+        source = "\n".join(
+            path.read_text(encoding="utf-8") for path in swift_sources
+        )
+
+        self.assertNotIn(".path(percentEncoded:", source)
+        self.assertNotIn(".appending(path:", source)
+
     def test_compatibility_commands_use_selected_path_toolchain(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         compatibility = workflow.split("\n  compatibility:\n", maxsplit=1)[1]


### PR DESCRIPTION
Closes #164

## Summary

- move both real Swift 5.9 compatibility cells from retiring `macos-14` to maintained `ubuntu-22.04`
- install the exact official Swift 5.9.2 Ubuntu 22.04 archive from immutable Swift.org release URLs
- pin the detached-signature SHA-256 and require the exact Swift 5.x signing-key fingerprint; use Swift.org’s evolving key bundle with Swift’s documented Ubuntu keyserver as an exact-fingerprint fallback
- compile and privately link exact official SQLite 3.53.3 after checking SQLite's published SHA3-256, so Ubuntu 22.04's older system SQLite cannot silently reduce the conformance surface
- retain the complete compatibility build and all 688 package tests in committed- and clean-resolution modes
- add exact OpenCombine 0.14.0 plus a demand-driven GRDB observation bridge so Linux exercises publisher, retry, cancellation, codec, SQLite, macro, and benchmark surfaces without skips
- consistently select GRDB's custom-SQLite compile path on Linux and compile/export its optional snapshot API, preventing GRDB's documented unconditional startup refetch while keeping exact runtime reporting and full execution tests authoritative
- keep the compiler override beside the selected toolchain so SwiftPM resolves the matching frontend and index-store runtime
- make source, tests, documentation examples, benchmark CLI, and manifest hashing portable across Swift 5.9 Linux
- make the environment gate fail closed on signature, compiler patch, runner OS, distribution version, architecture, target triple, dependency, link, SQLite digest/version/capability, and compiler-warning drift
- keep the Swift 6.0/Xcode 16.2 Apple support cells unchanged
- document reproduction, maintenance, security, and recovery ownership

## Why Linux?

GitHub's maintained macOS images no longer contain Xcode 15. The official signed Swift 5.9.2 macOS package installs on `macos-15-intel`, but cannot consume the Xcode 16.2/macOS 15.2 SDK interfaces built with Swift 6.0.3. This repository has no self-hosted runner and no credentialed Xcode download secret. Issue #164 explicitly permits official Swift 5.9 Linux when the full product surface and complete suite are proven, so this change implements the missing Combine-compatible surface instead of excluding it.

## Validation

Local host (Xcode 26.5 / Swift 6.3.2):

- `python3 scripts/ci/test-swift-compatibility-workflow.py` — 10 tests passed
- `python3 scripts/ci/test-source-coverage-report.py` — 26 tests passed
- shell syntax, workflow YAML, and `git diff --check` — passed
- warning-clean build — no blocking first-party or unclassified warnings
- benchmark CLI product build — passed
- portable SHA-256 published-vector test — passed
- deterministic combinatorial-manifest checksum test — passed
- existing publisher contract suite — 15 tests passed
- full suite — 688 tests passed, 0 failures
- documentation contract suite — 37 tests passed
- Swift.org signature issuer and pinned full fingerprint were independently inspected
- Swift’s Ubuntu-keyserver result was independently checked for that same fingerprint
- SQLite.org's official 3.53.3 archive URL and published SHA3-256 were independently checked
- a SwiftPM `SWIFT_EXEC` probe confirmed the Linux compatibility define reaches dependency compilation

Hosted proof is complete at exact head `1af505b319e6c97b74420ac590b11ceca962a257`. [Swift compatibility run 29755403057](https://github.com/lukevanin/swiftql/actions/runs/29755403057) passed all nine jobs: both real Swift 5.9 Linux modes, both Swift 6.0 modes, Swift 6.1–6.3, release tooling fixtures, and reproducible first-party source coverage. [Documentation run 29755403294](https://github.com/lukevanin/swiftql/actions/runs/29755403294) passed exact-source verification, DocC build and inspection, provenance recording, clean-checkout enforcement, and Pages artifact upload. The final head also synchronizes the downstream Swift 5 client lockfile byte-for-byte with the root lockfile, and both Swift 6.0 resolution modes proved that client gate green.