### PR TITLE
Implement alias-first recursive CTE construction lifecycle (#205)

### DIFF
--- a/Sources/SwiftQL/SQLFunctionalSyntax.swift
+++ b/Sources/SwiftQL/SQLFunctionalSyntax.swift
@@ -127,7 +127,7 @@ public struct XLSchema {
     }
 
     ///
-    /// Constructs a recursive common table expression using a select query that returns an `SQLTable`.
+    /// Constructs a recursive common table expression using a select query that returns an `SQLResult`.
     ///
     public func recursiveCommonTableExpression<T>(_ type: T.Type, alias: XLName? = nil, @XLQueryExpressionBuilder statement: (XLSchema, T.MetaCommonTable.Result.MetaNamedResult) -> any XLQueryStatement<T>) -> T.MetaCommonTable where T: XLResult {
         makeRecursiveCommonTable(T.self, alias: alias, body: statement)

--- a/Sources/SwiftQL/SQLFunctionalSyntax.swift
+++ b/Sources/SwiftQL/SQLFunctionalSyntax.swift
@@ -118,7 +118,9 @@ public struct XLSchema {
     /// Constructs a recursive common table expression using a select query that returns
     /// an `SQLResult`.
     ///
-    /// > Note: Recursive common table requires heap allocation.
+    /// The self-reference passed to `statement` is derived from the reserved
+    /// alias alone through a value-semantic ``XLRecursiveCommonTableDraft``; no
+    /// mutable completion cell is involved.
     ///
     public func recursiveCommonTable<T>(_ type: T.Type, alias: XLName? = nil, statement: (XLSchema, T.MetaCommonTable.Result.MetaNamedResult) -> any XLQueryStatement<T>) -> T.MetaCommonTable where T: XLResult {
         makeRecursiveCommonTable(T.self, alias: alias, body: statement)
@@ -148,10 +150,7 @@ public struct XLSchema {
         let bodySchema = XLSchema()
         var draft = XLRecursiveCommonTableDraft(
             alias: reservedAlias,
-            layout: XLCompositeRecursiveCommonTableLayout<T>(
-                schema: bodySchema,
-                commonTableNamespace: commonTableNamespace
-            )
+            layout: XLCompositeRecursiveCommonTableLayout<T>(schema: bodySchema)
         )
         let dependency = draft.completeWithNonThrowingBody { reference in
             body(bodySchema, reference)

--- a/Sources/SwiftQL/SQLFunctionalSyntax.swift
+++ b/Sources/SwiftQL/SQLFunctionalSyntax.swift
@@ -121,30 +121,42 @@ public struct XLSchema {
     /// > Note: Recursive common table requires heap allocation.
     ///
     public func recursiveCommonTable<T>(_ type: T.Type, alias: XLName? = nil, statement: (XLSchema, T.MetaCommonTable.Result.MetaNamedResult) -> any XLQueryStatement<T>) -> T.MetaCommonTable where T: XLResult {
-        let alias = commonTableNamespace.makeAlias(alias: alias)
-        let schema = XLSchema()
-        let recursiveStatement = XLRecursiveCommonTableStatement()
-        let dependency = XLCommonTableDependency(alias: alias, statement: recursiveStatement)
-        let commonTable = T.makeSQLCommonTable(namespace: commonTableNamespace, dependency: dependency)
-        let table = schema.table(commonTable)
-        recursiveStatement.statement = statement(schema, table)
-        return commonTable
+        makeRecursiveCommonTable(T.self, alias: alias, body: statement)
     }
-    
+
     ///
     /// Constructs a recursive common table expression using a select query that returns an `SQLTable`.
     ///
-    /// > Note: Recursive common table requires heap allocation.
-    ///
     public func recursiveCommonTableExpression<T>(_ type: T.Type, alias: XLName? = nil, @XLQueryExpressionBuilder statement: (XLSchema, T.MetaCommonTable.Result.MetaNamedResult) -> any XLQueryStatement<T>) -> T.MetaCommonTable where T: XLResult {
-        let alias = commonTableNamespace.makeAlias(alias: alias)
-        let schema = XLSchema()
-        let recursiveStatement = XLRecursiveCommonTableStatement()
-        let dependency = XLCommonTableDependency(alias: alias, statement: recursiveStatement)
-        let commonTable = T.makeSQLCommonTable(namespace: commonTableNamespace, dependency: dependency)
-        let table = schema.table(commonTable)
-        recursiveStatement.statement = statement(schema, table)
-        return commonTable
+        makeRecursiveCommonTable(T.self, alias: alias, body: statement)
+    }
+
+    ///
+    /// Shared alias-first construction for the recursive common table surface.
+    ///
+    /// Reserves an immutable alias, derives the self-reference from that alias
+    /// alone, then completes the body through a value-semantic
+    /// ``XLRecursiveCommonTableDraft``. No mutable completion cell is involved,
+    /// and the rendered SQL is identical to the previous mechanism.
+    ///
+    private func makeRecursiveCommonTable<T>(
+        _ type: T.Type,
+        alias: XLName?,
+        body: (XLSchema, T.MetaCommonTable.Result.MetaNamedResult) -> any XLQueryStatement<T>
+    ) -> T.MetaCommonTable where T: XLResult {
+        let reservedAlias = commonTableNamespace.makeAlias(alias: alias)
+        let bodySchema = XLSchema()
+        var draft = XLRecursiveCommonTableDraft(
+            alias: reservedAlias,
+            layout: XLCompositeRecursiveCommonTableLayout<T>(
+                schema: bodySchema,
+                commonTableNamespace: commonTableNamespace
+            )
+        )
+        let dependency = draft.completeWithNonThrowingBody { reference in
+            body(bodySchema, reference)
+        }
+        return T.makeSQLCommonTable(namespace: commonTableNamespace, dependency: dependency)
     }
     
     ///

--- a/Sources/SwiftQL/SQLMeta.swift
+++ b/Sources/SwiftQL/SQLMeta.swift
@@ -927,24 +927,6 @@ public struct XLCommonTableDependency: XLColumnDependency, XLNamedDependency {
 
 
 ///
-/// A recursive common table expression.
-///
-/// A recursive common table expression is a common table expression which contains a reference to itself.
-///
-/// > Note: Recursive common table expressions are represented by a reference type and therefore require
-/// stack allocation.
-///
-internal class XLRecursiveCommonTableStatement: XLEncodable {
-    
-    internal var statement: (any XLEncodable)!
-
-    func makeSQL(context: inout XLBuilder) {
-        statement.makeSQL(context: &context)
-    }
-}
-
-
-///
 /// The result of a select statement.
 ///
 public struct XLSelectResultDependency: XLTableDeclaration {

--- a/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
+++ b/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
@@ -26,8 +26,6 @@
 //  copies can be completed concurrently and deterministically.
 //
 
-import Foundation
-
 
 ///
 /// Structured, adapter-neutral failures raised while constructing a recursive
@@ -245,8 +243,12 @@ public struct XLRecursiveCommonTableDraft<Layout> where Layout: XLRecursiveCommo
 ///
 /// Validates that a set of common-table definitions reserve distinct aliases,
 /// throwing ``XLRecursiveCommonTableConstructionError/duplicateAlias(_:)`` for
-/// the first collision. Alias comparison is case-insensitive, matching SQLite's
-/// identifier resolution.
+/// the first collision.
+///
+/// Alias comparison is case-insensitive using Swift's Unicode `lowercased()`,
+/// consistent with how ``XLNamespace`` tracks reserved aliases. (SQLite folds
+/// only ASCII `A`–`Z`, so this is marginally stricter for non-ASCII aliases,
+/// which the library never generates automatically.)
 ///
 public func xlValidateUniqueCommonTableAliases(
     _ definitions: [XLCommonTableDependency]

--- a/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
+++ b/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
@@ -161,7 +161,12 @@ public struct XLRecursiveCommonTableDraft<Layout> where Layout: XLRecursiveCommo
     /// raise a construction error, which is the case for the public recursive
     /// CTE surface. This keeps that surface free of spurious `try`.
     ///
-    public mutating func completeWithNonThrowingBody(
+    /// This is an internal convenience: it traps on the construction errors that
+    /// are unreachable for a fresh single-shot draft. Callers that reuse or copy
+    /// drafts must use the throwing ``complete(_:)`` and handle
+    /// ``XLRecursiveCommonTableConstructionError`` explicitly.
+    ///
+    internal mutating func completeWithNonThrowingBody(
         _ makeBody: (Layout.Reference) -> any XLEncodable
     ) -> XLCommonTableDependency {
         do {
@@ -218,7 +223,14 @@ public struct XLRecursiveCommonTableDraft<Layout> where Layout: XLRecursiveCommo
     /// layout, throwing ``XLRecursiveCommonTableConstructionError/resultLayoutMismatch(alias:expected:actual:)``
     /// when they differ. Used by callers that can observe the body's columns.
     ///
+    /// Layouts that opt out of a fixed column list (an empty `resultColumns`,
+    /// such as the generated composite surface whose shape the type system
+    /// already enforces) are not validated.
+    ///
     public func validateResultLayout(actualColumns: [XLName]) throws {
+        guard !layout.resultColumns.isEmpty else {
+            return
+        }
         guard layout.resultColumns == actualColumns else {
             throw XLRecursiveCommonTableConstructionError.resultLayoutMismatch(
                 alias: alias,
@@ -273,10 +285,14 @@ struct XLAliasOnlyCommonTableBody: XLEncodable {
 /// the reserved alias, by building an alias-only common-table dependency and
 /// projecting it through the body schema's `table(_:)`.
 ///
+/// The layout holds the body schema so the reference alias is allocated from the
+/// same namespace the recursive body uses, keeping the rendered SQL consistent.
+/// It deliberately does not retain a common-table namespace: the macro-generated
+/// `makeSQLCommonTable` ignores its `namespace` argument, so a throwaway is used.
+///
 struct XLCompositeRecursiveCommonTableLayout<T>: XLRecursiveCommonTableReferenceLayout where T: XLResult {
 
     let schema: XLSchema
-    let commonTableNamespace: XLNamespace
 
     func makeReference(cteAlias: XLName) -> T.MetaCommonTable.Result.MetaNamedResult {
         let dependency = XLCommonTableDependency(
@@ -284,7 +300,7 @@ struct XLCompositeRecursiveCommonTableLayout<T>: XLRecursiveCommonTableReference
             statement: XLAliasOnlyCommonTableBody()
         )
         let commonTable = T.makeSQLCommonTable(
-            namespace: commonTableNamespace,
+            namespace: .common(),
             dependency: dependency
         )
         return schema.table(commonTable)

--- a/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
+++ b/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
@@ -1,0 +1,292 @@
+//
+//  SQLRecursiveCommonTable.swift
+//
+//
+//  Alias-first, value-semantic construction lifecycle for recursive common
+//  table expressions (issue #205).
+//
+//  A recursive common table expression contains a reference to itself: the
+//  recursive body is written in terms of a self-reference that names the very
+//  table being defined. That circularity historically forced an internal
+//  mutable completion cell (a class with an implicitly-unwrapped body that was
+//  populated after the reference had already been handed to the body closure).
+//
+//  This file replaces that mutable indirection with a two-phase lifecycle whose
+//  name, typed reference, completion state, and completed definition all have
+//  value semantics:
+//
+//    1. Reserve an immutable common-table name.
+//    2. Derive the typed self-reference from that name plus static result-layout
+//       metadata — never from the body. The reference therefore does not retain
+//       the definition it is used to build.
+//    3. Evaluate the body transactionally; only a completed draft yields a
+//       renderable definition.
+//
+//  Copying a draft copies its completion state, so independent drafts and their
+//  copies can be completed concurrently and deterministically.
+//
+
+import Foundation
+
+
+///
+/// Structured, adapter-neutral failures raised while constructing a recursive
+/// common table expression through the alias-first two-phase lifecycle.
+///
+/// These errors carry only the reserved common-table name (and, for layout
+/// mismatches, the offending column aliases). They never reference GRDB,
+/// connections, prepared statements, or any other adapter state, so the same
+/// vocabulary applies regardless of which database backend renders the query.
+///
+public enum XLRecursiveCommonTableConstructionError: Error, Equatable {
+
+    /// The draft has not completed a body, so it has no renderable definition.
+    case incomplete(XLName)
+
+    /// The draft already completed a body. A second completion is rejected
+    /// before its body closure is evaluated.
+    case alreadyCompleted(XLName)
+
+    /// Completion was requested while another completion of the same draft value
+    /// was already in progress. Recursive/re-entrant completion of a single
+    /// draft value is not permitted.
+    case reentrantCompletion(XLName)
+
+    /// Two common tables reserved the same alias within one statement.
+    case duplicateAlias(XLName)
+
+    /// A recursive body produced a result layout whose columns do not match the
+    /// columns declared by the self-reference layout.
+    case resultLayoutMismatch(alias: XLName, expected: [XLName], actual: [XLName])
+}
+
+
+///
+/// Immutable metadata needed to derive a fresh typed self-reference for a single
+/// completion attempt.
+///
+/// A layout retains only the value data required to rebuild the reference from
+/// the reserved alias — never a generated result, statement body, namespace, or
+/// completed definition. Keeping the reference derivable from the alias alone is
+/// what allows the self-reference to avoid retaining the body it helps build.
+///
+/// The associated `Reference` is the typed, `FROM`-able projection of the common
+/// table (for the generated composite surface this is
+/// `T.MetaCommonTable.Result.MetaNamedResult`). Issue #43 adds a one-column
+/// direct-scalar layout by conforming a new type to this same protocol, without
+/// introducing another construction mechanism.
+///
+public protocol XLRecursiveCommonTableReferenceLayout {
+
+    associatedtype Reference
+
+    /// The ordered column aliases the self-reference exposes. Used to validate a
+    /// completed body against the declared result layout. Layouts that do not
+    /// expose a fixed column list (such as the generated composite surface,
+    /// whose columns are validated by the type system) may leave this empty.
+    var resultColumns: [XLName] { get }
+
+    /// Builds a fresh self-reference from only the reserved common-table alias.
+    func makeReference(cteAlias: XLName) -> Reference
+}
+
+
+extension XLRecursiveCommonTableReferenceLayout {
+
+    /// Composite, macro-generated surfaces validate their column shape through
+    /// the type system, so they expose no explicit result-column list.
+    public var resultColumns: [XLName] { [] }
+}
+
+
+///
+/// An alias-first, two-phase, value-semantic recursive CTE construction draft.
+///
+/// The reserved alias is fixed at initialization and never changes, even across
+/// copies or failed completions. Completion evaluates the body transactionally:
+/// a throwing body rolls the draft back to its declared state so it can be
+/// retried, and only a completed draft yields a renderable
+/// ``XLCommonTableDependency``. Because the draft is a value with no shared
+/// mutable indirection, copying it copies its completion state, and independent
+/// drafts — including copies — can be completed concurrently and
+/// deterministically.
+///
+public struct XLRecursiveCommonTableDraft<Layout> where Layout: XLRecursiveCommonTableReferenceLayout {
+
+    private enum State: Equatable {
+        case declared
+        case building
+        case completed
+    }
+
+    /// The immutable reserved common-table name. Stable across copies, failed
+    /// completions, and retries.
+    public let alias: XLName
+
+    private let layout: Layout
+
+    private var state: State = .declared
+
+    public init(alias: XLName, layout: Layout) {
+        self.alias = alias
+        self.layout = layout
+    }
+
+    ///
+    /// Completes the draft by evaluating a recursive body against a freshly
+    /// derived self-reference.
+    ///
+    /// On success the draft transitions to `completed` and a renderable
+    /// definition is returned. If the body throws, the draft is rolled back to
+    /// its declared state — leaving it reusable — and the error is rethrown.
+    ///
+    public mutating func complete(
+        _ makeBody: (Layout.Reference) throws -> any XLEncodable
+    ) throws -> XLCommonTableDependency {
+        let reference = try beginCompletion()
+        do {
+            let body = try makeBody(reference)
+            state = .completed
+            return XLCommonTableDependency(alias: alias, statement: body)
+        } catch {
+            rollbackCompletion()
+            throw error
+        }
+    }
+
+    ///
+    /// Completes the draft with a body that cannot fail.
+    ///
+    /// A fresh draft completed exactly once with a non-throwing body can never
+    /// raise a construction error, which is the case for the public recursive
+    /// CTE surface. This keeps that surface free of spurious `try`.
+    ///
+    public mutating func completeWithNonThrowingBody(
+        _ makeBody: (Layout.Reference) -> any XLEncodable
+    ) -> XLCommonTableDependency {
+        do {
+            return try complete(makeBody)
+        } catch {
+            preconditionFailure(
+                "A fresh recursive CTE draft completed once with a non-throwing body cannot fail: \(error)"
+            )
+        }
+    }
+
+    ///
+    /// Begins a completion attempt and returns the derived self-reference.
+    ///
+    /// Rejects re-entrant completion (`building`) and re-completion (`completed`)
+    /// with structured errors before any body is evaluated.
+    ///
+    public mutating func beginCompletion() throws -> Layout.Reference {
+        switch state {
+        case .declared:
+            state = .building
+            return layout.makeReference(cteAlias: alias)
+        case .building:
+            throw XLRecursiveCommonTableConstructionError.reentrantCompletion(alias)
+        case .completed:
+            throw XLRecursiveCommonTableConstructionError.alreadyCompleted(alias)
+        }
+    }
+
+    ///
+    /// Rolls an in-progress completion back to the declared state. A no-op when
+    /// the draft is not currently building.
+    ///
+    public mutating func rollbackCompletion() {
+        guard case .building = state else {
+            return
+        }
+        state = .declared
+    }
+
+    ///
+    /// Returns the reserved alias once the draft has completed, or throws
+    /// ``XLRecursiveCommonTableConstructionError/incomplete(_:)`` otherwise.
+    ///
+    public func completedAlias() throws -> XLName {
+        guard case .completed = state else {
+            throw XLRecursiveCommonTableConstructionError.incomplete(alias)
+        }
+        return alias
+    }
+
+    ///
+    /// Validates a completed body's column aliases against the declared result
+    /// layout, throwing ``XLRecursiveCommonTableConstructionError/resultLayoutMismatch(alias:expected:actual:)``
+    /// when they differ. Used by callers that can observe the body's columns.
+    ///
+    public func validateResultLayout(actualColumns: [XLName]) throws {
+        guard layout.resultColumns == actualColumns else {
+            throw XLRecursiveCommonTableConstructionError.resultLayoutMismatch(
+                alias: alias,
+                expected: layout.resultColumns,
+                actual: actualColumns
+            )
+        }
+    }
+}
+
+
+///
+/// Validates that a set of common-table definitions reserve distinct aliases,
+/// throwing ``XLRecursiveCommonTableConstructionError/duplicateAlias(_:)`` for
+/// the first collision. Alias comparison is case-insensitive, matching SQLite's
+/// identifier resolution.
+///
+public func xlValidateUniqueCommonTableAliases(
+    _ definitions: [XLCommonTableDependency]
+) throws {
+    var seen: Set<String> = []
+    for definition in definitions {
+        let key = definition.alias.rawValue.lowercased()
+        guard seen.insert(key).inserted else {
+            throw XLRecursiveCommonTableConstructionError.duplicateAlias(definition.alias)
+        }
+    }
+}
+
+
+///
+/// A never-rendering placeholder body for the alias-only self-reference used
+/// during recursive CTE construction.
+///
+/// A recursive self-reference needs only the reserved alias; it must never
+/// retain or render the definition that is completed afterwards. Rendering this
+/// body indicates a construction bug (a reference retained a body), so it traps.
+///
+struct XLAliasOnlyCommonTableBody: XLEncodable {
+    func makeSQL(context: inout XLBuilder) {
+        preconditionFailure(
+            "An alias-only recursive CTE self-reference must not render a definition body."
+        )
+    }
+}
+
+
+///
+/// Reference layout for the generated composite-row recursive CTE surface.
+///
+/// Derives a `T.MetaCommonTable.Result.MetaNamedResult` self-reference from only
+/// the reserved alias, by building an alias-only common-table dependency and
+/// projecting it through the body schema's `table(_:)`.
+///
+struct XLCompositeRecursiveCommonTableLayout<T>: XLRecursiveCommonTableReferenceLayout where T: XLResult {
+
+    let schema: XLSchema
+    let commonTableNamespace: XLNamespace
+
+    func makeReference(cteAlias: XLName) -> T.MetaCommonTable.Result.MetaNamedResult {
+        let dependency = XLCommonTableDependency(
+            alias: cteAlias,
+            statement: XLAliasOnlyCommonTableBody()
+        )
+        let commonTable = T.makeSQLCommonTable(
+            namespace: commonTableNamespace,
+            dependency: dependency
+        )
+        return schema.table(commonTable)
+    }
+}

--- a/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
+++ b/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
@@ -217,9 +217,14 @@ public struct XLRecursiveCommonTableDraft<Layout> where Layout: XLRecursiveCommo
     }
 
     ///
-    /// Validates a completed body's column aliases against the declared result
-    /// layout, throwing ``XLRecursiveCommonTableConstructionError/resultLayoutMismatch(alias:expected:actual:)``
-    /// when they differ. Used by callers that can observe the body's columns.
+    /// Validates a body's column aliases against the declared result layout,
+    /// throwing ``XLRecursiveCommonTableConstructionError/resultLayoutMismatch(alias:expected:actual:)``
+    /// when they differ.
+    ///
+    /// This is a pure comparison against the layout's declared columns and does
+    /// not depend on the draft's state, so callers may run it while a body is
+    /// being built (after ``beginCompletion()``) or against an already-completed
+    /// definition — wherever the produced columns first become observable.
     ///
     /// Layouts that opt out of a fixed column list (an empty `resultColumns`,
     /// such as the generated composite surface whose shape the type system

--- a/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
+++ b/Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift
@@ -64,9 +64,12 @@ public enum XLRecursiveCommonTableConstructionError: Error, Equatable {
 /// completion attempt.
 ///
 /// A layout retains only the value data required to rebuild the reference from
-/// the reserved alias — never a generated result, statement body, namespace, or
-/// completed definition. Keeping the reference derivable from the alias alone is
-/// what allows the self-reference to avoid retaining the body it helps build.
+/// the reserved alias — never a generated result, statement body, or completed
+/// definition. (A layout may hold the body schema so the reference's table alias
+/// is drawn from the same sequence as the recursive body, but it never retains a
+/// common-table namespace or the body itself.) Keeping the reference derivable
+/// from the alias alone is what allows the self-reference to avoid retaining the
+/// body it helps build.
 ///
 /// The associated `Reference` is the typed, `FROM`-able projection of the common
 /// table (for the generated composite surface this is

--- a/Tests/SQLTests/RecursiveCommonTableConstructionTests.swift
+++ b/Tests/SQLTests/RecursiveCommonTableConstructionTests.swift
@@ -5,30 +5,45 @@ import XCTest
 
 
 @SQLResult
-struct RecursiveCTEConstructionPrototypeRow: Equatable {
+struct RecursiveCommonTableConstructionRow: Equatable {
     let value: Int
     let depth: Int
 }
 
 
-final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
+///
+/// Exercises the production alias-first recursive CTE construction lifecycle
+/// (`XLRecursiveCommonTableDraft`, `XLRecursiveCommonTableReferenceLayout`, and
+/// `XLRecursiveCommonTableConstructionError`) introduced by #205.
+///
+/// The tests use a test-only direct-scalar layout to prove the reference/layout
+/// contract is generic enough for #43's one-column layout, and a composite
+/// layout to prove the generated surface renders and executes. Byte-for-byte SQL
+/// preservation of the public `recursiveCommonTable` /
+/// `recursiveCommonTableExpression` surface is covered separately by
+/// `XLSyntaxTests` and `XLExecutionTests`.
+///
+final class RecursiveCommonTableConstructionTests: XCTestCase {
 
-    func testGeneratedCompositeReferenceRendersAndExecutesRecursiveCTE() throws {
-        var draft = makeCompositeDraft(
-            RecursiveCTEConstructionPrototypeRow.self,
+    func testCompositeReferenceRendersAndExecutesRecursiveCTE() throws {
+        var draft = XLRecursiveCommonTableDraft(
             alias: "number_walk",
-            referenceAlias: "recursive_row"
+            layout: TestCompositeLayout<RecursiveCommonTableConstructionRow>(
+                schema: XLSchema(),
+                commonTableNamespace: .common(),
+                tableAlias: "recursive_row"
+            )
         )
         let definition = try draft.complete { recursiveRow in
             select(
-                RecursiveCTEConstructionPrototypeRow.columns(
+                RecursiveCommonTableConstructionRow.columns(
                     value: 1,
                     depth: 0
                 )
             )
             .unionAll {
                 select(
-                    RecursiveCTEConstructionPrototypeRow.columns(
+                    RecursiveCommonTableConstructionRow.columns(
                         value: recursiveRow.value + 1,
                         depth: recursiveRow.depth + 1
                     )
@@ -39,7 +54,7 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
         }
 
         let output = makeCompositeReference(
-            RecursiveCTEConstructionPrototypeRow.self,
+            RecursiveCommonTableConstructionRow.self,
             cteAlias: definition.alias,
             tableAlias: "result_row"
         )
@@ -54,8 +69,8 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
             "WITH `number_walk` AS (SELECT 1 AS `value`, 0 AS `depth` UNION ALL SELECT (`recursive_row`.`value` + 1) AS `value`, (`recursive_row`.`depth` + 1) AS `depth` FROM `number_walk` AS `recursive_row` WHERE (`recursive_row`.`depth` < 2)) SELECT `result_row`.`value` AS `value`, `result_row`.`depth` AS `depth` FROM `number_walk` AS `result_row` ORDER BY `result_row`.`value` ASC"
         )
 
-        let rows: [RecursiveCTEConstructionPrototypeRow] = try readRows(sql) { row in
-            RecursiveCTEConstructionPrototypeRow(
+        let rows: [RecursiveCommonTableConstructionRow] = try readRows(sql) { row in
+            RecursiveCommonTableConstructionRow(
                 value: row["value"],
                 depth: row["depth"]
             )
@@ -63,9 +78,9 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
         XCTAssertEqual(
             rows,
             [
-                RecursiveCTEConstructionPrototypeRow(value: 1, depth: 0),
-                RecursiveCTEConstructionPrototypeRow(value: 2, depth: 1),
-                RecursiveCTEConstructionPrototypeRow(value: 3, depth: 2),
+                RecursiveCommonTableConstructionRow(value: 1, depth: 0),
+                RecursiveCommonTableConstructionRow(value: 2, depth: 1),
+                RecursiveCommonTableConstructionRow(value: 3, depth: 2),
             ]
         )
     }
@@ -78,15 +93,15 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
             columnAlias: "value"
         )
         let definition = try draft.complete { recursiveValue in
-            PrototypeUnionAll(
+            TestUnionAll(
                 select(
-                    PrototypeAliasedExpression(
+                    TestAliasedExpression(
                         expression: 1,
                         alias: "value"
                     )
                 ),
                 select(
-                    PrototypeAliasedExpression(
+                    TestAliasedExpression(
                         expression: recursiveValue.value + 1,
                         alias: "value"
                     )
@@ -96,7 +111,7 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
             )
         }
 
-        let output = PrototypeScalarReference<Int>(
+        let output = TestScalarReference<Int>(
             cteAlias: definition.alias,
             tableAlias: "result_value",
             columnAlias: "value"
@@ -131,11 +146,14 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
                 render(recursiveValue),
                 "`stable_alias` AS `recursive_value`"
             )
-            return select(PrototypeAliasedExpression<Int>(expression: 1, alias: "value"))
+            return select(TestAliasedExpression<Int>(expression: 1, alias: "value"))
         }
 
         XCTAssertThrowsError(try original.completedAlias()) { error in
-            XCTAssertEqual(error as? PrototypeConstructionError, .incomplete("stable_alias"))
+            XCTAssertEqual(
+                error as? XLRecursiveCommonTableConstructionError,
+                .incomplete("stable_alias")
+            )
         }
         XCTAssertEqual(try copy.completedAlias(), "stable_alias")
 
@@ -144,7 +162,7 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
                 render(recursiveValue),
                 "`stable_alias` AS `recursive_value`"
             )
-            return select(PrototypeAliasedExpression<Int>(expression: 2, alias: "value"))
+            return select(TestAliasedExpression<Int>(expression: 2, alias: "value"))
         }
         XCTAssertEqual(originalDefinition.alias, copyDefinition.alias)
         XCTAssertEqual(
@@ -172,15 +190,15 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
                 columnAlias: "value"
             )
             let innerDefinition = try innerDraft.complete { innerRecursiveValue in
-                PrototypeUnionAll(
+                TestUnionAll(
                     select(
-                        PrototypeAliasedExpression<Int>(
+                        TestAliasedExpression<Int>(
                             expression: 1,
                             alias: "value"
                         )
                     ),
                     select(
-                        PrototypeAliasedExpression(
+                        TestAliasedExpression(
                             expression: innerRecursiveValue.value + 1,
                             alias: "value"
                         )
@@ -189,15 +207,15 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
                     .where(innerRecursiveValue.value < 2)
                 )
             }
-            let innerOutput = PrototypeScalarReference<Int>(
+            let innerOutput = TestScalarReference<Int>(
                 cteAlias: innerDefinition.alias,
                 tableAlias: "inner_seed",
                 columnAlias: "value"
             )
-            return PrototypeUnionAll(
+            return TestUnionAll(
                 XLWithStatement([innerDefinition])
                     .select(
-                        PrototypeAliasedExpression(
+                        TestAliasedExpression(
                             expression: innerOutput.value * 10,
                             alias: "value"
                         )
@@ -205,7 +223,7 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
                     .from(innerOutput)
                     .where(innerOutput.value == 1),
                 select(
-                    PrototypeAliasedExpression(
+                    TestAliasedExpression(
                         expression: recursiveValue.value + 10,
                         alias: "value"
                     )
@@ -215,7 +233,7 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
             )
         }
 
-        let output = PrototypeScalarReference<Int>(
+        let output = TestScalarReference<Int>(
             cteAlias: outerDefinition.alias,
             tableAlias: "outer_result",
             columnAlias: "value"
@@ -272,7 +290,10 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
         )
 
         XCTAssertThrowsError(try draft.completedAlias()) { error in
-            XCTAssertEqual(error as? PrototypeConstructionError, .incomplete("single_completion"))
+            XCTAssertEqual(
+                error as? XLRecursiveCommonTableConstructionError,
+                .incomplete("single_completion")
+            )
         }
 
         _ = try draft.complete { recursiveValue in
@@ -280,16 +301,19 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
                 render(recursiveValue),
                 "`single_completion` AS `recursive_value`"
             )
-            return select(PrototypeAliasedExpression<Int>(expression: 1, alias: "value"))
+            return select(TestAliasedExpression<Int>(expression: 1, alias: "value"))
         }
         var secondBodyWasEvaluated = false
         XCTAssertThrowsError(
             try draft.complete { _ in
                 secondBodyWasEvaluated = true
-                return select(PrototypeAliasedExpression<Int>(expression: 2, alias: "value"))
+                return select(TestAliasedExpression<Int>(expression: 2, alias: "value"))
             }
         ) { error in
-            XCTAssertEqual(error as? PrototypeConstructionError, .alreadyCompleted("single_completion"))
+            XCTAssertEqual(
+                error as? XLRecursiveCommonTableConstructionError,
+                .alreadyCompleted("single_completion")
+            )
         }
         XCTAssertFalse(secondBodyWasEvaluated)
     }
@@ -305,7 +329,7 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
         _ = try draft.beginCompletion()
         XCTAssertThrowsError(try draft.beginCompletion()) { error in
             XCTAssertEqual(
-                error as? PrototypeConstructionError,
+                error as? XLRecursiveCommonTableConstructionError,
                 .reentrantCompletion("reentrant_completion")
             )
         }
@@ -317,7 +341,7 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
                 "`reentrant_completion` AS `recursive_value`"
             )
             return select(
-                PrototypeAliasedExpression<Int>(expression: 1, alias: "value")
+                TestAliasedExpression<Int>(expression: 1, alias: "value")
             )
         }
         XCTAssertEqual(definition.alias, "reentrant_completion")
@@ -333,19 +357,22 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
         )
 
         XCTAssertThrowsError(
-            try draft.complete { recursiveValue -> XLQuerySelectStatement<Int> in
+            try draft.complete { recursiveValue -> any XLEncodable in
                 XCTAssertEqual(
                     render(recursiveValue),
                     "`retry_after_failure` AS `recursive_value`"
                 )
-                throw PrototypeConstructionError.bodyFailure
+                throw TestBodyError.bodyFailure
             }
         ) { error in
-            XCTAssertEqual(error as? PrototypeConstructionError, .bodyFailure)
+            XCTAssertEqual(error as? TestBodyError, .bodyFailure)
         }
         XCTAssertEqual(draft.alias, "retry_after_failure")
         XCTAssertThrowsError(try draft.completedAlias()) { error in
-            XCTAssertEqual(error as? PrototypeConstructionError, .incomplete("retry_after_failure"))
+            XCTAssertEqual(
+                error as? XLRecursiveCommonTableConstructionError,
+                .incomplete("retry_after_failure")
+            )
         }
 
         let definition = try draft.complete { recursiveValue in
@@ -353,7 +380,7 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
                 render(recursiveValue),
                 "`retry_after_failure` AS `recursive_value`"
             )
-            return select(PrototypeAliasedExpression<Int>(expression: 7, alias: "value"))
+            return select(TestAliasedExpression<Int>(expression: 7, alias: "value"))
         }
         XCTAssertEqual(definition.alias, "retry_after_failure")
         XCTAssertEqual(
@@ -361,110 +388,65 @@ final class RecursiveCTEConstructionPrototypeTests: XCTestCase {
             "WITH `retry_after_failure` AS (SELECT 7 AS `value`) SELECT `output`.`value` FROM `retry_after_failure` AS `output`"
         )
     }
+
+    func testDuplicateAliasesAreRejected() throws {
+        let unique = [
+            XLCommonTableDependency(alias: "a", statement: TestAliasedExpression<Int>(expression: 1, alias: "value")),
+            XLCommonTableDependency(alias: "b", statement: TestAliasedExpression<Int>(expression: 2, alias: "value")),
+        ]
+        XCTAssertNoThrow(try xlValidateUniqueCommonTableAliases(unique))
+
+        // Duplicate detection is case-insensitive, matching SQLite identifier resolution.
+        let duplicated = [
+            XLCommonTableDependency(alias: "series", statement: TestAliasedExpression<Int>(expression: 1, alias: "value")),
+            XLCommonTableDependency(alias: "other", statement: TestAliasedExpression<Int>(expression: 2, alias: "value")),
+            XLCommonTableDependency(alias: "SERIES", statement: TestAliasedExpression<Int>(expression: 3, alias: "value")),
+        ]
+        XCTAssertThrowsError(try xlValidateUniqueCommonTableAliases(duplicated)) { error in
+            XCTAssertEqual(
+                error as? XLRecursiveCommonTableConstructionError,
+                .duplicateAlias("SERIES")
+            )
+        }
+    }
+
+    func testResultLayoutMismatchIsRejected() throws {
+        var draft = XLRecursiveCommonTableDraft(
+            alias: "shaped",
+            layout: TestScalarLayout<Int>(
+                tableAlias: "recursive_value",
+                columnAlias: "value"
+            )
+        )
+        _ = try draft.beginCompletion()
+
+        XCTAssertNoThrow(try draft.validateResultLayout(actualColumns: ["value"]))
+        XCTAssertThrowsError(try draft.validateResultLayout(actualColumns: ["value", "extra"])) { error in
+            XCTAssertEqual(
+                error as? XLRecursiveCommonTableConstructionError,
+                .resultLayoutMismatch(alias: "shaped", expected: ["value"], actual: ["value", "extra"])
+            )
+        }
+    }
 }
 
 
-private enum PrototypeConstructionError: Error, Equatable {
-    case incomplete(XLName)
-    case alreadyCompleted(XLName)
-    case reentrantCompletion(XLName)
+private enum TestBodyError: Error, Equatable {
     case bodyFailure
 }
 
 
-/// Test-only model of an alias-first, two-phase recursive CTE construction.
-///
-/// Completion mutates only this struct value. A failed body leaves the draft in
-/// its declared state, and copying the draft copies its completion state instead
-/// of sharing the mutable indirection used by the current production API.
-private struct PrototypeRecursiveCTEDraft<Layout> where Layout: PrototypeReferenceLayout {
-
-    private enum State {
-        case declared
-        case building
-        case completed
-    }
-
-    let alias: XLName
-    let layout: Layout
-    private var state: State = .declared
-
-    init(alias: XLName, layout: Layout) {
-        self.alias = alias
-        self.layout = layout
-    }
-
-    mutating func complete<Body>(
-        _ makeBody: (Layout.Reference) throws -> Body
-    ) throws -> XLCommonTableDependency where Body: XLEncodable {
-        let reference = try beginCompletion()
-        do {
-            let body = try makeBody(reference)
-            state = .completed
-            return XLCommonTableDependency(alias: alias, statement: body)
-        } catch {
-            rollbackCompletion()
-            throw error
-        }
-    }
-
-    mutating func beginCompletion() throws -> Layout.Reference {
-        switch state {
-        case .declared:
-            state = .building
-            return layout.makeReference(cteAlias: alias)
-        case .building:
-            throw PrototypeConstructionError.reentrantCompletion(alias)
-        case .completed:
-            throw PrototypeConstructionError.alreadyCompleted(alias)
-        }
-    }
-
-    mutating func rollbackCompletion() {
-        guard case .building = state else {
-            return
-        }
-        state = .declared
-    }
-
-    func completedAlias() throws -> XLName {
-        guard case .completed = state else {
-            throw PrototypeConstructionError.incomplete(alias)
-        }
-        return alias
-    }
-}
-
-
-/// Immutable data needed to create a fresh current-v1 typed reference for one
-/// completion attempt. The draft retains this value layout, never a generated
-/// result, `XLNamespace`, statement body, or completed dependency.
-private protocol PrototypeReferenceLayout {
-    associatedtype Reference
-
-    func makeReference(cteAlias: XLName) -> Reference
-}
-
-
-private struct PrototypeCompositeReferenceLayout<Row>: PrototypeReferenceLayout where Row: XLResult {
-    let tableAlias: XLName
-
-    func makeReference(cteAlias: XLName) -> Row.MetaNamedResult {
-        makeCompositeReference(
-            Row.self,
-            cteAlias: cteAlias,
-            tableAlias: tableAlias
-        )
-    }
-}
-
-
-private struct PrototypeScalarReferenceLayout<Value>: PrototypeReferenceLayout where Value: XLLiteral {
+/// Test-only direct-scalar reference layout — demonstrates that the production
+/// `XLRecursiveCommonTableReferenceLayout` contract is generic enough for a
+/// one-column scalar reference (the shape #43 will add to the library).
+private struct TestScalarLayout<Value>: XLRecursiveCommonTableReferenceLayout where Value: XLLiteral {
     let tableAlias: XLName
     let columnAlias: XLName
 
-    func makeReference(cteAlias: XLName) -> PrototypeScalarReference<Value> {
-        PrototypeScalarReference(
+    var resultColumns: [XLName] { [columnAlias] }
+
+    func makeReference(cteAlias: XLName) -> TestScalarReference<Value> {
+        TestScalarReference(
             cteAlias: cteAlias,
             tableAlias: tableAlias,
             columnAlias: columnAlias
@@ -473,8 +455,30 @@ private struct PrototypeScalarReferenceLayout<Value>: PrototypeReferenceLayout w
 }
 
 
+/// Test-only composite reference layout backed by the production alias-only
+/// self-reference primitives, but pinning the reference table alias so the
+/// rendered SQL is deterministic in the render test.
+private struct TestCompositeLayout<Row>: XLRecursiveCommonTableReferenceLayout where Row: XLResult {
+    let schema: XLSchema
+    let commonTableNamespace: XLNamespace
+    let tableAlias: XLName
+
+    func makeReference(cteAlias: XLName) -> Row.MetaCommonTable.Result.MetaNamedResult {
+        let dependency = XLCommonTableDependency(
+            alias: cteAlias,
+            statement: XLAliasOnlyCommonTableBody()
+        )
+        let commonTable = Row.makeSQLCommonTable(
+            namespace: commonTableNamespace,
+            dependency: dependency
+        )
+        return schema.table(commonTable, as: tableAlias)
+    }
+}
+
+
 /// Test-only direct scalar equivalent of a macro-generated named result.
-private struct PrototypeScalarReference<Value>: XLMetaNamedResult where Value: XLLiteral {
+private struct TestScalarReference<Value>: XLMetaNamedResult where Value: XLLiteral {
     typealias Row = Value
 
     let _namespace: XLNamespace
@@ -482,7 +486,10 @@ private struct PrototypeScalarReference<Value>: XLMetaNamedResult where Value: X
     let value: XLColumnReference<Value>
 
     init(cteAlias: XLName, tableAlias: XLName, columnAlias: XLName) {
-        let commonTable = prototypeAliasOnlyDependency(alias: cteAlias)
+        let commonTable = XLCommonTableDependency(
+            alias: cteAlias,
+            statement: XLAliasOnlyCommonTableBody()
+        )
         let dependency = XLFromTableDependency(
             commonTable: commonTable,
             alias: tableAlias
@@ -498,7 +505,7 @@ private struct PrototypeScalarReference<Value>: XLMetaNamedResult where Value: X
 }
 
 
-private struct PrototypeAliasedExpression<Value>: XLExpression where Value: XLLiteral {
+private struct TestAliasedExpression<Value>: XLExpression where Value: XLLiteral {
     typealias T = Value
 
     let expression: any XLExpression<Value>
@@ -515,10 +522,10 @@ private struct PrototypeAliasedExpression<Value>: XLExpression where Value: XLLi
 }
 
 
-/// The direct-scalar prototype cannot use SwiftQL's current compound-query
-/// constraint because that constraint requires `Row: XLResult`. Keeping this
-/// node test-only demonstrates the rendering seam without implementing #43.
-private struct PrototypeUnionAll: XLEncodable {
+/// A minimal `UNION ALL` node for the test-only direct-scalar path, which cannot
+/// use SwiftQL's compound-query combinator until #43 relaxes its `Row: XLResult`
+/// constraint.
+private struct TestUnionAll: XLEncodable {
     let lhs: any XLEncodable
     let rhs: any XLEncodable
 
@@ -537,27 +544,16 @@ private struct PrototypeUnionAll: XLEncodable {
 }
 
 
-/// This body must never render. References need only the immutable CTE alias;
-/// they do not retain or mutate the definition that is completed later.
-private struct PrototypeAliasOnlyBody: XLEncodable {
-    func makeSQL(context: inout XLBuilder) {
-        preconditionFailure("An alias-only recursive CTE reference cannot render a definition")
-    }
-}
-
-
-private func prototypeAliasOnlyDependency(alias: XLName) -> XLCommonTableDependency {
-    XLCommonTableDependency(alias: alias, statement: PrototypeAliasOnlyBody())
-}
-
-
 private func makeCompositeReference<Row>(
     _ type: Row.Type,
     cteAlias: XLName,
     tableAlias: XLName
 ) -> Row.MetaNamedResult where Row: XLResult {
     let dependency = XLFromTableDependency(
-        commonTable: prototypeAliasOnlyDependency(alias: cteAlias),
+        commonTable: XLCommonTableDependency(
+            alias: cteAlias,
+            statement: XLAliasOnlyCommonTableBody()
+        ),
         alias: tableAlias
     )
     return Row.makeSQLAnonymousNamedResult(
@@ -567,29 +563,15 @@ private func makeCompositeReference<Row>(
 }
 
 
-private func makeCompositeDraft<Row>(
-    _ type: Row.Type,
-    alias: XLName,
-    referenceAlias: XLName
-) -> PrototypeRecursiveCTEDraft<PrototypeCompositeReferenceLayout<Row>> where Row: XLResult {
-    PrototypeRecursiveCTEDraft(
-        alias: alias,
-        layout: PrototypeCompositeReferenceLayout(
-            tableAlias: referenceAlias
-        )
-    )
-}
-
-
 private func makeScalarDraft<Value>(
     _ type: Value.Type,
     alias: XLName,
     referenceAlias: XLName,
     columnAlias: XLName
-) -> PrototypeRecursiveCTEDraft<PrototypeScalarReferenceLayout<Value>> where Value: XLLiteral {
-    PrototypeRecursiveCTEDraft(
+) -> XLRecursiveCommonTableDraft<TestScalarLayout<Value>> where Value: XLLiteral {
+    XLRecursiveCommonTableDraft(
         alias: alias,
-        layout: PrototypeScalarReferenceLayout(
+        layout: TestScalarLayout(
             tableAlias: referenceAlias,
             columnAlias: columnAlias
         )
@@ -604,7 +586,7 @@ private func render(_ expression: any XLEncodable) -> String {
 
 
 private func renderScalarDefinition(_ definition: XLCommonTableDependency) -> String {
-    let output = PrototypeScalarReference<Int>(
+    let output = TestScalarReference<Int>(
         cteAlias: definition.alias,
         tableAlias: "output",
         columnAlias: "value"
@@ -627,13 +609,13 @@ private func makeIndependentScalarSQL(index: Int) throws -> String {
     )
     let definition = try draft.complete { _ in
         select(
-            PrototypeAliasedExpression<Int>(
+            TestAliasedExpression<Int>(
                 expression: index,
                 alias: "value"
             )
         )
     }
-    let output = PrototypeScalarReference<Int>(
+    let output = TestScalarReference<Int>(
         cteAlias: definition.alias,
         tableAlias: XLName("output_\(index)"),
         columnAlias: "value"


### PR DESCRIPTION
Closes #205.

## Summary

Replaces the internal mutable `XLRecursiveCommonTableStatement` completion cell — a reference type with an implicitly-unwrapped `var statement` populated *after* the recursive self-reference had already been handed to the body closure — with an **alias-first, two-phase, value-semantic** construction lifecycle.

### New public types (`Sources/SwiftQL/Statements/SQLRecursiveCommonTable.swift`)

- **`XLRecursiveCommonTableDraft<Layout>`** — a value type whose reserved alias, typed reference, completion state, and completed definition all have value semantics. Completion is transactional: a throwing body rolls the draft back to its declared state so it can be retried, and only a completed draft yields a renderable `XLCommonTableDependency`. Copying a draft copies its completion state — there is no shared mutable indirection — so independent drafts and their copies complete concurrently and deterministically.
- **`XLRecursiveCommonTableReferenceLayout`** — the self-reference is derived from the reserved alias plus static result-layout metadata and **never retains the body**. The contract is deliberately generic so #43 can add a one-column direct-scalar layout without another lifecycle mechanism.
- **`XLRecursiveCommonTableConstructionError`** — adapter-neutral structured errors: `incomplete`, `alreadyCompleted`, `reentrantCompletion`, `duplicateAlias`, `resultLayoutMismatch`. Plus `xlValidateUniqueCommonTableAliases(_:)` (case-insensitive, matching SQLite identifier resolution).

### Reimplemented surface

`recursiveCommonTable` / `recursiveCommonTableExpression` now build on the draft. The reserved alias is unchanged and the macro's `makeSQLCommonTable` ignores its namespace argument, so:

- **SQL is byte-for-byte identical** — existing `XLSyntaxTests` / `XLExecutionTests` recursive-CTE render and execution tests pass unchanged.
- **Existing v1 call sites and Swift 5 language-mode clients compile unchanged** — the public signatures are untouched.
- `XLRecursiveCommonTableStatement` (the mutable cell) is removed.

## Testing

Productionized the former research prototype into `RecursiveCommonTableConstructionTests`, exercising the real types: incomplete/multiple completion, failure cleanup and reuse, copy independence, nesting, alias stability, duplicate aliases, result-layout mismatch, and 16-way independent concurrency — plus composite render + real-SQLite execution and a test-only direct-scalar layout proving the reference/layout contract is generic enough for #43.

- `swift build` — clean, no warnings.
- `swift test` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)