### PR TITLE
Spike #369 PoC: direct-result @SQLQuery signatures + @SQLQueries container encoding

### DIFF
--- a/Sources/SQLMacros/SQLMacro.swift
+++ b/Sources/SQLMacros/SQLMacro.swift
@@ -155,5 +155,6 @@ extension SQLResultMacro: ExtensionMacro {
     let providingMacros: [Macro.Type] = [
         SQLTableMacro.self,
         SQLResultMacro.self,
+        SQLQueryMacro.self,
     ]
 }

--- a/Sources/SQLMacros/SQLMacro.swift
+++ b/Sources/SQLMacros/SQLMacro.swift
@@ -156,5 +156,6 @@ extension SQLResultMacro: ExtensionMacro {
         SQLTableMacro.self,
         SQLResultMacro.self,
         SQLQueryMacro.self,
+        SQLQueriesMacro.self,
     ]
 }

--- a/Sources/SQLMacros/SQLQueriesMacro.swift
+++ b/Sources/SQLMacros/SQLQueriesMacro.swift
@@ -59,6 +59,12 @@ extension SQLQueriesMacro: MemberMacro {
         }
         let databaseType = extensionDecl.extendedType.trimmedDescription
 
+        // Propagate the extension's modifiers (access level) to every
+        // generated member, so a `public extension` exposes the executors to
+        // outside-module callers.
+        let extensionModifiers = extensionDecl.modifiers.trimmedDescription
+        let modifierPrefix = extensionModifiers.isEmpty ? "" : extensionModifiers + " "
+
         var builders: [SQLQueryBuilder] = []
         var diagnostics: [Diagnostic] = []
         var foundContainer = false
@@ -73,7 +79,11 @@ extension SQLQueriesMacro: MemberMacro {
                     continue
                 }
                 do {
-                    builders.append(try SQLQueryBuilder(node: node, declaration: function))
+                    builders.append(try SQLQueryBuilder(
+                        node: node,
+                        declaration: function,
+                        macroName: "@SQLQueries"
+                    ))
                 }
                 catch let error as DiagnosticsError {
                     diagnostics.append(contentsOf: error.diagnostics)
@@ -95,10 +105,14 @@ extension SQLQueriesMacro: MemberMacro {
         }
 
         var members: [String] = []
-        members.append(makeContextStruct(databaseType: databaseType, builders: builders))
-        members.append(makeExecuteFunction())
+        members.append(makeContextStruct(
+            databaseType: databaseType,
+            builders: builders,
+            modifierPrefix: modifierPrefix
+        ))
+        members.append(makeExecuteFunction(modifierPrefix: modifierPrefix))
         for builder in builders {
-            members.append(builder.makeDatabaseExecutorFunction())
+            members.append(builder.makeDatabaseExecutorFunction(modifierPrefix: modifierPrefix))
         }
         return members.map { DeclSyntax(stringLiteral: $0) }
     }
