### PR TITLE
Reconcile the agent SKILL.md description with the v1.4 surface (#228)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swiftql
-description: Use when Codex works in a Swift package or Apple application that uses SwiftQL to define typed tables or results, build or modify SQLite queries, pass immutable bindings, add contextual codecs, prepare reusable static queries, integrate a database adapter, or diagnose SwiftQL execution boundaries. Use the checked-out public v1 contract; 1.4.3 is the latest published package and adds typed SQLite date-and-time functions on the retained v1 surface. Do not use this skill to teach SQL generally or claim unshipped features.
+description: Use when Codex works in a Swift package or Apple application that uses SwiftQL to define typed tables or results, build or modify SQLite queries, pass immutable bindings, add contextual codecs, prepare reusable static queries, integrate a database adapter, or diagnose SwiftQL execution boundaries. Use the checked-out public v1 contract; 1.4.3 is the latest published package, and the v1.4 line broadened the retained v1 surface with typed SQLite date-and-time functions and additional common-SQLite operators. Do not use this skill to teach SQL generally or claim unshipped features.
 ---
 
 # SwiftQL

--- a/Tests/SQLTests/SQLSkillDocumentationTests.swift
+++ b/Tests/SQLTests/SQLSkillDocumentationTests.swift
@@ -51,7 +51,7 @@ final class SQLSkillDocumentationTests: XCTestCase {
             "SwiftQL exposes no general raw-fragment API",
             "`XLRequest` across tasks; it is not `Sendable`",
             "checked-out public v1 contract",
-            "1.4.3 is the latest published package and adds typed SQLite date-and-time functions on the retained v1 surface",
+            "1.4.3 is the latest published package, and the v1.4 line broadened the retained v1 surface with typed SQLite date-and-time functions and additional common-SQLite operators",
             "`1.4.3` is the latest published package",
             "Keep those five statuses distinct",
             "recorded SQLite version, source ID, compile options, capabilities",


### PR DESCRIPTION
Closes #228.

## Summary

v1.4 housekeeping for the agent skill. `SKILL.md` is kept current and test‑green by the `SQLSkillDocumentationTests` contract, and it sits at its enforced 220‑line cap (219 lines), so this is a **net‑neutral reconciliation**, not an expansion.

The one genuine drift: the agent‑facing frontmatter `description` named only the v1.4.3 date‑and‑time functions, under‑representing what the v1.4 line added to the retained v1 surface (the v1.4.1/v1.4.2 comparison, membership, range, and pattern operators — `IN`/`NOT IN`, `BETWEEN`, `LIKE ESCAPE`, `REGEXP`/`GLOB`, custom collations, expanded aggregates, `CAST`). Broadened the description to characterize the full v1.4 common‑SQLite surface, with the enforcing documentation‑contract phrase in `SQLSkillDocumentationTests` updated in lockstep.

Everything else is deliberately unchanged: the stable v1.x contract labels (kept consistent with `COMPATIBILITY.md`), the single compiled example, the validation command block, and every other enforced phrase.

## Validation

```bash
swift test --filter SQLSkillDocumentationTests                 # 4 tests, 0 failures
scripts/ci/check-downstream-swift5-client.sh committed          # SWIFTQL_DOWNSTREAM_SWIFT5_CLIENT ok
```

The skill's example still compiles and runs in the maintained Swift 5 consumer fixture; the skill stays at 219 lines (under the 220 cap).

## Note for the readiness audit (#229)

The skill body is at its line cap, so it still defers the expression/function catalogue to DocC without linking the expressions guide directly. That's a candidate atomic follow‑up (add an expressions‑guide link, offset by trimming) for the #229 audit to weigh rather than forcing a lossy swap here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)