### PR TITLE
Add real-SQLite IN-subquery conformance cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 ### Added
 
 - Added the #190 canonical SQLite conformance inventory and deterministic
-  generated report. It records 101 public-surface feature records: 88
-  supported, 3 partial, 2 capability-gated, 1 intentionally unsupported, and
-  7 unimplemented. Of the 104 evidence records, 68 exercise real SQLite and
+  generated report. It records 101 public-surface feature records: 89
+  supported, 2 partial, 2 capability-gated, 1 intentionally unsupported, and
+  7 unimplemented. Of the 106 evidence records, 69 exercise real SQLite and
   cite one captured SQLite 3.51.0 environment.
 - Added the #191 bounded combinatorial SQLite corpus with 141 stable generated
   cases across joins, subqueries, common table expressions, grouping,

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -55,20 +55,20 @@ The report is evidence for SwiftQL's existing public SQLite subset; it is not a
 claim of complete SQLite grammar coverage. The inventory remains the source of
 truth, while the report is its readable generated view.
 
-The v1.3 inventory contains 101 feature records and 104 evidence records. Its
+The v1.3 inventory contains 101 feature records and 106 evidence records. Its
 support-status totals are exact and mutually exclusive:
 
 | Support status | Features |
 | --- | ---: |
-| Supported | 88 |
-| Partial | 3 |
+| Supported | 89 |
+| Partial | 2 |
 | Capability-gated | 2 |
 | Intentionally unsupported | 1 |
 | Unimplemented | 7 |
 
-Of those 104 evidence records, 68 exercise real SQLite and
+Of those 106 evidence records, 69 exercise real SQLite and
 cite one captured environment, SQLite 3.51.0. An inventory entry is counted in
-the 88 supported features only when it links to successful preparation by a
+the 89 supported features only when it links to successful preparation by a
 real SQLite engine whose version and source ID are recorded. Partial,
 capability-gated, intentionally unsupported, and unimplemented entries remain
 visible with their evidence, requirements, or rationale, but are excluded

--- a/Conformance/SQLite/COMBINATORIAL_CASES.json
+++ b/Conformance/SQLite/COMBINATORIAL_CASES.json
@@ -9529,6 +9529,216 @@
       ],
       "strength" : "targeted",
       "template" : "expression.string-printf-array"
+    },
+    {
+      "bindings" : [
+        {
+          "key_kind" : "named",
+          "key_name" : "in_subquery_employee_id",
+          "logical_index" : 0,
+          "repeat_count" : 1,
+          "storage" : "integer",
+          "tagged_value" : {
+            "tag" : "integer",
+            "value" : -1
+          }
+        }
+      ],
+      "constraint_ids" : [
+
+      ],
+      "dimension_vector" : [
+        {
+          "dimension_id" : "in-subquery-case",
+          "value_id" : "in-query-builder-empty"
+        }
+      ],
+      "id" : "c288.v1.subquery.in-query-builder-empty",
+      "inventory_feature_ids" : [
+        "syntax.expression.current-operators",
+        "syntax.select.core",
+        "syntax.subquery.table-and-in-prepare-gap"
+      ],
+      "mode" : "semantic",
+      "oracle" : {
+        "id" : "oracle.c288.subquery.in-query-builder-empty",
+        "kind" : "raw-sql"
+      },
+      "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"employeeID\" IN (SELECT \"t0\".\"employeeID\" FROM \"Employees\" AS \"t0\" WHERE (\"t0\".\"employeeID\" == :in_subquery_employee_id))) ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+      "reproduction_command" : "SWIFTQL_COMBINATORIAL_CASE=c288.v1.subquery.in-query-builder-empty swift test --filter SQLiteCombinatorialConformanceTests",
+      "required_capabilities" : [
+
+      ],
+      "strength" : "targeted",
+      "template" : "subquery.in-query-builder-empty"
+    },
+    {
+      "bindings" : [
+        {
+          "key_kind" : "named",
+          "key_name" : "in_subquery_employee_id",
+          "logical_index" : 0,
+          "repeat_count" : 1,
+          "storage" : "integer",
+          "tagged_value" : {
+            "tag" : "integer",
+            "value" : 5
+          }
+        }
+      ],
+      "constraint_ids" : [
+
+      ],
+      "dimension_vector" : [
+        {
+          "dimension_id" : "in-subquery-case",
+          "value_id" : "in-query-builder-nonempty"
+        }
+      ],
+      "id" : "c288.v1.subquery.in-query-builder-nonempty",
+      "inventory_feature_ids" : [
+        "syntax.expression.current-operators",
+        "syntax.select.core",
+        "syntax.subquery.table-and-in-prepare-gap"
+      ],
+      "mode" : "semantic",
+      "oracle" : {
+        "id" : "oracle.c288.subquery.in-query-builder-nonempty",
+        "kind" : "raw-sql"
+      },
+      "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"employeeID\" IN (SELECT \"t0\".\"employeeID\" FROM \"Employees\" AS \"t0\" WHERE (\"t0\".\"employeeID\" == :in_subquery_employee_id))) ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+      "reproduction_command" : "SWIFTQL_COMBINATORIAL_CASE=c288.v1.subquery.in-query-builder-nonempty swift test --filter SQLiteCombinatorialConformanceTests",
+      "required_capabilities" : [
+
+      ],
+      "strength" : "targeted",
+      "template" : "subquery.in-query-builder-nonempty"
+    },
+    {
+      "bindings" : [
+        {
+          "key_kind" : "named",
+          "key_name" : "in_subquery_customer_id",
+          "logical_index" : 0,
+          "repeat_count" : 1,
+          "storage" : "text",
+          "tagged_value" : {
+            "tag" : "text",
+            "value" : "VINET"
+          }
+        }
+      ],
+      "constraint_ids" : [
+
+      ],
+      "dimension_vector" : [
+        {
+          "dimension_id" : "in-subquery-case",
+          "value_id" : "in-query-functional-nonempty"
+        }
+      ],
+      "id" : "c288.v1.subquery.in-query-functional-nonempty",
+      "inventory_feature_ids" : [
+        "syntax.expression.current-operators",
+        "syntax.select.core",
+        "syntax.subquery.table-and-in-prepare-gap"
+      ],
+      "mode" : "semantic",
+      "oracle" : {
+        "id" : "oracle.c288.subquery.in-query-functional-nonempty",
+        "kind" : "raw-sql"
+      },
+      "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"customerID\" IN (SELECT \"t1\".\"customerID\" FROM \"Customers\" AS \"t1\" WHERE (\"t1\".\"customerID\" == :in_subquery_customer_id))) ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+      "reproduction_command" : "SWIFTQL_COMBINATORIAL_CASE=c288.v1.subquery.in-query-functional-nonempty swift test --filter SQLiteCombinatorialConformanceTests",
+      "required_capabilities" : [
+
+      ],
+      "strength" : "targeted",
+      "template" : "subquery.in-query-functional-nonempty"
+    },
+    {
+      "bindings" : [
+        {
+          "key_kind" : "named",
+          "key_name" : "in_table_employee_id",
+          "logical_index" : 0,
+          "repeat_count" : 1,
+          "storage" : "integer",
+          "tagged_value" : {
+            "tag" : "integer",
+            "value" : -1
+          }
+        }
+      ],
+      "constraint_ids" : [
+
+      ],
+      "dimension_vector" : [
+        {
+          "dimension_id" : "in-subquery-case",
+          "value_id" : "in-table-empty"
+        }
+      ],
+      "id" : "c288.v1.subquery.in-table-empty",
+      "inventory_feature_ids" : [
+        "syntax.expression.current-operators",
+        "syntax.select.core",
+        "syntax.subquery.table-and-in-prepare-gap"
+      ],
+      "mode" : "semantic",
+      "oracle" : {
+        "id" : "oracle.c288.subquery.in-table-empty",
+        "kind" : "raw-sql"
+      },
+      "rendered_sql" : "WITH \"cte0\" AS (SELECT \"t0\".\"employeeID\" AS \"employeeID\" FROM \"Employees\" AS \"t0\" WHERE (\"t0\".\"employeeID\" == :in_table_employee_id)) SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"employeeID\" IN \"cte0\") ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+      "reproduction_command" : "SWIFTQL_COMBINATORIAL_CASE=c288.v1.subquery.in-table-empty swift test --filter SQLiteCombinatorialConformanceTests",
+      "required_capabilities" : [
+
+      ],
+      "strength" : "targeted",
+      "template" : "subquery.in-table-empty"
+    },
+    {
+      "bindings" : [
+        {
+          "key_kind" : "named",
+          "key_name" : "in_table_employee_id",
+          "logical_index" : 0,
+          "repeat_count" : 1,
+          "storage" : "integer",
+          "tagged_value" : {
+            "tag" : "integer",
+            "value" : 4
+          }
+        }
+      ],
+      "constraint_ids" : [
+
+      ],
+      "dimension_vector" : [
+        {
+          "dimension_id" : "in-subquery-case",
+          "value_id" : "in-table-nonempty"
+        }
+      ],
+      "id" : "c288.v1.subquery.in-table-nonempty",
+      "inventory_feature_ids" : [
+        "syntax.expression.current-operators",
+        "syntax.select.core",
+        "syntax.subquery.table-and-in-prepare-gap"
+      ],
+      "mode" : "semantic",
+      "oracle" : {
+        "id" : "oracle.c288.subquery.in-table-nonempty",
+        "kind" : "raw-sql"
+      },
+      "rendered_sql" : "WITH \"cte0\" AS (SELECT \"t0\".\"employeeID\" AS \"employeeID\" FROM \"Employees\" AS \"t0\" WHERE (\"t0\".\"employeeID\" == :in_table_employee_id)) SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"employeeID\" IN \"cte0\") ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+      "reproduction_command" : "SWIFTQL_COMBINATORIAL_CASE=c288.v1.subquery.in-table-nonempty swift test --filter SQLiteCombinatorialConformanceTests",
+      "required_capabilities" : [
+
+      ],
+      "strength" : "targeted",
+      "template" : "subquery.in-table-nonempty"
     }
   ],
   "constraints" : [
@@ -10034,6 +10244,32 @@
         {
           "id" : "cte-order-subtotals",
           "label" : "cte-order-subtotals"
+        }
+      ]
+    },
+    {
+      "id" : "in-subquery-case",
+      "title" : "Query-backed IN entry point",
+      "values" : [
+        {
+          "id" : "in-query-builder-nonempty",
+          "label" : "in-query-builder-nonempty"
+        },
+        {
+          "id" : "in-query-builder-empty",
+          "label" : "in-query-builder-empty"
+        },
+        {
+          "id" : "in-query-functional-nonempty",
+          "label" : "in-query-functional-nonempty"
+        },
+        {
+          "id" : "in-table-nonempty",
+          "label" : "in-table-nonempty"
+        },
+        {
+          "id" : "in-table-empty",
+          "label" : "in-table-empty"
         }
       ]
     },

