### PR TITLE
Add nullable-table and flattened scalar subquery shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 ### Added
 
 - Added the #190 canonical SQLite conformance inventory and deterministic
-  generated report. It records 103 public-surface feature records: 93
+  generated report. It records 103 public-surface feature records: 94
   supported, 1 partial, 2 capability-gated, 1 intentionally unsupported, and
-  6 unimplemented. Of the 125 evidence records, 81 exercise real SQLite and
+  5 unimplemented. Of the 128 evidence records, 82 exercise real SQLite and
   cite one captured SQLite 3.51.0 environment.
 - Added the #191 bounded combinatorial SQLite corpus with 141 stable generated
   cases across joins, subqueries, common table expressions, grouping,

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -55,20 +55,20 @@ The report is evidence for SwiftQL's existing public SQLite subset; it is not a
 claim of complete SQLite grammar coverage. The inventory remains the source of
 truth, while the report is its readable generated view.
 
-The v1.3 inventory contains 103 feature records and 125 evidence records. Its
+The v1.3 inventory contains 103 feature records and 128 evidence records. Its
 support-status totals are exact and mutually exclusive:
 
 | Support status | Features |
 | --- | ---: |
-| Supported | 93 |
+| Supported | 94 |
 | Partial | 1 |
 | Capability-gated | 2 |
 | Intentionally unsupported | 1 |
-| Unimplemented | 6 |
+| Unimplemented | 5 |
 
-Of those 125 evidence records, 81 exercise real SQLite and
+Of those 128 evidence records, 82 exercise real SQLite and
 cite one captured environment, SQLite 3.51.0. An inventory entry is counted in
-the 93 supported features only when it links to successful preparation by a
+the 94 supported features only when it links to successful preparation by a
 real SQLite engine whose version and source ID are recorded. Partial,
 capability-gated, intentionally unsupported, and unimplemented entries remain
 visible with their evidence, requirements, or rationale, but are excluded

--- a/Conformance/SQLite/REPORT.md
+++ b/Conformance/SQLite/REPORT.md
@@ -22,9 +22,9 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 ## Summary
 
 - Total feature records: **103**
-- Supported feature records: **93**
+- Supported feature records: **94**
 - SQLite environments: **1**
-- Evidence records: **125**
+- Evidence records: **128**
 
 ### Support status
 
@@ -33,17 +33,17 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `capability-gated` | 2 |
 | `intentionally-unsupported` | 1 |
 | `partial` | 1 |
-| `supported` | 93 |
-| `unimplemented` | 6 |
+| `supported` | 94 |
+| `unimplemented` | 5 |
 
 ### Adoption status
 
 | Value | Features |
 | --- | ---: |
 | `adapter/API-gated` | 2 |
-| `already-covered` | 94 |
+| `already-covered` | 95 |
 | `intentionally-out-of-scope` | 1 |
-| `syntax-gated` | 6 |
+| `syntax-gated` | 5 |
 
 ### Record kind
 
