### PR TITLE
Support NATURAL JOIN and USING (...) join constraints (#45)

### DIFF
--- a/Sources/SwiftQL/Builders/QueryBuilder.swift
+++ b/Sources/SwiftQL/Builders/QueryBuilder.swift
@@ -180,18 +180,18 @@ public struct QueryBuilder<Row> {
     ///
     /// Adds an inner join whose constraint is a `USING (columns...)` clause.
     ///
-    public func innerJoin<T>(_ table: T, using columns: XLName...) -> QueryBuilder where T: XLMetaNamedResult {
+    public func innerJoin<T>(_ table: T, using firstColumn: XLName, _ otherColumns: XLName...) -> QueryBuilder where T: XLMetaNamedResult {
         copy {
-            $0.joins.append(Join(kind: .innerJoin, table: table, using: columns))
+            $0.joins.append(Join(kind: .innerJoin, table: table, using: [firstColumn] + otherColumns))
         }
     }
 
     ///
     /// Adds a left join whose constraint is a `USING (columns...)` clause.
     ///
-    public func leftJoin<T>(_ table: T, using columns: XLName...) -> QueryBuilder where T: XLMetaNullableNamedResult {
+    public func leftJoin<T>(_ table: T, using firstColumn: XLName, _ otherColumns: XLName...) -> QueryBuilder where T: XLMetaNullableNamedResult {
         copy {
-            $0.joins.append(Join(kind: .leftJoin, table: table, using: columns))
+            $0.joins.append(Join(kind: .leftJoin, table: table, using: [firstColumn] + otherColumns))
         }
     }
 

--- a/Sources/SwiftQL/Builders/QueryBuilder.swift
+++ b/Sources/SwiftQL/Builders/QueryBuilder.swift
@@ -178,6 +178,42 @@ public struct QueryBuilder<Row> {
     }
 
     ///
+    /// Adds an inner join whose constraint is a `USING (columns...)` clause.
+    ///
+    public func innerJoin<T>(_ table: T, using columns: XLName...) -> QueryBuilder where T: XLMetaNamedResult {
+        copy {
+            $0.joins.append(Join(kind: .innerJoin, table: table, using: columns))
+        }
+    }
+
+    ///
+    /// Adds a left join whose constraint is a `USING (columns...)` clause.
+    ///
+    public func leftJoin<T>(_ table: T, using columns: XLName...) -> QueryBuilder where T: XLMetaNullableNamedResult {
+        copy {
+            $0.joins.append(Join(kind: .leftJoin, table: table, using: columns))
+        }
+    }
+
+    ///
+    /// Adds a natural (inner) join, which implicitly matches every shared column.
+    ///
+    public func naturalJoin<T>(_ table: T) -> QueryBuilder where T: XLMetaNamedResult {
+        copy {
+            $0.joins.append(Join(kind: .naturalJoin, table: table, constraint: nil))
+        }
+    }
+
+    ///
+    /// Adds a natural left join, whose joined table can resolve to `NULL`.
+    ///
+    public func naturalLeftJoin<T>(_ table: T) -> QueryBuilder where T: XLMetaNullableNamedResult {
+        copy {
+            $0.joins.append(Join(kind: .naturalLeftJoin, table: table, constraint: nil))
+        }
+    }
+
+    ///
     /// Adds an and expression to the where clause.
     ///
     public func and(_ condition: any XLExpression<Bool>) -> QueryBuilder {

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -516,7 +516,7 @@ public struct Join: XLTableStatement {
         switch kind {
         case .naturalJoin, .naturalLeftJoin, .crossJoin:
             return
-        case .innerJoin, .leftJoin:
+        case .innerJoin, .leftJoin, .rightJoin:
             break
         }
         if let constraint {

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -511,6 +511,14 @@ public struct Join: XLTableStatement {
 
     public func makeSQL(context: inout XLBuilder) {
         context.unaryPrefix(kind.rawValue, expression: table.makeSQL)
+        // NATURAL and CROSS joins never take an ON/USING constraint, even if one
+        // were supplied through the internal initializer.
+        switch kind {
+        case .naturalJoin, .naturalLeftJoin, .crossJoin:
+            return
+        case .innerJoin, .leftJoin:
+            break
+        }
         if let constraint {
             context.unaryPrefix("ON", expression: constraint.makeSQL)
         } else if let using {

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -554,8 +554,8 @@ public struct Join: XLTableStatement {
     /// both tables — are equal, and SQLite coalesces each named column into a
     /// single output column.
     ///
-    public static func Inner<T>(_ table: T, using columns: XLName...) -> Join where T: XLMetaNamedResult {
-        Join(kind: .innerJoin, table: table, using: columns)
+    public static func Inner<T>(_ table: T, using firstColumn: XLName, _ otherColumns: XLName...) -> Join where T: XLMetaNamedResult {
+        Join(kind: .innerJoin, table: table, using: [firstColumn] + otherColumns)
     }
 
     ///
@@ -583,8 +583,8 @@ public struct Join: XLTableStatement {
     ///
     /// Creates a left join whose constraint is a `USING (columns...)` clause.
     ///
-    public static func Left<T>(_ table: T, using columns: XLName...) -> Join where T: XLMetaNullableNamedResult {
-        Join(kind: .leftJoin, table: table, using: columns)
+    public static func Left<T>(_ table: T, using firstColumn: XLName, _ otherColumns: XLName...) -> Join where T: XLMetaNullableNamedResult {
+        Join(kind: .leftJoin, table: table, using: [firstColumn] + otherColumns)
     }
 
     ///

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -474,13 +474,19 @@ public struct Join: XLTableStatement {
         case leftJoin = "LEFT JOIN"
         case rightJoin = "RIGHT JOIN"
         case crossJoin = "CROSS JOIN"
+        case naturalJoin = "NATURAL JOIN"
+        case naturalLeftJoin = "NATURAL LEFT JOIN"
     }
-    
+
     private let kind: Kind
-    
+
     private let table: XLEncodable
-    
+
     private let constraint: (any XLExpression)?
+
+    /// Column names shared by both tables for a `USING (...)` join constraint.
+    /// Mutually exclusive with `constraint`; `NATURAL` joins use neither.
+    private let using: [XLName]?
 
     ///
     /// `Join` is a synonym for `Join.Inner`.
@@ -493,12 +499,30 @@ public struct Join: XLTableStatement {
         self.kind = kind
         self.table = table
         self.constraint = constraint
+        self.using = nil
     }
- 
+
+    internal init(kind: Kind, table: XLEncodable, using: [XLName]) {
+        self.kind = kind
+        self.table = table
+        self.constraint = nil
+        self.using = using
+    }
+
     public func makeSQL(context: inout XLBuilder) {
         context.unaryPrefix(kind.rawValue, expression: table.makeSQL)
         if let constraint {
             context.unaryPrefix("ON", expression: constraint.makeSQL)
+        } else if let using {
+            context.unaryPrefix("USING", expression: { context in
+                context.parenthesis { context in
+                    context.list(separator: .list) { list in
+                        for column in using {
+                            list.listItem { $0.name(column) }
+                        }
+                    }
+                }
+            })
         }
     }
     
@@ -524,6 +548,17 @@ public struct Join: XLTableStatement {
     }
 
     ///
+    /// Creates an inner join whose constraint is a `USING (columns...)` clause.
+    ///
+    /// A `USING` join matches rows where the named columns — which must exist in
+    /// both tables — are equal, and SQLite coalesces each named column into a
+    /// single output column.
+    ///
+    public static func Inner<T>(_ table: T, using columns: XLName...) -> Join where T: XLMetaNamedResult {
+        Join(kind: .innerJoin, table: table, using: columns)
+    }
+
+    ///
     /// Creates a left join with a column constraint.
     ///
     public static func Left<T, U>(_ table: T, on constraint: any XLExpression<U>) -> Join where T: XLMetaNullableNamedResult, U: XLBoolean {
@@ -543,6 +578,31 @@ public struct Join: XLTableStatement {
     ///
     public static func Right<T, U>(_ table: T, on constraint: any XLExpression<U>) -> Join where T: XLMetaNamedResult, U: XLBoolean {
         Join(kind: .rightJoin, table: table, constraint: constraint)
+    }
+
+    ///
+    /// Creates a left join whose constraint is a `USING (columns...)` clause.
+    ///
+    public static func Left<T>(_ table: T, using columns: XLName...) -> Join where T: XLMetaNullableNamedResult {
+        Join(kind: .leftJoin, table: table, using: columns)
+    }
+
+    ///
+    /// Creates a natural (inner) join.
+    ///
+    /// A `NATURAL JOIN` implicitly matches every column the two tables share by
+    /// name and takes no `ON` or `USING` constraint. If the tables share no
+    /// column names it degenerates to a cross join.
+    ///
+    public static func Natural<T>(_ table: T) -> Join where T: XLMetaNamedResult {
+        Join(kind: .naturalJoin, table: table, constraint: nil)
+    }
+
+    ///
+    /// Creates a natural left join, whose joined table can resolve to `NULL`.
+    ///
+    public static func NaturalLeft<T>(_ table: T) -> Join where T: XLMetaNullableNamedResult {
+        Join(kind: .naturalLeftJoin, table: table, constraint: nil)
     }
 
     ///

--- a/Sources/SwiftQL/Statements/SQLQueryStatement.swift
+++ b/Sources/SwiftQL/Statements/SQLQueryStatement.swift
@@ -181,15 +181,15 @@ public struct XLQueryTableStatement<Row>: XLQueryStatement, XLSimpleSelectQueryS
     ///
     /// Adds an inner join whose constraint is a `USING (columns...)` clause.
     ///
-    public func innerJoin<T>(_ t: T, using columns: XLName...) -> XLQueryTableStatement<Row> where T: XLMetaNamedResult {
-        XLQueryTableStatement(components: components.appending(Join(kind: .innerJoin, table: t, using: columns)))
+    public func innerJoin<T>(_ t: T, using firstColumn: XLName, _ otherColumns: XLName...) -> XLQueryTableStatement<Row> where T: XLMetaNamedResult {
+        XLQueryTableStatement(components: components.appending(Join(kind: .innerJoin, table: t, using: [firstColumn] + otherColumns)))
     }
 
     ///
     /// Adds a left join whose constraint is a `USING (columns...)` clause.
     ///
-    public func leftJoin<T>(_ t: T, using columns: XLName...) -> XLQueryTableStatement<Row> where T: XLMetaNullableNamedResult {
-        XLQueryTableStatement(components: components.appending(Join(kind: .leftJoin, table: t, using: columns)))
+    public func leftJoin<T>(_ t: T, using firstColumn: XLName, _ otherColumns: XLName...) -> XLQueryTableStatement<Row> where T: XLMetaNullableNamedResult {
+        XLQueryTableStatement(components: components.appending(Join(kind: .leftJoin, table: t, using: [firstColumn] + otherColumns)))
     }
 
     ///

--- a/Sources/SwiftQL/Statements/SQLQueryStatement.swift
+++ b/Sources/SwiftQL/Statements/SQLQueryStatement.swift
@@ -178,6 +178,34 @@ public struct XLQueryTableStatement<Row>: XLQueryStatement, XLSimpleSelectQueryS
         XLQueryTableStatement(components: components.appending(Join(kind: .rightJoin, table: t, constraint: condition)))
     }
 
+    ///
+    /// Adds an inner join whose constraint is a `USING (columns...)` clause.
+    ///
+    public func innerJoin<T>(_ t: T, using columns: XLName...) -> XLQueryTableStatement<Row> where T: XLMetaNamedResult {
+        XLQueryTableStatement(components: components.appending(Join(kind: .innerJoin, table: t, using: columns)))
+    }
+
+    ///
+    /// Adds a left join whose constraint is a `USING (columns...)` clause.
+    ///
+    public func leftJoin<T>(_ t: T, using columns: XLName...) -> XLQueryTableStatement<Row> where T: XLMetaNullableNamedResult {
+        XLQueryTableStatement(components: components.appending(Join(kind: .leftJoin, table: t, using: columns)))
+    }
+
+    ///
+    /// Adds a natural (inner) join, which implicitly matches every shared column.
+    ///
+    public func naturalJoin<T>(_ t: T) -> XLQueryTableStatement<Row> where T: XLMetaNamedResult {
+        XLQueryTableStatement(components: components.appending(Join(kind: .naturalJoin, table: t, constraint: nil)))
+    }
+
+    ///
+    /// Adds a natural left join, whose joined table can resolve to `NULL`.
+    ///
+    public func naturalLeftJoin<T>(_ t: T) -> XLQueryTableStatement<Row> where T: XLMetaNullableNamedResult {
+        XLQueryTableStatement(components: components.appending(Join(kind: .naturalLeftJoin, table: t, constraint: nil)))
+    }
+
     // MARK: Where
     
     public func `where`<T>(_ condition: any XLExpression<T>) -> XLQueryWhereStatement<Row> where T: XLBoolean {

--- a/Tests/SQLTests/NaturalUsingJoinTests.swift
+++ b/Tests/SQLTests/NaturalUsingJoinTests.swift
@@ -31,6 +31,13 @@ struct PassportCitizenRow: Equatable {
 }
 
 
+@SQLResult
+struct PassportCitizenLeftRow: Equatable {
+    let name: String?
+    let country: String
+}
+
+
 final class NaturalUsingJoinTests: XCTestCase {
 
     var encoder: XLiteEncoder!
@@ -104,6 +111,56 @@ final class NaturalUsingJoinTests: XCTestCase {
         XCTAssertEqual(
             encoder.makeSQL(using).sql,
             "SELECT `t1`.`fullName` AS `name`, `t0`.`country` AS `country` FROM `Passport` AS `t0` INNER JOIN `Citizen` AS `t1` USING (`id`)"
+        )
+    }
+
+    func testFluentNaturalLeftAndLeftUsingJoinsRender() {
+        let schema = XLSchema()
+        let passport = schema.table(PassportTable.self)
+        let citizen = schema.nullableTable(CitizenTable.self)
+        let naturalLeft = select(PassportCitizenLeftRow.columns(name: citizen.fullName, country: passport.country))
+            .from(passport)
+            .naturalLeftJoin(citizen)
+        XCTAssertEqual(
+            encoder.makeSQL(naturalLeft).sql,
+            "SELECT `t1`.`fullName` AS `name`, `t0`.`country` AS `country` FROM `Passport` AS `t0` NATURAL LEFT JOIN `Citizen` AS `t1`"
+        )
+
+        let schema2 = XLSchema()
+        let passport2 = schema2.table(PassportTable.self)
+        let citizen2 = schema2.nullableTable(CitizenTable.self)
+        let leftUsing = select(PassportCitizenLeftRow.columns(name: citizen2.fullName, country: passport2.country))
+            .from(passport2)
+            .leftJoin(citizen2, using: "id")
+        XCTAssertEqual(
+            encoder.makeSQL(leftUsing).sql,
+            "SELECT `t1`.`fullName` AS `name`, `t0`.`country` AS `country` FROM `Passport` AS `t0` LEFT JOIN `Citizen` AS `t1` USING (`id`)"
+        )
+    }
+
+    func testExpressionBuilderNaturalLeftAndLeftUsingJoinsRender() {
+        let naturalLeft = sql { schema in
+            let passport = schema.table(PassportTable.self)
+            let citizen = schema.nullableTable(CitizenTable.self)
+            Select(PassportCitizenLeftRow.columns(name: citizen.fullName, country: passport.country))
+            From(passport)
+            Join.NaturalLeft(citizen)
+        }
+        XCTAssertEqual(
+            encoder.makeSQL(naturalLeft).sql,
+            "SELECT `t1`.`fullName` AS `name`, `t0`.`country` AS `country` FROM `Passport` AS `t0` NATURAL LEFT JOIN `Citizen` AS `t1`"
+        )
+
+        let leftUsing = sql { schema in
+            let passport = schema.table(PassportTable.self)
+            let citizen = schema.nullableTable(CitizenTable.self)
+            Select(PassportCitizenLeftRow.columns(name: citizen.fullName, country: passport.country))
+            From(passport)
+            Join.Left(citizen, using: "id")
+        }
+        XCTAssertEqual(
+            encoder.makeSQL(leftUsing).sql,
+            "SELECT `t1`.`fullName` AS `name`, `t0`.`country` AS `country` FROM `Passport` AS `t0` LEFT JOIN `Citizen` AS `t1` USING (`id`)"
         )
     }
 

--- a/Tests/SQLTests/NaturalUsingJoinTests.swift
+++ b/Tests/SQLTests/NaturalUsingJoinTests.swift
@@ -55,6 +55,7 @@ final class NaturalUsingJoinTests: XCTestCase {
     }
 
     override func tearDown() {
+        try? databasePool?.close()
         encoder = nil
         databasePool = nil
         database = nil
@@ -192,6 +193,46 @@ final class NaturalUsingJoinTests: XCTestCase {
         }
         let rows = try database.makeRequest(with: statement).fetchAll()
         XCTAssertEqual(rows, [PassportCitizenRow(name: "Ann", country: "US")])
+    }
+
+    func testNaturalLeftJoinExecutesWithNullForUnmatchedRow() throws {
+        try seed()
+        let statement = sql { schema in
+            let passport = schema.table(PassportTable.self)
+            let citizen = schema.nullableTable(CitizenTable.self)
+            Select(PassportCitizenLeftRow.columns(name: citizen.fullName, country: passport.country))
+            From(passport)
+            Join.NaturalLeft(citizen)
+            OrderBy(passport.id.ascending())
+        }
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(
+            rows,
+            [
+                PassportCitizenLeftRow(name: "Ann", country: "US"),
+                PassportCitizenLeftRow(name: nil, country: "UK"),
+            ]
+        )
+    }
+
+    func testLeftUsingJoinExecutesWithNullForUnmatchedRow() throws {
+        try seed()
+        let statement = sql { schema in
+            let passport = schema.table(PassportTable.self)
+            let citizen = schema.nullableTable(CitizenTable.self)
+            Select(PassportCitizenLeftRow.columns(name: citizen.fullName, country: passport.country))
+            From(passport)
+            Join.Left(citizen, using: "id")
+            OrderBy(passport.id.ascending())
+        }
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(
+            rows,
+            [
+                PassportCitizenLeftRow(name: "Ann", country: "US"),
+                PassportCitizenLeftRow(name: nil, country: "UK"),
+            ]
+        )
     }
 
     private func seed() throws {

--- a/Tests/SQLTests/NaturalUsingJoinTests.swift
+++ b/Tests/SQLTests/NaturalUsingJoinTests.swift
@@ -1,0 +1,156 @@
+//
+//  NaturalUsingJoinTests.swift
+//
+//  Coverage for NATURAL JOIN and USING (...) join constraints (#45).
+//
+
+import Foundation
+import XCTest
+import GRDB
+import SwiftQL
+
+
+@SQLTable(name: "Passport")
+struct PassportTable: Equatable, Identifiable {
+    let id: String
+    let country: String
+}
+
+
+@SQLTable(name: "Citizen")
+struct CitizenTable: Equatable, Identifiable {
+    let id: String
+    let fullName: String
+}
+
+
+@SQLResult
+struct PassportCitizenRow: Equatable {
+    let name: String
+    let country: String
+}
+
+
+final class NaturalUsingJoinTests: XCTestCase {
+
+    var encoder: XLiteEncoder!
+    var databasePool: DatabasePool!
+    var database: GRDBDatabase!
+
+    override func setUp() {
+        let formatter = XLiteFormatter(identifierFormattingOptions: .mysqlCompatible)
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: false)
+            .appendingPathExtension("sqlite")
+        encoder = XLiteEncoder(formatter: formatter)
+        databasePool = try! DatabasePool(path: fileURL.path)
+        database = try! GRDBDatabase(databasePool: databasePool, formatter: formatter, logger: nil)
+    }
+
+    override func tearDown() {
+        encoder = nil
+        databasePool = nil
+        database = nil
+    }
+
+    // MARK: - Rendering
+
+    func testNaturalJoinRendersWithoutConstraint() {
+        let statement = sql { schema in
+            let passport = schema.table(PassportTable.self)
+            let citizen = schema.table(CitizenTable.self)
+            Select(PassportCitizenRow.columns(name: citizen.fullName, country: passport.country))
+            From(passport)
+            Join.Natural(citizen)
+        }
+        XCTAssertEqual(
+            encoder.makeSQL(statement).sql,
+            "SELECT `t1`.`fullName` AS `name`, `t0`.`country` AS `country` FROM `Passport` AS `t0` NATURAL JOIN `Citizen` AS `t1`"
+        )
+    }
+
+    func testUsingJoinRendersColumnList() {
+        let statement = sql { schema in
+            let passport = schema.table(PassportTable.self)
+            let citizen = schema.table(CitizenTable.self)
+            Select(PassportCitizenRow.columns(name: citizen.fullName, country: passport.country))
+            From(passport)
+            Join.Inner(citizen, using: "id")
+        }
+        XCTAssertEqual(
+            encoder.makeSQL(statement).sql,
+            "SELECT `t1`.`fullName` AS `name`, `t0`.`country` AS `country` FROM `Passport` AS `t0` INNER JOIN `Citizen` AS `t1` USING (`id`)"
+        )
+    }
+
+    func testFluentNaturalAndUsingJoinsRender() {
+        let schema = XLSchema()
+        let passport = schema.table(PassportTable.self)
+        let citizen = schema.table(CitizenTable.self)
+        let natural = select(PassportCitizenRow.columns(name: citizen.fullName, country: passport.country))
+            .from(passport)
+            .naturalJoin(citizen)
+        XCTAssertEqual(
+            encoder.makeSQL(natural).sql,
+            "SELECT `t1`.`fullName` AS `name`, `t0`.`country` AS `country` FROM `Passport` AS `t0` NATURAL JOIN `Citizen` AS `t1`"
+        )
+
+        let schema2 = XLSchema()
+        let passport2 = schema2.table(PassportTable.self)
+        let citizen2 = schema2.table(CitizenTable.self)
+        let using = select(PassportCitizenRow.columns(name: citizen2.fullName, country: passport2.country))
+            .from(passport2)
+            .innerJoin(citizen2, using: "id")
+        XCTAssertEqual(
+            encoder.makeSQL(using).sql,
+            "SELECT `t1`.`fullName` AS `name`, `t0`.`country` AS `country` FROM `Passport` AS `t0` INNER JOIN `Citizen` AS `t1` USING (`id`)"
+        )
+    }
+
+    // MARK: - Execution
+
+    func testNaturalJoinExecutesMatchingSharedColumn() throws {
+        try seed()
+        let statement = sql { schema in
+            let passport = schema.table(PassportTable.self)
+            let citizen = schema.table(CitizenTable.self)
+            Select(PassportCitizenRow.columns(name: citizen.fullName, country: passport.country))
+            From(passport)
+            Join.Natural(citizen)
+            OrderBy(citizen.fullName.ascending())
+        }
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(rows, [PassportCitizenRow(name: "Ann", country: "US")])
+    }
+
+    func testUsingJoinExecutesMatchingSharedColumn() throws {
+        try seed()
+        let statement = sql { schema in
+            let passport = schema.table(PassportTable.self)
+            let citizen = schema.table(CitizenTable.self)
+            Select(PassportCitizenRow.columns(name: citizen.fullName, country: passport.country))
+            From(passport)
+            Join.Inner(citizen, using: "id")
+            OrderBy(citizen.fullName.ascending())
+        }
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(rows, [PassportCitizenRow(name: "Ann", country: "US")])
+    }
+
+    private func seed() throws {
+        try database.makeRequest(with: sqlCreate(PassportTable.self)).execute()
+        try database.makeRequest(with: sqlCreate(CitizenTable.self)).execute()
+        for passport in [
+            PassportTable(id: "a", country: "US"),
+            PassportTable(id: "b", country: "UK"),
+        ] {
+            try database.makeRequest(with: sqlInsert(passport)).execute()
+        }
+        for citizen in [
+            CitizenTable(id: "a", fullName: "Ann"),
+            CitizenTable(id: "c", fullName: "Cy"),
+        ] {
+            try database.makeRequest(with: sqlInsert(citizen)).execute()
+        }
+    }
+}


### PR DESCRIPTION
Closes #45.

## Summary

Adds the two remaining SQLite join constraints: `NATURAL JOIN` (implicitly matches every column two tables share by name, no `ON`/`USING`) and `USING (columns...)` (matches on named columns present in both tables, coalescing each into one output column).

A `Join` now renders exactly one of `ON <expr>`, `USING (cols)`, or — for a `NATURAL` join — no constraint at all.

### API

**Expression-builder factories**

- `Join.Natural(_:)` — `NATURAL JOIN` (inner; joined table non-nullable)
- `Join.NaturalLeft(_:)` — `NATURAL LEFT JOIN` (joined table nullable)
- `Join.Inner(_:using:)` — `INNER JOIN ... USING (cols)`
- `Join.Left(_:using:)` — `LEFT JOIN ... USING (cols)` (joined table nullable)

**Fluent statement + QueryBuilder**

`naturalJoin`, `naturalLeftJoin`, `innerJoin(_:using:)`, `leftJoin(_:using:)` on both surfaces.

```swift
sql { schema in
    let passport = schema.table(PassportTable.self)
    let citizen = schema.table(CitizenTable.self)
    Select(PassportCitizenRow.columns(name: citizen.fullName, country: passport.country))
    From(passport)
    Join.Inner(citizen, using: "id")   // FROM Passport AS t0 INNER JOIN Citizen AS t1 USING (`id`)
}
```

## Testing

New `NaturalUsingJoinTests`:
- Render assertions for the expression-builder and fluent forms (`NATURAL JOIN`, `INNER JOIN ... USING (id)`).
- Real-SQLite execution tests proving NATURAL and USING joins match on the shared column and return the expected coalesced rows.

`swift build` clean (no warnings); full `swift test` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)