--- a/Conformance/SQLite/COMBINATORIAL_SUMMARY.md
+++ b/Conformance/SQLite/COMBINATORIAL_SUMMARY.md
@@ -4,7 +4,7 @@
 - Generator version: `c191-v2`
 - Coordination issue: `#191`
 - Inventory version: `1.3.0`
-- Cases: `168`
+- Cases: `173`
 
 ## Hard bounds
 
@@ -34,6 +34,7 @@
 | compound-operator | Compound operator | union: union, union-all: union-all, intersect: intersect, except: except |
 | expression-case | Adopted expression case | indexed-binding: indexed-binding, numeric-abs: numeric-abs, numeric-round: numeric-round, numeric-floor: numeric-floor, comparable-min: comparable-min, string-printf: string-printf, cast-text-integer: cast-text-integer, cast-text-blob: cast-text-blob, date-unixepoch: date-unixepoch, json-valid: json-valid, json-array-length: json-array-length, operator-arithmetic-precedence: operator-arithmetic-precedence, operator-glob: operator-glob, aggregate-count-distinct: aggregate-count-distinct, aggregate-min-distinct: aggregate-min-distinct, aggregate-max-distinct: aggregate-max-distinct, aggregate-average-distinct: aggregate-average-distinct, aggregate-sum-distinct: aggregate-sum-distinct, aggregate-group-concat-distinct: aggregate-group-concat-distinct, numeric-round-no-places: numeric-round-no-places, numeric-round-optional: numeric-round-optional, comparable-max: comparable-max, string-printf-array: string-printf-array, json-array-length-path: json-array-length-path, cast-bool-integer: cast-bool-integer, cast-optional-bool-integer: cast-optional-bool-integer, cast-integer-real: cast-integer-real, cast-integer-text: cast-integer-text, cast-optional-integer-real: cast-optional-integer-real, cast-optional-integer-text: cast-optional-integer-text, cast-real-integer: cast-real-integer, cast-real-text: cast-real-text, cast-optional-real-integer: cast-optional-real-integer, cast-optional-real-text: cast-optional-real-text, cast-text-real: cast-text-real, cast-optional-text-integer: cast-optional-text-integer, cast-optional-text-real: cast-optional-text-real, cast-optional-text-blob: cast-optional-text-blob, cast-blob-text: cast-blob-text, cast-optional-blob-text: cast-optional-blob-text |
 | northwind-adaptation | Pinned Northwind adaptation | compound-customer-supplier-cities: compound-customer-supplier-cities, cte-order-subtotals: cte-order-subtotals |
+| in-subquery-case | Query-backed IN entry point | in-query-builder-nonempty: in-query-builder-nonempty, in-query-builder-empty: in-query-builder-empty, in-query-functional-nonempty: in-query-functional-nonempty, in-table-nonempty: in-table-nonempty, in-table-empty: in-table-empty |
 | gated-prerequisite | Explicitly gated typed prerequisite | issue-43-direct-scalar-compounds: #43 direct scalar compounds, issue-10-cte-materialization-hints: #10 CTE materialization hints, issue-139-typed-ddl: #139 typed DDL, issue-57-dml-returning: #57 DML RETURNING, issue-21-like-escape: #21 LIKE ESCAPE, issue-45-natural-using-joins: #45 NATURAL and USING joins, issue-70-nullable-subquery-shapes: #70 nullable subquery shapes |
 
 ## Constraints