@@ -178,7 +178,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `syntax.select.ordering-terms`<br>Typed ascending and descending ORDER BY terms | `select` | `syntax` | `supported` | `already-covered` | [`www.sqlite.org/lang_select.html#orderby`](https://www.sqlite.org/lang_select.html#orderby) | `3.0.0` | `XLExpression.ascending` [verified: `ascending`] ([`Sources/SwiftQL/Functions/ExpressionFunctions.swift`](../../Sources/SwiftQL/Functions/ExpressionFunctions.swift)), `XLExpression.descending` [verified: `descending`] ([`Sources/SwiftQL/Functions/ExpressionFunctions.swift`](../../Sources/SwiftQL/Functions/ExpressionFunctions.swift)) | `evidence.combinatorial.positive.sqlite`, `evidence.syntax.expression.render-string-ordering-functions` | — |
 | `northwind.subquery.products-above-average`<br>Products above average price scalar subquery | `subquery` | `adopted-behavior` | `supported` | `already-covered` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)) | `evidence.northwind.subquery-compound-cte.sqlite` | — |
 | `syntax.subquery.correlated-scalar`<br>Correlated scalar subqueries | `subquery` | `syntax` | `supported` | `already-covered` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)) | `evidence.syntax.subquery.sqlite-correlated` | [#70](https://github.com/lukevanin/swiftql/issues/70) |
-| `syntax.subquery.nullable-shape-gap`<br>Nullable-table and direct-scalar subquery result shapes | `subquery` | `syntax` | `unimplemented` | `syntax-gated` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)) | — | [#70](https://github.com/lukevanin/swiftql/issues/70) |
+| `syntax.subquery.nullable-shape-gap`<br>Nullable-table and direct-scalar subquery result shapes | `subquery` | `syntax` | `supported` | `already-covered` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)) | `evidence.syntax.subquery.render-flattened-scalar`, `evidence.syntax.subquery.render-nullable-left-join`, `evidence.syntax.subquery.sqlite-nullable-left-join` | — |
 | `syntax.subquery.table-and-in-prepare-gap`<br>Table and IN-subquery real-SQLite prepare coverage | `subquery` | `syntax` | `supported` | `already-covered` | [`www.sqlite.org/lang_expr.html#subquery_expressions`](https://www.sqlite.org/lang_expr.html#subquery_expressions) | `3.0.0` | `subquery` [verified: `subquery`] ([`Sources/SwiftQL/SQLFunctionalSyntax.swift`](../../Sources/SwiftQL/SQLFunctionalSyntax.swift)), `XLExpression.in(expression:)` [verified: `in`] ([`Sources/SwiftQL/Operators/InOperator.swift`](../../Sources/SwiftQL/Operators/InOperator.swift)), `XLExpression.in(_ table:)` [verified: `in`] ([`Sources/SwiftQL/Operators/InOperator.swift`](../../Sources/SwiftQL/Operators/InOperator.swift)) | `evidence.combinatorial.in-subquery-execution.sqlite`, `evidence.combinatorial.in-subquery-matrix`, `evidence.combinatorial.positive.sqlite`, `evidence.syntax.subquery.render-in`, `evidence.syntax.subquery.render-table` | [#70](https://github.com/lukevanin/swiftql/issues/70) |
 
 ## Gates, deviations, and deferrals
@@ -286,7 +286,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `syntax.select.ordering-terms` | `sqlite-core-parser` | Ordering terms wrap a typed expression in a SELECT ORDER BY clause. | — | — |
 | `northwind.subquery.products-above-average` | `database-pool-driver`, `sqlite-core-parser` | Products contains deterministic prices for a scalar AVG subquery and ordered outer result. | — | — |
 | `syntax.subquery.correlated-scalar` | `sqlite-core-parser` | The inner query has a typed row reader and may reference a visible outer table dependency. | The registered real-SQLite evidence covers a correlated scalar aggregate; table and IN-subquery preparation remain separate. | — |
-| `syntax.subquery.nullable-shape-gap` | `sqlite-core-parser` | Nullable table references and scalar cardinality must preserve typed result metadata. | The current overload set cannot represent every nullable-table and scalar result shape. | [#70](https://github.com/lukevanin/swiftql/issues/70) for `v1.4`: Issue #70 owns nullable-table and scalar subquery shapes. |
+| `syntax.subquery.nullable-shape-gap` | `sqlite-core-parser` | Nullable table references and scalar cardinality must preserve typed result metadata. | `nullableSubquery` is a distinct function rather than another `subquery` overload, because the two would differ only by return type and could not be disambiguated at a call site.<br>The pre-existing `subquery(alias:)` overload constrained to `XLMetaNullable` is deprecated rather than removed. It was unreachable: no `select` function produces a statement whose row type is a generated `Nullable` companion, so no argument satisfying it could be constructed.<br>A scalar subquery over an already-optional statement now yields one `Optional` rather than nesting a second. The `XLTypeAffinityExpression` re-labelling that previously collapsed the nested type by hand is no longer needed and has been removed from its two call sites. | — |
 | `syntax.subquery.table-and-in-prepare-gap` | `sqlite-core-parser` | The subquery exposes a compatible typed row or scalar layout to the enclosing query. | Issue #288 proves both query-backed entry points with real SQLite: the result-builder and functional forms of `in(expression:)`, and `in(_ table:)` rendered as SQLite's `expr IN table-name` form, each with a non-empty and an empty inner result.<br>Optional operands of the IN overloads remain unproven and stay recorded by syntax.subquery.nullable-shape-gap. | — |
 
 ## Evidence index
@@ -402,9 +402,12 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `evidence.syntax.join.sqlite-left` | [`Tests/SQLTests/SQLExampleTests.swift`](../../Tests/SQLTests/SQLExampleTests.swift)<br>`XLDocumentationTests.testExample_LeftJoin_Statement_NullRows` | — | `execution`, `prepare`, `rendering`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.syntax.select.sqlite-limit-offset` | [`Tests/SQLTests/SQLExecutionTests.swift`](../../Tests/SQLTests/SQLExecutionTests.swift)<br>`XLExecutionTests.testQueryBuilderLimitAndOffsetExecution` | — | `bindings`, `execution`, `prepare`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.syntax.select.sqlite-named-binding` | [`Tests/SQLTests/SQLExampleTests.swift`](../../Tests/SQLTests/SQLExampleTests.swift)<br>`XLDocumentationTests.testExample_Variable_ExplicitAlias` | — | `bindings`, `execution`, `prepare`, `rendering`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
+| `evidence.syntax.subquery.render-flattened-scalar` | [`Tests/SQLTests/SQLSyntaxTests.swift`](../../Tests/SQLTests/SQLSyntaxTests.swift)<br>`XLSyntaxTests.testSelectSubqueryAggregate` | — | `rendering`, `swift-typecheck` | no | — |
 | `evidence.syntax.subquery.render-in` | [`Tests/SQLTests/SQLSyntaxTests.swift`](../../Tests/SQLTests/SQLSyntaxTests.swift)<br>`XLSyntaxTests.testScalarSelectWhereIn` | — | `rendering`, `swift-typecheck` | no | — |
+| `evidence.syntax.subquery.render-nullable-left-join` | [`Tests/SQLTests/SQLSyntaxTests.swift`](../../Tests/SQLTests/SQLSyntaxTests.swift)<br>`XLSyntaxTests.testNullableSubqueryOnLeftJoin` | — | `rendering`, `swift-typecheck` | no | — |
 | `evidence.syntax.subquery.render-table` | [`Tests/SQLTests/SQLSyntaxTests.swift`](../../Tests/SQLTests/SQLSyntaxTests.swift)<br>`XLSyntaxTests.testSubquery` | — | `rendering`, `swift-typecheck` | no | — |
 | `evidence.syntax.subquery.sqlite-correlated` | [`Tests/SQLTests/SQLExampleTests.swift`](../../Tests/SQLTests/SQLExampleTests.swift)<br>`XLDocumentationTests.testExample_Subquery` | — | `execution`, `prepare`, `rendering`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
+| `evidence.syntax.subquery.sqlite-nullable-left-join` | [`Tests/SQLTests/SQLExecutionTests.swift`](../../Tests/SQLTests/SQLExecutionTests.swift)<br>`XLExecutionTests.testNullableSubqueryLeftJoinExecutesWithUnmatchedRows` | — | `execution`, `prepare`, `rendering`, `semantic-oracle` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.transaction.commit.sqlite` | [`Tests/SQLTests/SQLiteTransactionInvariantGRDBTests.swift`](../../Tests/SQLTests/SQLiteTransactionInvariantGRDBTests.swift)<br>`GRDBDriverContractTests_TransactionInvariants.testSharedCommitCasesVerifyDurableStateReturnValuesAndVisibility` | — | `execution`, `prepare`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.transaction.fixture-contract` | [`Tests/SwiftQLCoreTests/SQLDriverContractTests.swift`](../../Tests/SwiftQLCoreTests/SQLDriverContractTests.swift)<br>`SQLDriverContractTests.testSharedTransactionFixturesCoverEveryStableCaseAndCapability` | — | `structured-error`, `swift-typecheck` | no | — |
 | `evidence.transaction.independent-databases.sqlite` | [`Tests/SQLTests/SQLiteTransactionInvariantGRDBTests.swift`](../../Tests/SQLTests/SQLiteTransactionInvariantGRDBTests.swift)<br>`GRDBDriverContractTests_TransactionInvariants.testIndependentDatabasesCommitWithoutCrossContamination` | — | `execution`, `prepare`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ for the complete contracts and current limitations.
 
 SwiftQL v1.3 adds evidence around that public surface rather than claiming
 complete SQLite grammar coverage. The canonical inventory records 103 features:
-93 supported, 1 partial, 2 capability-gated, 1 intentionally unsupported, and
-6 unimplemented. Of its 125 evidence records, 81 exercise real SQLite and
+94 supported, 1 partial, 2 capability-gated, 1 intentionally unsupported, and
+5 unimplemented. Of its 128 evidence records, 82 exercise real SQLite and
 cite one recorded SQLite 3.51.0 environment. See
 [SQLite conformance](COMPATIBILITY.md#sqlite-conformance-inventory) for what
 those counts prove, how the #191/#286 combinatorial cases, #254 Northwind

--- a/SKILL.md
+++ b/SKILL.md
@@ -148,12 +148,12 @@ contracts.
 - Treat the versioned [inventory](Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json) as
   the source of truth and its [report](Conformance/SQLite/REPORT.md) as a generated
   view; use the [compatibility guide](COMPATIBILITY.md#sqlite-conformance-inventory)
-  to interpret it. It records 103 feature records: 93 supported, 1 partial,
-  2 capability-gated, 1 intentionally unsupported, and 6 unimplemented.
+  to interpret it. It records 103 feature records: 94 supported, 1 partial,
+  2 capability-gated, 1 intentionally unsupported, and 5 unimplemented.
 - Keep those five statuses distinct. Bind every claim to the feature's recorded
   SQLite version, source ID, compile options, capabilities, evidence, and
   rationale before claiming support.
-- Of the 125 evidence records, 81 exercise real SQLite against one captured
+- Of the 128 evidence records, 82 exercise real SQLite against one captured
   environment, SQLite 3.51.0. Evidence is reusable, so evidence and feature
   counts do not map one to one; never turn this into an exhaustive-SQL claim.
 - The generated corpus holds 208 positives plus one broken-renderer control:

--- a/Sources/SwiftQL/Expression Builder/SQLQueryExpressionBuilder.swift
+++ b/Sources/SwiftQL/Expression Builder/SQLQueryExpressionBuilder.swift
@@ -283,6 +283,34 @@ public func subqueryExpression<T>(@XLQueryExpressionBuilder statement: () -> any
     return XLSubquery(statement: statement())
 }
 
+
+///
+/// Constructs a scalar subquery whose inner statement is already nullable, so
+/// the subquery's own nullability does not nest a second `Optional`.
+///
+public func subqueryExpression<Wrapped>(@XLQueryExpressionBuilder statement: (XLSchema) -> any XLQueryStatement<Optional<Wrapped>>) -> some XLExpression<Optional<Wrapped>> where Wrapped: XLLiteral {
+    let schema = XLSchema()
+    return XLSubquery<Wrapped>(statement: statement(schema))
+}
+
+
+public func subqueryExpression<Wrapped>(@XLQueryExpressionBuilder statement: () -> any XLQueryStatement<Optional<Wrapped>>) -> some XLExpression<Optional<Wrapped>> where Wrapped: XLLiteral {
+    XLSubquery<Wrapped>(statement: statement())
+}
+
+
+///
+/// Constructs a subquery whose columns can evaluate to NULL, for use on the
+/// nullable side of a `LEFT JOIN`.
+///
+public func nullableSubqueryExpression<T>(alias: XLName? = nil, @XLQueryExpressionBuilder statement: (XLSchema) -> any XLQueryStatement<T>) -> T.MetaNullableNamedResult where T: XLResult {
+    let newNamespace = XLNamespace.table()
+    let schema = XLSchema()
+    let alias = newNamespace.makeAlias(alias: alias)
+    let dependency = XLSubqueryDependency(alias: alias, statement: statement(schema))
+    return T.makeSQLAnonymousNullableNamedResult(namespace: newNamespace, dependency: dependency)
+}
+
 // MARK: - SQL
 
 ///

--- a/Sources/SwiftQL/SQLExpression.swift
+++ b/Sources/SwiftQL/SQLExpression.swift
@@ -725,6 +725,16 @@ struct XLSubquery<Wrapped>: XLExpression where Wrapped: XLLiteral {
     init(statement: any XLQueryStatement<Wrapped>) {
         self.statement = statement
     }
+
+    ///
+    /// Accepts a statement that is already optional, so the subquery's own
+    /// nullability does not nest a second `Optional` around it. The statement
+    /// is type-erased for rendering either way; the two initialisers differ
+    /// only in what they accept.
+    ///
+    init(statement: any XLQueryStatement<Optional<Wrapped>>) {
+        self.statement = statement
+    }
     
     func makeSQL(context: inout XLBuilder) {
         context.parenthesis(contents: statement.makeSQL)

--- a/Sources/SwiftQL/SQLFunctionalSyntax.swift
+++ b/Sources/SwiftQL/SQLFunctionalSyntax.swift
@@ -265,8 +265,30 @@ public func subquery<T>(alias: XLName? = nil, _ statement: (XLSchema) -> any XLQ
 
 
 ///
+/// Constructs a subquery whose columns can evaluate to NULL, for use on the
+/// nullable side of a `LEFT JOIN`.
+///
+/// This is the subquery counterpart of `XLSchema.nullableTable(_:as:)`. The
+/// inner statement is an ordinary one selecting `T`; nullability describes how
+/// the *result* is joined, not what the subquery selects.
+///
+public func nullableSubquery<T>(alias: XLName? = nil, _ statement: (XLSchema) -> any XLQueryStatement<T>) -> T.MetaNullableNamedResult where T: XLResult {
+    let newNamespace = XLNamespace.table()
+    let schema = XLSchema()
+    let alias = newNamespace.makeAlias(alias: alias)
+    let dependency = XLSubqueryDependency(alias: alias, statement: statement(schema))
+    return T.makeSQLAnonymousNullableNamedResult(namespace: newNamespace, dependency: dependency)
+}
+
+
+///
 /// Constructs a subquery with a select query statement that returns a column set that can evaluate to NULL.
 ///
+/// - Warning: Unreachable through SwiftQL's own `select` functions, which only
+///   produce a statement whose row type is the basis type rather than its
+///   generated `Nullable` companion. Use ``nullableSubquery(alias:_:)``.
+///
+@available(*, deprecated, message: "Use nullableSubquery(alias:_:); this overload cannot be selected because no select function produces a statement over a Nullable row type.")
 public func subquery<T>(alias: XLName? = nil, _ statement: (XLSchema) -> any XLQueryStatement<T>) -> T.Basis.MetaNullableNamedResult where T: XLMetaNullable, T.Basis: XLResult {
     let newNamespace = XLNamespace.table()
     let schema = XLSchema()
@@ -291,6 +313,25 @@ public func subquery<T>(_ statement: (XLSchema) -> any XLQueryStatement<T>) -> s
 ///
 public func subquery<T>(_ statement: () -> any XLQueryStatement<T>) -> some XLExpression<Optional<T>> where T: XLLiteral {
     return XLSubquery(statement: statement())
+}
+
+
+///
+/// Constructs a scalar subquery whose inner statement is already nullable.
+///
+/// A scalar subquery is always nullable, because it yields NULL when it selects
+/// no row. When the inner statement is itself optional — an aggregate such as
+/// `sumOrNull()`, or a nullable column — the two sources of NULL collapse into
+/// one rather than nesting into `Optional<Optional<Wrapped>>`.
+///
+public func subquery<Wrapped>(_ statement: (XLSchema) -> any XLQueryStatement<Optional<Wrapped>>) -> some XLExpression<Optional<Wrapped>> where Wrapped: XLLiteral {
+    let schema = XLSchema()
+    return XLSubquery<Wrapped>(statement: statement(schema))
+}
+
+
+public func subquery<Wrapped>(_ statement: () -> any XLQueryStatement<Optional<Wrapped>>) -> some XLExpression<Optional<Wrapped>> where Wrapped: XLLiteral {
+    XLSubquery<Wrapped>(statement: statement())
 }
 
 

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -11,6 +11,13 @@ import GRDB
 import SwiftQL
 
 @SQLResult
+struct NullableSubqueryJoinRow: Equatable {
+    let company: String
+    let employee: String?
+}
+
+
+@SQLResult
 struct ColumnsResultShadowingProjection: Equatable {
     let id: String
     let result: Int
@@ -605,6 +612,44 @@ final class XLExecutionTests: XCTestCase {
         // NOT IN is the exact complement of IN for every reachable shape.
         XCTAssertEqual(try evaluate({ $0.in([2, 3]) }, probeValue: 1), false)
         XCTAssertEqual(try evaluate({ $0.in([]) }, probeValue: 1), false)
+    }
+
+    /// A subquery on the nullable side of a LEFT JOIN, executed. The company
+    /// with no staff must still appear, with NULL columns from the subquery —
+    /// which is the whole point of the nullable shape and is not observable
+    /// from rendering alone.
+    func testNullableSubqueryLeftJoinExecutesWithUnmatchedRows() throws {
+        try database.makeRequest(with: sqlCreate(CompanyTable.self)).execute()
+        try createEmployeeTable()
+        for company in [
+            CompanyTable(id: "c1", name: "Staffed"),
+            CompanyTable(id: "c2", name: "Empty"),
+        ] {
+            try database.makeRequest(with: sqlInsert(company)).execute()
+        }
+        try insertEmployee(EmployeeTable(id: "e1", name: "Worker", companyId: "c1", managerEmployeeId: nil))
+
+        let statement = sql { schema in
+            let company = schema.table(CompanyTable.self)
+            let staff = nullableSubqueryExpression(alias: "staff") { inner in
+                let e = inner.table(EmployeeTable.self)
+                Select(e)
+                From(e)
+            }
+            Select(NullableSubqueryJoinRow.columns(company: company.name, employee: staff.name))
+            From(company)
+            Join.Left(staff, on: staff.companyId == company.id)
+            OrderBy(company.id.ascending())
+        }
+
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(
+            rows,
+            [
+                NullableSubqueryJoinRow(company: "Staffed", employee: "Worker"),
+                NullableSubqueryJoinRow(company: "Empty", employee: nil),
+            ]
+        )
     }
 
     /// The query-backed optional shapes. Before #68 the result-builder form had

--- a/Tests/SQLTests/SQLSyntaxTests.swift
+++ b/Tests/SQLTests/SQLSyntaxTests.swift
@@ -1477,17 +1477,41 @@ final class XLSyntaxTests: XCTestCase {
         XCTAssertEqual(encoder.makeSQL(expression).sql, "SELECT t0.id FROM Test AS t0")
     }
     
+    /// A subquery on the nullable side of a LEFT JOIN. Before #70 this was not
+    /// expressible: `subquery(alias:)` returns a non-nullable result, and the
+    /// nullable overload could never be selected because no `select` function
+    /// produces a statement over a generated `Nullable` row type.
+    func testNullableSubqueryOnLeftJoin() {
+        let schema = XLSchema()
+        let company = schema.table(CompanyTable.self)
+        let employees = nullableSubquery(alias: "staff") { inner in
+            let e = inner.table(EmployeeTable.self)
+            return select(e).from(e)
+        }
+        let expression = select(company)
+            .from(company)
+            .leftJoin(employees, on: employees.companyId == company.id)
+        // The subquery opens its own namespace, so its inner alias restarts at
+        // t0 rather than continuing the outer numbering. The two t0 scopes do
+        // not collide because the inner one is only visible inside the
+        // parentheses.
+        XCTAssertEqual(
+            encoder.makeSQL(expression).sql,
+            "SELECT t0.id AS id, t0.name AS name FROM Company AS t0 LEFT JOIN (SELECT t0.id AS id, t0.name AS name, t0.companyId AS companyId, t0.managerEmployeeId AS managerEmployeeId FROM Employee AS t0) AS staff ON (staff.companyId IS t0.id)"
+        )
+    }
+
     func testSelectSubqueryAggregate() {
         let s = XLSchema()
         let t = s.table(TestTable.self)
         let r = TestColumns.columns(
             id: t.id,
-            value: XLTypeAffinityExpression<Int?>(
-                expression: subquery {
-                    let t = s.table(TestTable.self)
-                    return select(t.value.sumOrNull()).from(t)
-                }
-            )
+            // No XLTypeAffinityExpression wrapper: the scalar subquery now
+            // yields Int? directly instead of Int??.
+            value: subquery {
+                let t = s.table(TestTable.self)
+                return select(t.value.sumOrNull()).from(t)
+            }
         )
         let expression = select(r).from(t)
         XCTAssertEqual(encoder.makeSQL(expression).sql, "SELECT t0.id AS id, (SELECT SUM(t1.value) FROM Test AS t1) AS value FROM Test AS t0")

--- a/Tests/SQLTests/Tests/Expression Builder/SQLQueryExpressionBuilderTests.swift
+++ b/Tests/SQLTests/Tests/Expression Builder/SQLQueryExpressionBuilderTests.swift
@@ -461,13 +461,13 @@ final class XLQueryExpressionBuilderTests: XCTestCase {
             let t = schema.table(TestTable.self)
             let r = TestColumns.columns(
                 id: t.id,
-                value: XLTypeAffinityExpression<Int?>(
-                    expression: subqueryExpression { schema in
-                        let t = schema.table(TestTable.self)
-                        Select(t.value.sumOrNull())
-                        From(t)
-                    }
-                )
+                // No XLTypeAffinityExpression wrapper: see the functional
+                // twin in XLSyntaxTests.testSelectSubqueryAggregate.
+                value: subqueryExpression { schema in
+                    let t = schema.table(TestTable.self)
+                    Select(t.value.sumOrNull())
+                    From(t)
+                }
             )
             Select(r)
             From(t)

--- a/Tests/SwiftQLCoreTests/SQLiteValueConformanceBoundaryTests.swift
+++ b/Tests/SwiftQLCoreTests/SQLiteValueConformanceBoundaryTests.swift
@@ -202,12 +202,21 @@ final class SQLiteValueConformanceBoundaryTests: XCTestCase {
             "syntax.ddl.typed-model-gap": 139,
             "syntax.dml.returning-gap": 57,
             "syntax.join.natural-using-gap": 45,
-            "syntax.subquery.nullable-shape-gap": 70,
         ]
         let featuresByID = Dictionary(
             uniqueKeysWithValues: inventory.features.map { ($0.id, $0) }
         )
-        XCTAssertEqual(gatedBlockers.count, 6)
+        XCTAssertEqual(gatedBlockers.count, 5)
+
+        // Issue #70 shipped the nullable-table and flattened-scalar subquery
+        // shapes, so this record is supported rather than gated.
+        let nullableSubquery = try XCTUnwrap(
+            featuresByID["syntax.subquery.nullable-shape-gap"]
+        )
+        XCTAssertEqual(nullableSubquery.status, .supported)
+        XCTAssertEqual(nullableSubquery.adoptionStatus, .alreadyCovered)
+        XCTAssertNil(nullableSubquery.deferral)
+        XCTAssertFalse(nullableSubquery.evidenceIDs.isEmpty)
 
         let likeEscape = try XCTUnwrap(
             featuresByID["syntax.expression.like-escape-gap"]

--- a/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json
+++ b/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json
@@ -1443,6 +1443,50 @@
       ]
     },
     {
+      "id": "evidence.syntax.subquery.render-flattened-scalar",
+      "source_path": "Tests/SQLTests/SQLSyntaxTests.swift",
+      "test_case": "XLSyntaxTests.testSelectSubqueryAggregate",
+      "runner_path": null,
+      "layers": [
+        "rendering",
+        "swift-typecheck"
+      ],
+      "real_sqlite": false,
+      "environment_ids": [
+
+      ]
+    },
+    {
+      "id": "evidence.syntax.subquery.render-nullable-left-join",
+      "source_path": "Tests/SQLTests/SQLSyntaxTests.swift",
+      "test_case": "XLSyntaxTests.testNullableSubqueryOnLeftJoin",
+      "runner_path": null,
+      "layers": [
+        "rendering",
+        "swift-typecheck"
+      ],
+      "real_sqlite": false,
+      "environment_ids": [
+
+      ]
+    },
+    {
+      "id": "evidence.syntax.subquery.sqlite-nullable-left-join",
+      "source_path": "Tests/SQLTests/SQLExecutionTests.swift",
+      "test_case": "XLExecutionTests.testNullableSubqueryLeftJoinExecutesWithUnmatchedRows",
+      "runner_path": null,
+      "layers": [
+        "execution",
+        "prepare",
+        "rendering",
+        "semantic-oracle"
+      ],
+      "real_sqlite": true,
+      "environment_ids": [
+        "sqlite-3.51.0-macos-arm64"
+      ]
+    },
+    {
       "id": "evidence.syntax.subquery.render-in",
       "source_path": "Tests/SQLTests/SQLSyntaxTests.swift",
       "test_case": "XLSyntaxTests.testScalarSelectWhereIn",
@@ -7337,8 +7381,8 @@
       "kind": "syntax",
       "family": "subquery",
       "title": "Nullable-table and direct-scalar subquery result shapes",
-      "status": "unimplemented",
-      "adoption_status": "syntax-gated",
+      "status": "supported",
+      "adoption_status": "already-covered",
       "public_api": [
         {
           "symbol": "subquery",
@@ -7362,19 +7406,19 @@
         "Nullable table references and scalar cardinality must preserve typed result metadata."
       ],
       "evidence_ids": [
-
+        "evidence.syntax.subquery.render-flattened-scalar",
+        "evidence.syntax.subquery.render-nullable-left-join",
+        "evidence.syntax.subquery.sqlite-nullable-left-join"
       ],
       "deviations": [
-        "The current overload set cannot represent every nullable-table and scalar result shape."
+        "`nullableSubquery` is a distinct function rather than another `subquery` overload, because the two would differ only by return type and could not be disambiguated at a call site.",
+        "The pre-existing `subquery(alias:)` overload constrained to `XLMetaNullable` is deprecated rather than removed. It was unreachable: no `select` function produces a statement whose row type is a generated `Nullable` companion, so no argument satisfying it could be constructed.",
+        "A scalar subquery over an already-optional statement now yields one `Optional` rather than nesting a second. The `XLTypeAffinityExpression` re-labelling that previously collapsed the nested type by hand is no longer needed and has been removed from its two call sites."
       ],
       "follow_up_issues": [
-        70
+
       ],
-      "deferral": {
-        "blocking_issue": 70,
-        "target_milestone": "v1.4",
-        "reason": "Issue #70 owns nullable-table and scalar subquery shapes."
-      },
+      "deferral": null,
       "provenance": [
 
       ]


### PR DESCRIPTION
Closes #70.

Two distinct gaps, each confirmed by compiling a probe before writing anything.

## Gap 1 — nullable-table subqueries were not expressible

`subquery(alias:)` returns a non-nullable result, so it cannot sit on the nullable side of a `LEFT JOIN`.

There *appeared* to be an overload covering this — `subquery(alias:) where T: XLMetaNullable`. It is **unreachable**. It needs an argument of type `any XLQueryStatement<Table.Nullable>`, and no `select` function produces one:

```
error: global function 'sqlQuery(builder:)' requires the types 'TestTable.Nullable'
       and 'TestTable.MetaNamedResult.Row' (aka 'TestTable') be equivalent
```

So `nullableSubquery` is a **new function**, not a fix to that one. It has to be a distinct name rather than another `subquery` overload: the two would differ only by return type and could not be disambiguated at a call site.

The unreachable overload is **deprecated, not removed**. Removal would be source-breaking on paper — a third party could in principle conform their own type to `XLMetaNullable` — even though nothing in SwiftQL can construct an argument for it. The deprecation message names the replacement.

## Gap 2 — scalar subqueries double-wrapped Optional

Because `Optional` is itself an `XLLiteral`, an inner statement that was already nullable bound `T` to `Optional<Int>` and produced:

```
some XLExpression<Optional<Int?>>
```

New overloads accept an already-optional statement, so the subquery's own nullability collapses into it rather than nesting. A non-optional inner statement is unaffected — both now yield `XLExpression<Optional<Int>>`.

I initially applied `@_disfavoredOverload` here and it was **backwards** — it disfavoured the overload I wanted to win, and the probe showed the type unchanged. Removed; Swift picks the more specific overload correctly on its own.

## The acceptance signal is subtractive

Both existing tests wrapped their scalar subquery in `XLTypeAffinityExpression<Int?>` — an unchecked type re-label — purely to hand-collapse that nested type:

```swift
value: XLTypeAffinityExpression<Int?>(expression: subquery { … })   // before
value: subquery { … }                                              // after
```

**Both wrappers are deleted and the rendered SQL is byte-identical.** That is what shows the change addressed the actual cause instead of adding a parallel path alongside the workaround.

## Execution coverage

`testNullableSubqueryLeftJoinExecutesWithUnmatchedRows` asserts the property rendering cannot show: a company with no staff still appears in the result with NULL columns from the subquery. That is the entire point of the nullable shape, and a rendering test would pass whether or not it held.

## Inventory

`syntax.subquery.nullable-shape-gap` moves `unimplemented`/`syntax-gated` → `supported`/`already-covered`, deferral cleared, with three new evidence records. The `SQLiteValueConformanceBoundaryTests` gated-blocker snapshot is updated (6 → 5) and now asserts this record is supported — that guard failing is what confirms the promotion took effect.

## Validation

- `swift test` — 721 tests, 0 failures.
- `sqlite-conformance-inventory.py validate` / `check` — clean; 28 validator self-tests OK.
- `./make-docs.sh` — DocC builds warning-free. (A `` ``XLSchema/nullableTable(_:as:)`` `` symbol link had to become plain text: that name has two overloads and DocC rejected the ambiguous reference.)

Totals: supported 93 → 94, unimplemented 6 → 5, evidence 125 → 128 (82 real-SQLite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)