@@ -109,14 +123,15 @@ extension SQLQueriesMacro: MemberMacro {
     ///
     private static func makeContextStruct(
         databaseType: String,
-        builders: [SQLQueryBuilder]
+        builders: [SQLQueryBuilder],
+        modifierPrefix: String
     ) -> String {
         var lines: [String] = []
-        lines.append("struct Context {")
+        lines.append("\(modifierPrefix)struct Context {")
         lines.append("    let database: \(databaseType)")
         for builder in builders {
             lines.append("")
-            lines.append(indent(builder.makeContextExecutorFunction(), by: 4))
+            lines.append(indent(builder.makeContextExecutorFunction(modifierPrefix: modifierPrefix), by: 4))
         }
         lines.append("}")
         return lines.joined(separator: "\n")
@@ -127,9 +142,9 @@ extension SQLQueriesMacro: MemberMacro {
     /// straight to the database; connection checkout and transaction scoping
     /// are runtime design outside this macro spike.
     ///
-    private static func makeExecuteFunction() -> String {
+    private static func makeExecuteFunction(modifierPrefix: String) -> String {
         var lines: [String] = []
-        lines.append("func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {")
+        lines.append("\(modifierPrefix)func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {")
         lines.append("    try __xlWork(Context(database: self))")
         lines.append("}")
         return lines.joined(separator: "\n")
@@ -156,13 +171,13 @@ extension SQLQueryBuilder {
     /// The value-free statement is built inline from the rewritten body, so
     /// the specification's placeholder SQL invariant carries over unchanged.
     ///
-    func makeContextExecutorFunction() -> String {
+    func makeContextExecutorFunction(modifierPrefix: String) -> String {
         let parameterClause = function.signature.parameterClause.trimmedDescription
         // The rewritten body is a code block; applying it as a closure yields
         // the value-free statement without a separate builder symbol.
         let statementExpression = indentSkippingFirstLine(rewrittenBodyText, by: 4)
         var lines: [String] = []
-        lines.append("func \(function.name.text)\(parameterClause) throws -> \(executorResultType) {")
+        lines.append("\(modifierPrefix)func \(function.name.text)\(parameterClause) throws -> \(executorResultType) {")
         lines.append("    let __xlStatement: any XLQueryStatement<\(rowType)> = \(statementExpression)()")
         lines.append("    let __xlRequest = database.makeRequest(with: __xlStatement)")
         lines.append("    let __xlLayout = __xlRequest.parameterLayout")
@@ -189,7 +204,7 @@ extension SQLQueryBuilder {
     /// `execute`, so the implicit one-shot form is transparently the explicit
     /// context form.
     ///
-    func makeDatabaseExecutorFunction() -> String {
+    func makeDatabaseExecutorFunction(modifierPrefix: String) -> String {
         let parameterClause = function.signature.parameterClause.trimmedDescription
         var arguments: [String] = []
         for parameter in function.signature.parameterClause.parameters {
@@ -203,7 +218,7 @@ extension SQLQueryBuilder {
         }
         let argumentList = arguments.joined(separator: ", ")
         var lines: [String] = []
-        lines.append("func \(function.name.text)\(parameterClause) throws -> \(executorResultType) {")
+        lines.append("\(modifierPrefix)func \(function.name.text)\(parameterClause) throws -> \(executorResultType) {")
         lines.append("    try execute { __xlContext in")
         lines.append("        try __xlContext.\(function.name.text)(\(argumentList))")
         lines.append("    }")

--- a/Sources/SQLMacros/SQLQueriesMacro.swift
+++ b/Sources/SQLMacros/SQLQueriesMacro.swift
@@ -1,0 +1,231 @@
+//
+//  SQLQueriesMacro.swift
+//  SwiftQL
+//
+//  Spike (#369, container encoding): attached member macro that reads query
+//  specifications from a nested `Query` container inside a database extension
+//  and generates the executors as members of the database itself.
+//
+
+import Foundation
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+
+///
+/// Generates executors for the query specifications declared in a nested
+/// `Query` container.
+///
+/// A per-function peer macro cannot produce this shape: peers land in the same
+/// scope as the attached function (so a same-name executor is an invalid
+/// redeclaration) and independent expansions cannot cooperate on one shared
+/// `Context` type. A member macro attached to the *extension* sees every
+/// specification in one expansion, so the executors can carry the
+/// specification's own name in a different scope.
+///
+/// Generated members (names provisional per #26):
+///   * `struct Context` — connection-scoped executors; one per specification.
+///   * `execute(_:)` — runs a closure against a context. The spike stub wraps
+///     the database directly; pooling/transaction scoping is runtime design.
+///   * One database-level convenience executor per specification, defined as
+///     sugar over `execute`, so the implicit form is transparently the
+///     explicit one.
+///
+/// The `Query` container itself is never referenced by the generated code —
+/// it is a pure specification namespace, so the user may declare it `private`
+/// or `fileprivate` to remove the trapping spec functions from the visible
+/// API surface.
+///
+public struct SQLQueriesMacro {
+}
+
+extension SQLQueriesMacro: MemberMacro {
+
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let extensionDecl = declaration.as(ExtensionDeclSyntax.self) else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(
+                    node: node,
+                    id: "sqlqueries-extension-only",
+                    message: "'@SQLQueries' can only be applied to an extension of a database type. The generated executors prepare requests through the extended type's 'makeRequest(with:)'."
+                )
+            ])
+        }
+        let databaseType = extensionDecl.extendedType.trimmedDescription
+
+        var builders: [SQLQueryBuilder] = []
+        var diagnostics: [Diagnostic] = []
+        var foundContainer = false
+        for member in extensionDecl.memberBlock.members {
+            guard let container = member.decl.as(StructDeclSyntax.self),
+                  container.name.text == "Query" else {
+                continue
+            }
+            foundContainer = true
+            for containerMember in container.memberBlock.members {
+                guard let function = containerMember.decl.as(FunctionDeclSyntax.self) else {
+                    continue
+                }
+                do {
+                    builders.append(try SQLQueryBuilder(node: node, declaration: function))
+                }
+                catch let error as DiagnosticsError {
+                    diagnostics.append(contentsOf: error.diagnostics)
+                }
+            }
+        }
+
+        guard foundContainer else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(
+                    node: node,
+                    id: "sqlqueries-container-required",
+                    message: "'@SQLQueries' requires a nested 'struct Query' container declaring the query specifications."
+                )
+            ])
+        }
+        guard diagnostics.isEmpty else {
+            throw DiagnosticsError(diagnostics: diagnostics)
+        }
+
+        var members: [String] = []
+        members.append(makeContextStruct(databaseType: databaseType, builders: builders))
+        members.append(makeExecuteFunction())
+        for builder in builders {
+            members.append(builder.makeDatabaseExecutorFunction())
+        }
+        return members.map { DeclSyntax(stringLiteral: $0) }
+    }
+
+    ///
+    /// Generates the `Context` container holding one connection-scoped
+    /// executor per specification.
+    ///
+    private static func makeContextStruct(
+        databaseType: String,
+        builders: [SQLQueryBuilder]
+    ) -> String {
+        var lines: [String] = []
+        lines.append("struct Context {")
+        lines.append("    let database: \(databaseType)")
+        for builder in builders {
+            lines.append("")
+            lines.append(indent(builder.makeContextExecutorFunction(), by: 4))
+        }
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Generates the `execute` entry point. The spike stub binds the context
+    /// straight to the database; connection checkout and transaction scoping
+    /// are runtime design outside this macro spike.
+    ///
+    private static func makeExecuteFunction() -> String {
+        var lines: [String] = []
+        lines.append("func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {")
+        lines.append("    try __xlWork(Context(database: self))")
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+}
+
+
+///
+/// Indents every line of a multi-line declaration by the given column count.
+///
+internal func indent(_ text: String, by spaces: Int) -> String {
+    let padding = String(repeating: " ", count: spaces)
+    return text
+        .components(separatedBy: "\n")
+        .map { $0.isEmpty ? $0 : padding + $0 }
+        .joined(separator: "\n")
+}
+
+
+extension SQLQueryBuilder {
+
+    ///
+    /// Generates the connection-scoped executor for the `Context` container.
+    /// The value-free statement is built inline from the rewritten body, so
+    /// the specification's placeholder SQL invariant carries over unchanged.
+    ///
+    func makeContextExecutorFunction() -> String {
+        let parameterClause = function.signature.parameterClause.trimmedDescription
+        // The rewritten body is a code block; applying it as a closure yields
+        // the value-free statement without a separate builder symbol.
+        let statementExpression = indentSkippingFirstLine(rewrittenBodyText, by: 4)
+        var lines: [String] = []
+        lines.append("func \(function.name.text)\(parameterClause) throws -> \(executorResultType) {")
+        lines.append("    let __xlStatement: any XLQueryStatement<\(rowType)> = \(statementExpression)()")
+        lines.append("    let __xlRequest = database.makeRequest(with: __xlStatement)")
+        lines.append("    let __xlLayout = __xlRequest.parameterLayout")
+        if parameters.isEmpty {
+            lines.append("    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()")
+        }
+        else {
+            lines.append("    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(")
+            lines.append("        layout: __xlLayout,")
+            lines.append("        bindings: [")
+            for parameter in parameters {
+                lines.append("            try _xlQueryParameterBinding(\(parameter.swiftName), named: \"\(parameter.placeholderName)\", in: __xlLayout),")
+            }
+            lines.append("        ]")
+            lines.append("    ).validatingComplete()")
+        }
+        lines.append("    return try __xlRequest.\(fetchCallName)(bindings: __xlPacket)")
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Generates the database-level convenience executor: sugar over
+    /// `execute`, so the implicit one-shot form is transparently the explicit
+    /// context form.
+    ///
+    func makeDatabaseExecutorFunction() -> String {
+        let parameterClause = function.signature.parameterClause.trimmedDescription
+        var arguments: [String] = []
+        for parameter in function.signature.parameterClause.parameters {
+            let value = (parameter.secondName ?? parameter.firstName).text
+            if parameter.firstName.tokenKind == .wildcard {
+                arguments.append(value)
+            }
+            else {
+                arguments.append("\(parameter.firstName.text): \(value)")
+            }
+        }
+        let argumentList = arguments.joined(separator: ", ")
+        var lines: [String] = []
+        lines.append("func \(function.name.text)\(parameterClause) throws -> \(executorResultType) {")
+        lines.append("    try execute { __xlContext in")
+        lines.append("        try __xlContext.\(function.name.text)(\(argumentList))")
+        lines.append("    }")
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Indents every line except the first — used when a multi-line block is
+    /// embedded after an assignment on an already-indented line.
+    ///
+    private func indentSkippingFirstLine(_ text: String, by spaces: Int) -> String {
+        var lines = text.components(separatedBy: "\n")
+        guard lines.count > 1 else {
+            return text
+        }
+        let padding = String(repeating: " ", count: spaces)
+        for index in 1 ..< lines.count {
+            if !lines[index].isEmpty {
+                lines[index] = padding + lines[index]
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -161,6 +161,14 @@ internal struct SQLQueryBuilder {
         shadowingVisitor.walk(body)
         diagnostics.append(contentsOf: shadowingVisitor.diagnostics)
 
+        if shadowingVisitor.diagnostics.isEmpty {
+            // A shadowed name makes lexical parameter analysis unreliable, so
+            // member-access checking waits until the shadowing is resolved.
+            let memberAccessVisitor = SQLQueryParameterMemberAccessVisitor(parameters: parameters)
+            memberAccessVisitor.walk(body)
+            diagnostics.append(contentsOf: memberAccessVisitor.diagnostics)
+        }
+
         guard diagnostics.isEmpty else {
             throw DiagnosticsError(diagnostics: diagnostics)
         }
@@ -289,7 +297,7 @@ internal struct SQLQueryBuilder {
                 Diagnostic(
                     node: Syntax(function.signature.returnClause?.type) ?? Syntax(function.signature),
                     id: "sqlquery-return-type",
-                    message: "'@SQLQuery' requires the function to return 'any XLQueryStatement<Row>' with an explicit row type. The row type declares the executor's result element."
+                    message: "'@SQLQuery' requires the function to return 'any XLQueryStatement<Row>' or 'some XLQueryStatement<Row>' with an explicit row type. The row type declares the executor's result element."
                 )
             )
             return ""
@@ -448,5 +456,44 @@ internal final class SQLQueryShadowingVisitor: SyntaxVisitor {
                 message: "'\(identifier)' shadows a query parameter inside the '@SQLQuery' body. The macro rewrites every reference to '\(identifier)' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration."
             )
         )
+    }
+}
+
+
+///
+/// Rejects member access whose base is a query parameter.
+///
+/// A parameter reference must be rewriteable to a named binding as a whole
+/// expression. An access such as `name.lowercased()` transforms the value in
+/// Swift, which no placeholder can represent, so the generated peer would fail
+/// to type-check.
+///
+internal final class SQLQueryParameterMemberAccessVisitor: SyntaxVisitor {
+
+    private let parameterNames: Set<String>
+
+    private(set) var diagnostics: [Diagnostic] = []
+
+    init(parameters: [SQLQueryParameter]) {
+        self.parameterNames = Set(parameters.map(\.placeholderName))
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+        guard let base = node.base?.as(DeclReferenceExprSyntax.self) else {
+            return .visitChildren
+        }
+        let identifier = normalizedIdentifier(base.baseName.text)
+        guard parameterNames.contains(identifier) else {
+            return .visitChildren
+        }
+        diagnostics.append(
+            Diagnostic(
+                node: base,
+                id: "sqlquery-parameter-member-access",
+                message: "'\(identifier)' cannot be used through member access in a '@SQLQuery' body. A parameter reference is rewritten to a named binding as a whole expression; compute the derived value before building the statement, or pass it as a separate parameter."
+            )
+        )
+        return .visitChildren
     }
 }

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -351,7 +351,7 @@ internal struct SQLQueryBuilder {
             lines.append("        layout: __xlLayout,")
             lines.append("        bindings: [")
             for parameter in parameters {
-                lines.append("            _xlQueryParameterBinding(\(parameter.swiftName), named: \"\(parameter.placeholderName)\", in: __xlLayout),")
+                lines.append("            try _xlQueryParameterBinding(\(parameter.swiftName), named: \"\(parameter.placeholderName)\", in: __xlLayout),")
             }
             lines.append("        ]")
             lines.append("    ).validatingComplete()")

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -1,0 +1,360 @@
+//
+//  SQLQueryMacro.swift
+//  SwiftQL
+//
+//  Spike (#359): attached peer macro that rewrites a statement-returning
+//  function into a value-free statement builder plus a `fetchAll` executor.
+//
+
+import Foundation
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+
+///
+/// Declares a statement-returning function as a reusable prepared query.
+///
+/// The attached function builds a `SELECT` statement from its parameters. The
+/// macro generates two peers: a value-free statement builder in which every
+/// parameter reference is replaced by a typed `XLNamedBindingReference`, and an
+/// executor that renders the statement once per call through the enclosing
+/// database's `makeRequest(with:)`, binds the parameter values into an
+/// immutable invocation packet, and returns the `fetchAll` rows.
+///
+public struct SQLQueryMacro {
+}
+
+extension SQLQueryMacro: PeerMacro {
+
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        let builder = try SQLQueryBuilder(node: node, declaration: declaration)
+        return [
+            DeclSyntax(stringLiteral: builder.makeStatementFunction()),
+            DeclSyntax(stringLiteral: builder.makeExecutorFunction()),
+        ]
+    }
+}
+
+
+///
+/// One named function parameter that participates in the signature-driven body
+/// rewrite.
+///
+internal struct SQLQueryParameter {
+
+    /// The internal parameter name. Doubles as the SQL placeholder name.
+    var name: String
+
+    /// The type annotation exactly as written in the signature.
+    var type: String
+
+    /// The typed named-binding reference that replaces every reference to the
+    /// parameter inside the statement body.
+    var bindingReference: String {
+        "XLNamedBindingReference<\(type)>(name: \"\(name)\")"
+    }
+}
+
+
+///
+/// Parses the attached function and generates the statement-builder and
+/// executor peers for the `@SQLQuery` macro.
+///
+internal struct SQLQueryBuilder {
+
+    private let function: FunctionDeclSyntax
+
+    private let parameters: [SQLQueryParameter]
+
+    private let rowType: String
+
+    private let rewrittenBodyText: String
+
+    init(node: AttributeSyntax, declaration: some DeclSyntaxProtocol) throws {
+        guard let function = declaration.as(FunctionDeclSyntax.self) else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(
+                    node: node,
+                    id: "sqlquery-function-only",
+                    message: "'@SQLQuery' can only be applied to a function."
+                )
+            ])
+        }
+        self.function = function
+
+        var diagnostics: [Diagnostic] = []
+
+        if let genericParameterClause = function.genericParameterClause {
+            diagnostics.append(
+                Diagnostic(
+                    node: genericParameterClause,
+                    id: "sqlquery-generic-function",
+                    message: "'@SQLQuery' cannot be applied to a generic function. The generated statement builder takes no arguments, so generic parameters cannot be inferred."
+                )
+            )
+        }
+
+        if let effectSpecifiers = function.signature.effectSpecifiers {
+            diagnostics.append(
+                Diagnostic(
+                    node: effectSpecifiers,
+                    id: "sqlquery-effect-specifiers",
+                    message: "'@SQLQuery' requires a nonthrowing, synchronous function. Statement builders only construct a value-free statement."
+                )
+            )
+        }
+
+        self.parameters = Self.makeParameters(
+            of: function,
+            diagnostics: &diagnostics
+        )
+        self.rowType = Self.makeRowType(of: function, diagnostics: &diagnostics)
+
+        guard let body = function.body else {
+            diagnostics.append(
+                Diagnostic(
+                    node: Syntax(function.signature),
+                    id: "sqlquery-body-required",
+                    message: "'@SQLQuery' requires a function body that returns the query statement."
+                )
+            )
+            throw DiagnosticsError(diagnostics: diagnostics)
+        }
+
+        guard diagnostics.isEmpty else {
+            throw DiagnosticsError(diagnostics: diagnostics)
+        }
+
+        let rewriter = SQLQueryParameterRewriter(parameters: parameters)
+        self.rewrittenBodyText = Self.makeBodyText(rewriter.visit(body))
+    }
+
+    ///
+    /// Removes the source-column indentation from the rewritten body so the
+    /// generated peer is independent of how deeply the attached function is
+    /// nested. The closing brace's column measures the indentation to strip.
+    ///
+    private static func makeBodyText(_ body: CodeBlockSyntax) -> String {
+        let text = body.trimmedDescription
+        var lines = text.components(separatedBy: "\n")
+        guard lines.count > 1, let closingLine = lines.last else {
+            return text
+        }
+        let indentation = closingLine.prefix { $0 == " " }.count
+        guard indentation > 0 else {
+            return text
+        }
+        for index in 1 ..< lines.count {
+            var line = lines[index]
+            var removed = 0
+            while removed < indentation, line.first == " " {
+                line.removeFirst()
+                removed += 1
+            }
+            lines[index] = line
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Classifies the function parameters, reporting shapes that cannot be
+    /// rewritten to a named binding.
+    ///
+    private static func makeParameters(
+        of function: FunctionDeclSyntax,
+        diagnostics: inout [Diagnostic]
+    ) -> [SQLQueryParameter] {
+        var parameters: [SQLQueryParameter] = []
+        for parameter in function.signature.parameterClause.parameters {
+            if let ellipsis = parameter.ellipsis {
+                diagnostics.append(
+                    Diagnostic(
+                        node: ellipsis,
+                        id: "sqlquery-variadic-parameter",
+                        message: "'@SQLQuery' cannot bind a variadic parameter to a single named placeholder."
+                    )
+                )
+                continue
+            }
+            if let attributedType = parameter.type.as(AttributedTypeSyntax.self),
+               let specifier = attributedType.specifier {
+                diagnostics.append(
+                    Diagnostic(
+                        node: attributedType,
+                        id: "sqlquery-parameter-specifier",
+                        message: "'@SQLQuery' cannot bind a '\(specifier.text)' parameter to a named placeholder."
+                    )
+                )
+                continue
+            }
+            let name = parameter.secondName ?? parameter.firstName
+            guard name.tokenKind != .wildcard else {
+                diagnostics.append(
+                    Diagnostic(
+                        node: name,
+                        id: "sqlquery-unnamed-parameter",
+                        message: "'@SQLQuery' requires every parameter to have a name. The name identifies the SQL placeholder."
+                    )
+                )
+                continue
+            }
+            parameters.append(
+                SQLQueryParameter(
+                    name: name.text,
+                    type: parameter.type.trimmedDescription
+                )
+            )
+        }
+        return parameters
+    }
+
+    ///
+    /// Extracts the row type from a `some XLQueryStatement<Row>` or
+    /// `any XLQueryStatement<Row>` return annotation.
+    ///
+    private static func makeRowType(
+        of function: FunctionDeclSyntax,
+        diagnostics: inout [Diagnostic]
+    ) -> String {
+        let returnType = function.signature.returnClause?.type.trimmed
+        var constraint = returnType
+        if let someOrAny = constraint?.as(SomeOrAnyTypeSyntax.self) {
+            constraint = someOrAny.constraint.trimmed
+        }
+
+        let name: TokenSyntax?
+        let genericArguments: GenericArgumentClauseSyntax?
+        if let identifierType = constraint?.as(IdentifierTypeSyntax.self) {
+            name = identifierType.name
+            genericArguments = identifierType.genericArgumentClause
+        }
+        else if let memberType = constraint?.as(MemberTypeSyntax.self) {
+            name = memberType.name
+            genericArguments = memberType.genericArgumentClause
+        }
+        else {
+            name = nil
+            genericArguments = nil
+        }
+
+        guard
+            let name,
+            name.text == "XLQueryStatement",
+            let arguments = genericArguments?.arguments,
+            arguments.count == 1,
+            let rowType = arguments.first?.argument.trimmedDescription
+        else {
+            diagnostics.append(
+                Diagnostic(
+                    node: Syntax(function.signature.returnClause?.type) ?? Syntax(function.signature),
+                    id: "sqlquery-return-type",
+                    message: "'@SQLQuery' requires the function to return 'any XLQueryStatement<Row>' with an explicit row type. The row type declares the executor's result element."
+                )
+            )
+            return ""
+        }
+        return rowType
+    }
+
+    private var modifierPrefix: String {
+        let modifiers = function.modifiers.trimmedDescription
+        if modifiers.isEmpty {
+            return ""
+        }
+        return modifiers + " "
+    }
+
+    private var statementFunctionName: String {
+        "\(function.name.text)Statement"
+    }
+
+    private var executorFunctionName: String {
+        "fetch\(function.name.text.prefix(1).uppercased())\(function.name.text.dropFirst())"
+    }
+
+    ///
+    /// Generates the value-free statement builder. The rewritten body renders
+    /// named placeholders instead of inline value literals, so the SQL text is
+    /// identical for every invocation.
+    ///
+    func makeStatementFunction() -> String {
+        let returnType = function.signature.returnClause?.type.trimmedDescription ?? ""
+        return "\(modifierPrefix)func \(statementFunctionName)() -> \(returnType) \(rewrittenBodyText)"
+    }
+
+    ///
+    /// Generates the executor peer. The executor prepares a request from the
+    /// value-free statement, encodes the parameter values into one immutable
+    /// invocation packet, and fetches all rows.
+    ///
+    func makeExecutorFunction() -> String {
+        let parameterClause = function.signature.parameterClause.trimmedDescription
+        var lines: [String] = []
+        lines.append("\(modifierPrefix)func \(executorFunctionName)\(parameterClause) throws -> [\(rowType)] {")
+        lines.append("    let __xlStatement = \(statementFunctionName)()")
+        lines.append("    let __xlRequest = self.makeRequest(with: __xlStatement)")
+        lines.append("    let __xlLayout = __xlRequest.parameterLayout")
+        if parameters.isEmpty {
+            lines.append("    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()")
+        }
+        else {
+            lines.append("    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(")
+            lines.append("        layout: __xlLayout,")
+            lines.append("        bindings: [")
+            for parameter in parameters {
+                lines.append("            _xlQueryParameterBinding(\(parameter.name), named: \"\(parameter.name)\", in: __xlLayout),")
+            }
+            lines.append("        ]")
+            lines.append("    ).validatingComplete()")
+        }
+        lines.append("    return try __xlRequest.fetchAll(bindings: __xlPacket)")
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+}
+
+
+///
+/// Replaces every expression reference to a function parameter with the
+/// parameter's typed named-binding reference.
+///
+/// Member names are never rewritten: `person.name` keeps its member `name`
+/// while a parameter also called `name` is still rewritten wherever it appears
+/// as the base of a member access or as a standalone reference.
+///
+internal final class SQLQueryParameterRewriter: SyntaxRewriter {
+
+    private let replacements: [String: String]
+
+    init(parameters: [SQLQueryParameter]) {
+        var replacements: [String: String] = [:]
+        for parameter in parameters {
+            replacements[parameter.name] = parameter.bindingReference
+        }
+        self.replacements = replacements
+        super.init()
+    }
+
+    override func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
+        guard let replacement = replacements[node.baseName.text] else {
+            return ExprSyntax(node)
+        }
+        var expression = ExprSyntax("\(raw: replacement)")
+        expression.leadingTrivia = node.leadingTrivia
+        expression.trailingTrivia = node.trailingTrivia
+        return expression
+    }
+
+    override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
+        guard let base = node.base else {
+            return ExprSyntax(node)
+        }
+        return ExprSyntax(node.with(\.base, visit(base)))
+    }
+}

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -48,8 +48,13 @@ extension SQLQueryMacro: PeerMacro {
 ///
 internal struct SQLQueryParameter {
 
-    /// The internal parameter name. Doubles as the SQL placeholder name.
-    var name: String
+    /// The internal parameter name exactly as written, including any escaping
+    /// backticks. Used where generated code passes the parameter value.
+    var swiftName: String
+
+    /// The internal parameter name without escaping backticks. Doubles as the
+    /// SQL placeholder name and as the rewrite-matching key.
+    var placeholderName: String
 
     /// The type annotation exactly as written in the signature.
     var type: String
@@ -57,8 +62,20 @@ internal struct SQLQueryParameter {
     /// The typed named-binding reference that replaces every reference to the
     /// parameter inside the statement body.
     var bindingReference: String {
-        "XLNamedBindingReference<\(type)>(name: \"\(name)\")"
+        "XLNamedBindingReference<\(type)>(name: \"\(placeholderName)\")"
     }
+}
+
+
+///
+/// Removes the escaping backticks from an identifier spelling, so escaped and
+/// unescaped references to the same declaration compare equal.
+///
+internal func normalizedIdentifier(_ text: String) -> String {
+    guard text.count >= 2, text.hasPrefix("`"), text.hasSuffix("`") else {
+        return text
+    }
+    return String(text.dropFirst().dropLast())
 }
 
 
@@ -89,6 +106,19 @@ internal struct SQLQueryBuilder {
         self.function = function
 
         var diagnostics: [Diagnostic] = []
+
+        if let typeLevelModifier = function.modifiers.first(where: { modifier in
+            modifier.name.tokenKind == .keyword(.static)
+                || modifier.name.tokenKind == .keyword(.class)
+        }) {
+            diagnostics.append(
+                Diagnostic(
+                    node: typeLevelModifier,
+                    id: "sqlquery-instance-method-only",
+                    message: "'@SQLQuery' can only be applied to an instance method. The generated executor prepares its request through 'self.makeRequest(with:)'."
+                )
+            )
+        }
 
         if let genericParameterClause = function.genericParameterClause {
             diagnostics.append(
@@ -126,6 +156,10 @@ internal struct SQLQueryBuilder {
             )
             throw DiagnosticsError(diagnostics: diagnostics)
         }
+
+        let shadowingVisitor = SQLQueryShadowingVisitor(parameters: parameters)
+        shadowingVisitor.walk(body)
+        diagnostics.append(contentsOf: shadowingVisitor.diagnostics)
 
         guard diagnostics.isEmpty else {
             throw DiagnosticsError(diagnostics: diagnostics)
@@ -206,7 +240,8 @@ internal struct SQLQueryBuilder {
             }
             parameters.append(
                 SQLQueryParameter(
-                    name: name.text,
+                    swiftName: name.text,
+                    placeholderName: normalizedIdentifier(name.text),
                     type: parameter.type.trimmedDescription
                 )
             )
@@ -308,7 +343,7 @@ internal struct SQLQueryBuilder {
             lines.append("        layout: __xlLayout,")
             lines.append("        bindings: [")
             for parameter in parameters {
-                lines.append("            _xlQueryParameterBinding(\(parameter.name), named: \"\(parameter.name)\", in: __xlLayout),")
+                lines.append("            _xlQueryParameterBinding(\(parameter.swiftName), named: \"\(parameter.placeholderName)\", in: __xlLayout),")
             }
             lines.append("        ]")
             lines.append("    ).validatingComplete()")
@@ -335,14 +370,14 @@ internal final class SQLQueryParameterRewriter: SyntaxRewriter {
     init(parameters: [SQLQueryParameter]) {
         var replacements: [String: String] = [:]
         for parameter in parameters {
-            replacements[parameter.name] = parameter.bindingReference
+            replacements[parameter.placeholderName] = parameter.bindingReference
         }
         self.replacements = replacements
         super.init()
     }
 
     override func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
-        guard let replacement = replacements[node.baseName.text] else {
+        guard let replacement = replacements[normalizedIdentifier(node.baseName.text)] else {
             return ExprSyntax(node)
         }
         var expression = ExprSyntax("\(raw: replacement)")
@@ -356,5 +391,62 @@ internal final class SQLQueryParameterRewriter: SyntaxRewriter {
             return ExprSyntax(node)
         }
         return ExprSyntax(node.with(\.base, visit(base)))
+    }
+}
+
+
+///
+/// Rejects declarations inside the attached body that shadow a query
+/// parameter.
+///
+/// The rewrite is lexical: every expression reference whose name matches a
+/// parameter becomes a named binding. A local binding, closure parameter, or
+/// nested function parameter with the same name would make those references
+/// mean something else, so the collision is reported instead of silently
+/// rewriting the shadowed uses.
+///
+internal final class SQLQueryShadowingVisitor: SyntaxVisitor {
+
+    private let parameterNames: Set<String>
+
+    private(set) var diagnostics: [Diagnostic] = []
+
+    init(parameters: [SQLQueryParameter]) {
+        self.parameterNames = Set(parameters.map(\.placeholderName))
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
+        check(node.identifier)
+        return .visitChildren
+    }
+
+    override func visit(_ node: ClosureShorthandParameterSyntax) -> SyntaxVisitorContinueKind {
+        check(node.name)
+        return .visitChildren
+    }
+
+    override func visit(_ node: ClosureParameterSyntax) -> SyntaxVisitorContinueKind {
+        check(node.secondName ?? node.firstName)
+        return .visitChildren
+    }
+
+    override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
+        check(node.secondName ?? node.firstName)
+        return .visitChildren
+    }
+
+    private func check(_ name: TokenSyntax) {
+        let identifier = normalizedIdentifier(name.text)
+        guard parameterNames.contains(identifier) else {
+            return
+        }
+        diagnostics.append(
+            Diagnostic(
+                node: name,
+                id: "sqlquery-shadowed-parameter",
+                message: "'\(identifier)' shadows a query parameter inside the '@SQLQuery' body. The macro rewrites every reference to '\(identifier)' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration."
+            )
+        )
     }
 }

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -80,6 +80,40 @@ internal func normalizedIdentifier(_ text: String) -> String {
 
 
 ///
+/// Result cardinality derived from the attached function's return type.
+///
+/// Spike (#369): with a direct-result signature the return annotation is the
+/// only source of cardinality. `[Row]` maps to `fetchAll`, `Row?` to
+/// `fetchOne`. The legacy `XLQueryStatement<Row>` spelling from #359 is treated
+/// as `.many` for source compatibility.
+///
+internal enum SQLQueryCardinality {
+    case many // [Row]  -> fetchAll
+    case one  // Row?   -> fetchOne
+}
+
+
+///
+/// The row element type, cardinality, and spelling style extracted from the
+/// return clause.
+///
+internal struct SQLQueryReturnShape {
+
+    /// The element type the executor decodes (e.g. `Person`).
+    var rowType: String
+
+    /// Whether the executor fetches all rows or an optional single row.
+    var cardinality: SQLQueryCardinality
+
+    /// `true` when the function declares its result directly (`[Row]` / `Row?`,
+    /// spike #369); `false` for the legacy `XLQueryStatement<Row>` spelling
+    /// (#359). In the direct-result case the statement-builder peer must swap
+    /// the trapping `sqlQuery` entry point for the real `sql` builder.
+    var isDirectResult: Bool
+}
+
+
+///
 /// Parses the attached function and generates the statement-builder and
 /// executor peers for the `@SQLQuery` macro.
 ///
@@ -89,7 +123,9 @@ internal struct SQLQueryBuilder {
 
     private let parameters: [SQLQueryParameter]
 
-    private let rowType: String
+    private let returnShape: SQLQueryReturnShape
+
+    private var rowType: String { returnShape.rowType }
 
     private let rewrittenBodyText: String
 
@@ -144,7 +180,7 @@ internal struct SQLQueryBuilder {
             of: function,
             diagnostics: &diagnostics
         )
-        self.rowType = Self.makeRowType(of: function, diagnostics: &diagnostics)
+        self.returnShape = Self.makeReturnShape(of: function, diagnostics: &diagnostics)
 
         guard let body = function.body else {
             diagnostics.append(
@@ -173,7 +209,17 @@ internal struct SQLQueryBuilder {
             throw DiagnosticsError(diagnostics: diagnostics)
         }
 
-        let rewriter = SQLQueryParameterRewriter(parameters: parameters)
+        // In the direct-result case the spec body calls the trapping `sqlResult`
+        // entry point (so the user's `-> [Row]` / `-> Row?` function type-checks
+        // without executing). The generated statement builder must call the real
+        // `sql` builder instead, so the rewriter renames that callee too.
+        // (`sqlResult` is provisional — `sqlQuery` is already the labeled-closure
+        // statement builder in SQLFunctionalSyntax.swift.)
+        let calleeRenames = returnShape.isDirectResult ? ["sqlResult": "sql"] : [:]
+        let rewriter = SQLQueryParameterRewriter(
+            parameters: parameters,
+            calleeRenames: calleeRenames
+        )
         self.rewrittenBodyText = Self.makeBodyText(rewriter.visit(body))
     }
 
@@ -258,51 +304,88 @@ internal struct SQLQueryBuilder {
     }
 
     ///
-    /// Extracts the row type from a `some XLQueryStatement<Row>` or
-    /// `any XLQueryStatement<Row>` return annotation.
+    /// Derives the row type and cardinality from the return annotation.
     ///
-    private static func makeRowType(
+    /// Three spellings are accepted:
+    ///   * `[Row]` (spike #369)                 → `.many`, direct result
+    ///   * `Row?` (spike #369)                  → `.one`, direct result
+    ///   * `any/some XLQueryStatement<Row>` (#359) → `.many`, legacy statement
+    ///
+    private static func makeReturnShape(
         of function: FunctionDeclSyntax,
         diagnostics: inout [Diagnostic]
-    ) -> String {
+    ) -> SQLQueryReturnShape {
         let returnType = function.signature.returnClause?.type.trimmed
+
+        // `[Row]` and `Array<Row>` -> fetchAll, direct result.
+        if let arrayType = returnType?.as(ArrayTypeSyntax.self) {
+            return SQLQueryReturnShape(
+                rowType: arrayType.element.trimmedDescription,
+                cardinality: .many,
+                isDirectResult: true
+            )
+        }
+        // `Row?` and `Optional<Row>` -> fetchOne, direct result.
+        if let optionalType = returnType?.as(OptionalTypeSyntax.self) {
+            return SQLQueryReturnShape(
+                rowType: optionalType.wrappedType.trimmedDescription,
+                cardinality: .one,
+                isDirectResult: true
+            )
+        }
+        if let (name, arguments) = genericConstraint(of: returnType),
+           name == "Array", let element = singleGenericArgument(arguments) {
+            return SQLQueryReturnShape(rowType: element, cardinality: .many, isDirectResult: true)
+        }
+        if let (name, arguments) = genericConstraint(of: returnType),
+           name == "Optional", let element = singleGenericArgument(arguments) {
+            return SQLQueryReturnShape(rowType: element, cardinality: .one, isDirectResult: true)
+        }
+
+        // Legacy #359 spelling: `any/some XLQueryStatement<Row>` -> fetchAll.
         var constraint = returnType
         if let someOrAny = constraint?.as(SomeOrAnyTypeSyntax.self) {
             constraint = someOrAny.constraint.trimmed
         }
-
-        let name: TokenSyntax?
-        let genericArguments: GenericArgumentClauseSyntax?
-        if let identifierType = constraint?.as(IdentifierTypeSyntax.self) {
-            name = identifierType.name
-            genericArguments = identifierType.genericArgumentClause
-        }
-        else if let memberType = constraint?.as(MemberTypeSyntax.self) {
-            name = memberType.name
-            genericArguments = memberType.genericArgumentClause
-        }
-        else {
-            name = nil
-            genericArguments = nil
+        if let (name, arguments) = genericConstraint(of: constraint),
+           name == "XLQueryStatement", let rowType = singleGenericArgument(arguments) {
+            return SQLQueryReturnShape(rowType: rowType, cardinality: .many, isDirectResult: false)
         }
 
-        guard
-            let name,
-            name.text == "XLQueryStatement",
-            let arguments = genericArguments?.arguments,
-            arguments.count == 1,
-            let rowType = arguments.first?.argument.trimmedDescription
-        else {
-            diagnostics.append(
-                Diagnostic(
-                    node: Syntax(function.signature.returnClause?.type) ?? Syntax(function.signature),
-                    id: "sqlquery-return-type",
-                    message: "'@SQLQuery' requires the function to return 'any XLQueryStatement<Row>' or 'some XLQueryStatement<Row>' with an explicit row type. The row type declares the executor's result element."
-                )
+        diagnostics.append(
+            Diagnostic(
+                node: Syntax(function.signature.returnClause?.type) ?? Syntax(function.signature),
+                id: "sqlquery-return-type",
+                message: "'@SQLQuery' requires the function to return '[Row]' (fetch all), 'Row?' (fetch one), or the legacy 'any/some XLQueryStatement<Row>', with an explicit row type. The row type declares the executor's result element and the shape selects the fetch."
             )
-            return ""
+        )
+        return SQLQueryReturnShape(rowType: "", cardinality: .many, isDirectResult: false)
+    }
+
+    ///
+    /// Splits a nominal type into its name token and generic argument clause,
+    /// handling both a bare identifier (`Array<Row>`) and a member type
+    /// (`Swift.Array<Row>`).
+    ///
+    private static func genericConstraint(
+        of type: TypeSyntax?
+    ) -> (name: String, arguments: GenericArgumentClauseSyntax?)? {
+        if let identifierType = type?.as(IdentifierTypeSyntax.self) {
+            return (identifierType.name.text, identifierType.genericArgumentClause)
         }
-        return rowType
+        if let memberType = type?.as(MemberTypeSyntax.self) {
+            return (memberType.name.text, memberType.genericArgumentClause)
+        }
+        return nil
+    }
+
+    private static func singleGenericArgument(
+        _ arguments: GenericArgumentClauseSyntax?
+    ) -> String? {
+        guard let arguments, arguments.arguments.count == 1 else {
+            return nil
+        }
+        return arguments.arguments.first?.argument.trimmedDescription
     }
 
     private var modifierPrefix: String {
@@ -327,7 +410,18 @@ internal struct SQLQueryBuilder {
     /// identical for every invocation.
     ///
     func makeStatementFunction() -> String {
-        let returnType = function.signature.returnClause?.type.trimmedDescription ?? ""
+        // The value-free statement is always an `XLQueryStatement<Row>`. In the
+        // legacy #359 spelling the function already declared exactly that, so the
+        // written return type is reused. In the direct-result case (#369) the
+        // function declared `[Row]` / `Row?`, so the statement builder's return
+        // type is synthesized from the extracted row type instead.
+        let returnType: String
+        if returnShape.isDirectResult {
+            returnType = "any XLQueryStatement<\(rowType)>"
+        }
+        else {
+            returnType = function.signature.returnClause?.type.trimmedDescription ?? ""
+        }
         return "\(modifierPrefix)func \(statementFunctionName)() -> \(returnType) \(rewrittenBodyText)"
     }
 
@@ -338,8 +432,18 @@ internal struct SQLQueryBuilder {
     ///
     func makeExecutorFunction() -> String {
         let parameterClause = function.signature.parameterClause.trimmedDescription
+        let resultType: String
+        let fetchCall: String
+        switch returnShape.cardinality {
+        case .many:
+            resultType = "[\(rowType)]"
+            fetchCall = "fetchAll"
+        case .one:
+            resultType = "\(rowType)?"
+            fetchCall = "fetchOne"
+        }
         var lines: [String] = []
-        lines.append("\(modifierPrefix)func \(executorFunctionName)\(parameterClause) throws -> [\(rowType)] {")
+        lines.append("\(modifierPrefix)func \(executorFunctionName)\(parameterClause) throws -> \(resultType) {")
         lines.append("    let __xlStatement = \(statementFunctionName)()")
         lines.append("    let __xlRequest = self.makeRequest(with: __xlStatement)")
         lines.append("    let __xlLayout = __xlRequest.parameterLayout")
@@ -356,7 +460,7 @@ internal struct SQLQueryBuilder {
             lines.append("        ]")
             lines.append("    ).validatingComplete()")
         }
-        lines.append("    return try __xlRequest.fetchAll(bindings: __xlPacket)")
+        lines.append("    return try __xlRequest.\(fetchCall)(bindings: __xlPacket)")
         lines.append("}")
         return lines.joined(separator: "\n")
     }
@@ -375,23 +479,36 @@ internal final class SQLQueryParameterRewriter: SyntaxRewriter {
 
     private let replacements: [String: String]
 
-    init(parameters: [SQLQueryParameter]) {
+    /// Identifier renames applied to references that are *not* parameters —
+    /// used to swap the trapping `sqlQuery` spec entry point for the real `sql`
+    /// builder in the direct-result encoding (#369).
+    private let calleeRenames: [String: String]
+
+    init(parameters: [SQLQueryParameter], calleeRenames: [String: String] = [:]) {
         var replacements: [String: String] = [:]
         for parameter in parameters {
             replacements[parameter.placeholderName] = parameter.bindingReference
         }
         self.replacements = replacements
+        self.calleeRenames = calleeRenames
         super.init()
     }
 
     override func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
-        guard let replacement = replacements[normalizedIdentifier(node.baseName.text)] else {
-            return ExprSyntax(node)
+        let identifier = normalizedIdentifier(node.baseName.text)
+        if let replacement = replacements[identifier] {
+            var expression = ExprSyntax("\(raw: replacement)")
+            expression.leadingTrivia = node.leadingTrivia
+            expression.trailingTrivia = node.trailingTrivia
+            return expression
         }
-        var expression = ExprSyntax("\(raw: replacement)")
-        expression.leadingTrivia = node.leadingTrivia
-        expression.trailingTrivia = node.trailingTrivia
-        return expression
+        if let renamed = calleeRenames[identifier] {
+            let token = TokenSyntax.identifier(renamed)
+                .with(\.leadingTrivia, node.baseName.leadingTrivia)
+                .with(\.trailingTrivia, node.baseName.trailingTrivia)
+            return ExprSyntax(node.with(\.baseName, token))
+        }
+        return ExprSyntax(node)
     }
 
     override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -122,15 +122,15 @@ internal struct SQLQueryReturnShape {
 ///
 internal struct SQLQueryBuilder {
 
-    private let function: FunctionDeclSyntax
+    let function: FunctionDeclSyntax
 
-    private let parameters: [SQLQueryParameter]
+    let parameters: [SQLQueryParameter]
 
-    private let returnShape: SQLQueryReturnShape
+    let returnShape: SQLQueryReturnShape
 
-    private var rowType: String { returnShape.rowType }
+    var rowType: String { returnShape.rowType }
 
-    private let rewrittenBodyText: String
+    let rewrittenBodyText: String
 
     init(node: AttributeSyntax, declaration: some DeclSyntaxProtocol) throws {
         guard let function = declaration.as(FunctionDeclSyntax.self) else {
@@ -456,18 +456,30 @@ internal struct SQLQueryBuilder {
     /// value-free statement, encodes the parameter values into one immutable
     /// invocation packet, and fetches all rows.
     ///
-    func makeExecutorFunction() -> String {
-        let parameterClause = function.signature.parameterClause.trimmedDescription
-        let resultType: String
-        let fetchCall: String
+    /// The executor's declared result type, derived from the cardinality.
+    var executorResultType: String {
         switch returnShape.cardinality {
         case .many:
-            resultType = "[\(rowType)]"
-            fetchCall = "fetchAll"
+            return "[\(rowType)]"
         case .one:
-            resultType = "\(rowType)?"
-            fetchCall = "fetchOne"
+            return "\(rowType)?"
         }
+    }
+
+    /// The request fetch the executor dispatches to.
+    var fetchCallName: String {
+        switch returnShape.cardinality {
+        case .many:
+            return "fetchAll"
+        case .one:
+            return "fetchOne"
+        }
+    }
+
+    func makeExecutorFunction() -> String {
+        let parameterClause = function.signature.parameterClause.trimmedDescription
+        let resultType = executorResultType
+        let fetchCall = fetchCallName
         var lines: [String] = []
         lines.append("\(modifierPrefix)func \(executorFunctionName)\(parameterClause) throws -> \(resultType) {")
         lines.append("    let __xlStatement = \(statementFunctionName)()")

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -132,13 +132,23 @@ internal struct SQLQueryBuilder {
 
     let rewrittenBodyText: String
 
-    init(node: AttributeSyntax, declaration: some DeclSyntaxProtocol) throws {
+    /// The user-facing attribute name used in diagnostics — `@SQLQuery` for
+    /// the per-function peer macro, `@SQLQueries` when specifications are
+    /// parsed out of a container by the member macro.
+    let macroName: String
+
+    init(
+        node: AttributeSyntax,
+        declaration: some DeclSyntaxProtocol,
+        macroName: String = "@SQLQuery"
+    ) throws {
+        self.macroName = macroName
         guard let function = declaration.as(FunctionDeclSyntax.self) else {
             throw DiagnosticsError(diagnostics: [
                 Diagnostic(
                     node: node,
                     id: "sqlquery-function-only",
-                    message: "'@SQLQuery' can only be applied to a function."
+                    message: "'\(macroName)' can only be applied to a function."
                 )
             ])
         }
@@ -154,7 +164,7 @@ internal struct SQLQueryBuilder {
                 Diagnostic(
                     node: typeLevelModifier,
                     id: "sqlquery-instance-method-only",
-                    message: "'@SQLQuery' can only be applied to an instance method. The generated executor prepares its request through 'self.makeRequest(with:)'."
+                    message: "'\(macroName)' can only be applied to an instance method. The generated executor prepares its request through 'self.makeRequest(with:)'."
                 )
             )
         }
@@ -164,7 +174,7 @@ internal struct SQLQueryBuilder {
                 Diagnostic(
                     node: genericParameterClause,
                     id: "sqlquery-generic-function",
-                    message: "'@SQLQuery' cannot be applied to a generic function. The generated statement builder takes no arguments, so generic parameters cannot be inferred."
+                    message: "'\(macroName)' cannot be applied to a generic function. The generated statement builder takes no arguments, so generic parameters cannot be inferred."
                 )
             )
         }
@@ -174,36 +184,41 @@ internal struct SQLQueryBuilder {
                 Diagnostic(
                     node: effectSpecifiers,
                     id: "sqlquery-effect-specifiers",
-                    message: "'@SQLQuery' requires a nonthrowing, synchronous function. Statement builders only construct a value-free statement."
+                    message: "'\(macroName)' requires a nonthrowing, synchronous function. Statement builders only construct a value-free statement."
                 )
             )
         }
 
         self.parameters = Self.makeParameters(
             of: function,
+            macroName: macroName,
             diagnostics: &diagnostics
         )
-        self.returnShape = Self.makeReturnShape(of: function, diagnostics: &diagnostics)
+        self.returnShape = Self.makeReturnShape(
+            of: function,
+            macroName: macroName,
+            diagnostics: &diagnostics
+        )
 
         guard let body = function.body else {
             diagnostics.append(
                 Diagnostic(
                     node: Syntax(function.signature),
                     id: "sqlquery-body-required",
-                    message: "'@SQLQuery' requires a function body that returns the query statement."
+                    message: "'\(macroName)' requires a function body that returns the query statement."
                 )
             )
             throw DiagnosticsError(diagnostics: diagnostics)
         }
 
-        let shadowingVisitor = SQLQueryShadowingVisitor(parameters: parameters)
+        let shadowingVisitor = SQLQueryShadowingVisitor(parameters: parameters, macroName: macroName)
         shadowingVisitor.walk(body)
         diagnostics.append(contentsOf: shadowingVisitor.diagnostics)
 
         if shadowingVisitor.diagnostics.isEmpty {
             // A shadowed name makes lexical parameter analysis unreliable, so
             // member-access checking waits until the shadowing is resolved.
-            let memberAccessVisitor = SQLQueryParameterMemberAccessVisitor(parameters: parameters)
+            let memberAccessVisitor = SQLQueryParameterMemberAccessVisitor(parameters: parameters, macroName: macroName)
             memberAccessVisitor.walk(body)
             diagnostics.append(contentsOf: memberAccessVisitor.diagnostics)
         }
@@ -268,6 +283,7 @@ internal struct SQLQueryBuilder {
     ///
     private static func makeParameters(
         of function: FunctionDeclSyntax,
+        macroName: String,
         diagnostics: inout [Diagnostic]
     ) -> [SQLQueryParameter] {
         var parameters: [SQLQueryParameter] = []
@@ -277,7 +293,7 @@ internal struct SQLQueryBuilder {
                     Diagnostic(
                         node: ellipsis,
                         id: "sqlquery-variadic-parameter",
-                        message: "'@SQLQuery' cannot bind a variadic parameter to a single named placeholder."
+                        message: "'\(macroName)' cannot bind a variadic parameter to a single named placeholder."
                     )
                 )
                 continue
@@ -288,7 +304,7 @@ internal struct SQLQueryBuilder {
                     Diagnostic(
                         node: attributedType,
                         id: "sqlquery-parameter-specifier",
-                        message: "'@SQLQuery' cannot bind a '\(specifier.text)' parameter to a named placeholder."
+                        message: "'\(macroName)' cannot bind a '\(specifier.text)' parameter to a named placeholder."
                     )
                 )
                 continue
@@ -299,7 +315,7 @@ internal struct SQLQueryBuilder {
                     Diagnostic(
                         node: name,
                         id: "sqlquery-unnamed-parameter",
-                        message: "'@SQLQuery' requires every parameter to have a name. The name identifies the SQL placeholder."
+                        message: "'\(macroName)' requires every parameter to have a name. The name identifies the SQL placeholder."
                     )
                 )
                 continue
@@ -313,7 +329,7 @@ internal struct SQLQueryBuilder {
                     Diagnostic(
                         node: name,
                         id: "sqlquery-reserved-parameter-name",
-                        message: "'@SQLQuery' cannot bind a parameter named '\(normalizedIdentifier(name.text))'. The name collides with a statement-builder entry point, so rewriting its references would corrupt the builder call in the generated peer. Rename the parameter."
+                        message: "'\(macroName)' cannot bind a parameter named '\(normalizedIdentifier(name.text))'. The name collides with a statement-builder entry point, so rewriting its references would corrupt the builder call in the generated peer. Rename the parameter."
                     )
                 )
                 continue
@@ -339,6 +355,7 @@ internal struct SQLQueryBuilder {
     ///
     private static func makeReturnShape(
         of function: FunctionDeclSyntax,
+        macroName: String,
         diagnostics: inout [Diagnostic]
     ) -> SQLQueryReturnShape {
         let returnType = function.signature.returnClause?.type.trimmed
@@ -382,7 +399,7 @@ internal struct SQLQueryBuilder {
             Diagnostic(
                 node: Syntax(function.signature.returnClause?.type) ?? Syntax(function.signature),
                 id: "sqlquery-return-type",
-                message: "'@SQLQuery' requires the function to return '[Row]' (fetch all), 'Row?' (fetch one), or the legacy 'any/some XLQueryStatement<Row>', with an explicit row type. The row type declares the executor's result element and the shape selects the fetch."
+                message: "'\(macroName)' requires the function to return '[Row]' (fetch all), 'Row?' (fetch one), or the legacy 'any/some XLQueryStatement<Row>', with an explicit row type. The row type declares the executor's result element and the shape selects the fetch."
             )
         )
         return SQLQueryReturnShape(rowType: "", cardinality: .many, isDirectResult: false)
@@ -580,10 +597,13 @@ internal final class SQLQueryShadowingVisitor: SyntaxVisitor {
 
     private let parameterNames: Set<String>
 
+    private let macroName: String
+
     private(set) var diagnostics: [Diagnostic] = []
 
-    init(parameters: [SQLQueryParameter]) {
+    init(parameters: [SQLQueryParameter], macroName: String = "@SQLQuery") {
         self.parameterNames = Set(parameters.map(\.placeholderName))
+        self.macroName = macroName
         super.init(viewMode: .sourceAccurate)
     }
 
@@ -616,7 +636,7 @@ internal final class SQLQueryShadowingVisitor: SyntaxVisitor {
             Diagnostic(
                 node: name,
                 id: "sqlquery-shadowed-parameter",
-                message: "'\(identifier)' shadows a query parameter inside the '@SQLQuery' body. The macro rewrites every reference to '\(identifier)' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration."
+                message: "'\(identifier)' shadows a query parameter inside the '\(macroName)' body. The macro rewrites every reference to '\(identifier)' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration."
             )
         )
     }
@@ -635,10 +655,13 @@ internal final class SQLQueryParameterMemberAccessVisitor: SyntaxVisitor {
 
     private let parameterNames: Set<String>
 
+    private let macroName: String
+
     private(set) var diagnostics: [Diagnostic] = []
 
-    init(parameters: [SQLQueryParameter]) {
+    init(parameters: [SQLQueryParameter], macroName: String = "@SQLQuery") {
         self.parameterNames = Set(parameters.map(\.placeholderName))
+        self.macroName = macroName
         super.init(viewMode: .sourceAccurate)
     }
 
@@ -654,7 +677,7 @@ internal final class SQLQueryParameterMemberAccessVisitor: SyntaxVisitor {
             Diagnostic(
                 node: base,
                 id: "sqlquery-parameter-member-access",
-                message: "'\(identifier)' cannot be used through member access in a '@SQLQuery' body. A parameter reference is rewritten to a named binding as a whole expression; compute the derived value before building the statement, or pass it as a separate parameter."
+                message: "'\(identifier)' cannot be used through member access in a '\(macroName)' body. A parameter reference is rewritten to a named binding as a whole expression; compute the derived value before building the statement, or pass it as a separate parameter."
             )
         )
         return .visitChildren

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -234,6 +234,21 @@ internal struct SQLQueryBuilder {
         // (`sqlResult` is provisional — `sqlQuery` is already the labeled-closure
         // statement builder in SQLFunctionalSyntax.swift.)
         let calleeRenames = returnShape.isDirectResult ? ["sqlResult": "sql"] : [:]
+
+        if returnShape.isDirectResult {
+            // The rename is lexical and applies only to an unqualified callee.
+            // A qualified spelling (`SwiftQL.sqlResult`) cannot be told apart
+            // from another object's member of the same name, so it is rejected
+            // rather than silently left to trap in the generated builder.
+            let qualifiedVisitor = SQLQueryQualifiedEntryPointVisitor(
+                entryPointNames: Set(calleeRenames.keys),
+                macroName: macroName
+            )
+            qualifiedVisitor.walk(body)
+            guard qualifiedVisitor.diagnostics.isEmpty else {
+                throw DiagnosticsError(diagnostics: qualifiedVisitor.diagnostics)
+            }
+        }
         let rewriter = SQLQueryParameterRewriter(
             parameters: parameters,
             calleeRenames: calleeRenames
@@ -579,6 +594,49 @@ internal final class SQLQueryParameterRewriter: SyntaxRewriter {
             return ExprSyntax(node)
         }
         return ExprSyntax(node.with(\.base, visit(base)))
+    }
+}
+
+
+///
+/// Rejects qualified calls to a spec entry point in a direct-result body.
+///
+/// The `sqlResult` -> `sql` swap is lexical and matches only an unqualified
+/// callee. A qualified spelling such as `SwiftQL.sqlResult { … }` cannot be
+/// distinguished from another object's member of the same name, so it is
+/// diagnosed instead of being left to trap at runtime in the generated
+/// statement builder.
+///
+internal final class SQLQueryQualifiedEntryPointVisitor: SyntaxVisitor {
+
+    private let entryPointNames: Set<String>
+
+    private let macroName: String
+
+    private(set) var diagnostics: [Diagnostic] = []
+
+    init(entryPointNames: Set<String>, macroName: String) {
+        self.entryPointNames = entryPointNames
+        self.macroName = macroName
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        guard let callee = node.calledExpression.as(MemberAccessExprSyntax.self) else {
+            return .visitChildren
+        }
+        let name = normalizedIdentifier(callee.declName.baseName.text)
+        guard entryPointNames.contains(name) else {
+            return .visitChildren
+        }
+        diagnostics.append(
+            Diagnostic(
+                node: Syntax(callee),
+                id: "sqlquery-qualified-entry-point",
+                message: "'\(name)' must be called unqualified in a '\(macroName)' specification. The macro rewrites the entry point lexically and cannot distinguish a module qualifier from another object's member of the same name."
+            )
+        )
+        return .visitChildren
     }
 }
 

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -254,6 +254,15 @@ internal struct SQLQueryBuilder {
     }
 
     ///
+    /// Parameter names that collide with a statement-builder entry point. The
+    /// rewrite replaces every reference to a parameter, so a parameter with one
+    /// of these names would corrupt the builder call in the generated code.
+    ///
+    private static let reservedParameterNames: Set<String> = [
+        "sql", "sqlQuery", "sqlResult",
+    ]
+
+    ///
     /// Classifies the function parameters, reporting shapes that cannot be
     /// rewritten to a named binding.
     ///
@@ -291,6 +300,20 @@ internal struct SQLQueryBuilder {
                         node: name,
                         id: "sqlquery-unnamed-parameter",
                         message: "'@SQLQuery' requires every parameter to have a name. The name identifies the SQL placeholder."
+                    )
+                )
+                continue
+            }
+            if reservedParameterNames.contains(normalizedIdentifier(name.text)) {
+                // The rewrite replaces every reference to a parameter, and the
+                // builder callee is itself a plain identifier reference — a
+                // parameter with the same name would corrupt the builder call
+                // in the generated peer.
+                diagnostics.append(
+                    Diagnostic(
+                        node: name,
+                        id: "sqlquery-reserved-parameter-name",
+                        message: "'@SQLQuery' cannot bind a parameter named '\(normalizedIdentifier(name.text))'. The name collides with a statement-builder entry point, so rewriting its references would corrupt the builder call in the generated peer. Rename the parameter."
                     )
                 )
                 continue

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -2,8 +2,9 @@
 //  SQLQueryMacro.swift
 //  SwiftQL
 //
-//  Spike (#359): attached peer macro that rewrites a statement-returning
-//  function into a value-free statement builder plus a `fetchAll` executor.
+//  Spike (#359/#369): attached peer macro that rewrites a query-specification
+//  function into a value-free statement builder plus an executor whose fetch
+//  (`fetchAll` / `fetchOne`) is dispatched from the return annotation.
 //
 
 import Foundation
@@ -14,14 +15,16 @@ import SwiftSyntaxMacros
 
 
 ///
-/// Declares a statement-returning function as a reusable prepared query.
+/// Declares a query-specification function as a reusable prepared query.
 ///
 /// The attached function builds a `SELECT` statement from its parameters. The
 /// macro generates two peers: a value-free statement builder in which every
 /// parameter reference is replaced by a typed `XLNamedBindingReference`, and an
 /// executor that renders the statement once per call through the enclosing
 /// database's `makeRequest(with:)`, binds the parameter values into an
-/// immutable invocation packet, and returns the `fetchAll` rows.
+/// immutable invocation packet, and fetches the result. The fetch is dispatched
+/// from the function's return annotation: `[Row]` (or the legacy
+/// `any/some XLQueryStatement<Row>`) fetches all rows, `Row?` fetches one.
 ///
 public struct SQLQueryMacro {
 }
@@ -108,7 +111,7 @@ internal struct SQLQueryReturnShape {
     /// `true` when the function declares its result directly (`[Row]` / `Row?`,
     /// spike #369); `false` for the legacy `XLQueryStatement<Row>` spelling
     /// (#359). In the direct-result case the statement-builder peer must swap
-    /// the trapping `sqlQuery` entry point for the real `sql` builder.
+    /// the trapping `sqlResult` entry point for the real `sql` builder.
     var isDirectResult: Bool
 }
 
@@ -480,8 +483,8 @@ internal final class SQLQueryParameterRewriter: SyntaxRewriter {
     private let replacements: [String: String]
 
     /// Identifier renames applied to references that are *not* parameters —
-    /// used to swap the trapping `sqlQuery` spec entry point for the real `sql`
-    /// builder in the direct-result encoding (#369).
+    /// used to swap the trapping `sqlResult` spec entry point for the real
+    /// `sql` builder in the direct-result encoding (#369).
     private let calleeRenames: [String: String]
 
     init(parameters: [SQLQueryParameter], calleeRenames: [String: String] = [:]) {

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -482,9 +482,10 @@ internal final class SQLQueryParameterRewriter: SyntaxRewriter {
 
     private let replacements: [String: String]
 
-    /// Identifier renames applied to references that are *not* parameters —
-    /// used to swap the trapping `sqlResult` spec entry point for the real
-    /// `sql` builder in the direct-result encoding (#369).
+    /// Identifier renames applied only to the called expression of a function
+    /// call — used to swap the trapping `sqlResult` spec entry point for the
+    /// real `sql` builder in the direct-result encoding (#369). References
+    /// outside callee position are never renamed.
     private let calleeRenames: [String: String]
 
     init(parameters: [SQLQueryParameter], calleeRenames: [String: String] = [:]) {
@@ -498,20 +499,27 @@ internal final class SQLQueryParameterRewriter: SyntaxRewriter {
     }
 
     override func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
-        let identifier = normalizedIdentifier(node.baseName.text)
-        if let replacement = replacements[identifier] {
-            var expression = ExprSyntax("\(raw: replacement)")
-            expression.leadingTrivia = node.leadingTrivia
-            expression.trailingTrivia = node.trailingTrivia
-            return expression
+        guard let replacement = replacements[normalizedIdentifier(node.baseName.text)] else {
+            return ExprSyntax(node)
         }
-        if let renamed = calleeRenames[identifier] {
+        var expression = ExprSyntax("\(raw: replacement)")
+        expression.leadingTrivia = node.leadingTrivia
+        expression.trailingTrivia = node.trailingTrivia
+        return expression
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+        // A callee rename applies only in callee position: a reference that
+        // merely *names* the entry point elsewhere in the body is left alone.
+        var node = node
+        if let callee = node.calledExpression.as(DeclReferenceExprSyntax.self),
+           let renamed = calleeRenames[normalizedIdentifier(callee.baseName.text)] {
             let token = TokenSyntax.identifier(renamed)
-                .with(\.leadingTrivia, node.baseName.leadingTrivia)
-                .with(\.trailingTrivia, node.baseName.trailingTrivia)
-            return ExprSyntax(node.with(\.baseName, token))
+                .with(\.leadingTrivia, callee.baseName.leadingTrivia)
+                .with(\.trailingTrivia, callee.baseName.trailingTrivia)
+            node = node.with(\.calledExpression, ExprSyntax(callee.with(\.baseName, token)))
         }
-        return ExprSyntax(node)
+        return super.visit(node)
     }
 
     override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {

--- a/Sources/SwiftQL/SQL.swift
+++ b/Sources/SwiftQL/SQL.swift
@@ -15,12 +15,15 @@ public macro SQLResult() = #externalMacro(module: "SQLMacros", type: "SQLResultM
 ///
 /// Defines the `@SQLQuery` macro.
 ///
-/// Spike (#359): attaches to a statement-returning function in a database
+/// Spike (#359/#369): attaches to a query-specification function in a database
 /// extension and generates two peers — a value-free statement builder whose
 /// parameter references are rewritten to typed `XLNamedBindingReference`
-/// placeholders, and a `fetchAll` executor that binds the parameter values
-/// through an immutable invocation packet. Generated names are provisional
-/// while #26 settles the packaging decision.
+/// placeholders, and an executor that binds the parameter values through an
+/// immutable invocation packet. The fetch is dispatched from the function's
+/// return annotation: `[Row]` (or the legacy `any/some XLQueryStatement<Row>`)
+/// fetches all rows, `Row?` fetches one. Direct-result specifications write
+/// their body with the trapping `sqlResult {}` entry point instead of `sql {}`.
+/// Generated names are provisional while #26 settles the packaging decision.
 ///
 @attached(peer, names: arbitrary)
 public macro SQLQuery() = #externalMacro(module: "SQLMacros", type: "SQLQueryMacro")

--- a/Sources/SwiftQL/SQL.swift
+++ b/Sources/SwiftQL/SQL.swift
@@ -11,3 +11,16 @@ public macro SQLTable(name: String? = nil) = #externalMacro(module: "SQLMacros",
 @attached(member, names: arbitrary)
 @attached(extension, conformances: XLResult, names: arbitrary)
 public macro SQLResult() = #externalMacro(module: "SQLMacros", type: "SQLResultMacro")
+
+///
+/// Defines the `@SQLQuery` macro.
+///
+/// Spike (#359): attaches to a statement-returning function in a database
+/// extension and generates two peers — a value-free statement builder whose
+/// parameter references are rewritten to typed `XLNamedBindingReference`
+/// placeholders, and a `fetchAll` executor that binds the parameter values
+/// through an immutable invocation packet. Generated names are provisional
+/// while #26 settles the packaging decision.
+///
+@attached(peer, names: arbitrary)
+public macro SQLQuery() = #externalMacro(module: "SQLMacros", type: "SQLQueryMacro")

--- a/Sources/SwiftQL/SQL.swift
+++ b/Sources/SwiftQL/SQL.swift
@@ -27,3 +27,19 @@ public macro SQLResult() = #externalMacro(module: "SQLMacros", type: "SQLResultM
 ///
 @attached(peer, names: arbitrary)
 public macro SQLQuery() = #externalMacro(module: "SQLMacros", type: "SQLQueryMacro")
+
+///
+/// Defines the `@SQLQueries` macro.
+///
+/// Spike (#369, container encoding): attaches to a database extension holding
+/// a nested `Query` container of specification functions, and generates the
+/// executors as members of the database — a connection-scoped `Context` with
+/// one executor per specification, an `execute(_:)` entry point, and one
+/// database-level convenience executor per specification (sugar over
+/// `execute`). Executors carry the specification's own name; the `Query`
+/// container is never referenced by generated code, so it may be declared
+/// `private` to hide the trapping specs from the visible API. Generated names
+/// are provisional while #26 settles the packaging decision.
+///
+@attached(member, names: arbitrary)
+public macro SQLQueries() = #externalMacro(module: "SQLMacros", type: "SQLQueriesMacro")

--- a/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
+++ b/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
@@ -70,9 +70,48 @@ public func _xlQueryParameterBinding<T>(
     }
     var context: any XLBindingContext = XLSQLiteValueCaptureContext()
     value.bind(context: &context)
-    let sqliteValue = (context as! XLSQLiteValueCaptureContext).value
+    guard let capture = context as? XLSQLiteValueCaptureContext else {
+        // `bind(context:)` receives the context `inout`, so a conformer could
+        // replace it with a different type. Intrinsic literal conformers never
+        // do; fail with a diagnostic that names the offender if one does.
+        preconditionFailure(
+            "\(T.self).bind(context:) replaced the binding context with "
+            + "\(type(of: context)); expected it to write the value into the "
+            + "provided XLSQLiteValueCaptureContext."
+        )
+    }
+    let sqliteValue = capture.value
     if sqliteValue == .null, slot.nullability == .required {
         throw XLInvocationBindingError.nullForRequiredParameter(slot: slot)
     }
     return try XLInvocationBinding(slot: slot, value: sqliteValue)
+}
+
+
+///
+/// The trapping direct-result entry point for `@SQLQuery` specifications.
+///
+/// Spike (#369): a `@SQLQuery` spec written with a direct result type
+/// (`[Row]` / `Row?`) calls this instead of `sql {}` so the function
+/// type-checks without the `XLQueryStatement` return-type boilerplate. `Result`
+/// appears only in return position, so it is inferred from the enclosing
+/// function's declared return type — one entry point satisfies both
+/// cardinalities with no overload ambiguity.
+///
+/// This function is only a type-check anchor and a syntax source for the macro;
+/// invoking it directly traps loudly, because the real work happens in the
+/// macro-generated executor peer. The macro rewrites this callee back to
+/// `sql {}` when it emits the value-free statement builder.
+///
+/// The name is provisional (per #26, generated and entry-point names are not
+/// frozen) — `sqlQuery` is already the labeled-closure statement builder in
+/// `SQLFunctionalSyntax.swift`, so the direct-result anchor needs its own name.
+///
+public func sqlResult<Row, Result>(
+    @XLQueryExpressionBuilder _ builder: (XLSchema) -> any XLQueryStatement<Row>
+) -> Result {
+    fatalError(
+        "'sqlResult' marks a @SQLQuery specification, not an executor. "
+        + "Call the generated executor peer (e.g. fetchPersonByName) instead."
+    )
 }

--- a/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
+++ b/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
@@ -1,0 +1,78 @@
+//
+//  SQLQueryPeerMacroSupport.swift
+//  SwiftQL
+//
+//  Spike (#359): runtime support for `@SQLQuery` macro-generated executors.
+//
+
+import Foundation
+
+
+///
+/// Captures one normalized SQLite value from an `XLBindable` conformer.
+///
+private struct XLSQLiteValueCaptureContext: XLBindingContext {
+
+    var value: XLSQLiteValue = .null
+
+    mutating func bindNull() {
+        self.value = .null
+    }
+
+    mutating func bindInteger(value: Int) {
+        self.value = .integer(Int64(value))
+    }
+
+    mutating func bindReal(value: Double) {
+        self.value = .real(value)
+    }
+
+    mutating func bindText(value: String) {
+        self.value = .text(value)
+    }
+
+    mutating func bindBlob(value: Data) {
+        self.value = .blob(value)
+    }
+}
+
+
+///
+/// Encodes one intrinsic literal parameter value for a named placeholder in a
+/// prepared parameter layout.
+///
+/// Spike (#359) support for `@SQLQuery` macro-generated executors. The macro
+/// rewrites function-parameter references into typed `XLNamedBindingReference`
+/// placeholders, and the generated executor calls this function to encode each
+/// runtime value into the immutable invocation packet. The static metadata
+/// derived from `T` must match the rendered slot exactly, mirroring the
+/// validation performed by the request `set` compatibility shim.
+///
+public func _xlQueryParameterBinding<T>(
+    _ value: T,
+    named name: XLName,
+    in layout: XLParameterLayout
+) throws -> XLInvocationBinding<XLSQLiteValue> where T: XLBindable & XLLiteral {
+    let declaration = _xlLegacyParameterDeclaration(
+        for: T.self,
+        key: .named(name.rawValue)
+    )
+    guard let slot = layout.slot(for: declaration.key) else {
+        throw XLInvocationBindingError.parameterDeclarationNotInLayout(
+            declaration: declaration
+        )
+    }
+    guard slot.declaration == declaration else {
+        throw XLInvocationBindingError.parameterMetadataMismatch(
+            expected: slot,
+            actual: declaration.slot(at: slot.index)
+        )
+    }
+    var context: any XLBindingContext = XLSQLiteValueCaptureContext()
+    value.bind(context: &context)
+    let sqliteValue = (context as! XLSQLiteValueCaptureContext).value
+    if sqliteValue == .null, slot.nullability == .required {
+        throw XLInvocationBindingError.nullForRequiredParameter(slot: slot)
+    }
+    return try XLInvocationBinding(slot: slot, value: sqliteValue)
+}

--- a/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
+++ b/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
@@ -112,6 +112,6 @@ public func sqlResult<Row, Result>(
 ) -> Result {
     fatalError(
         "'sqlResult' marks a @SQLQuery specification, not an executor. "
-        + "Call the generated executor peer (e.g. fetchPersonByName) instead."
+        + "Call the macro-generated executor peer instead."
     )
 }

--- a/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
@@ -147,7 +147,122 @@ final class SQLQueriesMacroExpansionTests: XCTestCase {
 }
 
 
+final class SQLQueriesMacroAccessLevelTests: XCTestCase {
+
+    ///
+    /// The extension's access level propagates to every generated member, so a
+    /// `public extension` exposes `Context`, `execute`, and the database-level
+    /// executors to outside-module callers.
+    ///
+    func test_publicExtension_propagatesAccessLevelToGeneratedMembers() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            public extension MyDatabase {
+                private struct Query {
+                    func allPeople() -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                        }
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            public extension MyDatabase {
+                private struct Query {
+                    func allPeople() -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                        }
+                    }
+                }
+
+                public struct Context {
+                    let database: MyDatabase
+
+                    public func allPeople() throws -> [Person] {
+                        let __xlStatement: any XLQueryStatement<Person> = {
+                            sql { schema in
+                                let person = schema.table(Person.self)
+                                Select(person)
+                                From(person)
+                            }
+                        }()
+                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlLayout = __xlRequest.parameterLayout
+                        let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()
+                        return try __xlRequest.fetchAll(bindings: __xlPacket)
+                    }
+                }
+
+                public func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {
+                    try __xlWork(Context(database: self))
+                }
+
+                public func allPeople() throws -> [Person] {
+                    try execute { __xlContext in
+                        try __xlContext.allPeople()
+                    }
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+}
+
+
 final class SQLQueriesMacroDiagnosticTests: XCTestCase {
+
+    ///
+    /// A malformed specification inside the container is diagnosed with the
+    /// container macro's own name, not '@SQLQuery' (which the user never
+    /// wrote).
+    ///
+    func test_malformedContainerSpec_diagnosticNamesSQLQueries() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            extension MyDatabase {
+                struct Query {
+                    func allPeople() throws -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                        }
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                struct Query {
+                    func allPeople() throws -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                        }
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQueries' requires a nonthrowing, synchronous function. Statement builders only construct a value-free statement.",
+                    line: 4,
+                    column: 26
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
 
     func test_nonExtensionDeclaration_emitsError() {
         assertMacroExpansion(

--- a/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
@@ -1,0 +1,195 @@
+//
+//  SQLQueriesMacroTests.swift
+//  SwiftQL
+//
+//  Tests for the `@SQLQueries` member macro (#369, container encoding): the
+//  macro reads specifications from a nested `Query` container and generates a
+//  connection-scoped `Context`, the `execute` entry point, and database-level
+//  convenience executors.
+//
+
+import SwiftDiagnostics
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import SQLMacros
+
+
+private func makeTestMacros() -> [String: Macro.Type] {
+    [
+        "SQLQueries": SQLQueriesMacro.self,
+    ]
+}
+
+
+final class SQLQueriesMacroExpansionTests: XCTestCase {
+
+    ///
+    /// The container's specifications become executors carrying the
+    /// specification's own name: connection-scoped on `Context`, one-shot
+    /// sugar on the database. `[Row]` dispatches `fetchAll`, `Row?` dispatches
+    /// `fetchOne`. The `Query` container itself is left untouched and is never
+    /// referenced by the generated members.
+    ///
+    func test_container_generatesContextExecuteAndDatabaseExecutors() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            extension MyDatabase {
+                private struct Query {
+                    func personByName(name: String) -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.name == name)
+                        }
+                    }
+                    func personById(id: String) -> Person? {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.id == id)
+                        }
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                private struct Query {
+                    func personByName(name: String) -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.name == name)
+                        }
+                    }
+                    func personById(id: String) -> Person? {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.id == id)
+                        }
+                    }
+                }
+
+                struct Context {
+                    let database: MyDatabase
+
+                    func personByName(name: String) throws -> [Person] {
+                        let __xlStatement: any XLQueryStatement<Person> = {
+                            sql { schema in
+                                let person = schema.table(Person.self)
+                                Select(person)
+                                From(person)
+                                Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                            }
+                        }()
+                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlLayout = __xlRequest.parameterLayout
+                        let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                            layout: __xlLayout,
+                            bindings: [
+                                try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                            ]
+                        ).validatingComplete()
+                        return try __xlRequest.fetchAll(bindings: __xlPacket)
+                    }
+
+                    func personById(id: String) throws -> Person? {
+                        let __xlStatement: any XLQueryStatement<Person> = {
+                            sql { schema in
+                                let person = schema.table(Person.self)
+                                Select(person)
+                                From(person)
+                                Where(person.id == XLNamedBindingReference<String>(name: "id"))
+                            }
+                        }()
+                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlLayout = __xlRequest.parameterLayout
+                        let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                            layout: __xlLayout,
+                            bindings: [
+                                try _xlQueryParameterBinding(id, named: "id", in: __xlLayout),
+                            ]
+                        ).validatingComplete()
+                        return try __xlRequest.fetchOne(bindings: __xlPacket)
+                    }
+                }
+
+                func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {
+                    try __xlWork(Context(database: self))
+                }
+
+                func personByName(name: String) throws -> [Person] {
+                    try execute { __xlContext in
+                        try __xlContext.personByName(name: name)
+                    }
+                }
+
+                func personById(id: String) throws -> Person? {
+                    try execute { __xlContext in
+                        try __xlContext.personById(id: id)
+                    }
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+}
+
+
+final class SQLQueriesMacroDiagnosticTests: XCTestCase {
+
+    func test_nonExtensionDeclaration_emitsError() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            struct MyDatabase {
+            }
+            """,
+            expandedSource: """
+            struct MyDatabase {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQueries' can only be applied to an extension of a database type. The generated executors prepare requests through the extended type's 'makeRequest(with:)'.",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_missingQueryContainer_emitsError() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            extension MyDatabase {
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQueries' requires a nested 'struct Query' container declaring the query specifications.",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+}

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -902,4 +902,47 @@ final class SQLQueryMacroDiagnosticTests: XCTestCase {
             macros: makeTestMacros()
         )
     }
+
+    ///
+    /// The `sqlResult` -> `sql` swap matches only an unqualified callee, so a
+    /// qualified spelling is rejected rather than left to trap at runtime in
+    /// the generated statement builder.
+    ///
+    func test_qualifiedEntryPoint_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> [Person] {
+                    SwiftQL.sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> [Person] {
+                    SwiftQL.sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'sqlResult' must be called unqualified in a '@SQLQuery' specification. The macro rewrites the entry point lexically and cannot distinguish a module qualifier from another object's member of the same name.",
+                    line: 4,
+                    column: 9
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
 }

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -340,7 +340,7 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
 
     ///
     /// A `[Row]` direct-result signature (no `XLQueryStatement` boilerplate)
-    /// dispatches to `fetchAll`. The spec calls the trapping `sqlQuery` entry
+    /// dispatches to `fetchAll`. The spec calls the trapping `sqlResult` entry
     /// point; the generated statement builder swaps it for the real `sql`
     /// builder and declares the value-free `any XLQueryStatement<Row>` result.
     ///

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -238,6 +238,59 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
         )
     }
 
+    func test_backtickedParameter_stripsEscapingFromPlaceholderName() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func rowsForKind(`class`: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.kind == `class`)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func rowsForKind(`class`: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.kind == `class`)
+                    }
+                }
+
+                func rowsForKindStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.kind == XLNamedBindingReference<String>(name: "class"))
+                    }
+                }
+
+                func fetchRowsForKind(`class`: String) throws -> [Person] {
+                    let __xlStatement = rowsForKindStatement()
+                    let __xlRequest = self.makeRequest(with: __xlStatement)
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            _xlQueryParameterBinding(`class`, named: "class", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
     func test_zeroParameters_generatesEmptyPacketExecutor() {
         assertMacroExpansion(
             """
@@ -447,6 +500,118 @@ final class SQLQueryMacroDiagnosticTests: XCTestCase {
                     message: "'@SQLQuery' cannot be applied to a generic function. The generated statement builder takes no arguments, so generic parameters cannot be inferred.",
                     line: 3,
                     column: 14
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_staticFunction_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                static func allPeople() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                static func allPeople() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' can only be applied to an instance method. The generated executor prepares its request through 'self.makeRequest(with:)'.",
+                    line: 3,
+                    column: 5
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_shadowingLocalBinding_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        let name = "frozen"
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        let name = "frozen"
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' shadows a query parameter inside the '@SQLQuery' body. The macro rewrites every reference to 'name' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration.",
+                    line: 6,
+                    column: 17
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_shadowingClosureParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { name in
+                        let person = name.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { name in
+                        let person = name.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' shadows a query parameter inside the '@SQLQuery' body. The macro rewrites every reference to 'name' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration.",
+                    line: 4,
+                    column: 15
                 )
             ],
             macros: makeTestMacros()

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -1,0 +1,479 @@
+//
+//  SQLQueryMacroTests.swift
+//  SwiftQL
+//
+//  Tests for the `@SQLQuery` peer macro: signature-driven body rewriting,
+//  executor generation, and diagnostics for unsupported declaration shapes.
+//
+
+import SwiftDiagnostics
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import SQLMacros
+
+
+private func makeTestMacros() -> [String: Macro.Type] {
+    [
+        "SQLQuery": SQLQueryMacro.self,
+    ]
+}
+
+
+final class SQLQueryMacroExpansionTests: XCTestCase {
+
+    func test_oneParameter_rewritesReferenceAndGeneratesExecutor() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+
+                func personByNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                    }
+                }
+
+                func fetchPersonByName(name: String) throws -> [Person] {
+                    let __xlStatement = personByNameStatement()
+                    let __xlRequest = self.makeRequest(with: __xlStatement)
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_twoParameters_rewritesEveryReferenceWithItsOwnType() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                public func peopleInCohort(name: String, minimumAge: Int) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name && person.age >= minimumAge)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                public func peopleInCohort(name: String, minimumAge: Int) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name && person.age >= minimumAge)
+                    }
+                }
+
+                public func peopleInCohortStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name") && person.age >= XLNamedBindingReference<Int>(name: "minimumAge"))
+                    }
+                }
+
+                public func fetchPeopleInCohort(name: String, minimumAge: Int) throws -> [Person] {
+                    let __xlStatement = peopleInCohortStatement()
+                    let __xlRequest = self.makeRequest(with: __xlStatement)
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                            _xlQueryParameterBinding(minimumAge, named: "minimumAge", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_optionalParameter_bindsThroughOptionalReference() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func peopleByNickname(nickname: String?) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.nickname == nickname)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func peopleByNickname(nickname: String?) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.nickname == nickname)
+                    }
+                }
+
+                func peopleByNicknameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.nickname == XLNamedBindingReference<String?>(name: "nickname"))
+                    }
+                }
+
+                func fetchPeopleByNickname(nickname: String?) throws -> [Person] {
+                    let __xlStatement = peopleByNicknameStatement()
+                    let __xlRequest = self.makeRequest(with: __xlStatement)
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            _xlQueryParameterBinding(nickname, named: "nickname", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_memberNameMatchingParameterName_isNotRewritten() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name && name == person.name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name && name == person.name)
+                    }
+                }
+
+                func personByNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name") && XLNamedBindingReference<String>(name: "name") == person.name)
+                    }
+                }
+
+                func fetchPersonByName(name: String) throws -> [Person] {
+                    let __xlStatement = personByNameStatement()
+                    let __xlRequest = self.makeRequest(with: __xlStatement)
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_zeroParameters_generatesEmptyPacketExecutor() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+
+                func allPeopleStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+
+                func fetchAllPeople() throws -> [Person] {
+                    let __xlStatement = allPeopleStatement()
+                    let __xlRequest = self.makeRequest(with: __xlStatement)
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+}
+
+
+final class SQLQueryMacroDiagnosticTests: XCTestCase {
+
+    func test_nonFunctionDeclaration_emitsError() {
+        assertMacroExpansion(
+            """
+            @SQLQuery
+            struct Sample {
+            }
+            """,
+            expandedSource: """
+            struct Sample {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' can only be applied to a function.",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_missingRowType_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() -> any XLQueryStatement {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() -> any XLQueryStatement {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' requires the function to return 'any XLQueryStatement<Row>' with an explicit row type. The row type declares the executor's result element.",
+                    line: 3,
+                    column: 25
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_throwingFunction_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() throws -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() throws -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' requires a nonthrowing, synchronous function. Statement builders only construct a value-free statement.",
+                    line: 3,
+                    column: 22
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_variadicParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func peopleNamed(names: String...) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func peopleNamed(names: String...) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' cannot bind a variadic parameter to a single named placeholder.",
+                    line: 3,
+                    column: 35
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_genericFunction_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func rows<Value>(value: Value) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func rows<Value>(value: Value) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' cannot be applied to a generic function. The generated statement builder takes no arguments, so generic parameters cannot be inferred.",
+                    line: 3,
+                    column: 14
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_missingBody_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() -> any XLQueryStatement<Person>
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() -> any XLQueryStatement<Person>
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' requires a function body that returns the query statement.",
+                    line: 3,
+                    column: 19
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+}

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -454,6 +454,68 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
             macros: makeTestMacros()
         )
     }
+
+    ///
+    /// The `sqlResult` -> `sql` swap applies only in callee position. A
+    /// reference that merely names the entry point elsewhere in the body is
+    /// left untouched. (The expansion is syntactic, so the contrived non-callee
+    /// reference needs no runtime meaning.)
+    ///
+    func test_directResult_calleeRenameAppliesOnlyInCalleePosition() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func auditedPersonByName(name: String) -> [Person] {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                        audit(sqlResult)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func auditedPersonByName(name: String) -> [Person] {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                        audit(sqlResult)
+                    }
+                }
+
+                func auditedPersonByNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                        audit(sqlResult)
+                    }
+                }
+
+                func fetchAuditedPersonByName(name: String) throws -> [Person] {
+                    let __xlStatement = auditedPersonByNameStatement()
+                    let __xlRequest = self.makeRequest(with: __xlStatement)
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
 }
 
 

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -389,7 +389,7 @@ final class SQLQueryMacroDiagnosticTests: XCTestCase {
             """,
             diagnostics: [
                 DiagnosticSpec(
-                    message: "'@SQLQuery' requires the function to return 'any XLQueryStatement<Row>' with an explicit row type. The row type declares the executor's result element.",
+                    message: "'@SQLQuery' requires the function to return 'any XLQueryStatement<Row>' or 'some XLQueryStatement<Row>' with an explicit row type. The row type declares the executor's result element.",
                     line: 3,
                     column: 25
                 )
@@ -612,6 +612,44 @@ final class SQLQueryMacroDiagnosticTests: XCTestCase {
                     message: "'name' shadows a query parameter inside the '@SQLQuery' body. The macro rewrites every reference to 'name' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration.",
                     line: 4,
                     column: 15
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_parameterMemberAccess_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name.uppercased())
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name.uppercased())
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' cannot be used through member access in a '@SQLQuery' body. A parameter reference is rewritten to a named binding as a whole expression; compute the derived value before building the statement, or pass it as a separate parameter.",
+                    line: 8,
+                    column: 34
                 )
             ],
             macros: makeTestMacros()

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -860,4 +860,46 @@ final class SQLQueryMacroDiagnosticTests: XCTestCase {
             macros: makeTestMacros()
         )
     }
+
+    ///
+    /// A parameter named after a statement-builder entry point would be
+    /// rewritten wherever the builder is called, corrupting the generated code.
+    ///
+    func test_reservedParameterName_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func rowsMatching(sql: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == sql)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func rowsMatching(sql: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == sql)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' cannot bind a parameter named 'sql'. The name collides with a statement-builder entry point, so rewriting its references would corrupt the builder call in the generated peer. Rename the parameter.",
+                    line: 3,
+                    column: 23
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
 }

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -335,6 +335,125 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
             macros: makeTestMacros()
         )
     }
+
+    // MARK: - Spike #369: direct-result signatures + return-shape dispatch
+
+    ///
+    /// A `[Row]` direct-result signature (no `XLQueryStatement` boilerplate)
+    /// dispatches to `fetchAll`. The spec calls the trapping `sqlQuery` entry
+    /// point; the generated statement builder swaps it for the real `sql`
+    /// builder and declares the value-free `any XLQueryStatement<Row>` result.
+    ///
+    func test_directResultArray_dispatchesFetchAll() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> [Person] {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> [Person] {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+
+                func personByNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                    }
+                }
+
+                func fetchPersonByName(name: String) throws -> [Person] {
+                    let __xlStatement = personByNameStatement()
+                    let __xlRequest = self.makeRequest(with: __xlStatement)
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A `Row?` direct-result signature dispatches to `fetchOne` and returns an
+    /// optional row. This is the only source of the cardinality — the return
+    /// annotation — since the macro is declaration-local.
+    ///
+    func test_directResultOptional_dispatchesFetchOne() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByExactName(name: String) -> Person? {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByExactName(name: String) -> Person? {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+
+                func personByExactNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                    }
+                }
+
+                func fetchPersonByExactName(name: String) throws -> Person? {
+                    let __xlStatement = personByExactNameStatement()
+                    let __xlRequest = self.makeRequest(with: __xlStatement)
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchOne(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
 }
 
 
@@ -389,7 +508,7 @@ final class SQLQueryMacroDiagnosticTests: XCTestCase {
             """,
             diagnostics: [
                 DiagnosticSpec(
-                    message: "'@SQLQuery' requires the function to return 'any XLQueryStatement<Row>' or 'some XLQueryStatement<Row>' with an explicit row type. The row type declares the executor's result element.",
+                    message: "'@SQLQuery' requires the function to return '[Row]' (fetch all), 'Row?' (fetch one), or the legacy 'any/some XLQueryStatement<Row>', with an explicit row type. The row type declares the executor's result element and the shape selects the fetch.",
                     line: 3,
                     column: 25
                 )

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -67,7 +67,7 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
                     let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
                         layout: __xlLayout,
                         bindings: [
-                            _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
                         ]
                     ).validatingComplete()
                     return try __xlRequest.fetchAll(bindings: __xlPacket)
@@ -120,8 +120,8 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
                     let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
                         layout: __xlLayout,
                         bindings: [
-                            _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
-                            _xlQueryParameterBinding(minimumAge, named: "minimumAge", in: __xlLayout),
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                            try _xlQueryParameterBinding(minimumAge, named: "minimumAge", in: __xlLayout),
                         ]
                     ).validatingComplete()
                     return try __xlRequest.fetchAll(bindings: __xlPacket)
@@ -174,7 +174,7 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
                     let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
                         layout: __xlLayout,
                         bindings: [
-                            _xlQueryParameterBinding(nickname, named: "nickname", in: __xlLayout),
+                            try _xlQueryParameterBinding(nickname, named: "nickname", in: __xlLayout),
                         ]
                     ).validatingComplete()
                     return try __xlRequest.fetchAll(bindings: __xlPacket)
@@ -227,7 +227,7 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
                     let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
                         layout: __xlLayout,
                         bindings: [
-                            _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
                         ]
                     ).validatingComplete()
                     return try __xlRequest.fetchAll(bindings: __xlPacket)
@@ -280,7 +280,7 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
                     let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
                         layout: __xlLayout,
                         bindings: [
-                            _xlQueryParameterBinding(`class`, named: "class", in: __xlLayout),
+                            try _xlQueryParameterBinding(`class`, named: "class", in: __xlLayout),
                         ]
                     ).validatingComplete()
                     return try __xlRequest.fetchAll(bindings: __xlPacket)

--- a/Tests/SQLTests/SQLQueriesContainerTests.swift
+++ b/Tests/SQLTests/SQLQueriesContainerTests.swift
@@ -1,0 +1,137 @@
+//
+//  SQLQueriesContainerTests.swift
+//  SwiftQL
+//
+//  Runtime tests for the `@SQLQueries` member macro (#369, container
+//  encoding): the macro attaches to a database extension on the v1.x
+//  toolchain floor, reads the specifications from the nested (fileprivate)
+//  `Query` container, and generates working executors — connection-scoped on
+//  `Context` and one-shot on the database.
+//
+
+import Foundation
+import XCTest
+import GRDB
+import SwiftQL
+
+
+@SQLQueries
+extension GRDBDatabase {
+
+    // The container is deliberately `fileprivate`: generated code never
+    // references it, so the trapping specification functions are invisible
+    // outside this file. Only the generated executors are callable.
+    fileprivate struct Query {
+
+        func containerRowsMatchingID(id: String) -> [TestTable] {
+            sqlResult { schema in
+                let table = schema.table(TestTable.self)
+                Select(table)
+                From(table)
+                Where(table.id == id)
+            }
+        }
+
+        func containerRowMatchingID(id: String) -> TestTable? {
+            sqlResult { schema in
+                let table = schema.table(TestTable.self)
+                Select(table)
+                From(table)
+                Where(table.id == id)
+            }
+        }
+    }
+}
+
+
+final class XLQueriesContainerTests: XCTestCase {
+
+    var databasePool: DatabasePool!
+    var database: GRDBDatabase!
+
+    override func setUp() {
+        let formatter = XLiteFormatter(
+            identifierFormattingOptions: .mysqlCompatible
+        )
+        let directory = FileManager.default.temporaryDirectory
+        let filename = UUID().uuidString
+        let fileURL = directory
+            .appendingPathComponent(filename, isDirectory: false)
+            .appendingPathExtension("sqlite")
+        databasePool = try! DatabasePool(path: fileURL.path)
+        database = try! GRDBDatabase(databasePool: databasePool, formatter: formatter, logger: nil)
+    }
+
+    override func tearDown() {
+        databasePool = nil
+        database = nil
+    }
+
+
+    // MARK: - Database-level executors (implicit, one-shot)
+
+    func testDatabaseExecutorFetchesAllMatchingRows() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "alpha", value: 5))
+        try insert(TestTable(id: "beta", value: 9))
+
+        XCTAssertEqual(try database.containerRowsMatchingID(id: "alpha").count, 2)
+        XCTAssertEqual(
+            try database.containerRowsMatchingID(id: "beta"),
+            [TestTable(id: "beta", value: 9)]
+        )
+        XCTAssertEqual(try database.containerRowsMatchingID(id: "gamma"), [])
+    }
+
+    func testDatabaseExecutorFetchesSingleOptionalRow() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+
+        XCTAssertEqual(
+            try database.containerRowMatchingID(id: "alpha"),
+            TestTable(id: "alpha", value: 1)
+        )
+        XCTAssertNil(try database.containerRowMatchingID(id: "gamma"))
+    }
+
+
+    // MARK: - Context-scoped execution (explicit)
+
+    func testExecuteClosureProvidesContextScopedExecutors() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 9))
+
+        let rows = try database.execute { context in
+            try context.containerRowsMatchingID(id: "alpha")
+        }
+        XCTAssertEqual(rows, [TestTable(id: "alpha", value: 1)])
+    }
+
+    func testExecuteClosureRunsMultipleQueriesInOneScope() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 9))
+
+        let (all, one) = try database.execute { context in
+            (
+                try context.containerRowsMatchingID(id: "alpha"),
+                try context.containerRowMatchingID(id: "beta")
+            )
+        }
+        XCTAssertEqual(all, [TestTable(id: "alpha", value: 1)])
+        XCTAssertEqual(one, TestTable(id: "beta", value: 9))
+    }
+
+
+    // MARK: - Helpers
+
+    private func createTestTable() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+    }
+
+    private func insert(_ row: TestTable) throws {
+        try database.makeRequest(with: sqlInsert(row)).execute()
+    }
+}

--- a/Tests/SQLTests/SQLQueryPeerMacroTests.swift
+++ b/Tests/SQLTests/SQLQueryPeerMacroTests.swift
@@ -1,0 +1,200 @@
+//
+//  SQLQueryPeerMacroTests.swift
+//  SwiftQL
+//
+//  Runtime tests for the `@SQLQuery` peer macro (#359): the generated
+//  statement builders render placeholder SQL with a typed parameter layout,
+//  and the generated executors bind invocation values and fetch rows from a
+//  GRDB database.
+//
+
+import Foundation
+import XCTest
+import GRDB
+import SwiftQL
+
+
+extension GRDBDatabase {
+
+    @SQLQuery
+    func rowsMatchingID(id: String) -> any XLQueryStatement<TestTable> {
+        sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id)
+        }
+    }
+
+    @SQLQuery
+    func rowsMatchingIDAndMinimumValue(id: String, minimumValue: Int) -> any XLQueryStatement<TestTable> {
+        sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id && table.value >= minimumValue)
+        }
+    }
+
+    @SQLQuery
+    func nullableRowsMatchingValue(value: Int?) -> any XLQueryStatement<TestNullablesTable> {
+        sql { schema in
+            let table = schema.table(TestNullablesTable.self)
+            Select(table)
+            From(table)
+            Where(table.value == value)
+        }
+    }
+}
+
+
+final class XLQueryPeerMacroTests: XCTestCase {
+
+    var encoder: XLiteEncoder!
+    var databasePool: DatabasePool!
+    var database: GRDBDatabase!
+
+    override func setUp() {
+        let formatter = XLiteFormatter(
+            identifierFormattingOptions: .mysqlCompatible
+        )
+        let directory = FileManager.default.temporaryDirectory
+        let filename = UUID().uuidString
+        let fileURL = directory
+            .appendingPathComponent(filename, isDirectory: false)
+            .appendingPathExtension("sqlite")
+        encoder = XLiteEncoder(formatter: formatter)
+        databasePool = try! DatabasePool(path: fileURL.path)
+        database = try! GRDBDatabase(databasePool: databasePool, formatter: formatter, logger: nil)
+    }
+
+    override func tearDown() {
+        encoder = nil
+        databasePool = nil
+        database = nil
+    }
+
+
+    // MARK: - Placeholder rendering
+
+    func testOneParameterStatementRendersNamedPlaceholderSQL() throws {
+        let encoding = encoder.makeSQL(database.rowsMatchingIDStatement())
+
+        XCTAssertEqual(
+            encoding.sql,
+            "SELECT `t0`.`id` AS `id`, `t0`.`value` AS `value` FROM `Test` AS `t0` WHERE (`t0`.`id` == :id)"
+        )
+        XCTAssertNil(encoding.parameterLayoutError)
+        XCTAssertEqual(encoding.parameterLayout.slots.map(\.key), [.named("id")])
+        XCTAssertEqual(encoding.parameterLayout.slots.map(\.nullability), [.required])
+    }
+
+    func testTwoParameterStatementRendersNamedPlaceholderSQL() throws {
+        let encoding = encoder.makeSQL(database.rowsMatchingIDAndMinimumValueStatement())
+
+        XCTAssertTrue(encoding.sql.contains(":id"), "expected ':id' placeholder in \(encoding.sql)")
+        XCTAssertTrue(encoding.sql.contains(":minimumValue"), "expected ':minimumValue' placeholder in \(encoding.sql)")
+        XCTAssertFalse(encoding.sql.contains("'"), "expected no inline value literal in \(encoding.sql)")
+        XCTAssertNil(encoding.parameterLayoutError)
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.key),
+            [.named("id"), .named("minimumValue")]
+        )
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.nullability),
+            [.required, .required]
+        )
+    }
+
+    func testOptionalParameterStatementRendersNullableSlot() throws {
+        let encoding = encoder.makeSQL(database.nullableRowsMatchingValueStatement())
+
+        XCTAssertTrue(encoding.sql.contains(":value"), "expected ':value' placeholder in \(encoding.sql)")
+        XCTAssertNil(encoding.parameterLayoutError)
+        XCTAssertEqual(encoding.parameterLayout.slots.map(\.key), [.named("value")])
+        XCTAssertEqual(encoding.parameterLayout.slots.map(\.nullability), [.nullable])
+    }
+
+    func testStatementBuilderRendersIdenticalSQLOnRepeatedCalls() throws {
+        let first = encoder.makeSQL(database.rowsMatchingIDStatement())
+        let second = encoder.makeSQL(database.rowsMatchingIDStatement())
+
+        XCTAssertEqual(first.sql, second.sql)
+        XCTAssertEqual(first.parameterLayout, second.parameterLayout)
+    }
+
+
+    // MARK: - Execution
+
+    func testOneParameterExecutorFetchesMatchingRowsForEachInvocation() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 2))
+
+        XCTAssertEqual(
+            try database.fetchRowsMatchingID(id: "alpha"),
+            [TestTable(id: "alpha", value: 1)]
+        )
+        XCTAssertEqual(
+            try database.fetchRowsMatchingID(id: "beta"),
+            [TestTable(id: "beta", value: 2)]
+        )
+        XCTAssertEqual(try database.fetchRowsMatchingID(id: "gamma"), [])
+    }
+
+    func testTwoParameterExecutorFetchesMatchingRows() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "alpha", value: 5))
+        try insert(TestTable(id: "beta", value: 9))
+
+        XCTAssertEqual(
+            try database.fetchRowsMatchingIDAndMinimumValue(id: "alpha", minimumValue: 2),
+            [TestTable(id: "alpha", value: 5)]
+        )
+        XCTAssertEqual(
+            try database.fetchRowsMatchingIDAndMinimumValue(id: "alpha", minimumValue: 0).count,
+            2
+        )
+        XCTAssertEqual(
+            try database.fetchRowsMatchingIDAndMinimumValue(id: "beta", minimumValue: 10),
+            []
+        )
+    }
+
+    func testOptionalParameterExecutorBindsValueAndSQLNull() throws {
+        try createNullablesTable()
+        try insert(TestNullablesTable(id: "with-value", value: 42))
+        try insert(TestNullablesTable(id: "without-value", value: nil))
+
+        XCTAssertEqual(
+            try database.fetchNullableRowsMatchingValue(value: 42),
+            [TestNullablesTable(id: "with-value", value: 42)]
+        )
+        // Optional equality renders as SQL `IS`, which is null-safe: a nil
+        // binding matches the row whose column is NULL.
+        XCTAssertEqual(
+            try database.fetchNullableRowsMatchingValue(value: nil),
+            [TestNullablesTable(id: "without-value", value: nil)]
+        )
+    }
+
+
+    // MARK: - Helpers
+
+    private func createTestTable() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+    }
+
+    private func createNullablesTable() throws {
+        try database.makeRequest(with: sqlCreate(TestNullablesTable.self)).execute()
+    }
+
+    private func insert(_ row: TestTable) throws {
+        try database.makeRequest(with: sqlInsert(row)).execute()
+    }
+
+    private func insert(_ row: TestNullablesTable) throws {
+        try database.makeRequest(with: sqlInsert(row)).execute()
+    }
+}

--- a/Tests/SQLTests/SQLQueryPeerMacroTests.swift
+++ b/Tests/SQLTests/SQLQueryPeerMacroTests.swift
@@ -14,11 +14,57 @@ import GRDB
 import SwiftQL
 
 
+///
+/// Spike (#369): the trapping direct-result entry point.
+///
+/// A `@SQLQuery` spec written with a direct result type (`[Row]` / `Row?`) calls
+/// this instead of `sql {}` so the function type-checks without the
+/// `XLQueryStatement` boilerplate. It is only a type-check anchor and a syntax
+/// source for the macro; invoking it directly traps loudly, because the real
+/// work happens in the generated executor peer. The macro rewrites this callee
+/// back to `sql {}` when it emits the value-free statement builder.
+///
+/// The name is provisional — `sqlQuery` is already the labeled-closure statement
+/// builder, so the direct-result anchor needs its own name.
+///
+func sqlResult<Row, Result>(
+    @XLQueryExpressionBuilder _ builder: (XLSchema) -> any XLQueryStatement<Row>
+) -> Result {
+    fatalError(
+        "'sqlResult' marks a @SQLQuery specification, not an executor. "
+        + "Call the generated executor peer (e.g. fetchPersonByName) instead."
+    )
+}
+
+
 extension GRDBDatabase {
 
     @SQLQuery
     func rowsMatchingID(id: String) -> any XLQueryStatement<TestTable> {
         sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id)
+        }
+    }
+
+    // Spike (#369): direct-result specs — no `XLQueryStatement` boilerplate.
+    // `[TestTable]` dispatches to fetchAll; `TestTable?` dispatches to fetchOne.
+
+    @SQLQuery
+    func directRowsMatchingID(id: String) -> [TestTable] {
+        sqlResult { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id)
+        }
+    }
+
+    @SQLQuery
+    func directRowMatchingID(id: String) -> TestTable? {
+        sqlResult { schema in
             let table = schema.table(TestTable.self)
             Select(table)
             From(table)
@@ -177,6 +223,53 @@ final class XLQueryPeerMacroTests: XCTestCase {
             try database.fetchNullableRowsMatchingValue(value: nil),
             [TestNullablesTable(id: "without-value", value: nil)]
         )
+    }
+
+
+    // MARK: - Spike #369: direct-result execution
+
+    func testDirectResultArrayExecutorFetchesAllMatchingRows() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "alpha", value: 5))
+        try insert(TestTable(id: "beta", value: 9))
+
+        // `-> [TestTable]` dispatched to fetchAll and returned every match.
+        XCTAssertEqual(
+            try database.fetchDirectRowsMatchingID(id: "alpha").count,
+            2
+        )
+        XCTAssertEqual(
+            try database.fetchDirectRowsMatchingID(id: "beta"),
+            [TestTable(id: "beta", value: 9)]
+        )
+        XCTAssertEqual(try database.fetchDirectRowsMatchingID(id: "gamma"), [])
+    }
+
+    func testDirectResultOptionalExecutorFetchesSingleRow() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 9))
+
+        // `-> TestTable?` dispatched to fetchOne and returned an optional row.
+        XCTAssertEqual(
+            try database.fetchDirectRowMatchingID(id: "beta"),
+            TestTable(id: "beta", value: 9)
+        )
+        XCTAssertNil(try database.fetchDirectRowMatchingID(id: "gamma"))
+    }
+
+    func testDirectResultStatementRendersSamePlaceholderSQLAsLegacyForm() throws {
+        // The direct-result spec produces the same value-free statement as the
+        // legacy XLQueryStatement spelling: a named placeholder, no inline
+        // literal. The `sqlResult` -> `sql` callee swap is transparent.
+        let direct = encoder.makeSQL(database.directRowsMatchingIDStatement())
+        let legacy = encoder.makeSQL(database.rowsMatchingIDStatement())
+
+        XCTAssertEqual(direct.sql, legacy.sql)
+        XCTAssertTrue(direct.sql.contains(":id"))
+        XCTAssertFalse(direct.sql.contains("'"))
+        XCTAssertEqual(direct.parameterLayout.slots.map(\.key), [.named("id")])
     }
 
 