@@ -241,3 +242,8 @@
 | c286.v1.expression.numeric-round-no-places | expression.numeric-round-no-places | targeted | semantic | expression-case=numeric-round-no-places | syntax.expression.numeric-comparable-functions |  | 1 |
 | c286.v1.expression.numeric-round-optional | expression.numeric-round-optional | targeted | semantic | expression-case=numeric-round-optional | syntax.expression.numeric-comparable-functions |  | 1 |
 | c286.v1.expression.string-printf-array | expression.string-printf-array | targeted | semantic | expression-case=string-printf-array | syntax.expression.string-functions |  | 2 |
+| c288.v1.subquery.in-query-builder-empty | subquery.in-query-builder-empty | targeted | semantic | in-subquery-case=in-query-builder-empty | syntax.expression.current-operators, syntax.select.core, syntax.subquery.table-and-in-prepare-gap |  | 1 |
+| c288.v1.subquery.in-query-builder-nonempty | subquery.in-query-builder-nonempty | targeted | semantic | in-subquery-case=in-query-builder-nonempty | syntax.expression.current-operators, syntax.select.core, syntax.subquery.table-and-in-prepare-gap |  | 1 |
+| c288.v1.subquery.in-query-functional-nonempty | subquery.in-query-functional-nonempty | targeted | semantic | in-subquery-case=in-query-functional-nonempty | syntax.expression.current-operators, syntax.select.core, syntax.subquery.table-and-in-prepare-gap |  | 1 |
+| c288.v1.subquery.in-table-empty | subquery.in-table-empty | targeted | semantic | in-subquery-case=in-table-empty | syntax.expression.current-operators, syntax.select.core, syntax.subquery.table-and-in-prepare-gap |  | 1 |
+| c288.v1.subquery.in-table-nonempty | subquery.in-table-nonempty | targeted | semantic | in-subquery-case=in-table-nonempty | syntax.expression.current-operators, syntax.select.core, syntax.subquery.table-and-in-prepare-gap |  | 1 |

--- a/Conformance/SQLite/REPORT.md
+++ b/Conformance/SQLite/REPORT.md
@@ -22,9 +22,9 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 ## Summary
 
 - Total feature records: **101**
-- Supported feature records: **88**
+- Supported feature records: **89**
 - SQLite environments: **1**
-- Evidence records: **104**
+- Evidence records: **106**
 
 ### Support status
 
@@ -32,8 +32,8 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | --- | ---: |
 | `capability-gated` | 2 |
 | `intentionally-unsupported` | 1 |
-| `partial` | 3 |
-| `supported` | 88 |
+| `partial` | 2 |
+| `supported` | 89 |
 | `unimplemented` | 7 |
 
 ### Adoption status
@@ -41,9 +41,9 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | Value | Features |
 | --- | ---: |
 | `adapter/API-gated` | 2 |
-| `already-covered` | 90 |
+| `already-covered` | 91 |
 | `intentionally-out-of-scope` | 1 |
-| `syntax-gated` | 8 |
+| `syntax-gated` | 7 |
 
 ### Record kind
 
