### PR TITLE
Reduce SwiftQL query rendering allocations (#166)

### DIFF
--- a/Benchmarks/Profiling/Issue166/README.md
+++ b/Benchmarks/Profiling/Issue166/README.md
@@ -1,0 +1,136 @@
+# Issue #166 — construction/rendering profile and reduction
+
+This directory records the profiling evidence and the before/after measurements
+for issue #166, "Profile and reduce SwiftQL query construction and rendering
+overhead." It is diagnostic evidence, not an absolute CI latency gate.
+
+The [#128 baseline](../../Baselines/README.md) established that the combined
+`swiftql_construction_and_rendering` phase is a material SwiftQL-owned cost for
+every workload. #166 owns attributing that cost to exact code and reducing it
+without changing rendered SQL, entity metadata, query semantics, or the public
+1.x API.
+
+## Method
+
+Two complementary instruments were used, because the #128 harness records only
+wall-clock samples and this machine has real background load (other test suites
+run concurrently), which adds process-to-process DVFS/core-placement noise to a
+sub-50-microsecond phase.
+
+1. **Deterministic allocation profile** — `swiftql-construction-profile` (a new
+   diagnostic executable in this package, `Benchmarks/Sources/SwiftQLConstructionProfile`)
+   installs the in-process Darwin `malloc_logger` hook and counts every heap
+   allocation issued while it (a) constructs only, (b) renders a prebuilt
+   statement only, and (c) does the combined construct+render the #128 harness
+   measures. Allocation counts are immune to scheduler noise, so they attribute
+   cost to the exact sub-phase. It rebuilds the exact two read queries the #128
+   harness measures (`simple_parameterized_lookup` and
+   `representative_multi_join_read`) against the public API.
+2. **Timing** — the checked-in `swiftql-benchmark` (#128) harness, 50 warmups
+   and 500 samples, run as eight independent release processes per condition,
+   before and after, back to back under the same machine load. Reported values
+   are the median of the eight process medians; spread is
+   `(max − min) / mean` of the process medians.
+
+## Environment
+
+- Machine: Mac16,8, Apple M4 Pro, arm64, macOS 26.5.1
+- Toolchain: release, Xcode 26.5 (17F42), Swift 6.3.2, macOS SDK 26.5
+- GRDB 6.29.3 (`2cf6c756`), SQLite 3.51.0 (`f0ca7bba…apl`), WAL, `synchronous = 1`
+
+This matches the #128 baseline machine and toolchain. The machine was **not**
+idle during timing (concurrent unrelated Swift test suites), so process spread
+is genuine and is reported rather than hidden.
+
+## What the profile attributed
+
+Rendering, not construction, dominates the phase. Per-operation heap
+allocations (deterministic, `iterations = 20000`):
+
+| Case | Construction allocs | Render allocs | Combined allocs | Render share |
+| --- | ---: | ---: | ---: | ---: |
+| Simple lookup | 73 | 249 | 322 | 77% |
+| Multi-join read | 128 | 434 | 562 | 77% |
+
+Rendering issued roughly three-quarters of all allocations. Attributing the
+render allocations to exact code (`Sources/SwiftQL/SQLiteEncoding.swift`):
+
+- **`XLiteBuilder.append(_ tokens: String...)`** was variadic and filtered, so
+  every builder node allocated a variadic `[String]` box *and* a `filter` copy
+  even though every one of its 29 call sites passes a single already-rendered
+  token.
+- **`build()`** always re-joined its token array, allocating a fresh joined
+  `String` even for the single-token leaf and wrapper builders that dominate the
+  tree.
+- **`XLiteFormatter.scopedName(_:)`** rendered every qualified reference through
+  `values.map(name).joined(".")`, allocating an intermediate `map` array for the
+  one- and two-component names that make up essentially all references.
+
+## The reduction
+
+Three output-preserving changes in `SQLiteEncoding.swift`:
+
+1. `append` takes a single token and appends it directly (keeping the
+   empty-token filter), removing the variadic box and `filter` copy per node.
+2. `build()` returns the sole token directly when there is exactly one, skipping
+   the join allocation; multi-token builders still join with their separator.
+3. `scopedName` special-cases zero/one/two components and only falls back to
+   `map`/`joined` for three or more, so the common reference allocates no
+   intermediate array.
+
+No rendered SQL, entity set, parameter layout, query semantics, or public API
+changed. Swift 5.9 support is unaffected (no new language features are used).
+
+### Allocation result (deterministic)
+
+| Case | Render allocs before → after | Combined allocs before → after |
+| --- | ---: | ---: |
+| Simple lookup | 249 → 212 (**−14.9%**) | 322 → 285 (**−11.5%**) |
+| Multi-join read | 434 → 365 (**−15.9%**) | 562 → 493 (**−12.3%**) |
+
+Raw: [`before-allocation-profile.json`](before-allocation-profile.json),
+[`after-allocation-profile.json`](after-allocation-profile.json).
+
+### Timing result (#128 harness, eight processes each)
+
+Median of process medians for the `swiftql_construction_and_rendering` phase,
+microseconds:
+
+| Case | Before | After | Median delta | Spread before → after |
+| --- | ---: | ---: | ---: | ---: |
+| Simple lookup | 29.10 | 24.96 | **−14.2%** | 7.6% → 16.1% |
+| Multi-join read | 47.35 | 40.04 | **−15.4%** | 11.2% → 12.6% |
+| Bounded write | 20.04 | 16.56 | **−17.4%** | 9.5% → 7.7% |
+| Deterministic decode | 32.03 | 27.83 | **−13.1%** | 10.0% → 7.5% |
+
+The median improvement (13–17%) is consistent across all four independent cases
+and tracks the deterministic allocation reduction, so it is a repeatable change
+rather than process noise — even though the absolute spread on this loaded
+machine is several percent. All four cases improve, including `bounded_write`,
+which shares the same builder even though only the two read queries were
+profiled. Per-process medians and p95 are in
+[`timing-summary.json`](timing-summary.json).
+
+## Reproduce
+
+```sh
+# Deterministic allocation profile (before vs after your working tree)
+swift run -c release swiftql-construction-profile \
+  --iterations 20000 --warmups 200 --samples 4000 \
+  --json /tmp/profile.json
+
+# Timing: run several independent release processes per condition and compare
+# the process medians and spread (see BENCHMARKS.md for the harness contract).
+swift run -c release swiftql-benchmark --warmups 50 --samples 500 \
+  --output /tmp/run-1.json
+```
+
+## Limits
+
+This is one machine, one toolchain, and the two representative read queries plus
+the two write/decode #128 cases. The allocation counts are deterministic; the
+timing values are not portable and are not a CI gate. Construction-side
+allocations (component-array copies in `XLQueryStatementComponents.appending`,
+namespace/alias churn) were profiled and left unchanged: they are the smaller
+share and could not be reduced without touching query-value semantics, which is
+out of scope for this SQL-output-preserving change.

--- a/Benchmarks/Profiling/Issue166/after-allocation-profile.json
+++ b/Benchmarks/Profiling/Issue166/after-allocation-profile.json
@@ -1,0 +1,45 @@
+{
+  "cases" : [
+    {
+      "allocationsPerOp" : {
+        "combined" : 285,
+        "construction" : 73,
+        "render" : 212
+      },
+      "bytesPerOp" : {
+        "combined" : 21976,
+        "construction" : 6688,
+        "render" : 15288
+      },
+      "medianMicros" : {
+        "combined" : 29.416,
+        "construction" : 7.0839999999999996,
+        "render" : 21
+      },
+      "name" : "simple_parameterized_lookup",
+      "sql" : "SELECT \"t0\".\"id\" AS \"id\", \"t0\".\"companyID\" AS \"companyID\", \"t0\".\"departmentID\" AS \"departmentID\", \"t0\".\"name\" AS \"name\", \"t0\".\"email\" AS \"email\", \"t0\".\"score\" AS \"score\", \"t0\".\"isActive\" AS \"isActive\", \"t0\".\"payload\" AS \"payload\" FROM \"benchmark_person\" AS \"t0\" WHERE (\"t0\".\"id\" == :personID)"
+    },
+    {
+      "allocationsPerOp" : {
+        "combined" : 493,
+        "construction" : 128,
+        "render" : 365
+      },
+      "bytesPerOp" : {
+        "combined" : 41056,
+        "construction" : 12000,
+        "render" : 29056
+      },
+      "medianMicros" : {
+        "combined" : 47,
+        "construction" : 10.75,
+        "render" : 36
+      },
+      "name" : "representative_multi_join_read",
+      "sql" : "SELECT \"t0\".\"id\" AS \"personID\", \"t0\".\"name\" AS \"personName\", \"t1\".\"name\" AS \"departmentName\", \"t2\".\"name\" AS \"companyName\", \"t0\".\"score\" AS \"score\", \"t0\".\"isActive\" AS \"isActive\" FROM \"benchmark_person\" AS \"t0\" INNER JOIN \"benchmark_department\" AS \"t1\" ON (\"t1\".\"id\" == \"t0\".\"departmentID\") INNER JOIN \"benchmark_company\" AS \"t2\" ON (\"t2\".\"id\" == \"t1\".\"companyID\") WHERE ((\"t2\".\"id\" == :companyID) AND (\"t0\".\"score\" >= :minimumScore)) ORDER BY \"t0\".\"score\" DESC LIMIT 32"
+    }
+  ],
+  "iterations" : 20000,
+  "samples" : 4000,
+  "warmups" : 200
+}

--- a/Benchmarks/Profiling/Issue166/before-allocation-profile.json
+++ b/Benchmarks/Profiling/Issue166/before-allocation-profile.json
@@ -1,0 +1,45 @@
+{
+  "cases" : [
+    {
+      "allocationsPerOp" : {
+        "combined" : 322,
+        "construction" : 73,
+        "render" : 249
+      },
+      "bytesPerOp" : {
+        "combined" : 23896,
+        "construction" : 6688,
+        "render" : 17208
+      },
+      "medianMicros" : {
+        "combined" : 31.416,
+        "construction" : 6.9580000000000002,
+        "render" : 23
+      },
+      "name" : "simple_parameterized_lookup",
+      "sql" : "SELECT \"t0\".\"id\" AS \"id\", \"t0\".\"companyID\" AS \"companyID\", \"t0\".\"departmentID\" AS \"departmentID\", \"t0\".\"name\" AS \"name\", \"t0\".\"email\" AS \"email\", \"t0\".\"score\" AS \"score\", \"t0\".\"isActive\" AS \"isActive\", \"t0\".\"payload\" AS \"payload\" FROM \"benchmark_person\" AS \"t0\" WHERE (\"t0\".\"id\" == :personID)"
+    },
+    {
+      "allocationsPerOp" : {
+        "combined" : 562,
+        "construction" : 128,
+        "render" : 434
+      },
+      "bytesPerOp" : {
+        "combined" : 44576,
+        "construction" : 12000,
+        "render" : 32576
+      },
+      "medianMicros" : {
+        "combined" : 51.625,
+        "construction" : 9.9160000000000004,
+        "render" : 40.207999999999998
+      },
+      "name" : "representative_multi_join_read",
+      "sql" : "SELECT \"t0\".\"id\" AS \"personID\", \"t0\".\"name\" AS \"personName\", \"t1\".\"name\" AS \"departmentName\", \"t2\".\"name\" AS \"companyName\", \"t0\".\"score\" AS \"score\", \"t0\".\"isActive\" AS \"isActive\" FROM \"benchmark_person\" AS \"t0\" INNER JOIN \"benchmark_department\" AS \"t1\" ON (\"t1\".\"id\" == \"t0\".\"departmentID\") INNER JOIN \"benchmark_company\" AS \"t2\" ON (\"t2\".\"id\" == \"t1\".\"companyID\") WHERE ((\"t2\".\"id\" == :companyID) AND (\"t0\".\"score\" >= :minimumScore)) ORDER BY \"t0\".\"score\" DESC LIMIT 32"
+    }
+  ],
+  "iterations" : 20000,
+  "samples" : 4000,
+  "warmups" : 200
+}

--- a/Benchmarks/Profiling/Issue166/timing-summary.json
+++ b/Benchmarks/Profiling/Issue166/timing-summary.json
@@ -1,0 +1,291 @@
+{
+  "after": {
+    "bounded_write": {
+      "medians": [
+        16.542,
+        16.166,
+        16.292,
+        17.292,
+        16.583,
+        16.542,
+        17.375,
+        17.459
+      ],
+      "p95": [
+        17.542,
+        16.958,
+        17.667,
+        70.583,
+        16.875,
+        17.75,
+        18.292,
+        18.5
+      ]
+    },
+    "deterministic_row_decode": {
+      "medians": [
+        26.75,
+        27.791,
+        27.125,
+        27.125,
+        28.792,
+        27.875,
+        28.833,
+        28.73
+      ],
+      "p95": [
+        27.875,
+        30.75,
+        28.958,
+        67.917,
+        29.292,
+        65.167,
+        90.0,
+        30.167
+      ]
+    },
+    "representative_multi_join_read": {
+      "medians": [
+        38.5,
+        38.958,
+        39.708,
+        38.875,
+        40.375,
+        40.625,
+        40.416,
+        43.541
+      ],
+      "p95": [
+        46.5,
+        52.875,
+        42.458,
+        39.5,
+        47.959,
+        45.292,
+        123.042,
+        48.334
+      ]
+    },
+    "simple_parameterized_lookup": {
+      "medians": [
+        28.042,
+        23.958,
+        24.334,
+        25.521,
+        25.125,
+        25.916,
+        24.792,
+        24.792
+      ],
+      "p95": [
+        30.209,
+        27.542,
+        51.917,
+        79.083,
+        87.417,
+        98.625,
+        59.625,
+        60.167
+      ]
+    }
+  },
+  "before": {
+    "bounded_write": {
+      "medians": [
+        20.083,
+        19.917,
+        21.042,
+        19.667,
+        20.375,
+        20.0,
+        20.167,
+        19.145
+      ],
+      "p95": [
+        20.541,
+        20.625,
+        24.125,
+        46.916,
+        46.208,
+        42.5,
+        49.291,
+        19.959
+      ]
+    },
+    "deterministic_row_decode": {
+      "medians": [
+        32.605,
+        31.125,
+        34.334,
+        31.625,
+        31.458,
+        31.666,
+        32.395,
+        32.541
+      ],
+      "p95": [
+        169.625,
+        36.875,
+        41.458,
+        122.042,
+        70.208,
+        32.458,
+        131.583,
+        253.166
+      ]
+    },
+    "representative_multi_join_read": {
+      "medians": [
+        47.584,
+        49.084,
+        51.208,
+        49.625,
+        46.917,
+        46.0,
+        47.125,
+        45.834
+      ],
+      "p95": [
+        48.084,
+        493.291,
+        52.125,
+        324.541,
+        52.458,
+        103.542,
+        107.458,
+        56.542
+      ]
+    },
+    "simple_parameterized_lookup": {
+      "medians": [
+        29.292,
+        29.042,
+        30.208,
+        29.167,
+        28.0,
+        28.709,
+        29.375,
+        28.792
+      ],
+      "p95": [
+        29.916,
+        29.375,
+        30.5,
+        30.0,
+        29.667,
+        28.959,
+        29.792,
+        77.0
+      ]
+    }
+  },
+  "environment": {
+    "configuration": {
+      "sampleCount": 500,
+      "warmupCount": 50
+    },
+    "database": {
+      "compileOptions": [
+        "ATOMIC_INTRINSICS=1",
+        "BUG_COMPATIBLE_20160819",
+        "CCCRYPT256",
+        "CODEC=see-cccrypt",
+        "COMPILER=clang-21.0.0",
+        "DEFAULT_AUTOVACUUM",
+        "DEFAULT_CACHE_SIZE=2000",
+        "DEFAULT_CKPTFULLFSYNC",
+        "DEFAULT_FILE_FORMAT=4",
+        "DEFAULT_JOURNAL_SIZE_LIMIT=32768",
+        "DEFAULT_LOOKASIDE=1200,102",
+        "DEFAULT_MEMSTATUS=0",
+        "DEFAULT_MMAP_SIZE=0",
+        "DEFAULT_PAGE_SIZE=4096",
+        "DEFAULT_PCACHE_INITSZ=20",
+        "DEFAULT_RECURSIVE_TRIGGERS",
+        "DEFAULT_SECTOR_SIZE=4096",
+        "DEFAULT_SYNCHRONOUS=2",
+        "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+        "DEFAULT_WAL_SYNCHRONOUS=1",
+        "DEFAULT_WORKER_THREADS=0",
+        "DIRECT_OVERFLOW_READ",
+        "DQS=3",
+        "ENABLE_API_ARMOR",
+        "ENABLE_BYTECODE_VTAB",
+        "ENABLE_COLUMN_METADATA",
+        "ENABLE_DBSTAT_VTAB",
+        "ENABLE_FTS3",
+        "ENABLE_FTS3_PARENTHESIS",
+        "ENABLE_FTS3_TOKENIZER",
+        "ENABLE_FTS4",
+        "ENABLE_FTS5",
+        "ENABLE_LOCKING_STYLE=1",
+        "ENABLE_MATH_FUNCTIONS",
+        "ENABLE_NORMALIZE",
+        "ENABLE_PREUPDATE_HOOK",
+        "ENABLE_RTREE",
+        "ENABLE_SESSION",
+        "ENABLE_SETLK_TIMEOUT",
+        "ENABLE_SNAPSHOT",
+        "ENABLE_SQLLOG",
+        "ENABLE_STMT_SCANSTATUS",
+        "ENABLE_UNKNOWN_SQL_FUNCTION",
+        "ENABLE_UPDATE_DELETE_LIMIT",
+        "HAS_CODEC_RESTRICTED",
+        "HAVE_ISNAN",
+        "MALLOC_SOFT_LIMIT=1024",
+        "MAX_ATTACHED=10",
+        "MAX_COLUMN=2000",
+        "MAX_COMPOUND_SELECT=500",
+        "MAX_DEFAULT_PAGE_SIZE=8192",
+        "MAX_EXPR_DEPTH=1000",
+        "MAX_FUNCTION_ARG=127",
+        "MAX_LENGTH=2147483645",
+        "MAX_LIKE_PATTERN_LENGTH=50000",
+        "MAX_MMAP_SIZE=1073741824",
+        "MAX_PAGE_COUNT=1073741823",
+        "MAX_PAGE_SIZE=65536",
+        "MAX_SQL_LENGTH=1000000000",
+        "MAX_TRIGGER_DEPTH=1000",
+        "MAX_VARIABLE_NUMBER=500000",
+        "MAX_VDBE_OP=250000000",
+        "MAX_WORKER_THREADS=8",
+        "MUTEX_UNFAIR",
+        "OMIT_AUTORESET",
+        "OMIT_LOAD_EXTENSION",
+        "STMTJRNL_SPILL=131072",
+        "SYSTEM_MALLOC",
+        "TEMP_STORE=1",
+        "THREADSAFE=2",
+        "USE_URI"
+      ],
+      "journalMode": "wal",
+      "pageSizeBytes": 4096,
+      "sqliteSourceID": "2025-06-12 13:14:41 f0ca7bba1c5e232e5d279fad6338121ab55af0c8c68c84cdfb18ba5114dcaapl",
+      "sqliteVersion": "3.51.0",
+      "storage": "temporary file-backed SQLite database",
+      "synchronous": 1
+    },
+    "environment": {
+      "activeProcessorCount": 14,
+      "architecture": "arm64",
+      "buildConfiguration": "release",
+      "grdbRevision": "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+      "grdbVersion": "6.29.3",
+      "machineModel": "Mac16,8",
+      "operatingSystem": "Version 26.5.1 (Build 25F80)",
+      "physicalMemoryBytes": 25769803776,
+      "processor": "Apple M4 Pro",
+      "processorCount": 14,
+      "repositoryRevision": "b0443b3710ab6db655a8539f2d0cde821ec3945e",
+      "repositoryState": "dirty",
+      "sdkVersion": "26.5",
+      "swiftVersion": "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)\nTarget: arm64-apple-macosx26.0",
+      "xcodeVersion": "Xcode 26.5\nBuild version 17F42"
+    }
+  },
+  "note": "Per-process construction+rendering statistics (microseconds). Raw #128 reports were not committed to keep the evidence directory small; regenerate with the documented command. Machine has background load, so process spread is real and reported.",
+  "phase": "swiftql_construction_and_rendering",
+  "processesPerCondition": 8,
+  "samples": 500,
+  "warmups": 50
+}

--- a/Benchmarks/Sources/SwiftQLConstructionProfile/ConstructionProfile.swift
+++ b/Benchmarks/Sources/SwiftQLConstructionProfile/ConstructionProfile.swift
@@ -23,6 +23,7 @@
 #if canImport(Darwin)
 import Darwin
 #endif
+import Dispatch
 import Foundation
 import SwiftQL
 
@@ -46,6 +47,12 @@ private final class AllocationProbe: @unchecked Sendable {
     var count = 0
     var bytes = 0
     var enabled = false
+    // The thread that owns the current measurement window. `malloc_logger` is a
+    // process-global hook fired on every thread, so the callback must only touch
+    // this probe from the measuring thread — otherwise a background allocation
+    // (Foundation/Dispatch worker) both races the counter and contaminates the
+    // count with work unrelated to the code under test.
+    var thread = pthread_self()
 
     func reset() {
         count = 0
@@ -56,9 +63,11 @@ private final class AllocationProbe: @unchecked Sendable {
 private let allocationProbe = AllocationProbe()
 
 // The callback runs with the malloc lock held, so it must not allocate. It only
-// mutates the global probe's fixed fields, which is allocation-free.
+// mutates the global probe's fixed fields, which is allocation-free, and only on
+// the measuring thread (`pthread_self` does not allocate).
 private let countingLogger: MallocLoggerFn = { type, _, arg2, arg3, result, _ in
-    guard allocationProbe.enabled else { return }
+    guard allocationProbe.enabled,
+          pthread_equal(pthread_self(), allocationProbe.thread) != 0 else { return }
     if (type & mallocLogTypeAllocate) != 0 && result != 0 {
         allocationProbe.count += 1
         // For malloc/calloc the requested size is arg2; for realloc it is arg3.
@@ -67,6 +76,16 @@ private let countingLogger: MallocLoggerFn = { type, _, arg2, arg3, result, _ in
 }
 
 private func installAllocationCounter() -> Bool {
+    // Force lazy initialization of every global the callback touches BEFORE the
+    // hook is installed. The globals are class/`let` values whose first access
+    // runs a `dispatch_once` that itself allocates; if that first access happened
+    // from inside the hook (during a malloc), it would re-enter `dispatch_once`
+    // and deadlock. Touching them here, with the hook not yet installed and
+    // counting disabled, makes every later in-hook access a plain field read.
+    allocationProbe.reset()
+    _ = allocationProbe.enabled
+    _ = allocationProbe.thread
+    _ = mallocLogTypeAllocate
     guard let slot = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "malloc_logger") else {
         return false
     }
@@ -83,6 +102,7 @@ private func measureAllocations(iterations: Int, _ body: () -> Void) -> Allocati
     // Warm once outside the count to settle any one-time lazy state.
     body()
     allocationProbe.reset()
+    allocationProbe.thread = pthread_self()
     allocationProbe.enabled = true
     for _ in 0..<iterations { body() }
     allocationProbe.enabled = false

--- a/Benchmarks/Sources/SwiftQLConstructionProfile/ConstructionProfile.swift
+++ b/Benchmarks/Sources/SwiftQLConstructionProfile/ConstructionProfile.swift
@@ -14,6 +14,11 @@
 // It reuses SwiftQL's public API and rebuilds the exact two read queries the
 // #128 harness measures (`simple_parameterized_lookup` and
 // `representative_multi_join_read`). It is diagnostic evidence, not a CI gate.
+//
+// The implementation avoids `nonisolated(unsafe)` and top-level code so it
+// builds on the package's declared minimum toolchain (Swift 5.9) and stays clean
+// under `-strict-concurrency=complete`: mutable counters live in an
+// `@unchecked Sendable` reference the C callback reaches as a global.
 
 #if canImport(Darwin)
 import Darwin
@@ -33,20 +38,31 @@ private typealias MallocLoggerFn = @convention(c) (
 // as one allocation, which matches "gross heap allocations issued").
 private let mallocLogTypeAllocate: UInt32 = 2
 
-nonisolated(unsafe) private var allocationCount: Int = 0
-nonisolated(unsafe) private var allocationBytes: Int = 0
-nonisolated(unsafe) private var counting = false
+// Counters live behind a reference type so the C callback — which cannot capture
+// context — reaches them as a single global `let`. `@unchecked Sendable` keeps a
+// global of this type clean under complete concurrency checking without the
+// Swift-6-only `nonisolated(unsafe)` attribute; the tool is single-threaded.
+private final class AllocationProbe: @unchecked Sendable {
+    var count = 0
+    var bytes = 0
+    var enabled = false
+
+    func reset() {
+        count = 0
+        bytes = 0
+    }
+}
+
+private let allocationProbe = AllocationProbe()
 
 // The callback runs with the malloc lock held, so it must not allocate. It only
-// touches fixed globals, which is allocation-free. `nonisolated(unsafe)` opts the
-// top-level (main-actor-isolated) declaration out of isolation checking; this
-// single-threaded diagnostic tool never touches it concurrently.
-nonisolated(unsafe) private let countingLogger: MallocLoggerFn = { type, arg1, arg2, arg3, result, _ in
-    guard counting else { return }
+// mutates the global probe's fixed fields, which is allocation-free.
+private let countingLogger: MallocLoggerFn = { type, _, arg2, arg3, result, _ in
+    guard allocationProbe.enabled else { return }
     if (type & mallocLogTypeAllocate) != 0 && result != 0 {
-        allocationCount += 1
-        // For malloc/calloc the requested size is arg2; for realloc arg3.
-        allocationBytes += Int(arg3 != 0 ? arg3 : arg2)
+        allocationProbe.count += 1
+        // For malloc/calloc the requested size is arg2; for realloc it is arg3.
+        allocationProbe.bytes += Int(arg3 != 0 ? arg3 : arg2)
     }
 }
 
@@ -66,12 +82,11 @@ private struct AllocationSample {
 private func measureAllocations(iterations: Int, _ body: () -> Void) -> AllocationSample {
     // Warm once outside the count to settle any one-time lazy state.
     body()
-    allocationCount = 0
-    allocationBytes = 0
-    counting = true
+    allocationProbe.reset()
+    allocationProbe.enabled = true
     for _ in 0..<iterations { body() }
-    counting = false
-    return AllocationSample(count: allocationCount, bytes: allocationBytes)
+    allocationProbe.enabled = false
+    return AllocationSample(count: allocationProbe.count, bytes: allocationProbe.bytes)
 }
 #endif
 
@@ -172,9 +187,7 @@ private func multiJoinRead() -> any XLQueryStatement<ProfileJoinedRow> {
 
 // MARK: - Driver
 
-nonisolated(unsafe) let encoder = XLiteEncoder(formatter: XLiteFormatter())
-
-struct CaseProfile {
+private struct CaseProfile {
     let name: String
     let sql: String
     let constructionAllocs: Int
@@ -188,8 +201,9 @@ struct CaseProfile {
     let combinedMicros: Double
 }
 
-func profileCase(
+private func profileCase(
     _ name: String,
+    encoder: XLiteEncoder,
     make: @escaping () -> XLEncodable,
     iterations: Int,
     warmups: Int,
@@ -227,67 +241,79 @@ func profileCase(
     )
 }
 
-// CLI: --iterations N --warmups N --samples N --json PATH
-var iterations = 20_000
-var warmups = 200
-var samples = 4_000
-var jsonPath: String?
-var args = Array(CommandLine.arguments.dropFirst())
-var i = 0
-while i < args.count {
-    switch args[i] {
-    case "--iterations": i += 1; iterations = Int(args[i]) ?? iterations
-    case "--warmups": i += 1; warmups = Int(args[i]) ?? warmups
-    case "--samples": i += 1; samples = Int(args[i]) ?? samples
-    case "--json": i += 1; jsonPath = args[i]
-    default: break
-    }
-    i += 1
-}
+@main
+struct ConstructionProfile {
+    static func main() throws {
+        // CLI: --iterations N --warmups N --samples N --json PATH
+        var iterations = 20_000
+        var warmups = 200
+        var samples = 4_000
+        var jsonPath: String?
+        let args = Array(CommandLine.arguments.dropFirst())
+        var i = 0
+        while i < args.count {
+            switch args[i] {
+            case "--iterations":
+                if i + 1 < args.count, let n = Int(args[i + 1]) { iterations = max(1, n); i += 1 }
+            case "--warmups":
+                if i + 1 < args.count, let n = Int(args[i + 1]) { warmups = max(0, n); i += 1 }
+            case "--samples":
+                if i + 1 < args.count, let n = Int(args[i + 1]) { samples = max(1, n); i += 1 }
+            case "--json":
+                if i + 1 < args.count { jsonPath = args[i + 1]; i += 1 }
+            default:
+                break
+            }
+            i += 1
+        }
 
-#if canImport(Darwin)
-let installed = installAllocationCounter()
-if !installed {
-    FileHandle.standardError.write(Data("warning: could not install malloc_logger; allocation counts will be 0\n".utf8))
-}
-#endif
+        #if canImport(Darwin)
+        if !installAllocationCounter() {
+            FileHandle.standardError.write(
+                Data("warning: could not install malloc_logger; allocation counts will be 0\n".utf8)
+            )
+        }
+        #endif
 
-let cases = [
-    profileCase("simple_parameterized_lookup", make: { simpleLookup() },
-                iterations: iterations, warmups: warmups, samples: samples),
-    profileCase("representative_multi_join_read", make: { multiJoinRead() },
-                iterations: iterations, warmups: warmups, samples: samples),
-]
-
-print("SwiftQL construction/rendering allocation + timing profile (issue #166)")
-print("iterations=\(iterations) (allocs)  warmups=\(warmups) samples=\(samples) (timing)")
-print("")
-for c in cases {
-    print("[\(c.name)]")
-    print("  SQL: \(c.sql)")
-    print("  allocations/op   construction=\(c.constructionAllocs)  render=\(c.renderAllocs)  combined=\(c.combinedAllocs)")
-    print("  bytes/op         construction=\(c.constructionBytes)  render=\(c.renderBytes)  combined=\(c.combinedBytes)")
-    print(String(format: "  median us/op     construction=%.3f  render=%.3f  combined=%.3f",
-                 c.constructionMicros, c.renderMicros, c.combinedMicros))
-    print("")
-}
-
-if let jsonPath {
-    var obj: [String: Any] = [
-        "iterations": iterations,
-        "warmups": warmups,
-        "samples": samples,
-    ]
-    obj["cases"] = cases.map { c in
-        [
-            "name": c.name,
-            "sql": c.sql,
-            "allocationsPerOp": ["construction": c.constructionAllocs, "render": c.renderAllocs, "combined": c.combinedAllocs],
-            "bytesPerOp": ["construction": c.constructionBytes, "render": c.renderBytes, "combined": c.combinedBytes],
-            "medianMicros": ["construction": c.constructionMicros, "render": c.renderMicros, "combined": c.combinedMicros],
+        let encoder = XLiteEncoder(formatter: XLiteFormatter())
+        let cases = [
+            profileCase("simple_parameterized_lookup", encoder: encoder, make: { simpleLookup() },
+                        iterations: iterations, warmups: warmups, samples: samples),
+            profileCase("representative_multi_join_read", encoder: encoder, make: { multiJoinRead() },
+                        iterations: iterations, warmups: warmups, samples: samples),
         ]
+
+        print("SwiftQL construction/rendering allocation + timing profile (issue #166)")
+        print("iterations=\(iterations) (allocs)  warmups=\(warmups) samples=\(samples) (timing)")
+        print("")
+        for c in cases {
+            print("[\(c.name)]")
+            print("  SQL: \(c.sql)")
+            print("  allocations/op   construction=\(c.constructionAllocs)  render=\(c.renderAllocs)  combined=\(c.combinedAllocs)")
+            print("  bytes/op         construction=\(c.constructionBytes)  render=\(c.renderBytes)  combined=\(c.combinedBytes)")
+            print(String(format: "  median us/op     construction=%.3f  render=%.3f  combined=%.3f",
+                         c.constructionMicros, c.renderMicros, c.combinedMicros))
+            print("")
+        }
+
+        if let jsonPath {
+            var obj: [String: Any] = [
+                "iterations": iterations,
+                "warmups": warmups,
+                "samples": samples,
+            ]
+            obj["cases"] = cases.map { c in
+                [
+                    "name": c.name,
+                    "sql": c.sql,
+                    "allocationsPerOp": ["construction": c.constructionAllocs, "render": c.renderAllocs, "combined": c.combinedAllocs],
+                    "bytesPerOp": ["construction": c.constructionBytes, "render": c.renderBytes, "combined": c.combinedBytes],
+                    "medianMicros": ["construction": c.constructionMicros, "render": c.renderMicros, "combined": c.combinedMicros],
+                ]
+            }
+            let data = try JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: URL(fileURLWithPath: jsonPath))
+            print("Wrote \(jsonPath)")
+        }
     }
-    let data = try JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys])
-    try data.write(to: URL(fileURLWithPath: jsonPath))
-    print("Wrote \(jsonPath)")
 }

--- a/Benchmarks/Sources/SwiftQLConstructionProfile/main.swift
+++ b/Benchmarks/Sources/SwiftQLConstructionProfile/main.swift
@@ -1,0 +1,293 @@
+// Deterministic allocation-and-timing profiler for issue #166.
+//
+// The checked-in #128 benchmark measures the combined
+// `swiftql_construction_and_rendering` phase but records only wall-clock
+// samples, which carry material process-to-process DVFS/core-placement noise on
+// Apple silicon. This tool adds two pieces of evidence that the timing harness
+// cannot:
+//
+//   1. A deterministic per-operation heap-allocation count (via the in-process
+//      `malloc_logger` hook), which is immune to scheduler noise and attributes
+//      allocation cost to the exact construction and rendering sub-phases.
+//   2. A construction-only vs. rendering-only timing split of the same phase.
+//
+// It reuses SwiftQL's public API and rebuilds the exact two read queries the
+// #128 harness measures (`simple_parameterized_lookup` and
+// `representative_multi_join_read`). It is diagnostic evidence, not a CI gate.
+
+#if canImport(Darwin)
+import Darwin
+#endif
+import Foundation
+import SwiftQL
+
+// MARK: - Deterministic allocation counter (Darwin malloc_logger hook)
+
+#if canImport(Darwin)
+private typealias MallocLoggerFn = @convention(c) (
+    UInt32, UInt, UInt, UInt, UInt, UInt32
+) -> Void
+
+// MALLOC_LOG_TYPE_ALLOCATE == 2. An allocation event has that bit set and a
+// non-zero result pointer (realloc sets ALLOCATE|DEALLOCATE; we still count it
+// as one allocation, which matches "gross heap allocations issued").
+private let mallocLogTypeAllocate: UInt32 = 2
+
+nonisolated(unsafe) private var allocationCount: Int = 0
+nonisolated(unsafe) private var allocationBytes: Int = 0
+nonisolated(unsafe) private var counting = false
+
+// The callback runs with the malloc lock held, so it must not allocate. It only
+// touches fixed globals, which is allocation-free. `nonisolated(unsafe)` opts the
+// top-level (main-actor-isolated) declaration out of isolation checking; this
+// single-threaded diagnostic tool never touches it concurrently.
+nonisolated(unsafe) private let countingLogger: MallocLoggerFn = { type, arg1, arg2, arg3, result, _ in
+    guard counting else { return }
+    if (type & mallocLogTypeAllocate) != 0 && result != 0 {
+        allocationCount += 1
+        // For malloc/calloc the requested size is arg2; for realloc arg3.
+        allocationBytes += Int(arg3 != 0 ? arg3 : arg2)
+    }
+}
+
+private func installAllocationCounter() -> Bool {
+    guard let slot = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "malloc_logger") else {
+        return false
+    }
+    slot.assumingMemoryBound(to: Optional<MallocLoggerFn>.self).pointee = countingLogger
+    return true
+}
+
+private struct AllocationSample {
+    var count: Int
+    var bytes: Int
+}
+
+private func measureAllocations(iterations: Int, _ body: () -> Void) -> AllocationSample {
+    // Warm once outside the count to settle any one-time lazy state.
+    body()
+    allocationCount = 0
+    allocationBytes = 0
+    counting = true
+    for _ in 0..<iterations { body() }
+    counting = false
+    return AllocationSample(count: allocationCount, bytes: allocationBytes)
+}
+#endif
+
+// MARK: - Timing
+
+private func median(_ xs: [UInt64]) -> Double {
+    let s = xs.sorted()
+    let n = s.count
+    if n == 0 { return 0 }
+    return n % 2 == 1 ? Double(s[n / 2]) : Double(s[n / 2 - 1] + s[n / 2]) / 2
+}
+
+private func measureNanos(warmups: Int, samples: Int, _ body: () -> Void) -> Double {
+    for _ in 0..<warmups { body() }
+    var out = [UInt64]()
+    out.reserveCapacity(samples)
+    for _ in 0..<samples {
+        let start = DispatchTime.now().uptimeNanoseconds
+        body()
+        let end = DispatchTime.now().uptimeNanoseconds
+        out.append(end - start)
+    }
+    return median(out) / 1000.0 // microseconds
+}
+
+// MARK: - Exact #128 read queries (rebuilt against the public API)
+
+@SQLTable(name: "benchmark_company")
+struct ProfileCompany: Identifiable {
+    let id: Int
+    let name: String
+}
+
+@SQLTable(name: "benchmark_department")
+struct ProfileDepartment: Identifiable {
+    let id: Int
+    let companyID: Int
+    let name: String
+}
+
+@SQLTable(name: "benchmark_person")
+struct ProfilePerson: Identifiable, Equatable {
+    let id: Int
+    let companyID: Int
+    let departmentID: Int
+    let name: String
+    let email: String
+    let score: Double
+    let isActive: Bool
+    let payload: Data
+}
+
+@SQLResult
+struct ProfileJoinedRow: Equatable {
+    let personID: Int
+    let personName: String
+    let departmentName: String
+    let companyName: String
+    let score: Double
+    let isActive: Bool
+}
+
+private let personID = XLNamedBindingReference<Int>(name: "personID")
+private let companyID = XLNamedBindingReference<Int>(name: "companyID")
+private let minimumScore = XLNamedBindingReference<Double>(name: "minimumScore")
+
+private func simpleLookup() -> any XLQueryStatement<ProfilePerson> {
+    sqlQuery { schema in
+        let person = schema.table(ProfilePerson.self)
+        return select(person)
+            .from(person)
+            .where(person.id == personID)
+    }
+}
+
+private func multiJoinRead() -> any XLQueryStatement<ProfileJoinedRow> {
+    sqlQuery { schema in
+        let person = schema.table(ProfilePerson.self)
+        let department = schema.table(ProfileDepartment.self)
+        let company = schema.table(ProfileCompany.self)
+        let row = ProfileJoinedRow.columns(
+            personID: person.id,
+            personName: person.name,
+            departmentName: department.name,
+            companyName: company.name,
+            score: person.score,
+            isActive: person.isActive
+        )
+        return select(row)
+            .from(person)
+            .innerJoin(department, on: department.id == person.departmentID)
+            .innerJoin(company, on: company.id == department.companyID)
+            .where((company.id == companyID) && (person.score >= minimumScore))
+            .orderBy(person.score.descending())
+            .limit(32)
+    }
+}
+
+// MARK: - Driver
+
+nonisolated(unsafe) let encoder = XLiteEncoder(formatter: XLiteFormatter())
+
+struct CaseProfile {
+    let name: String
+    let sql: String
+    let constructionAllocs: Int
+    let constructionBytes: Int
+    let renderAllocs: Int
+    let renderBytes: Int
+    let combinedAllocs: Int
+    let combinedBytes: Int
+    let constructionMicros: Double
+    let renderMicros: Double
+    let combinedMicros: Double
+}
+
+func profileCase(
+    _ name: String,
+    make: @escaping () -> XLEncodable,
+    iterations: Int,
+    warmups: Int,
+    samples: Int
+) -> CaseProfile {
+    let prebuilt = make()
+    let renderedSQL = encoder.makeSQL(prebuilt).sql
+
+    #if canImport(Darwin)
+    let construction = measureAllocations(iterations: iterations) { _ = make() }
+    let render = measureAllocations(iterations: iterations) { _ = encoder.makeSQL(prebuilt) }
+    let combined = measureAllocations(iterations: iterations) { _ = encoder.makeSQL(make()) }
+    #else
+    let construction = AllocationSample(count: 0, bytes: 0)
+    let render = AllocationSample(count: 0, bytes: 0)
+    let combined = AllocationSample(count: 0, bytes: 0)
+    #endif
+
+    let ctorMicros = measureNanos(warmups: warmups, samples: samples) { _ = make() }
+    let renderMicros = measureNanos(warmups: warmups, samples: samples) { _ = encoder.makeSQL(prebuilt) }
+    let combinedMicros = measureNanos(warmups: warmups, samples: samples) { _ = encoder.makeSQL(make()) }
+
+    return CaseProfile(
+        name: name,
+        sql: renderedSQL,
+        constructionAllocs: construction.count / iterations,
+        constructionBytes: construction.bytes / iterations,
+        renderAllocs: render.count / iterations,
+        renderBytes: render.bytes / iterations,
+        combinedAllocs: combined.count / iterations,
+        combinedBytes: combined.bytes / iterations,
+        constructionMicros: ctorMicros,
+        renderMicros: renderMicros,
+        combinedMicros: combinedMicros
+    )
+}
+
+// CLI: --iterations N --warmups N --samples N --json PATH
+var iterations = 20_000
+var warmups = 200
+var samples = 4_000
+var jsonPath: String?
+var args = Array(CommandLine.arguments.dropFirst())
+var i = 0
+while i < args.count {
+    switch args[i] {
+    case "--iterations": i += 1; iterations = Int(args[i]) ?? iterations
+    case "--warmups": i += 1; warmups = Int(args[i]) ?? warmups
+    case "--samples": i += 1; samples = Int(args[i]) ?? samples
+    case "--json": i += 1; jsonPath = args[i]
+    default: break
+    }
+    i += 1
+}
+
+#if canImport(Darwin)
+let installed = installAllocationCounter()
+if !installed {
+    FileHandle.standardError.write(Data("warning: could not install malloc_logger; allocation counts will be 0\n".utf8))
+}
+#endif
+
+let cases = [
+    profileCase("simple_parameterized_lookup", make: { simpleLookup() },
+                iterations: iterations, warmups: warmups, samples: samples),
+    profileCase("representative_multi_join_read", make: { multiJoinRead() },
+                iterations: iterations, warmups: warmups, samples: samples),
+]
+
+print("SwiftQL construction/rendering allocation + timing profile (issue #166)")
+print("iterations=\(iterations) (allocs)  warmups=\(warmups) samples=\(samples) (timing)")
+print("")
+for c in cases {
+    print("[\(c.name)]")
+    print("  SQL: \(c.sql)")
+    print("  allocations/op   construction=\(c.constructionAllocs)  render=\(c.renderAllocs)  combined=\(c.combinedAllocs)")
+    print("  bytes/op         construction=\(c.constructionBytes)  render=\(c.renderBytes)  combined=\(c.combinedBytes)")
+    print(String(format: "  median us/op     construction=%.3f  render=%.3f  combined=%.3f",
+                 c.constructionMicros, c.renderMicros, c.combinedMicros))
+    print("")
+}
+
+if let jsonPath {
+    var obj: [String: Any] = [
+        "iterations": iterations,
+        "warmups": warmups,
+        "samples": samples,
+    ]
+    obj["cases"] = cases.map { c in
+        [
+            "name": c.name,
+            "sql": c.sql,
+            "allocationsPerOp": ["construction": c.constructionAllocs, "render": c.renderAllocs, "combined": c.combinedAllocs],
+            "bytesPerOp": ["construction": c.constructionBytes, "render": c.renderBytes, "combined": c.combinedBytes],
+            "medianMicros": ["construction": c.constructionMicros, "render": c.renderMicros, "combined": c.combinedMicros],
+        ]
+    }
+    let data = try JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: URL(fileURLWithPath: jsonPath))
+    print("Wrote \(jsonPath)")
+}

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,10 @@ let package = Package(
             name: "swiftql-benchmark",
             targets: ["SwiftQLBenchmarkCLI"]
         ),
+        .executable(
+            name: "swiftql-construction-profile",
+            targets: ["SwiftQLConstructionProfile"]
+        ),
     ],
     dependencies: [
         // Depend on the latest Swift 5.9 prerelease of SwiftSyntax
@@ -108,6 +112,14 @@ let package = Package(
             name: "SwiftQLBenchmarkCLI",
             dependencies: ["SwiftQLBenchmarks"],
             path: "Benchmarks/Sources/SwiftQLBenchmarkCLI"
+        ),
+
+        // Deterministic allocation + sub-phase timing profiler for issue #166.
+        // Diagnostic evidence, not part of the #128 benchmark report or any gate.
+        .executableTarget(
+            name: "SwiftQLConstructionProfile",
+            dependencies: ["SwiftQL"],
+            path: "Benchmarks/Sources/SwiftQLConstructionProfile"
         ),
 
         // Package-private research engine for issue #132. This deliberately

--- a/Sources/SwiftQL/SQLiteEncoding.swift
+++ b/Sources/SwiftQL/SQLiteEncoding.swift
@@ -387,7 +387,12 @@ public struct XLiteFormatter: XLFormatter {
         case 1:
             return name(values[0])
         case 2:
-            return name(values[0]) + "." + name(values[1])
+            // Build in place so only the result string is allocated; `a + "." + b`
+            // would materialise an extra intermediate from the first `+`.
+            var scoped = name(values[0])
+            scoped += "."
+            scoped += name(values[1])
+            return scoped
         default:
             return values.map(name).joined(separator: ".")
         }

--- a/Sources/SwiftQL/SQLiteEncoding.swift
+++ b/Sources/SwiftQL/SQLiteEncoding.swift
@@ -378,7 +378,19 @@ public struct XLiteFormatter: XLFormatter {
     }
 
     public func scopedName(_ values: [String]) -> String {
-        values.map(name).joined(separator: ".")
+        // Qualified names are almost always one ("column") or two
+        // ("table"."column") components. Handle those without the intermediate
+        // `map` array that `joined` would otherwise allocate on every reference.
+        switch values.count {
+        case 0:
+            return ""
+        case 1:
+            return name(values[0])
+        case 2:
+            return name(values[0]) + "." + name(values[1])
+        default:
+            return values.map(name).joined(separator: ".")
+        }
     }
 
     public func namedBinding(_ named: String) -> String {
@@ -406,12 +418,24 @@ public struct XLiteBuilder: XLBuilder {
         self.formatter = formatter
     }
 
-    private mutating func append(_ tokens: String...) {
-        _tokens.append(contentsOf: tokens.filter({ !$0.isEmpty }))
+    // A single already-rendered token per call. Every caller passes exactly one
+    // string, so this avoids the variadic array box and the `filter` copy that
+    // the previous `String...` signature allocated on every builder node.
+    private mutating func append(_ token: String) {
+        if !token.isEmpty {
+            _tokens.append(token)
+        }
     }
 
     public func build() -> String {
-        _tokens.joined(separator: XLSeparator.tuple.rawValue)
+        // A single already-rendered token is by far the common case for leaf and
+        // wrapper builders; return it directly instead of allocating a new joined
+        // string. The separator is irrelevant for one element, so output is
+        // identical.
+        if _tokens.count == 1 {
+            return _tokens[0]
+        }
+        return _tokens.joined(separator: XLSeparator.tuple.rawValue)
     }
 
     public func entities() -> Set<String> {
@@ -627,7 +651,10 @@ public struct XLiteListBuilder: XLListBuilder {
     }
 
     public func build() -> String {
-        _tokens.joined(separator: separator)
+        if _tokens.count == 1 {
+            return _tokens[0]
+        }
+        return _tokens.joined(separator: separator)
     }
 
     public func entities() -> Set<String> {
@@ -659,7 +686,10 @@ public struct XLiteCommonTablesBuilder: XLCommonTablesBuilder {
     }
 
     public func build() -> String {
-        _tokens.joined(separator: XLSeparator.list.rawValue)
+        if _tokens.count == 1 {
+            return _tokens[0]
+        }
+        return _tokens.joined(separator: XLSeparator.list.rawValue)
     }
 
     public func entities() -> Set<String> {
@@ -689,7 +719,10 @@ public struct XLiteColumnDefinitionsBuilder: XLColumnDefinitionsBuilder {
     }
 
     public func build() -> String {
-        _tokens.joined(separator: XLSeparator.list.rawValue)
+        if _tokens.count == 1 {
+            return _tokens[0]
+        }
+        return _tokens.joined(separator: XLSeparator.list.rawValue)
     }
 
     ///

--- a/Tests/SQLTests/SQLDialectEncodingContractTests.swift
+++ b/Tests/SQLTests/SQLDialectEncodingContractTests.swift
@@ -487,4 +487,63 @@ final class SQLDialectEncodingContractTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - Issue #166 rendering fast paths
+
+    /// `scopedName` special-cases the one- and two-component names that dominate
+    /// qualified references to avoid the intermediate `map` array. The output
+    /// must stay identical to the general `map`/`joined` implementation for every
+    /// component count, including the three-plus case that still uses it.
+    func testScopedNameFastPathMatchesNaiveJoinAcrossComponentCounts() {
+        let formatter = XLiteFormatter()
+        let inputs: [[String]] = [
+            [],
+            ["id"],
+            ["t0", "id"],
+            ["main", "person", "id"],
+            ["a", "b", "c", "d"],
+        ]
+        for values in inputs {
+            let naive = values.map(formatter.name).joined(separator: ".")
+            XCTAssertEqual(
+                formatter.scopedName(values),
+                naive,
+                "scopedName diverged from map/joined for \(values)"
+            )
+        }
+        XCTAssertEqual(formatter.scopedName([]), "")
+        XCTAssertEqual(formatter.scopedName(["id"]), "\"id\"")
+        XCTAssertEqual(formatter.scopedName(["t0", "id"]), "\"t0\".\"id\"")
+        XCTAssertEqual(
+            formatter.scopedName(["main", "person", "id"]),
+            "\"main\".\"person\".\"id\""
+        )
+    }
+
+    /// `build()` returns a single already-rendered token directly instead of
+    /// re-joining it, and must still join multiple tokens with the builder's
+    /// separator (space for expression builders, ", " for list builders).
+    func testSingleTokenBuildersReturnTheirTokenAndMultiTokenBuildersJoin() {
+        var single: XLBuilder = XLiteBuilder(formatter: XLiteFormatter())
+        single.name("solo")
+        XCTAssertEqual(single.build(), "\"solo\"")
+
+        var multi: XLBuilder = XLiteBuilder(formatter: XLiteFormatter())
+        multi.name("left")
+        multi.name("right")
+        XCTAssertEqual(multi.build(), "\"left\" \"right\"")
+
+        var listSingle: XLBuilder = XLiteBuilder(formatter: XLiteFormatter())
+        listSingle.list(separator: XLSeparator.list.rawValue) { items in
+            items.listItem { $0.name("only") }
+        }
+        XCTAssertEqual(listSingle.build(), "\"only\"")
+
+        var listMulti: XLBuilder = XLiteBuilder(formatter: XLiteFormatter())
+        listMulti.list(separator: XLSeparator.list.rawValue) { items in
+            items.listItem { $0.name("a") }
+            items.listItem { $0.name("b") }
+        }
+        XCTAssertEqual(listMulti.build(), "\"a\", \"b\"")
+    }
 }


### PR DESCRIPTION
Closes #166.

## Summary

Profiles the `swiftql_construction_and_rendering` phase (the largest non‑decoding SwiftQL‑owned cost in the [#128 baseline](https://github.com/lukevanin/swiftql/blob/main/Benchmarks/Baselines/README.md)) and reduces its verified allocation cost **without changing rendered SQL, entity metadata, query semantics, or the public 1.x API**.

## Evidence first

This machine (Mac16,8 / M4 Pro / Swift 6.3.2 / GRDB 6.29.3 / SQLite 3.51.0) matches the baseline, but has real background load, so sub‑50 µs timing carries process‑to‑process noise. A new **deterministic allocation profiler** (`swiftql-construction-profile`) installs the in‑process Darwin `malloc_logger` hook and counts per‑operation heap allocations for construction‑only, rendering‑only, and combined. It attributed **~77% of the phase's allocations to rendering**, concentrated in the `XLiteBuilder` token/entity tree.

Full method + numbers: [`Benchmarks/Profiling/Issue166/README.md`](https://github.com/lukevanin/swiftql/blob/claude/166-construction-rendering/Benchmarks/Profiling/Issue166/README.md).

## The change (`Sources/SwiftQL/SQLiteEncoding.swift`)

Three output‑preserving edits, each targeting an allocation the profiler pinned:

1. `XLiteBuilder.append` takes a single already‑rendered token (all 29 call sites pass one), removing the variadic `[String]` box **and** the `filter` copy every builder node allocated.
2. `build()` returns the sole token directly when a builder holds exactly one — the common leaf/wrapper case — skipping the join allocation; multi‑token builders still join with their separator.
3. `scopedName` special‑cases zero/one/two components, avoiding the intermediate `map` array on essentially every qualified reference.

No new language features → Swift 5.9 support unaffected.

## Results

Deterministic allocations (`malloc_logger`, 20 000 iterations):

| Case | Render allocs before → after | Combined before → after |
| --- | ---: | ---: |
| Simple lookup | 249 → 212 (**−14.9%**) | 322 → 285 (−11.5%) |
| Multi‑join read | 434 → 365 (**−15.9%**) | 562 → 493 (−12.3%) |

Timing (#128 harness, 8 matched release processes per condition, median of process medians, µs):

| Case | Before | After | Delta | Spread b→a |
| --- | ---: | ---: | ---: | ---: |
| Simple lookup | 29.10 | 24.96 | **−14.2%** | 7.6% → 16.1% |
| Multi‑join read | 47.35 | 40.04 | **−15.4%** | 11.2% → 12.6% |
| Bounded write | 20.04 | 16.56 | **−17.4%** | 9.5% → 7.7% |
| Deterministic decode | 32.03 | 27.83 | **−13.1%** | 10.0% → 7.5% |

The 13–17% median improvement is consistent across all four independent cases and tracks the deterministic allocation reduction, so it is a repeatable change rather than process noise. No absolute CI latency gate is added.

## Validation

- `swift test` — **743 tests, 0 failures**; SQL output byte‑identical.
- Added focused regression tests (`SQLDialectEncodingContractTests`) locking the `scopedName` fast path and single‑/multi‑token `build()`.
- `scripts/ci/check-first-party-warnings.sh` clean; `scripts/ci/check-strict-concurrency.sh` clean (profiler included).

Commands:
```bash
swift run -c release swiftql-construction-profile --iterations 20000 --warmups 200 --samples 4000 --json /tmp/profile.json
swift test --filter SQLDialectEncodingContractTests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)