--- a/Tests/SQLTests/SQLQueryPeerMacroTests.swift
+++ b/Tests/SQLTests/SQLQueryPeerMacroTests.swift
@@ -14,29 +14,6 @@ import GRDB
 import SwiftQL
 
 
-///
-/// Spike (#369): the trapping direct-result entry point.
-///
-/// A `@SQLQuery` spec written with a direct result type (`[Row]` / `Row?`) calls
-/// this instead of `sql {}` so the function type-checks without the
-/// `XLQueryStatement` boilerplate. It is only a type-check anchor and a syntax
-/// source for the macro; invoking it directly traps loudly, because the real
-/// work happens in the generated executor peer. The macro rewrites this callee
-/// back to `sql {}` when it emits the value-free statement builder.
-///
-/// The name is provisional — `sqlQuery` is already the labeled-closure statement
-/// builder, so the direct-result anchor needs its own name.
-///
-func sqlResult<Row, Result>(
-    @XLQueryExpressionBuilder _ builder: (XLSchema) -> any XLQueryStatement<Row>
-) -> Result {
-    fatalError(
-        "'sqlResult' marks a @SQLQuery specification, not an executor. "
-        + "Call the generated executor peer (e.g. fetchPersonByName) instead."
-    )
-}
-
-
 extension GRDBDatabase {
 
     @SQLQuery


### PR DESCRIPTION
Proof-of-concept for #369 (milestone **Spike: @SQLQuery peer-macro encoding**). Proves two encodings on the v1.x floor (swift-tools 5.9, swift-syntax 509.1.1, Swift 5 language mode), the second superseding the first as the packaging recommendation after the 2026-07-24 design discussion.

> [!IMPORTANT]
> **Stacked on #364 (#359).** This branch is based on `claude/spike-359-sqlquery-peer-macro`, which is not yet merged into `experiment/sqlquery-peer-macro`. Until #364 merges, the diff includes #359's commits as well as this spike's. #369-specific commits: `878bec46` (direct-result peers), `8cab8754`/`a8719782`/`52e60c1b` (Copilot rounds 1–3), `1c298884` (container encoding).

## Encoding 1 — direct-result peer signatures (`@SQLQuery`, per-function)

The attached function declares its **result directly** and the macro derives cardinality from the annotation. Peers: `personByNameStatement()` + `fetchPersonByName(…)`. The spec calls a trapping `sqlResult {}` entry point.

```swift
@SQLQuery func personByName(name: String)      -> [Person]  { sqlResult { schema in … } }  // → fetchAll
@SQLQuery func personByExactName(name: String) -> Person?   { sqlResult { schema in … } }  // → fetchOne
```

Limitation proven along the way: a peer **cannot** give the executor the spec's own name (same-scope same-name overloads differing only in `throws`/nothing are invalid redeclarations), so the executor needs a `fetch…` name and the trapping spec stays visible.

## Encoding 2 — container + member macro (`@SQLQueries`) — **recommended**

Specifications live in a nested `Query` container; a **member macro on the extension** sees them all in one expansion and generates the executors as members of the database — carrying the spec's own pretty name, legally, because they land in a different scope:

```swift
@SQLQueries
extension MyDatabase {
    private struct Query {                    // never referenced by generated code →
        func personByName(name: String) -> [Person] { sqlResult { … } }   // specs can be private
        func personById(id: String) -> Person?      { sqlResult { … } }
    }
}

// generated (provisional names):
// struct Context { func personByName(…) throws -> [Person]; func personById(…) throws -> Person? }
// func execute<R>(_ work: (Context) throws -> R) throws -> R
// func personByName(…) throws -> [Person]   // sugar over execute
// func personById(…) throws -> Person?
```

Call sites:

```swift
let people = try database.personByName(name: "john")            // one-shot, implicit
let people = try database.execute { try $0.personByName(name: "john") }  // explicit scope (transactions/pooling home)
```

Why this beats per-function peers:
- **The natural call hits the executor**, not the trap; a `private`/`fileprivate` container removes the trapping specs from the visible API entirely — the strongest Wart-B mitigation available without body macros (SE-0415, Swift 6.0 + experimental flag, out per #26's floor constraint).
- Independent peer expansions can't cooperate on one shared `Context`; the member macro sees all specs at once.
- The `execute`/`Context` stub is deliberately thin — it binds the database directly; connection checkout, pooling, and transaction scoping are runtime design for #26/v1.5.x, and `async` (v1.5.0) lands there additively.

## Shared machinery (both encodings)

Signature-driven parameter rewrite to `XLNamedBindingReference<T>`, return-shape dispatch (`[Row]`→`fetchAll`, `Row?`→`fetchOne`, legacy `any/some XLQueryStatement<Row>`→`fetchAll`), byte-identical placeholder SQL to the #359 form, callee-position-only `sqlResult`→`sql` swap, reserved-parameter-name diagnostic (`sql`/`sqlQuery`/`sqlResult`).

## Tests (all on the floor)

- `SQLQueryMacroTests` — direct-result expansions, callee-position rename, reserved-name diagnostic (12 expansion + diagnostics green).
- `SQLQueriesMacroTests` — container expansion (Context + execute + sugar, both cardinalities) and diagnostics.
- `SQLQueryPeerMacroTests` / `SQLQueriesContainerTests` — GRDB runtime for both encodings, including `execute { }` scoped calls and SQL-identity assertions.
- **Full suite: 783 tests, 0 failures.**

All generated and entry-point names (`sqlResult`, `Query`, `Context`, `execute`, `…Statement`, `fetch…`) remain provisional per #26 — do not freeze on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)