@@ -70,6 +70,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `suite.255.observation-stress` | [#255](https://github.com/lukevanin/swiftql/issues/255) | `v1.3` | `completed` | 12 | 20 |
 | `suite.256.macro-downstream-regressions` | [#256](https://github.com/lukevanin/swiftql/issues/256) | `v1.5` | `planned` | 0 | 0 |
 | `suite.286.function-overload-conformance` | [#286](https://github.com/lukevanin/swiftql/issues/286) | `v1.4.1` | `completed` | 5 | 4 |
+| `suite.288.in-subquery-conformance` | [#288](https://github.com/lukevanin/swiftql/issues/288) | `v1.4.2` | `completed` | 3 | 4 |
 
 ## Feature inventory
 
@@ -175,7 +176,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `northwind.subquery.products-above-average`<br>Products above average price scalar subquery | `subquery` | `adopted-behavior` | `supported` | `already-covered` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)) | `evidence.northwind.subquery-compound-cte.sqlite` | — |
 | `syntax.subquery.correlated-scalar`<br>Correlated scalar subqueries | `subquery` | `syntax` | `supported` | `already-covered` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)) | `evidence.syntax.subquery.sqlite-correlated` | [#70](https://github.com/lukevanin/swiftql/issues/70) |
 | `syntax.subquery.nullable-shape-gap`<br>Nullable-table and direct-scalar subquery result shapes | `subquery` | `syntax` | `unimplemented` | `syntax-gated` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)) | — | [#70](https://github.com/lukevanin/swiftql/issues/70) |
-| `syntax.subquery.table-and-in-prepare-gap`<br>Table and IN-subquery real-SQLite prepare coverage | `subquery` | `syntax` | `partial` | `syntax-gated` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)), `XLExpression.in(expression:)` [verified: `in`] ([`Sources/SwiftQL/Operators/InOperator.swift`](../../Sources/SwiftQL/Operators/InOperator.swift)), `XLExpression.in(_ table:)` [verified: `in`] ([`Sources/SwiftQL/Operators/InOperator.swift`](../../Sources/SwiftQL/Operators/InOperator.swift)) | `evidence.combinatorial.positive.sqlite`, `evidence.syntax.subquery.render-in`, `evidence.syntax.subquery.render-table` | [#288](https://github.com/lukevanin/swiftql/issues/288) |
+| `syntax.subquery.table-and-in-prepare-gap`<br>Table and IN-subquery real-SQLite prepare coverage | `subquery` | `syntax` | `supported` | `already-covered` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)), `XLExpression.in(expression:)` [verified: `in`] ([`Sources/SwiftQL/Operators/InOperator.swift`](../../Sources/SwiftQL/Operators/InOperator.swift)), `XLExpression.in(_ table:)` [verified: `in`] ([`Sources/SwiftQL/Operators/InOperator.swift`](../../Sources/SwiftQL/Operators/InOperator.swift)) | `evidence.combinatorial.in-subquery-execution.sqlite`, `evidence.combinatorial.in-subquery-matrix`, `evidence.combinatorial.positive.sqlite`, `evidence.syntax.subquery.render-in`, `evidence.syntax.subquery.render-table` | [#70](https://github.com/lukevanin/swiftql/issues/70) |
 
 ## Gates, deviations, and deferrals
 
@@ -281,7 +282,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `northwind.subquery.products-above-average` | `database-pool-driver`, `sqlite-core-parser` | Products contains deterministic prices for a scalar AVG subquery and ordered outer result. | — | — |
 | `syntax.subquery.correlated-scalar` | `sqlite-core-parser` | The inner query has a typed row reader and may reference a visible outer table dependency. | The registered real-SQLite evidence covers a correlated scalar aggregate; table and IN-subquery preparation remain separate. | — |
 | `syntax.subquery.nullable-shape-gap` | `sqlite-core-parser` | Nullable table references and scalar cardinality must preserve typed result metadata. | The current overload set cannot represent every nullable-table and scalar result shape. | [#70](https://github.com/lukevanin/swiftql/issues/70) for `v1.4`: Issue #70 owns nullable-table and scalar subquery shapes. |
-| `syntax.subquery.table-and-in-prepare-gap` | `sqlite-core-parser` | The subquery exposes a compatible typed row or scalar layout to the enclosing query. | The generated suite prepares typed table-subquery branches; exhaustive table and IN-subquery overload combinations remain deferred. | [#288](https://github.com/lukevanin/swiftql/issues/288) for `v1.4`: Issue #288 owns exhaustive real-SQLite prepare and execution coverage for table and IN-subquery overloads. |
+| `syntax.subquery.table-and-in-prepare-gap` | `sqlite-core-parser` | The subquery exposes a compatible typed row or scalar layout to the enclosing query. | Issue #288 proves both query-backed entry points with real SQLite: the result-builder and functional forms of `in(expression:)`, and `in(_ table:)` rendered as SQLite's `expr IN table-name` form, each with a non-empty and an empty inner result.<br>Optional operands of the IN overloads remain unproven and stay recorded by syntax.subquery.nullable-shape-gap. | — |
 
 ## Evidence index
 
@@ -293,6 +294,8 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `evidence.combinatorial.compile-fail-where-after-order-by` | [`Tests/CompileFail/WhereAfterOrderBy.swift`](../../Tests/CompileFail/WhereAfterOrderBy.swift)<br>`compile-fail.query-clause-ordering.where-after-order-by` | [`scripts/ci/check-query-clause-ordering-type-safety.sh`](../../scripts/ci/check-query-clause-ordering-type-safety.sh) | `compile-fail`, `swift-typecheck` | no | — |
 | `evidence.combinatorial.compile-fail-where-requires-boolean` | [`Tests/CompileFail/WhereRequiresBoolean.swift`](../../Tests/CompileFail/WhereRequiresBoolean.swift)<br>`compile-fail.query-clause-ordering.where-requires-boolean` | [`scripts/ci/check-query-clause-ordering-type-safety.sh`](../../scripts/ci/check-query-clause-ordering-type-safety.sh) | `compile-fail`, `swift-typecheck` | no | — |
 | `evidence.combinatorial.function-overload-matrix` | [`Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift`](../../Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift)<br>`SQLiteCombinatorialConformanceTests.testIssue286FunctionOverloadMatrixIsExplicitAndBounded` | — | `bindings`, `rendering`, `swift-typecheck` | no | — |
+| `evidence.combinatorial.in-subquery-execution.sqlite` | [`Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift`](../../Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift)<br>`SQLiteCombinatorialConformanceTests.testIssue288EmptyAndNonEmptyINResultsExecuteAsClaimed` | — | `bindings`, `execution`, `prepare`, `semantic-oracle` | yes | `sqlite-3.51.0-macos-arm64` |
+| `evidence.combinatorial.in-subquery-matrix` | [`Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift`](../../Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift)<br>`SQLiteCombinatorialConformanceTests.testIssue288QueryBackedINCasesAreExplicitAndBounded` | — | `bindings`, `rendering`, `swift-typecheck` | no | — |
 | `evidence.combinatorial.json-capability.sqlite` | [`Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift`](../../Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift)<br>`SQLiteCombinatorialConformanceTests.testPinnedRuntimeAttestsJSONFunctionCapability` | — | `prepare`, `runtime-metadata` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.combinatorial.manifest-determinism` | [`Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift`](../../Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift)<br>`SQLiteCombinatorialConformanceTests.testGeneratedManifestIsDeterministicAndMatchesCheckedInArtifacts` | — | `bindings`, `rendering`, `swift-typecheck` | no | — |
 | `evidence.combinatorial.positive.sqlite` | [`Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift`](../../Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift)<br>`SQLiteCombinatorialConformanceTests.testEveryPositiveCasePreparesAndSemanticOraclesExecute` | — | `bindings`, `execution`, `prepare`, `rendering`, `runtime-metadata`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |

--- a/Documentation/Architecture/SQLiteBuildValidation.md
+++ b/Documentation/Architecture/SQLiteBuildValidation.md
@@ -37,8 +37,9 @@ model:
   [`SQLiteConformanceInventory.json`](../../Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json).
 - [#191](https://github.com/lukevanin/swiftql/issues/191) owns the bounded
   combinatorial manifest and its original 141 stable cases. [#286](https://github.com/lukevanin/swiftql/issues/286)
-  adds 27 finite typed function-overload cases, producing the current
-  `c191-v2` manifest with 168 cases and runtime provenance in
+  adds 27 finite typed function-overload cases and [#288](https://github.com/lukevanin/swiftql/issues/288)
+  adds 5 finite typed query-backed IN cases, producing the current
+  `c191-v2` manifest with 173 cases and runtime provenance in
   [`COMBINATORIAL_CASES.json`](../../Conformance/SQLite/COMBINATORIAL_CASES.json).
   Its runtime collector already records SQLite version/source ID, compile
   options, functions, collations, module names, caller-supplied extension names,

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ for the complete contracts and current limitations.
 
 SwiftQL v1.3 adds evidence around that public surface rather than claiming
 complete SQLite grammar coverage. The canonical inventory records 101 features:
-88 supported, 3 partial, 2 capability-gated, 1 intentionally unsupported, and
-7 unimplemented. Of its 104 evidence records, 68 exercise real SQLite and
+89 supported, 2 partial, 2 capability-gated, 1 intentionally unsupported, and
+7 unimplemented. Of its 106 evidence records, 69 exercise real SQLite and
 cite one recorded SQLite 3.51.0 environment. See
 [SQLite conformance](COMPATIBILITY.md#sqlite-conformance-inventory) for what
 those counts prove, how the #191/#286 combinatorial cases, #254 Northwind

--- a/SKILL.md
+++ b/SKILL.md
@@ -148,17 +148,17 @@ contracts.
 - Treat the versioned [inventory](Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json) as
   the source of truth and its [report](Conformance/SQLite/REPORT.md) as a generated
   view; use the [compatibility guide](COMPATIBILITY.md#sqlite-conformance-inventory)
-  to interpret it. It records 101 feature records: 88 supported, 3 partial,
+  to interpret it. It records 101 feature records: 89 supported, 2 partial,
   2 capability-gated, 1 intentionally unsupported, and 7 unimplemented.
 - Keep those five statuses distinct. Bind every claim to the feature's recorded
   SQLite version, source ID, compile options, capabilities, evidence, and
   rationale before claiming support.
-- Of the 104 evidence records, 68 exercise real SQLite against one captured
+- Of the 106 evidence records, 69 exercise real SQLite against one captured
   environment, SQLite 3.51.0. Evidence is reusable, so evidence and feature
   counts do not map one to one; never turn this into an exhaustive-SQL claim.
-- #191 contributes 141 original positives; #286 adds 27 typed function-overload
-  cases for 168 current positives plus one broken-renderer control. #254 adds 18
-  Northwind scenarios and #255 adds 12 observation-stress cases. No new syntax.
+- #191 contributes 141 positives; #286 adds 27 function-overload and #288 adds
+  5 IN cases for 173 current positives plus one broken-renderer control. #254
+  adds 18 Northwind and #255 adds 12 observation-stress cases; no new syntax.
 - #132 remains package-private research. It ships no public validator, build
   plugin, query macro, schema system, or new v1.3 API. It neither persists
   prepared statements nor removes runtime preparation on a physical connection.

--- a/Tests/SQLTests/SQLSkillDocumentationTests.swift
+++ b/Tests/SQLTests/SQLSkillDocumentationTests.swift
@@ -140,7 +140,12 @@ final class SQLSkillDocumentationTests: XCTestCase {
         let issue286CaseCount = combinatorialManifest.cases.filter {
             $0.id.hasPrefix("c286.v1.expression.")
         }.count
-        let issue191CaseCount = combinatorialManifest.cases.count - issue286CaseCount
+        let issue288CaseCount = combinatorialManifest.cases.filter {
+            $0.id.hasPrefix("c288.v1.subquery.")
+        }.count
+        let issue191CaseCount = combinatorialManifest.cases.count
+            - issue286CaseCount
+            - issue288CaseCount
         XCTAssertTrue(
             combinatorialSuite.evidenceIDs.contains(
                 "evidence.combinatorial.broken-renderer.sqlite"
@@ -157,12 +162,13 @@ final class SQLSkillDocumentationTests: XCTestCase {
                 + "\(environmentCountText) captured \(environmentNoun), SQLite "
                 + "\(sqliteVersions).",
             "Evidence is reusable, so evidence and feature counts do not map one to one",
-            "#191 contributes \(issue191CaseCount) original positives; #286 adds "
-                + "\(issue286CaseCount) typed function-overload cases for "
+            "#191 contributes \(issue191CaseCount) positives; #286 adds "
+                + "\(issue286CaseCount) function-overload and #288 adds "
+                + "\(issue288CaseCount) IN cases for "
                 + "\(combinatorialManifest.cases.count) current positives plus one "
                 + "broken-renderer control. #254 adds "
-                + "\(northwindSuite.caseIDs.count) Northwind scenarios and #255 adds "
-                + "\(observationSuite.caseIDs.count) observation-stress cases.",
+                + "\(northwindSuite.caseIDs.count) Northwind and #255 adds "
+                + "\(observationSuite.caseIDs.count) observation-stress cases",
             "It ships no public validator, build plugin, query macro, schema system, or new v1.3 API. It neither persists prepared statements nor removes runtime preparation on a physical connection.",
         ] {
             XCTAssertTrue(

--- a/Tests/SwiftQLSQLiteCombinatorialSupport/SQLiteCombinatorialSuite.swift
+++ b/Tests/SwiftQLSQLiteCombinatorialSupport/SQLiteCombinatorialSuite.swift
@@ -93,6 +93,7 @@ public enum SQLiteCombinatorialSuite {
         drafts.append(contentsOf: SQLiteTypedCombinatorialCases.compoundAndCTECases())
         drafts.append(contentsOf: SQLiteTypedCombinatorialCases.northwindAdaptationCases())
         drafts.append(contentsOf: SQLiteTypedCombinatorialCases.adoptedExpressionCases())
+        drafts.append(contentsOf: SQLiteTypedCombinatorialCases.inSubqueryCases())
         drafts.sort { $0.id < $1.id }
 
         try requireUniqueCaseIDs(drafts.map(\.id))
@@ -229,6 +230,7 @@ private extension SQLiteCombinatorialSuite {
         SQLiteTypedCombinatorialCases.compoundAndCTECases().count
             + SQLiteTypedCombinatorialCases.northwindAdaptationCases().count
             + SQLiteTypedCombinatorialCases.adoptedExpressionCases().count
+            + SQLiteTypedCombinatorialCases.inSubqueryCases().count
     }
 
     static var selectDimensions: [SQLiteCombinatorialDimension] {
@@ -381,6 +383,15 @@ private extension SQLiteCombinatorialSuite {
                     SQLiteCombinatorialManifestDimensionValue(id: $0, label: $0)
                 }
         )
+        let inSubquery = SQLiteCombinatorialManifestDimension(
+            id: "in-subquery-case",
+            title: "Query-backed IN entry point",
+            values: SQLiteTypedCombinatorialCases.inSubqueryCases()
+                .compactMap { $0.selections.first?.valueID }
+                .map {
+                    SQLiteCombinatorialManifestDimensionValue(id: $0, label: $0)
+                }
+        )
         let gated = SQLiteCombinatorialManifestDimension(
             id: "gated-prerequisite",
             title: "Explicitly gated typed prerequisite",
@@ -396,6 +407,7 @@ private extension SQLiteCombinatorialSuite {
             compoundOperator,
             expression,
             northwindAdaptation,
+            inSubquery,
             gated,
         ]
     }

--- a/Tests/SwiftQLSQLiteCombinatorialSupport/SQLiteTypedCombinatorialCases.swift
+++ b/Tests/SwiftQLSQLiteCombinatorialSupport/SQLiteTypedCombinatorialCases.swift
@@ -76,6 +76,15 @@ struct C191OrderSubtotal: Equatable {
 }
 
 
+/// Single-column common-table projection for the issue #288 `in(_ table:)`
+/// cases. SQLite's `expr IN table-name` form requires the referenced table to
+/// expose exactly one column.
+@SQLResult
+struct C288EmployeeIdentifier: Equatable {
+    let employeeID: Int
+}
+
+
 public struct SQLiteCombinatorialDraftSelection: Equatable {
     public let dimensionID: String
     public let valueID: String
@@ -498,6 +507,158 @@ public enum SQLiteTypedCombinatorialCases {
             ],
             statement: statement,
             semanticOracleID: "oracle.c191.northwind.cte-order-subtotals"
+        )
+    }
+
+    /// Issue #288: finite typed evidence for both query-backed IN entry points
+    /// against the pinned Northwind fixture.
+    ///
+    /// `in(expression:)` is exercised in its result-builder and its functional
+    /// form, and `in(_ table:)` against an ordinary common table expression.
+    /// Each entry point pairs a non-empty inner result with an empty one so the
+    /// outer statement's row behaviour is proven rather than only its
+    /// rendering. Nullable IN operands stay with #70 and `NOT IN` stays with
+    /// #84; neither is constructed here.
+    public static func inSubqueryCases() -> [SQLiteCombinatorialCaseDraft] {
+        [
+            inQueryBuilderCase(id: "in-query-builder-nonempty", employeeID: 5),
+            inQueryBuilderCase(id: "in-query-builder-empty", employeeID: -1),
+            inQueryFunctionalCase(),
+            inCommonTableCase(id: "in-table-nonempty", employeeID: 4),
+            inCommonTableCase(id: "in-table-empty", employeeID: -1),
+        ]
+    }
+
+    /// `XLExpression.in(expression:)` in its `@XLQueryExpressionBuilder` form.
+    /// The bound placeholder lives inside the subquery, so the rendered
+    /// parameter layout proves that nested query bindings reach the outer
+    /// statement's slot list.
+    private static func inQueryBuilderCase(
+        id: String,
+        employeeID: Int
+    ) -> SQLiteCombinatorialCaseDraft {
+        let employeeBinding = XLNamedBindingReference<Int>(
+            name: "in_subquery_employee_id"
+        )
+        let statement = sql { schema in
+            let orders = schema.table(C191Order.self)
+            Select(orders.orderID)
+            From(orders)
+            Where(
+                orders.employeeID.in { inner in
+                    let employees = inner.table(C191Employee.self)
+                    Select(employees.employeeID)
+                    From(employees)
+                    Where(employees.employeeID == employeeBinding)
+                }
+            )
+            OrderBy(orders.orderID.ascending())
+            Limit(5)
+        }
+
+        return inSubqueryCase(
+            id: id,
+            statement: statement,
+            bindings: [
+                .init(
+                    key: .named("in_subquery_employee_id"),
+                    value: .integer(Int64(employeeID))
+                ),
+            ]
+        )
+    }
+
+    /// `XLExpression.in(expression:)` in its functional form, over a text
+    /// operand so the entry point is proven for more than one storage class.
+    private static func inQueryFunctionalCase() -> SQLiteCombinatorialCaseDraft {
+        let customerBinding = XLNamedBindingReference<String>(
+            name: "in_subquery_customer_id"
+        )
+        let schema = XLSchema()
+        let orders = schema.table(C191Order.self)
+        let customers = schema.table(C191Customer.self)
+        let statement = select(orders.orderID)
+            .from(orders)
+            .where(
+                orders.customerID.in {
+                    select(customers.customerID)
+                        .from(customers)
+                        .where(customers.customerID == customerBinding)
+                }
+            )
+            .orderBy(orders.orderID.ascending())
+            .limit(5)
+
+        return inSubqueryCase(
+            id: "in-query-functional-nonempty",
+            statement: statement,
+            bindings: [
+                .init(
+                    key: .named("in_subquery_customer_id"),
+                    value: .text("VINET")
+                ),
+            ]
+        )
+    }
+
+    /// `XLExpression.in(_ table:)` against an ordinary common table
+    /// expression, which renders SQLite's `expr IN table-name` form.
+    private static func inCommonTableCase(
+        id: String,
+        employeeID: Int
+    ) -> SQLiteCombinatorialCaseDraft {
+        let employeeBinding = XLNamedBindingReference<Int>(
+            name: "in_table_employee_id"
+        )
+        let statement = sql { schema in
+            let matchingEmployees = schema.commonTableExpression { inner in
+                let employees = inner.table(C191Employee.self)
+                Select(C288EmployeeIdentifier.columns(
+                    employeeID: employees.employeeID
+                ))
+                From(employees)
+                Where(employees.employeeID == employeeBinding)
+            }
+            let orders = schema.table(C191Order.self)
+            With(matchingEmployees)
+            Select(orders.orderID)
+            From(orders)
+            Where(orders.employeeID.in(matchingEmployees))
+            OrderBy(orders.orderID.ascending())
+            Limit(5)
+        }
+
+        return inSubqueryCase(
+            id: id,
+            statement: statement,
+            bindings: [
+                .init(
+                    key: .named("in_table_employee_id"),
+                    value: .integer(Int64(employeeID))
+                ),
+            ]
+        )
+    }
+
+    private static func inSubqueryCase(
+        id: String,
+        statement: any XLEncodable,
+        bindings: [SQLiteCombinatorialDraftBinding]
+    ) -> SQLiteCombinatorialCaseDraft {
+        SQLiteCombinatorialCaseDraft(
+            id: "c288.v1.subquery.\(id)",
+            templateID: "subquery.\(id)",
+            strength: "targeted",
+            selections: [.init(dimensionID: "in-subquery-case", valueID: id)],
+            inventoryFeatureIDs: [
+                "syntax.expression.current-operators",
+                "syntax.select.core",
+                "syntax.subquery.table-and-in-prepare-gap",
+            ],
+            northwindAnchorCaseIDs: [],
+            statement: statement,
+            bindings: bindings,
+            semanticOracleID: "oracle.c288.subquery.\(id)"
         )
     }
 

--- a/Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialClauseCoverageTests.swift
+++ b/Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialClauseCoverageTests.swift
@@ -106,9 +106,10 @@ final class SQLiteCombinatorialClauseCoverageTests: XCTestCase {
             manifest.cases.count,
             SQLiteCombinatorialSuite.maximumCaseCount
         )
-        // Issue #286 adds 27 finite expression cases to issue #191's original
-        // 141-case manifest without changing the SELECT pairwise plan.
-        XCTAssertEqual(manifest.cases.count, 168)
+        // Issue #286 adds 27 finite expression cases and issue #288 adds five
+        // finite query-backed IN cases to issue #191's original 141-case
+        // manifest, neither changing the SELECT pairwise plan.
+        XCTAssertEqual(manifest.cases.count, 173)
         let requiredStrengthCounts = Dictionary(
             grouping: try SQLiteCombinatorialSuite.makeDrafts(from: plan)
                 .filter { $0.strength.hasPrefix("required-") },

--- a/Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift
+++ b/Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift
@@ -120,7 +120,7 @@ final class SQLiteCombinatorialConformanceTests: XCTestCase {
 
         XCTAssertEqual(actualSuffixes, expectedSuffixes)
         XCTAssertEqual(issue286Cases.count, 27)
-        XCTAssertEqual(manifest.cases.count, 168)
+        XCTAssertEqual(manifest.cases.count, 173)
         XCTAssertEqual(manifest.hardBounds.maximumCaseCount, 192)
         XCTAssertFalse(issue286Cases.contains { $0.id.contains("unixepoch") })
         XCTAssertTrue(issue286Cases.allSatisfy { $0.mode == .semantic })
@@ -141,6 +141,103 @@ final class SQLiteCombinatorialConformanceTests: XCTestCase {
                 .filter { $0.inventoryFeatureIDs == ["syntax.expression.json-functions"] }
                 .allSatisfy { $0.requiredCapabilities == ["sqlite-json-functions"] }
         )
+    }
+
+    func testIssue288QueryBackedINCasesAreExplicitAndBounded() throws {
+        let manifest = try SQLiteCombinatorialSuite.makeManifest()
+        let issue288Cases = manifest.cases.filter {
+            $0.id.hasPrefix("c288.v1.subquery.")
+        }
+        let expectedSuffixes: Set<String> = [
+            "in-query-builder-empty",
+            "in-query-builder-nonempty",
+            "in-query-functional-nonempty",
+            "in-table-empty",
+            "in-table-nonempty",
+        ]
+        let actualSuffixes = Set(issue288Cases.map {
+            String($0.id.dropFirst("c288.v1.subquery.".count))
+        })
+
+        XCTAssertEqual(actualSuffixes, expectedSuffixes)
+        XCTAssertEqual(issue288Cases.count, 5)
+        XCTAssertTrue(issue288Cases.allSatisfy { $0.mode == .semantic })
+        XCTAssertTrue(issue288Cases.allSatisfy { $0.oracle?.kind == .rawSQL })
+        XCTAssertTrue(issue288Cases.allSatisfy { $0.requiredCapabilities.isEmpty })
+        XCTAssertTrue(
+            issue288Cases.allSatisfy {
+                $0.inventoryFeatureIDs.contains(
+                    "syntax.subquery.table-and-in-prepare-gap"
+                )
+            }
+        )
+
+        // Every case binds exactly one named placeholder declared inside the
+        // subquery or common table expression, so the rendered parameter
+        // layout is evidence that nested query bindings reach the outer
+        // statement's slot list.
+        XCTAssertTrue(issue288Cases.allSatisfy { $0.bindings.count == 1 })
+        XCTAssertTrue(
+            issue288Cases.allSatisfy { $0.bindings.allSatisfy { $0.keyKind == .named } }
+        )
+
+        // Both query-backed entry points are represented: `in(expression:)`
+        // renders an inline subquery and `in(_ table:)` renders SQLite's
+        // `expr IN table-name` form.
+        let subqueryForm = issue288Cases.filter { $0.id.contains(".in-query-") }
+        let tableForm = issue288Cases.filter { $0.id.contains(".in-table-") }
+        XCTAssertEqual(subqueryForm.count, 3)
+        XCTAssertEqual(tableForm.count, 2)
+        XCTAssertTrue(subqueryForm.allSatisfy { $0.renderedSQL.contains("IN (SELECT") })
+        XCTAssertTrue(tableForm.allSatisfy { $0.renderedSQL.contains("WITH ") })
+        XCTAssertFalse(tableForm.contains { $0.renderedSQL.contains("IN (SELECT") })
+
+        // Neither NOT IN (#84) nor a nullable IN operand (#70) is constructed
+        // here.
+        XCTAssertFalse(issue288Cases.contains { $0.renderedSQL.contains("NOT IN") })
+        XCTAssertFalse(
+            issue288Cases.contains {
+                $0.inventoryFeatureIDs.contains("syntax.subquery.nullable-shape-gap")
+            }
+        )
+    }
+
+    /// Proves the empty and non-empty pairs actually differ at execution time.
+    /// Comparing an empty result against an empty oracle is not by itself
+    /// evidence that the inner query selects anything, so the row counts are
+    /// asserted directly against the pinned fixture.
+    func testIssue288EmptyAndNonEmptyINResultsExecuteAsClaimed() throws {
+        let manifest = try SQLiteCombinatorialSuite.makeManifest()
+        let issue288Cases = manifest.cases.filter {
+            $0.id.hasPrefix("c288.v1.subquery.")
+        }
+        XCTAssertEqual(issue288Cases.count, 5)
+
+        let pool = try NorthwindFixture.validatedReadOnlyPool()
+        defer { try? pool.close() }
+
+        try pool.read { database in
+            for testCase in issue288Cases {
+                let actual = try resultRows(
+                    database,
+                    sql: testCase.renderedSQL,
+                    arguments: arguments(for: testCase)
+                )
+                if testCase.id.hasSuffix("-empty") {
+                    XCTAssertTrue(
+                        actual.isEmpty,
+                        "\(testCase.id) should return no rows when the inner query is empty"
+                    )
+                }
+                else {
+                    XCTAssertEqual(
+                        actual.count,
+                        5,
+                        "\(testCase.id) should return the LIMIT-bounded non-empty page"
+                    )
+                }
+            }
+        }
     }
 
     func testPinnedRuntimeAttestsJSONFunctionCapability() throws {
@@ -799,6 +896,59 @@ private extension SQLiteCombinatorialConformanceTests {
                     HAVING COUNT(o.OrderID) > 1
                     ORDER BY o.OrderID DESC
                     LIMIT 5 OFFSET 2
+                    """,
+                arguments: arguments(for: testCase)
+            )
+        case "oracle.c288.subquery.in-query-builder-nonempty",
+             "oracle.c288.subquery.in-query-builder-empty":
+            return try resultRows(
+                database,
+                sql: """
+                    SELECT o.OrderID
+                    FROM Orders AS o
+                    WHERE o.EmployeeID IN (
+                        SELECT e.EmployeeID
+                        FROM Employees AS e
+                        WHERE e.EmployeeID = :in_subquery_employee_id
+                    )
+                    ORDER BY o.OrderID ASC
+                    LIMIT 5
+                    """,
+                arguments: arguments(for: testCase)
+            )
+        case "oracle.c288.subquery.in-query-functional-nonempty":
+            return try resultRows(
+                database,
+                sql: """
+                    SELECT o.OrderID
+                    FROM Orders AS o
+                    WHERE o.CustomerID IN (
+                        SELECT c.CustomerID
+                        FROM Customers AS c
+                        WHERE c.CustomerID = :in_subquery_customer_id
+                    )
+                    ORDER BY o.OrderID ASC
+                    LIMIT 5
+                    """,
+                arguments: arguments(for: testCase)
+            )
+        case "oracle.c288.subquery.in-table-nonempty",
+             "oracle.c288.subquery.in-table-empty":
+            // Written as an inline subquery rather than SQLite's
+            // `expr IN table-name` form so the oracle stays independent of the
+            // construction under test.
+            return try resultRows(
+                database,
+                sql: """
+                    SELECT o.OrderID
+                    FROM Orders AS o
+                    WHERE o.EmployeeID IN (
+                        SELECT e.EmployeeID
+                        FROM Employees AS e
+                        WHERE e.EmployeeID = :in_table_employee_id
+                    )
+                    ORDER BY o.OrderID ASC
+                    LIMIT 5
                     """,
                 arguments: arguments(for: testCase)
             )

--- a/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json
+++ b/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json
@@ -143,6 +143,37 @@
       ]
     },
     {
+      "id": "evidence.combinatorial.in-subquery-execution.sqlite",
+      "source_path": "Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift",
+      "test_case": "SQLiteCombinatorialConformanceTests.testIssue288EmptyAndNonEmptyINResultsExecuteAsClaimed",
+      "runner_path": null,
+      "layers": [
+        "bindings",
+        "execution",
+        "prepare",
+        "semantic-oracle"
+      ],
+      "real_sqlite": true,
+      "environment_ids": [
+        "sqlite-3.51.0-macos-arm64"
+      ]
+    },
+    {
+      "id": "evidence.combinatorial.in-subquery-matrix",
+      "source_path": "Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift",
+      "test_case": "SQLiteCombinatorialConformanceTests.testIssue288QueryBackedINCasesAreExplicitAndBounded",
+      "runner_path": null,
+      "layers": [
+        "bindings",
+        "rendering",
+        "swift-typecheck"
+      ],
+      "real_sqlite": false,
+      "environment_ids": [
+
+      ]
+    },
+    {
       "id": "evidence.combinatorial.json-capability.sqlite",
       "source_path": "Tests/SwiftQLSQLiteCombinatorialSupportTests/SQLiteCombinatorialConformanceTests.swift",
       "test_case": "SQLiteCombinatorialConformanceTests.testPinnedRuntimeAttestsJSONFunctionCapability",
@@ -1934,6 +1965,23 @@
       "evidence_ids": [
         "evidence.combinatorial.function-overload-matrix",
         "evidence.combinatorial.json-capability.sqlite",
+        "evidence.combinatorial.manifest-determinism",
+        "evidence.combinatorial.positive.sqlite"
+      ]
+    },
+    {
+      "id": "suite.288.in-subquery-conformance",
+      "issue": 288,
+      "milestone": "v1.4.2",
+      "status": "completed",
+      "case_ids": [
+        "syntax.expression.current-operators",
+        "syntax.select.core",
+        "syntax.subquery.table-and-in-prepare-gap"
+      ],
+      "evidence_ids": [
+        "evidence.combinatorial.in-subquery-execution.sqlite",
+        "evidence.combinatorial.in-subquery-matrix",
         "evidence.combinatorial.manifest-determinism",
         "evidence.combinatorial.positive.sqlite"
       ]
@@ -6919,8 +6967,8 @@
       "kind": "syntax",
       "family": "subquery",
       "title": "Table and IN-subquery real-SQLite prepare coverage",
-      "status": "partial",
-      "adoption_status": "syntax-gated",
+      "status": "supported",
+      "adoption_status": "already-covered",
       "public_api": [
         {
           "symbol": "subquery",
@@ -6958,21 +7006,20 @@
         "The subquery exposes a compatible typed row or scalar layout to the enclosing query."
       ],
       "evidence_ids": [
+        "evidence.combinatorial.in-subquery-execution.sqlite",
+        "evidence.combinatorial.in-subquery-matrix",
         "evidence.combinatorial.positive.sqlite",
         "evidence.syntax.subquery.render-in",
         "evidence.syntax.subquery.render-table"
       ],
       "deviations": [
-        "The generated suite prepares typed table-subquery branches; exhaustive table and IN-subquery overload combinations remain deferred."
+        "Issue #288 proves both query-backed entry points with real SQLite: the result-builder and functional forms of `in(expression:)`, and `in(_ table:)` rendered as SQLite's `expr IN table-name` form, each with a non-empty and an empty inner result.",
+        "Optional operands of the IN overloads remain unproven and stay recorded by syntax.subquery.nullable-shape-gap."
       ],
       "follow_up_issues": [
-        288
+        70
       ],
-      "deferral": {
-        "blocking_issue": 288,
-        "target_milestone": "v1.4",
-        "reason": "Issue #288 owns exhaustive real-SQLite prepare and execution coverage for table and IN-subquery overloads."
-      },
+      "deferral": null,
       "provenance": [
 
       ]

--- a/scripts/ci/sqlite-conformance-inventory.py
+++ b/scripts/ci/sqlite-conformance-inventory.py
@@ -37,6 +37,7 @@ REQUIRED_SUITE_STATUSES = {
     255: "completed",
     256: "planned",
     286: "completed",
+    288: "completed",
 }
 FEATURE_KINDS = {"syntax", "adopted-behavior", "adapter-contract"}
 FEATURE_STATUSES = {
@@ -826,7 +827,7 @@ def validate_suites(value: Any) -> List[Mapping[str, Any]]:
     if seen_issues != set(REQUIRED_SUITE_STATUSES):
         missing = sorted(set(REQUIRED_SUITE_STATUSES) - seen_issues)
         raise InventoryError(
-            "suites must register issues #191, #252-#256, and #286; missing: "
+            "suites must register issues #191, #252-#256, #286, and #288; missing: "
             + ", ".join(f"#{issue}" for issue in missing)
         )
     return result

--- a/scripts/ci/test-sqlite-conformance-inventory.py
+++ b/scripts/ci/test-sqlite-conformance-inventory.py
@@ -250,13 +250,15 @@ final class OtherTests {
             (255, "operator-property"),
             (256, "observation"),
             (286, "function-overload-conformance"),
+            (288, "in-subquery-conformance"),
         ]:
-            status = "completed" if issue in {254, 255, 286} else "planned"
+            status = "completed" if issue in {254, 255, 286, 288} else "planned"
+            milestone = {286: "v1.4.1", 288: "v1.4.2"}.get(issue, "v1.3")
             suites.append(
                 {
                     "id": f"suite.{name}",
                     "issue": issue,
-                    "milestone": "v1.4.1" if issue == 286 else "v1.3",
+                    "milestone": milestone,
                     "status": status,
                     "case_ids": (
                         [features[0]["id"]] if status == "completed" else []


### PR DESCRIPTION
Closes #288.

## What this adds

Five finite typed cases that give both query-backed IN entry points real-SQLite prepare and semantic execution evidence against the pinned Northwind fixture:

| Case | Entry point | Inner result |
| --- | --- | --- |
| `c288.v1.subquery.in-query-builder-nonempty` | `in(expression:)`, `@XLQueryExpressionBuilder` form | non-empty |
| `c288.v1.subquery.in-query-builder-empty` | `in(expression:)`, `@XLQueryExpressionBuilder` form | empty |
| `c288.v1.subquery.in-query-functional-nonempty` | `in(expression:)`, functional form, text operand | non-empty |
| `c288.v1.subquery.in-table-nonempty` | `in(_ table:)` over an ordinary CTE | non-empty |
| `c288.v1.subquery.in-table-empty` | `in(_ table:)` over an ordinary CTE | empty |

`in(expression:)` renders an inline subquery; `in(_ table:)` renders SQLite's `expr IN table-name` form. Each case binds exactly one named placeholder declared *inside* the subquery or CTE, so the rendered parameter layout is evidence that nested query bindings reach the outer statement's slot list.

Every case is `semantic` with an independent raw-SQL oracle. The `in(_ table:)` oracles are deliberately written as inline subqueries rather than `expr IN table-name` so the oracle does not mirror the construction under test.

## Evidence, not just rendering

Comparing an empty result against an empty oracle proves nothing on its own, so `testIssue288EmptyAndNonEmptyINResultsExecuteAsClaimed` asserts the row counts directly against the fixture: the `-empty` cases return zero rows and the non-empty cases return the full `LIMIT`-bounded page. `testIssue288QueryBackedINCasesAreExplicitAndBounded` pins the case set, binding shape, rendered form of each entry point, and the absence of `NOT IN` and nullable-shape features.

## Inventory

- `syntax.subquery.table-and-in-prepare-gap`: `partial`/`syntax-gated` → `supported`/`already-covered`, deferral cleared, follow-up moved from #288 to #70.
- New evidence records `evidence.combinatorial.in-subquery-{execution.sqlite,matrix}`.
- New `suite.288.in-subquery-conformance` (milestone `v1.4.2`), registered in the validator's fail-closed suite allowlist.
- Regenerated `COMBINATORIAL_CASES.json` (168 → 173 cases), `COMBINATORIAL_SUMMARY.md`, and `REPORT.md`.

## Out of scope

Nullable IN operands remain recorded by `syntax.subquery.nullable-shape-gap` and stay with #70; `NOT IN` stays with #84. Neither is constructed here.

## Doc counts

Supported features 88 → 89, partial 3 → 2, evidence records 104 → 106 (69 real-SQLite). Propagated to `README.md`, `COMPATIBILITY.md`, `CHANGELOG.md`, `SKILL.md`, and `Documentation/Architecture/SQLiteBuildValidation.md`. The `SKILL.md` conformance bullet was tightened to stay inside the file's existing 220-line conciseness gate.

## Validation

- `swift test` — 697 tests, 0 failures.
- `python3 scripts/ci/sqlite-conformance-inventory.py validate` / `check` — clean, report current.
- `python3 scripts/ci/test-sqlite-conformance-inventory.py` — 28 tests, OK.
- Two clean manifest generations are byte-identical to each other and to the checked-in artifact.
- Per-case reproduction: `SWIFTQL_COMBINATORIAL_CASE=c288.v1.subquery.in-table-nonempty swift test --filter SQLiteCombinatorialConformanceTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)