### PR TITLE
Refresh public documentation for v1.4 (#227)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -68,7 +68,7 @@ support-status totals are exact and mutually exclusive:
 
 Of those 144 evidence records, 91 exercise real SQLite and
 cite one captured environment, SQLite 3.51.0. An inventory entry is counted in
-the 97 supported features only when it links to successful preparation by a
+the 98 supported features only when it links to successful preparation by a
 real SQLite engine whose version and source ID are recorded. Partial,
 capability-gated, intentionally unsupported, and unimplemented entries remain
 visible with their evidence, requirements, or rationale, but are excluded

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ their SQL meaning.
   `@SQLTable` and `@SQLResult` derive typed table, column, and result metadata
   at compile time. There are no generated model files to keep in sync.
 - **[Expressions](https://lukevanin.github.io/swiftql/documentation/swiftql/expressions/).**
-  Compose boolean, numeric, text, optional, conditional, and aggregate
-  expressions with Swift operators and generic constraints.
+  Compose boolean, numeric, text, date/time, optional, conditional, and
+  aggregate expressions with Swift operators and generic constraints.
 - **[Queries](https://lukevanin.github.io/swiftql/documentation/swiftql/queries/).**
   Build selects with inner, left, and cross joins; grouping and `HAVING`;
   ordering and pagination; scalar and table subqueries; compound queries; and
@@ -185,8 +185,8 @@ For project guarantees and direction:
   toolchains and reproducible CI matrix.
 - [SQLite conformance](COMPATIBILITY.md#sqlite-conformance-inventory) records
   the evidence boundary for SwiftQL's currently supported public subset.
-- [Changelog](CHANGELOG.md) records released behavior and the unreleased v1.3
-  evidence milestone.
+- [Changelog](CHANGELOG.md) records the released behavior of each SwiftQL
+  version.
 - [Performance benchmarks](BENCHMARKS.md) measure query construction,
   preparation, caching, binding, execution, and decoding.
 - [First-party source coverage](Coverage/README.md) preserves the reproducible

--- a/Sources/SwiftQL/SwiftQL.docc/BuiltinFunctions.md
+++ b/Sources/SwiftQL/SwiftQL.docc/BuiltinFunctions.md
@@ -132,6 +132,11 @@ let rows = try database.makeRequest(with: statement).fetchAll()
 Converts a string representation of a date to an integer representing the number
 of seconds since the unix epoch.
 
+For the full date-and-time surface — the `date`, `time`, `datetime`,
+`julianDay`, `unixEpoch`, and `strftime` constructors, ordered `XLDateModifier`
+values, and the integer component accessors such as `year()` and `month()` — see
+the date-and-time functions section of <doc:Expressions>.
+
 ## Numeric functions
 
 ### abs()


### PR DESCRIPTION
Closes #227.

## Summary

v1.4 housekeeping: reconcile the public documentation with the API and behavior shipped by v1.4, where the conformance inventory and release history had drifted from the prose. The docs are otherwise kept current by the doc‑test contract (`SQLDocumentationCatalogTests`, `XLDocumentationTests`), so this is a focused reconciliation rather than a rewrite — the v1.4 feature additions (date/time functions, `REGEXP`, `IN`/`NOT IN`, `BETWEEN`, custom collations, `CAST`) are already documented in the DocC catalog.

## Changes

- **`COMPATIBILITY.md`** — correct the stale "97 supported features" prose to **98**, matching the support‑status table directly above it and the canonical [inventory](https://github.com/lukevanin/swiftql/blob/main/Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json). The supported count grew from 97→98 when `syntax.expression.date-functions` moved from partial to supported in v1.4.3; this line was left behind.
- **`README.md`** — drop the stale "unreleased v1.3 evidence milestone" framing (v1.3.0 shipped 2026‑07‑20) so the changelog pointer describes the released behavior of each version. Add `date/time` to the first‑class expression list, reflecting the v1.4.3 date‑and‑time functions.
- **`Sources/SwiftQL/SwiftQL.docc/BuiltinFunctions.md`** — the "Date functions" section only listed the legacy `toUnixTimestamp()`. Cross‑reference the v1.4.3 `date`/`time`/`datetime`/`julianDay`/`unixEpoch`/`strftime` constructors, ordered `XLDateModifier` values, and integer component accessors documented in `<doc:Expressions>`, so the headline v1.4.3 surface is discoverable from the functions page.

`INSERT OR` conflict resolution is intentionally **not** documented here: it is in the CHANGELOG under `[1.4.4]` but not yet tagged/published, and the docs' pinned contract is "1.4.3 is the latest published package." The v1.4 readiness audit (#229) will confirm complete coverage.

## Validation

```bash
swift test --filter "SQLDocumentationCatalogTests|XLDocumentationTests"   # 40 tests, 0 failures
./make-docs.sh docs                                                       # DocC builds clean; new cross-link resolves
```

- Required‑phrase, README‑link, file‑header, and README‑example contracts stay green.
- No test‑pinned phrase or version pin (`1.4.3 is the latest published package`) is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)