### PR TITLE
Add the REPLACE statement (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@
   and the functional `insert(_:or:)`. The conflict algorithm is part of the
   `INSERT` keyword and applies to every uniqueness constraint the statement
   violates.
-- Recorded the new conflict-resolution surface in the #190 canonical SQLite
-  conformance inventory. It records 106 public-surface feature records: 98
+- Added the `REPLACE INTO` statement through `Replace` and the functional
+  `replace(_:)`, the SQLite shorthand for `INSERT OR REPLACE INTO`.
+- Recorded the new conflict-resolution and replace surfaces in the #190
+  canonical SQLite conformance inventory. It records 107 public-surface feature records: 99
   supported, 0 partial, 2 capability-gated, 1 intentionally unsupported, and
-  5 unimplemented. Of the 144 evidence records, 91 exercise real SQLite and
+  5 unimplemented. Of the 146 evidence records, 92 exercise real SQLite and
   cite one captured SQLite 3.51.0 environment.
 
 ### Migration

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -55,18 +55,18 @@ The report is evidence for SwiftQL's existing public SQLite subset; it is not a
 claim of complete SQLite grammar coverage. The inventory remains the source of
 truth, while the report is its readable generated view.
 
-The v1.3 inventory contains 106 feature records and 144 evidence records. Its
+The v1.3 inventory contains 107 feature records and 146 evidence records. Its
 support-status totals are exact and mutually exclusive:
 
 | Support status | Features |
 | --- | ---: |
-| Supported | 98 |
+| Supported | 99 |
 | Partial | 0 |
 | Capability-gated | 2 |
 | Intentionally unsupported | 1 |
 | Unimplemented | 5 |
 
-Of those 144 evidence records, 91 exercise real SQLite and
+Of those 146 evidence records, 92 exercise real SQLite and
 cite one captured environment, SQLite 3.51.0. An inventory entry is counted in
 the 97 supported features only when it links to successful preparation by a
 real SQLite engine whose version and source ID are recorded. Partial,

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -68,7 +68,7 @@ support-status totals are exact and mutually exclusive:
 
 Of those 146 evidence records, 92 exercise real SQLite and
 cite one captured environment, SQLite 3.51.0. An inventory entry is counted in
-the 97 supported features only when it links to successful preparation by a
+the 99 supported features only when it links to successful preparation by a
 real SQLite engine whose version and source ID are recorded. Partial,
 capability-gated, intentionally unsupported, and unimplemented entries remain
 visible with their evidence, requirements, or rationale, but are excluded

--- a/Conformance/SQLite/REPORT.md
+++ b/Conformance/SQLite/REPORT.md
@@ -21,10 +21,10 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 
 ## Summary
 
-- Total feature records: **106**
-- Supported feature records: **98**
+- Total feature records: **107**
+- Supported feature records: **99**
 - SQLite environments: **1**
-- Evidence records: **144**
+- Evidence records: **146**
 
 ### Support status
 
@@ -32,7 +32,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | --- | ---: |
 | `capability-gated` | 2 |
 | `intentionally-unsupported` | 1 |
-| `supported` | 98 |
+| `supported` | 99 |
 | `unimplemented` | 5 |
 
 ### Adoption status
@@ -40,7 +40,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | Value | Features |
 | --- | ---: |
 | `adapter/API-gated` | 2 |
-| `already-covered` | 98 |
+| `already-covered` | 99 |
 | `intentionally-out-of-scope` | 1 |
 | `syntax-gated` | 5 |
 
@@ -50,7 +50,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | --- | ---: |
 | `adapter-contract` | 27 |
 | `adopted-behavior` | 47 |
-| `syntax` | 32 |
+| `syntax` | 33 |
 
 ## SQLite environments
 
@@ -104,6 +104,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `rollback.explicit-request`<br>Explicit rollback request preserves caller error | `dml` | `adapter-contract` | `supported` | `already-covered` | [`www.sqlite.org/lang_transaction.html`](https://www.sqlite.org/lang_transaction.html) | `3.0.0` | `XLDatabaseDriver.withTransaction` [verified: `withTransaction`] ([`Sources/SwiftQLCore/SQLDatabaseDriver.swift`](../../Sources/SwiftQLCore/SQLDatabaseDriver.swift)) | `evidence.transaction.fixture-contract`, `evidence.transaction.rollback.sqlite` | — |
 | `syntax.dml.conflict-clause`<br>INSERT OR conflict-resolution clause | `dml` | `syntax` | `supported` | `already-covered` | [`www.sqlite.org/lang_insert.html`](https://www.sqlite.org/lang_insert.html)<br>[`www.sqlite.org/lang_conflict.html`](https://www.sqlite.org/lang_conflict.html) | `3.0.0` | `Insert` [verified: `Insert`] ([`Sources/SwiftQL/SQLStatements.swift`](../../Sources/SwiftQL/SQLStatements.swift)), `XLInsertOrAction` [verified: `XLInsertOrAction`] ([`Sources/SwiftQL/SQLStatements.swift`](../../Sources/SwiftQL/SQLStatements.swift)) | `evidence.syntax.dml.render-insert-or`, `evidence.syntax.dml.sqlite-insert-or-ignore`, `evidence.syntax.dml.sqlite-insert-or-replace` | — |
 | `syntax.dml.current-crud`<br>Current INSERT, INSERT SELECT, UPDATE, and DELETE statement clauses | `dml` | `syntax` | `supported` | `already-covered` | [`www.sqlite.org/lang_delete.html`](https://www.sqlite.org/lang_delete.html)<br>[`www.sqlite.org/lang_insert.html`](https://www.sqlite.org/lang_insert.html)<br>[`www.sqlite.org/lang_update.html`](https://www.sqlite.org/lang_update.html) | `3.0.0` | `Insert` [verified: `Insert`] ([`Sources/SwiftQL/SQLStatements.swift`](../../Sources/SwiftQL/SQLStatements.swift)), `Update` [verified: `Update`] ([`Sources/SwiftQL/SQLStatements.swift`](../../Sources/SwiftQL/SQLStatements.swift)), `Delete` [verified: `Delete`] ([`Sources/SwiftQL/SQLStatements.swift`](../../Sources/SwiftQL/SQLStatements.swift)) | `evidence.syntax.dml.sqlite-delete`, `evidence.syntax.dml.sqlite-insert-select`, `evidence.syntax.dml.sqlite-update` | [#8](https://github.com/lukevanin/swiftql/issues/8), [#9](https://github.com/lukevanin/swiftql/issues/9), [#53](https://github.com/lukevanin/swiftql/issues/53), [#55](https://github.com/lukevanin/swiftql/issues/55), [#56](https://github.com/lukevanin/swiftql/issues/56), [#57](https://github.com/lukevanin/swiftql/issues/57), [#58](https://github.com/lukevanin/swiftql/issues/58), [#59](https://github.com/lukevanin/swiftql/issues/59) |
+| `syntax.dml.replace`<br>REPLACE statement | `dml` | `syntax` | `supported` | `already-covered` | [`www.sqlite.org/lang_replace.html`](https://www.sqlite.org/lang_replace.html)<br>[`www.sqlite.org/lang_insert.html`](https://www.sqlite.org/lang_insert.html) | `3.0.0` | `Replace` [verified: `Replace`] ([`Sources/SwiftQL/SQLStatements.swift`](../../Sources/SwiftQL/SQLStatements.swift)), `replace(_:)` [verified: `replace`] ([`Sources/SwiftQL/Statements/SQLDataChangingStatements.swift`](../../Sources/SwiftQL/Statements/SQLDataChangingStatements.swift)) | `evidence.syntax.dml.render-replace`, `evidence.syntax.dml.sqlite-replace` | — |
 | `syntax.dml.returning-gap`<br>INSERT, UPDATE, and DELETE RETURNING clauses | `dml` | `syntax` | `unimplemented` | `syntax-gated` | [`www.sqlite.org/lang_returning.html`](https://www.sqlite.org/lang_returning.html) | `3.35.0` | `XLInsertStatement` [verified: `XLInsertStatement`] ([`Sources/SwiftQL/Statements/SQLInsertStatement.swift`](../../Sources/SwiftQL/Statements/SQLInsertStatement.swift)), `XLUpdateStatement` [verified: `XLUpdateStatement`] ([`Sources/SwiftQL/Statements/SQLUpdateStatement.swift`](../../Sources/SwiftQL/Statements/SQLUpdateStatement.swift)), `XLDeleteStatement` [verified: `XLDeleteStatement`] ([`Sources/SwiftQL/Statements/SQLDeleteStatement.swift`](../../Sources/SwiftQL/Statements/SQLDeleteStatement.swift)) | — | [#53](https://github.com/lukevanin/swiftql/issues/53), [#57](https://github.com/lukevanin/swiftql/issues/57), [#58](https://github.com/lukevanin/swiftql/issues/58) |
 | `upstream.fluent.soft-delete-lifecycle`<br>Fluent model soft-delete, restore, force-delete, and default-filter lifecycle | `dml` | `adopted-behavior` | `intentionally-unsupported` | `intentionally-out-of-scope` | — | N/A | — | — | — |
 | `visibility.pinned-connection`<br>Writes are visible inside the pinned transaction connection | `dml` | `adapter-contract` | `supported` | `already-covered` | [`www.sqlite.org/lang_transaction.html`](https://www.sqlite.org/lang_transaction.html) | `3.0.0` | `XLDatabaseDriver.withTransaction` [verified: `withTransaction`] ([`Sources/SwiftQLCore/SQLDatabaseDriver.swift`](../../Sources/SwiftQLCore/SQLDatabaseDriver.swift)) | `evidence.transaction.commit.sqlite`, `evidence.transaction.fixture-contract` | — |
@@ -215,6 +216,7 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `rollback.explicit-request` | `database-pool-driver`, `transactions` | A transaction-owned table records stable logical row IDs before and after the operation. | — | — |
 | `syntax.dml.conflict-clause` | `sqlite-core-parser` | A generated writable table supplies insert metadata. | The conflict algorithm is part of the INSERT keyword and renders as INSERT OR ROLLBACK/ABORT/FAIL/IGNORE/REPLACE INTO. | — |
 | `syntax.dml.current-crud` | `sqlite-core-parser` | A generated writable table supplies insert, update, and delete metadata. | Conflict algorithms, UPSERT, and RETURNING are separate deferred sub-surfaces. | — |
+| `syntax.dml.replace` | `sqlite-core-parser` | A generated writable table supplies insert metadata. | REPLACE INTO is the SQLite shorthand for INSERT OR REPLACE INTO. | — |
 | `syntax.dml.returning-gap` | `sqlite-core-parser` | DML statements need typed result-row and cardinality metadata. | The current DML statement protocols are write-only and do not expose RETURNING rows. | [#57](https://github.com/lukevanin/swiftql/issues/57) for `v1.4`: Issue #57 is the first atomic RETURNING implementation; #53 and #58 cover DELETE and UPDATE. |
 | `upstream.fluent.soft-delete-lifecycle` | — | Fluent model lifecycle metadata, default query scopes, and restore semantics would be required. | SwiftQL is a typed SQL construction library and does not implement ORM soft-delete lifecycle behavior.<br>Soft-delete filtering and restore semantics are ORM record-lifecycle policy, not SQLite syntax. | — |
 | `visibility.pinned-connection` | `database-pool-driver`, `transactions` | A transaction-owned table records stable logical row IDs before and after the operation. | — | — |
@@ -348,10 +350,12 @@ A feature counts as supported only when it references explicit real-SQLite `prep
 | `evidence.syntax.ddl.sqlite-create` | [`Tests/SQLTests/SQLExecutionTests.swift`](../../Tests/SQLTests/SQLExecutionTests.swift)<br>`XLExecutionTests.testCreateTable` | — | `execution`, `prepare`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.syntax.ddl.sqlite-create-as-select` | [`Tests/SQLTests/SQLExecutionTests.swift`](../../Tests/SQLTests/SQLExecutionTests.swift)<br>`XLExecutionTests.testCreateTableAsSelect` | — | `execution`, `prepare`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.syntax.dml.render-insert-or` | [`Tests/SQLTests/Tests/Expression Builder/SQLDataChangingStatementsTests.swift`](../../Tests/SQLTests/Tests/Expression%20Builder/SQLDataChangingStatementsTests.swift)<br>`XLDataChangingStatementsTests.testInsertOrAllActionsRender` | — | `rendering`, `swift-typecheck` | no | — |
+| `evidence.syntax.dml.render-replace` | [`Tests/SQLTests/Tests/Expression Builder/SQLDataChangingStatementsTests.swift`](../../Tests/SQLTests/Tests/Expression%20Builder/SQLDataChangingStatementsTests.swift)<br>`XLDataChangingStatementsTests.testReplace` | — | `rendering`, `swift-typecheck` | no | — |
 | `evidence.syntax.dml.sqlite-delete` | [`Tests/SQLTests/SQLExecutionTests.swift`](../../Tests/SQLTests/SQLExecutionTests.swift)<br>`XLExecutionTests.testDelete` | — | `execution`, `prepare`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.syntax.dml.sqlite-insert-or-ignore` | [`Tests/SQLTests/SQLDataChangingExecutionTests.swift`](../../Tests/SQLTests/SQLDataChangingExecutionTests.swift)<br>`XLDataChangingExecutionTests.testInsertOrIgnoreKeepsExistingRow` | — | `execution`, `prepare`, `rendering`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.syntax.dml.sqlite-insert-or-replace` | [`Tests/SQLTests/SQLDataChangingExecutionTests.swift`](../../Tests/SQLTests/SQLDataChangingExecutionTests.swift)<br>`XLDataChangingExecutionTests.testInsertOrReplaceOverwritesExistingRow` | — | `execution`, `prepare`, `rendering`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.syntax.dml.sqlite-insert-select` | [`Tests/SQLTests/SQLExecutionTests.swift`](../../Tests/SQLTests/SQLExecutionTests.swift)<br>`XLExecutionTests.testInsertSelectFluentCompleteClauseChain` | — | `bindings`, `execution`, `prepare`, `rendering`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
+| `evidence.syntax.dml.sqlite-replace` | [`Tests/SQLTests/SQLDataChangingExecutionTests.swift`](../../Tests/SQLTests/SQLDataChangingExecutionTests.swift)<br>`XLDataChangingExecutionTests.testReplaceOverwritesConflictingRow` | — | `execution`, `prepare`, `rendering`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.syntax.dml.sqlite-update` | [`Tests/SQLTests/SQLExecutionTests.swift`](../../Tests/SQLTests/SQLExecutionTests.swift)<br>`XLExecutionTests.testUpdate` | — | `execution`, `prepare`, `semantic-oracle`, `swift-typecheck` | yes | `sqlite-3.51.0-macos-arm64` |
 | `evidence.syntax.expression.compile-fail-between-mismatched-types` | [`Tests/CompileFail/BetweenMismatchedTypes.swift`](../../Tests/CompileFail/BetweenMismatchedTypes.swift)<br>`compile-fail.between-mismatched-types` | [`scripts/ci/check-between-type-safety.sh`](../../scripts/ci/check-between-type-safety.sh) | `compile-fail`, `swift-typecheck` | no | — |
 | `evidence.syntax.expression.compile-fail-between-non-comparable` | [`Tests/CompileFail/BetweenNonComparableData.swift`](../../Tests/CompileFail/BetweenNonComparableData.swift)<br>`compile-fail.between-non-comparable` | [`scripts/ci/check-between-type-safety.sh`](../../scripts/ci/check-between-type-safety.sh) | `compile-fail`, `swift-typecheck` | no | — |

--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ and [contextual-codec migration](https://lukevanin.github.io/swiftql/documentati
 for the complete contracts and current limitations.
 
 SwiftQL v1.3 adds evidence around that public surface rather than claiming
-complete SQLite grammar coverage. The canonical inventory records 106 features:
-98 supported, 0 partial, 2 capability-gated, 1 intentionally unsupported, and
-5 unimplemented. Of its 144 evidence records, 91 exercise real SQLite and
+complete SQLite grammar coverage. The canonical inventory records 107 features:
+99 supported, 0 partial, 2 capability-gated, 1 intentionally unsupported, and
+5 unimplemented. Of its 146 evidence records, 92 exercise real SQLite and
 cite one recorded SQLite 3.51.0 environment. See
 [SQLite conformance](COMPATIBILITY.md#sqlite-conformance-inventory) for what
 those counts prove, how the #191/#286 combinatorial cases, #254 Northwind

--- a/SKILL.md
+++ b/SKILL.md
@@ -148,12 +148,12 @@ contracts.
 - Treat the versioned [inventory](Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json) as
   the source of truth and its [report](Conformance/SQLite/REPORT.md) as a generated
   view; use the [compatibility guide](COMPATIBILITY.md#sqlite-conformance-inventory)
-  to interpret it. It records 106 feature records: 98 supported, 0 partial,
+  to interpret it. It records 107 feature records: 99 supported, 0 partial,
   2 capability-gated, 1 intentionally unsupported, and 5 unimplemented.
 - Keep those five statuses distinct. Bind every claim to the feature's recorded
   SQLite version, source ID, compile options, capabilities, evidence, and
   rationale before claiming support.
-- Of the 144 evidence records, 91 exercise real SQLite against one captured
+- Of the 146 evidence records, 92 exercise real SQLite against one captured
   environment, SQLite 3.51.0. Evidence is reusable, so evidence and feature
   counts do not map one to one; never turn this into an exhaustive-SQL claim.
 - The generated corpus holds 208 positives plus one broken-renderer control:

--- a/Sources/SwiftQL/Expression Builder/SQLInsertExpressionBuilder.swift
+++ b/Sources/SwiftQL/Expression Builder/SQLInsertExpressionBuilder.swift
@@ -33,8 +33,22 @@ import Foundation
     public static func buildPartialBlock<Row>(first: Insert<Row>) -> XLInsertTableStatement<Row> {
         XLInsertTableStatement(components: XLInsertStatementComponents(insert: first))
     }
-    
-    
+
+    ///
+    /// Constructs a Replace expression.
+    ///
+    public static func buildPartialBlock<Row>(first: Replace<Row>) -> XLInsertTableStatement<Row> {
+        XLInsertTableStatement(components: XLInsertStatementComponents(insert: first.insert))
+    }
+
+    ///
+    /// Constructs a Replace expression using a With expression.
+    ///
+    public static func buildPartialBlock<Row>(accumulated: XLWithStatement, next: Replace<Row>) -> XLInsertTableStatement<Row> {
+        XLInsertTableStatement(components: XLInsertStatementComponents(commonTables: accumulated.commonTables, insert: next.insert))
+    }
+
+
     // MARK: Insert
     
     ///

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -337,12 +337,16 @@ public struct Insert<Row>: XLEncodable, XLRowWritable {
 /// that would violate a uniqueness constraint is deleted before the new row is
 /// inserted.
 ///
-public struct Replace<Row> {
+public struct Replace<Row>: XLEncodable, XLRowWritable {
 
     internal let insert: Insert<Row>
 
     public init<T>(_ meta: T) where T: XLMetaNamedResult, T.Row == Row {
         self.insert = Insert(table: meta._dependency, keyword: "REPLACE INTO")
+    }
+
+    public func makeSQL(context: inout XLBuilder) {
+        insert.makeSQL(context: &context)
     }
 }
 

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -330,6 +330,23 @@ public struct Insert<Row>: XLEncodable, XLRowWritable {
 }
 
 
+///
+/// Replace statement.
+///
+/// `REPLACE INTO` is the SQLite shorthand for `INSERT OR REPLACE INTO`. A row
+/// that would violate a uniqueness constraint is deleted before the new row is
+/// inserted.
+///
+public struct Replace<Row> {
+
+    internal let insert: Insert<Row>
+
+    public init<T>(_ meta: T) where T: XLMetaNamedResult, T.Row == Row {
+        self.insert = Insert(table: meta._dependency, keyword: "REPLACE INTO")
+    }
+}
+
+
 // MARK: - Values
 
 

--- a/Sources/SwiftQL/Statements/SQLDataChangingStatements.swift
+++ b/Sources/SwiftQL/Statements/SQLDataChangingStatements.swift
@@ -14,3 +14,26 @@ public func insert<T>(_ meta: T, or action: XLInsertOrAction) -> XLInsertTableSt
     let components = XLInsertStatementComponents(insert: Insert(meta, or: action))
     return XLInsertTableStatement(components: components)
 }
+
+
+///
+/// Constructs a `REPLACE INTO` statement.
+///
+public func replace<T>(_ meta: T) -> XLInsertTableStatement<T.Row> where T: XLMetaNamedResult {
+    let components = XLInsertStatementComponents(insert: Replace(meta).insert)
+    return XLInsertTableStatement(components: components)
+}
+
+
+extension XLWithStatement {
+
+    ///
+    /// Constructs a `REPLACE INTO` statement scoped by the with clause's common
+    /// table expressions.
+    ///
+    public func replace<T>(_ meta: T) -> XLInsertTableStatement<T.Row> where T: XLMetaNamedResult {
+        XLInsertTableStatement(
+            components: XLInsertStatementComponents(commonTables: commonTables, insert: Replace(meta).insert)
+        )
+    }
+}

--- a/Tests/SQLTests/SQLDataChangingExecutionTests.swift
+++ b/Tests/SQLTests/SQLDataChangingExecutionTests.swift
@@ -84,4 +84,19 @@ final class XLDataChangingExecutionTests: XCTestCase {
 
         XCTAssertEqual(try allTestRows(), [TestTable(id: "a", value: 7)])
     }
+
+
+    // MARK: - REPLACE
+
+    func testReplaceOverwritesConflictingRow() throws {
+        try createUniqueTestTable()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "a", value: 1))).execute()
+
+        let schema = XLSchema()
+        let t = schema.table(TestTable.self)
+        let statement = replace(t).values(TestTable.MetaInsert(TestTable(id: "a", value: 2)))
+        try database.makeRequest(with: statement).execute()
+
+        XCTAssertEqual(try allTestRows(), [TestTable(id: "a", value: 2)])
+    }
 }

--- a/Tests/SQLTests/Tests/Expression Builder/SQLDataChangingStatementsTests.swift
+++ b/Tests/SQLTests/Tests/Expression Builder/SQLDataChangingStatementsTests.swift
@@ -84,4 +84,29 @@ final class XLDataChangingStatementsTests: XCTestCase {
             "INSERT OR IGNORE INTO Test AS t0 (id,value) VALUES ('foo',42)"
         )
     }
+
+
+    // MARK: - REPLACE
+
+    func testReplace() {
+        let expression = sql { schema in
+            let t = schema.table(TestTable.self)
+            Replace(t)
+            Values(instanceValues())
+        }
+        XCTAssertEqual(
+            encoder.makeSQL(expression).sql,
+            "REPLACE INTO Test AS t0 (id,value) VALUES ('foo',42)"
+        )
+    }
+
+    func testReplaceFunctional() {
+        let schema = XLSchema()
+        let t = schema.table(TestTable.self)
+        let expression = replace(t).values(instanceValues())
+        XCTAssertEqual(
+            encoder.makeSQL(expression).sql,
+            "REPLACE INTO Test AS t0 (id,value) VALUES ('foo',42)"
+        )
+    }
 }

--- a/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json
+++ b/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json
@@ -2207,6 +2207,35 @@
       "environment_ids": [
         "sqlite-3.51.0-macos-arm64"
       ]
+    },
+    {
+      "id": "evidence.syntax.dml.render-replace",
+      "source_path": "Tests/SQLTests/Tests/Expression Builder/SQLDataChangingStatementsTests.swift",
+      "test_case": "XLDataChangingStatementsTests.testReplace",
+      "runner_path": null,
+      "layers": [
+        "rendering",
+        "swift-typecheck"
+      ],
+      "real_sqlite": false,
+      "environment_ids": []
+    },
+    {
+      "id": "evidence.syntax.dml.sqlite-replace",
+      "source_path": "Tests/SQLTests/SQLDataChangingExecutionTests.swift",
+      "test_case": "XLDataChangingExecutionTests.testReplaceOverwritesConflictingRow",
+      "runner_path": null,
+      "layers": [
+        "execution",
+        "prepare",
+        "rendering",
+        "semantic-oracle",
+        "swift-typecheck"
+      ],
+      "real_sqlite": true,
+      "environment_ids": [
+        "sqlite-3.51.0-macos-arm64"
+      ]
     }
   ],
   "suites": [
@@ -6058,6 +6087,54 @@
       ],
       "deviations": [
         "The conflict algorithm is part of the INSERT keyword and renders as INSERT OR ROLLBACK/ABORT/FAIL/IGNORE/REPLACE INTO."
+      ],
+      "follow_up_issues": [],
+      "deferral": null,
+      "provenance": []
+    },
+    {
+      "id": "syntax.dml.replace",
+      "kind": "syntax",
+      "family": "dml",
+      "title": "REPLACE statement",
+      "status": "supported",
+      "adoption_status": "already-covered",
+      "public_api": [
+        {
+          "symbol": "Replace",
+          "source_path": "Sources/SwiftQL/SQLStatements.swift",
+          "source_tokens": [
+            "Replace"
+          ]
+        },
+        {
+          "symbol": "replace(_:)",
+          "source_path": "Sources/SwiftQL/Statements/SQLDataChangingStatements.swift",
+          "source_tokens": [
+            "replace"
+          ]
+        }
+      ],
+      "sqlite_documentation_urls": [
+        "https://www.sqlite.org/lang_replace.html",
+        "https://www.sqlite.org/lang_insert.html"
+      ],
+      "not_sqlite_syntax_reason": null,
+      "minimum_sqlite_version": "3.0.0",
+      "reviewed_sqlite_release": "3.51.0",
+      "reviewed_sqlite_source_id": "2025-06-12 13:14:41 f0ca7bba1c5e232e5d279fad6338121ab55af0c8c68c84cdfb18ba5114dcaapl",
+      "required_capabilities": [
+        "sqlite-core-parser"
+      ],
+      "schema_requirements": [
+        "A generated writable table supplies insert metadata."
+      ],
+      "evidence_ids": [
+        "evidence.syntax.dml.render-replace",
+        "evidence.syntax.dml.sqlite-replace"
+      ],
+      "deviations": [
+        "REPLACE INTO is the SQLite shorthand for INSERT OR REPLACE INTO."
       ],
       "follow_up_issues": [],
       "deferral": null,


### PR DESCRIPTION
Part of milestone **v1.4.4** (data-changing statements). Closes #55. Builds on #56 (INSERT OR).

Adds `REPLACE INTO` — the SQLite shorthand for `INSERT OR REPLACE INTO` — where a row that would violate a uniqueness constraint is deleted before the new row is inserted.

## Changes
- `Replace` statement node, the functional `replace(_:)`, and `XLWithStatement.replace` (CTE-scoped), all rendering `REPLACE INTO`.
- Result-builder support (`Replace` as a first element and after a `With`).
- Rendering tests (result-builder + functional) and a real-SQLite execution test proving the overwrite-on-conflict behavior against a uniqueness constraint.
- #190 conformance inventory gains a `syntax.dml.replace` record with rendering + execution evidence; `REPORT.md` regenerated and census counts advanced to 107 features / 146 evidence.

Second of the per-issue PRs for milestone v1.4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UguAtcC3bPayS2HxzThhFM)_