### PR TITLE
Align ROADMAP direct-scalar-CTE note with delivered v1.4.5 work

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -260,8 +260,8 @@ The remaining wrapper requirement came from compound-query and common-table
 metadata that assumed every row is a macro-generated `XLResult`.
 
 v1.4 lets ordinary and recursive CTEs return `T` or `T?` directly
-([#43](https://github.com/lukevanin/swiftql/issues/43), delivered in the v1.4.5
-milestone). The implementation preserves the existing row reader across compound
+([#43](https://github.com/lukevanin/swiftql/issues/43), delivered in the
+[v1.4.5](https://github.com/lukevanin/swiftql/milestone/15) milestone). The implementation preserves the existing row reader across compound
 branches and exposes an adapter-neutral scalar CTE reference with a stable typed
 value column. `SQLScalarResult` remains source-compatible during v1; it is now a
 legacy shim rather than a requirement. Scalar-subquery conversion and nested

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -261,9 +261,10 @@ metadata that assumed every row is a macro-generated `XLResult`.
 
 v1.4 lets ordinary and recursive CTEs return `T` or `T?` directly
 ([#43](https://github.com/lukevanin/swiftql/issues/43), delivered in the
-[v1.4.5](https://github.com/lukevanin/swiftql/milestone/15) milestone). The implementation preserves the existing row reader across compound
-branches and exposes an adapter-neutral scalar CTE reference with a stable typed
-value column. `SQLScalarResult` remains source-compatible during v1; it is now a
+[v1.4.5](https://github.com/lukevanin/swiftql/milestone/15) milestone). The
+implementation preserves the existing row reader across compound branches and
+exposes an adapter-neutral scalar CTE reference with a stable typed value
+column. `SQLScalarResult` remains source-compatible during v1; it is now a
 legacy shim rather than a requirement. Scalar-subquery conversion and nested
 optional flattening remain separate concerns.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,13 +256,14 @@ is tracked by the
 ### Direct scalar rows
 
 Scalar SELECTs already have enough information to decode a direct Swift value.
-The remaining wrapper requirement comes from compound-query and common-table
-metadata that assumes every row is a macro-generated `XLResult`.
+The remaining wrapper requirement came from compound-query and common-table
+metadata that assumed every row is a macro-generated `XLResult`.
 
-v1.4 should let ordinary and recursive CTEs return `T` or `T?` directly. The
-implementation should preserve the existing row reader across compound branches
-and expose an adapter-neutral scalar CTE reference with a stable typed value
-column. `SQLScalarResult` remains source-compatible during v1; it becomes a
+v1.4 lets ordinary and recursive CTEs return `T` or `T?` directly
+([#43](https://github.com/lukevanin/swiftql/issues/43), delivered in the v1.4.5
+milestone). The implementation preserves the existing row reader across compound
+branches and exposes an adapter-neutral scalar CTE reference with a stable typed
+value column. `SQLScalarResult` remains source-compatible during v1; it is now a
 legacy shim rather than a requirement. Scalar-subquery conversion and nested
 optional flattening remain separate concerns.
 


### PR DESCRIPTION
Follow-up to the v1.4.6 readiness audit ([#229](https://github.com/lukevanin/swiftql/issues/229), disposition #4): align the ROADMAP with the actual milestone state.

## Change

The "Direct scalar rows" section described [#43](https://github.com/lukevanin/swiftql/issues/43) in **future tense** — *"v1.4 should let ordinary and recursive CTEs return `T`/`T?` directly… The implementation should preserve…"* — but #43 is **delivered and closed** in the **v1.4.5** milestone. Updated to present/delivered tense, with the issue and its milestone linked, so the roadmap matches reality.

A scan of `ROADMAP.md` found no other v1.4 claim written in future tense against shipped work (`grep -nE "v1\.4 (should|will)|should let|should preserve"` returns only this section).

## Why only a tense fix

The roadmap deliberately tracks the **version line** (v1.4 → milestone/9), while GitHub carries the sub‑version delivery milestones (v1.4.1–v1.4.6, v1.4.5 for #43). That abstraction is intentional and left unchanged; the audit's #43 finding was specifically that a delivered feature read as pending.

## Validation

```bash
swift test --filter SQLDocumentationCatalogTests   # 7 tests, 0 failures
```

No test enforces ROADMAP prose; the catalog suite only checks the README→ROADMAP link (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)