### PR TITLE
Add @SQLQuery / @SQLQueries declaration macros (#18, #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
   value-free statement builder and a cached, cardinality-dispatched executor.
   Labeled parameters and result cardinality are derived from the function's
   own signature: `[Row]` fetches all rows, `Row?` fetches zero-or-one, a bare
-  `Row` fetches exactly one (throwing `XLQueryCardinalityError
-  .exactlyOneRowExpected` on zero or many rows), and the legacy `any/some
+  `Row` fetches exactly one (throwing `XLQueryCardinalityError.noRowsMatched`
+  or `.moreThanOneRowMatched`), and the legacy `any/some
   XLQueryStatement<Row>` spelling fetches all rows. Every invocation
   constructs a fresh, immutable binding packet; callers never construct or
   mutate a binding themselves and never bind by textual SQL substitution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## [1.5.1] - 2026-07-24
+
+### Added
+
+- Added `@SQLQuery` (issues #18/#26), an attached peer macro that lowers a
+  query-specification function — an instance method on a database extension
+  whose body builds a `sql { }` statement from its own parameters — into a
+  value-free statement builder and a cached, cardinality-dispatched executor.
+  Labeled parameters and result cardinality are derived from the function's
+  own signature: `[Row]` fetches all rows, `Row?` fetches zero-or-one, a bare
+  `Row` fetches exactly one (throwing `XLQueryCardinalityError
+  .exactlyOneRowExpected` on zero or many rows), and the legacy `any/some
+  XLQueryStatement<Row>` spelling fetches all rows. Every invocation
+  constructs a fresh, immutable binding packet; callers never construct or
+  mutate a binding themselves and never bind by textual SQL substitution.
+- Added `@SQLQueries` (issues #18/#26, the recommended packaging), an
+  attached member macro that reads every specification out of a nested
+  `private struct Query` container inside one `@SQLQueries`-attached database
+  extension, and generates the executors as members of the database itself —
+  carrying the specification's own name (`personByName(name:)`, not
+  `fetchPersonByName`) because they land in a different scope. Generates a
+  connection-scoped `Context`, an `execute(_:)` entry point for running
+  several declared queries in one scope, and one database-level convenience
+  executor per specification.
+- Added the frozen-literal guard: both macros reject, at the declaration
+  site, every parameter-reference shape their signature-driven rewrite cannot
+  turn into a named placeholder — a string interpolation, a nested-closure
+  capture, a direct call argument, a local-binding initializer, a
+  hand-constructed binding, a shadowing declaration, member access on a
+  parameter, a collection-typed parameter, and an unreferenced parameter.
+  Every remaining reference shape the rewrite reaches is rewritten to a named
+  placeholder, so the encoding has no path that silently freezes a stale
+  argument value into the cached SQL.
+- Added `XLRenderOnceCache` and `XLPreparedQueryCacheKey`: each declaration
+  renders its value-free statement to SQL at most once per
+  `(databaseIdentifier, dialectIdentifier)` and reuses the resulting request
+  on every later call, so the underlying GRDB connection reuses one physical
+  prepared statement across calls with different argument values.
+  `GRDBDatabase.preparedQueryCacheKey` opts the GRDB adapter into this
+  reuse; `XLDatabase.preparedQueryCacheKey` defaults to `nil` (render on every
+  call) so existing third-party adapters keep compiling.
+- Added the `DeclaredQueries` DocC article covering the `@SQLQuery` and
+  `@SQLQueries` forms, the frozen-literal guard, render-once caching and its
+  concurrency/`Sendable` story, and the v1.5 transitional-syntax note.
+
+### Migration
+
+No migration is required for v1.5.1. `@SQLQuery` and `@SQLQueries` are new,
+additive macros; the one new `XLDatabase.preparedQueryCacheKey` protocol
+requirement has a default (`nil`) that keeps every existing conformer,
+including third-party `XLDatabase` adapters, source-compatible.
+
+### Known limitations
+
+- Only `SELECT`-shaped specifications are supported; a write statement
+  (`INSERT`/`UPDATE`/`DELETE`, with or without `RETURNING`) is not yet an
+  accepted return shape. A `.command` cardinality dispatching to
+  `XLWriteRequest.execute` remains future work.
+- Collection-typed parameters (`[T]`, `Set`, `Dictionary`) are rejected,
+  because a variable-length `IN` list would change the rendered SQL text with
+  the element count.
+- The generated executor is synchronous and throwing; an `async` variant is
+  additive future work.
+- Peer and member names are derived from the specification's base name only,
+  so two `@SQLQuery` functions sharing a base name but differing in
+  parameter list generate colliding peer declarations — a loud
+  duplicate-declaration compile error, not a silent one.
+- Only one `@SQLQueries`-attached extension is supported per database type; a
+  second would redeclare `Context` and `execute(_:)`.
+
 ## [1.4.6] - 2026-07-25
 
 ### Changed

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/DeclaredQueriesFixture.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/DeclaredQueriesFixture.swift
@@ -1,0 +1,54 @@
+import SwiftQL
+
+// Downstream compatibility check for issues #18/#26: `@SQLQuery` (the direct
+// peer form) and `@SQLQueries` (the container form) must expand and execute
+// under the Swift 5 language-mode floor this fixture package pins to — the
+// same floor `SwiftQLSwift5Client` validates for every other macro in this
+// file.
+
+extension GRDBDatabase {
+
+    @SQLQuery
+    func skillPersonByName(name: String) -> SkillPerson? {
+        sqlResult { schema in
+            let person = schema.table(SkillPerson.self)
+            Select(person)
+            From(person)
+            Where(person.name == name)
+        }
+    }
+}
+
+
+@SQLQueries
+extension GRDBDatabase {
+
+    // Never referenced by the generated code, so it is safe to keep private
+    // to this file.
+    fileprivate struct Query {
+
+        func skillPeopleByName(name: String) -> [SkillPerson] {
+            sqlResult { schema in
+                let person = schema.table(SkillPerson.self)
+                Select(person)
+                From(person)
+                Where(person.name == name)
+            }
+        }
+    }
+}
+
+
+func validateDeclaredQueryMacros(database: GRDBDatabase) throws {
+    let expected = SkillPerson(id: "ada", name: "Ada Lovelace")
+
+    let direct = try database.fetchSkillPersonByName(name: "Ada Lovelace")
+    guard direct == expected else {
+        throw FixtureError.unexpectedDeclaredQueryResult(direct)
+    }
+
+    let container = try database.skillPeopleByName(name: "Ada Lovelace")
+    guard container == [expected] else {
+        throw FixtureError.unexpectedDeclaredQueriesResult(container)
+    }
+}

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -36,6 +36,8 @@ enum FixtureError: Error {
     case unexpectedPacketResult(Int?)
     case unexpectedStaticQueryResult(Int64)
     case unexpectedSkillQueryResult([SkillPerson])
+    case unexpectedDeclaredQueryResult(SkillPerson?)
+    case unexpectedDeclaredQueriesResult([SkillPerson])
     case unexpectedResult(PersonSummary?)
 }
 
@@ -235,6 +237,7 @@ private func executeFixture(
     guard skillPeople == [SkillPerson(id: "ada", name: "Ada Lovelace")] else {
         throw FixtureError.unexpectedSkillQueryResult(skillPeople)
     }
+    try validateDeclaredQueryMacros(database: database)
 
     let token = try database.contextualBinding(
         DownstreamToken.self,

--- a/Sources/SQLMacros/SQLMacro.swift
+++ b/Sources/SQLMacros/SQLMacro.swift
@@ -155,5 +155,7 @@ extension SQLResultMacro: ExtensionMacro {
     let providingMacros: [Macro.Type] = [
         SQLTableMacro.self,
         SQLResultMacro.self,
+        SQLQueryMacro.self,
+        SQLQueriesMacro.self,
     ]
 }

--- a/Sources/SQLMacros/SQLQueriesMacro.swift
+++ b/Sources/SQLMacros/SQLQueriesMacro.swift
@@ -145,6 +145,8 @@ extension SQLQueriesMacro: MemberMacro {
         lines.append("    let database: \(databaseType)")
         for builder in builders {
             lines.append("")
+            lines.append(indent(builder.makeRenderOnceCacheDeclaration(), by: 4))
+            lines.append("")
             lines.append(indent(builder.makeContextExecutorFunction(modifierPrefix: modifierPrefix), by: 4))
         }
         lines.append("}")
@@ -182,18 +184,23 @@ extension SQLQueryBuilder {
 
     ///
     /// Generates the connection-scoped executor for the `Context` container.
-    /// The value-free statement is built inline from the rewritten body, so
-    /// the specification's placeholder SQL invariant carries over unchanged.
+    /// The value-free statement is built inline from the rewritten body and
+    /// prepared through this specification's own `XLRenderOnceCache` (a
+    /// sibling `static` member of `Context`, emitted alongside this
+    /// function), so the container form gets the same render-once behavior
+    /// as the `@SQLQuery` peer macro's executor rather than re-rendering SQL
+    /// on every call.
     ///
     func makeContextExecutorFunction(modifierPrefix: String) -> String {
         let parameterClause = function.signature.parameterClause.trimmedDescription
         // The rewritten body is a code block; applying it as a closure yields
         // the value-free statement without a separate builder symbol.
-        let statementExpression = indentSkippingFirstLine(rewrittenBodyText, by: 4)
+        let statementExpression = indentSkippingFirstLine(rewrittenBodyText, by: 8)
         var lines: [String] = []
         lines.append("\(modifierPrefix)func \(function.name.text)\(parameterClause) throws -> \(executorResultType) {")
-        lines.append("    let __xlStatement: any XLQueryStatement<\(rowType)> = \(statementExpression)()")
-        lines.append("    let __xlRequest = database.makeRequest(with: __xlStatement)")
+        lines.append("    let __xlRequest = Self.\(renderOnceCacheName).request(for: database) {")
+        lines.append("        \(statementExpression)()")
+        lines.append("    }")
         lines.append("    let __xlLayout = __xlRequest.parameterLayout")
         if parameters.isEmpty {
             lines.append("    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()")

--- a/Sources/SQLMacros/SQLQueriesMacro.swift
+++ b/Sources/SQLMacros/SQLQueriesMacro.swift
@@ -1,0 +1,250 @@
+//
+//  SQLQueriesMacro.swift
+//  SwiftQL
+//
+//  Issues #18/#26 (container encoding): attached member macro that reads query
+//  specifications from a nested `Query` container inside a database extension
+//  and generates the executors as members of the database itself. Ported from
+//  the milestone #28 spike on `experiment/sqlquery-peer-macro`.
+//
+
+import Foundation
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+
+///
+/// Generates executors for the query specifications declared in a nested
+/// `Query` container.
+///
+/// A per-function peer macro cannot produce this shape: peers land in the same
+/// scope as the attached function (so a same-name executor is an invalid
+/// redeclaration) and independent expansions cannot cooperate on one shared
+/// `Context` type. A member macro attached to the *extension* sees every
+/// specification in one expansion, so the executors can carry the
+/// specification's own name in a different scope.
+///
+/// Generated members:
+///   * `struct Context` — connection-scoped executors; one per specification.
+///   * `execute(_:)` — runs a closure against a context. The current
+///     implementation binds the context directly to the database; connection
+///     pooling and transaction scoping remain future runtime-design work.
+///   * One database-level convenience executor per specification, defined as
+///     sugar over `execute`, so the implicit form is transparently the
+///     explicit one.
+///
+/// The `Query` container itself is never referenced by the generated code —
+/// it is a pure specification namespace, so the user may declare it `private`
+/// or `fileprivate` to remove the trapping spec functions from the visible
+/// API surface.
+///
+public struct SQLQueriesMacro {
+}
+
+extension SQLQueriesMacro: MemberMacro {
+
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let extensionDecl = declaration.as(ExtensionDeclSyntax.self) else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(
+                    node: node,
+                    id: "sqlqueries-extension-only",
+                    message: "'@SQLQueries' can only be applied to an extension of a database type. The generated executors prepare requests through the extended type's 'makeRequest(with:)'."
+                )
+            ])
+        }
+        let databaseType = extensionDecl.extendedType.trimmedDescription
+
+        // Propagate the extension's modifiers (access level) to every
+        // generated member, so a `public extension` exposes the executors to
+        // outside-module callers.
+        let extensionModifiers = extensionDecl.modifiers.trimmedDescription
+        let modifierPrefix = extensionModifiers.isEmpty ? "" : extensionModifiers + " "
+
+        var builders: [SQLQueryBuilder] = []
+        var diagnostics: [Diagnostic] = []
+        var foundContainer = false
+        for member in extensionDecl.memberBlock.members {
+            guard let container = member.decl.as(StructDeclSyntax.self),
+                  container.name.text == "Query" else {
+                continue
+            }
+            foundContainer = true
+            for containerMember in container.memberBlock.members {
+                guard let function = containerMember.decl.as(FunctionDeclSyntax.self) else {
+                    continue
+                }
+                do {
+                    builders.append(try SQLQueryBuilder(
+                        node: node,
+                        declaration: function,
+                        macroName: "@SQLQueries"
+                    ))
+                }
+                catch let error as DiagnosticsError {
+                    diagnostics.append(contentsOf: error.diagnostics)
+                }
+            }
+        }
+
+        guard foundContainer else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(
+                    node: node,
+                    id: "sqlqueries-container-required",
+                    message: "'@SQLQueries' requires a nested 'struct Query' container declaring the query specifications."
+                )
+            ])
+        }
+        guard diagnostics.isEmpty else {
+            throw DiagnosticsError(diagnostics: diagnostics)
+        }
+
+        var members: [String] = []
+        members.append(makeContextStruct(
+            databaseType: databaseType,
+            builders: builders,
+            modifierPrefix: modifierPrefix
+        ))
+        members.append(makeExecuteFunction(modifierPrefix: modifierPrefix))
+        for builder in builders {
+            members.append(builder.makeDatabaseExecutorFunction(modifierPrefix: modifierPrefix))
+        }
+        return members.map { DeclSyntax(stringLiteral: $0) }
+    }
+
+    ///
+    /// Generates the `Context` container holding one connection-scoped
+    /// executor per specification.
+    ///
+    private static func makeContextStruct(
+        databaseType: String,
+        builders: [SQLQueryBuilder],
+        modifierPrefix: String
+    ) -> String {
+        var lines: [String] = []
+        lines.append("\(modifierPrefix)struct Context {")
+        lines.append("    let database: \(databaseType)")
+        for builder in builders {
+            lines.append("")
+            lines.append(indent(builder.makeContextExecutorFunction(modifierPrefix: modifierPrefix), by: 4))
+        }
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Generates the `execute` entry point. The current implementation binds
+    /// the context straight to the database; connection checkout and
+    /// transaction scoping are runtime design left for future work.
+    ///
+    private static func makeExecuteFunction(modifierPrefix: String) -> String {
+        var lines: [String] = []
+        lines.append("\(modifierPrefix)func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {")
+        lines.append("    try __xlWork(Context(database: self))")
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+}
+
+
+///
+/// Indents every line of a multi-line declaration by the given column count.
+///
+internal func indent(_ text: String, by spaces: Int) -> String {
+    let padding = String(repeating: " ", count: spaces)
+    return text
+        .components(separatedBy: "\n")
+        .map { $0.isEmpty ? $0 : padding + $0 }
+        .joined(separator: "\n")
+}
+
+
+extension SQLQueryBuilder {
+
+    ///
+    /// Generates the connection-scoped executor for the `Context` container.
+    /// The value-free statement is built inline from the rewritten body, so
+    /// the specification's placeholder SQL invariant carries over unchanged.
+    ///
+    func makeContextExecutorFunction(modifierPrefix: String) -> String {
+        let parameterClause = function.signature.parameterClause.trimmedDescription
+        // The rewritten body is a code block; applying it as a closure yields
+        // the value-free statement without a separate builder symbol.
+        let statementExpression = indentSkippingFirstLine(rewrittenBodyText, by: 4)
+        var lines: [String] = []
+        lines.append("\(modifierPrefix)func \(function.name.text)\(parameterClause) throws -> \(executorResultType) {")
+        lines.append("    let __xlStatement: any XLQueryStatement<\(rowType)> = \(statementExpression)()")
+        lines.append("    let __xlRequest = database.makeRequest(with: __xlStatement)")
+        lines.append("    let __xlLayout = __xlRequest.parameterLayout")
+        if parameters.isEmpty {
+            lines.append("    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()")
+        }
+        else {
+            lines.append("    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(")
+            lines.append("        layout: __xlLayout,")
+            lines.append("        bindings: [")
+            for parameter in parameters {
+                lines.append("            try _xlQueryParameterBinding(\(parameter.swiftName), named: \"\(parameter.placeholderName)\", in: __xlLayout),")
+            }
+            lines.append("        ]")
+            lines.append("    ).validatingComplete()")
+        }
+        for fetchLine in makeFetchLines(requestVariable: "__xlRequest", packetVariable: "__xlPacket") {
+            lines.append("    " + fetchLine)
+        }
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Generates the database-level convenience executor: sugar over
+    /// `execute`, so the implicit one-shot form is transparently the explicit
+    /// context form.
+    ///
+    func makeDatabaseExecutorFunction(modifierPrefix: String) -> String {
+        let parameterClause = function.signature.parameterClause.trimmedDescription
+        var arguments: [String] = []
+        for parameter in function.signature.parameterClause.parameters {
+            let value = (parameter.secondName ?? parameter.firstName).text
+            if parameter.firstName.tokenKind == .wildcard {
+                arguments.append(value)
+            }
+            else {
+                arguments.append("\(parameter.firstName.text): \(value)")
+            }
+        }
+        let argumentList = arguments.joined(separator: ", ")
+        var lines: [String] = []
+        lines.append("\(modifierPrefix)func \(function.name.text)\(parameterClause) throws -> \(executorResultType) {")
+        lines.append("    try execute { __xlContext in")
+        lines.append("        try __xlContext.\(function.name.text)(\(argumentList))")
+        lines.append("    }")
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Indents every line except the first — used when a multi-line block is
+    /// embedded after an assignment on an already-indented line.
+    ///
+    private func indentSkippingFirstLine(_ text: String, by spaces: Int) -> String {
+        var lines = text.components(separatedBy: "\n")
+        guard lines.count > 1 else {
+            return text
+        }
+        let padding = String(repeating: " ", count: spaces)
+        for index in 1 ..< lines.count {
+            if !lines[index].isEmpty {
+                lines[index] = padding + lines[index]
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/SQLMacros/SQLQueriesMacro.swift
+++ b/Sources/SQLMacros/SQLQueriesMacro.swift
@@ -69,31 +69,13 @@ extension SQLQueriesMacro: MemberMacro {
 
         var builders: [SQLQueryBuilder] = []
         var diagnostics: [Diagnostic] = []
-        var foundContainer = false
-        for member in extensionDecl.memberBlock.members {
-            guard let container = member.decl.as(StructDeclSyntax.self),
-                  container.name.text == "Query" else {
-                continue
-            }
-            foundContainer = true
-            for containerMember in container.memberBlock.members {
-                guard let function = containerMember.decl.as(FunctionDeclSyntax.self) else {
-                    continue
-                }
-                do {
-                    builders.append(try SQLQueryBuilder(
-                        node: node,
-                        declaration: function,
-                        macroName: "@SQLQueries"
-                    ))
-                }
-                catch let error as DiagnosticsError {
-                    diagnostics.append(contentsOf: error.diagnostics)
-                }
+        let containers = extensionDecl.memberBlock.members.compactMap { member in
+            member.decl.as(StructDeclSyntax.self).flatMap { container in
+                container.name.text == "Query" ? container : nil
             }
         }
 
-        guard foundContainer else {
+        guard let container = containers.first else {
             throw DiagnosticsError(diagnostics: [
                 Diagnostic(
                     node: node,
@@ -102,6 +84,36 @@ extension SQLQueriesMacro: MemberMacro {
                 )
             ])
         }
+
+        // A second `Query` container's specifications would silently merge into the same
+        // generated executor set with no indication which container a given executor came
+        // from -- diagnose it instead of merging.
+        for extraContainer in containers.dropFirst() {
+            diagnostics.append(
+                Diagnostic(
+                    node: Syntax(extraContainer),
+                    id: "sqlqueries-multiple-containers",
+                    message: "'@SQLQueries' found more than one nested 'struct Query' container in this extension. Declare every query specification in a single 'Query' container."
+                )
+            )
+        }
+
+        for containerMember in container.memberBlock.members {
+            guard let function = containerMember.decl.as(FunctionDeclSyntax.self) else {
+                continue
+            }
+            do {
+                builders.append(try SQLQueryBuilder(
+                    node: node,
+                    declaration: function,
+                    macroName: "@SQLQueries"
+                ))
+            }
+            catch let error as DiagnosticsError {
+                diagnostics.append(contentsOf: error.diagnostics)
+            }
+        }
+
         guard diagnostics.isEmpty else {
             throw DiagnosticsError(diagnostics: diagnostics)
         }

--- a/Sources/SQLMacros/SQLQueriesMacro.swift
+++ b/Sources/SQLMacros/SQLQueriesMacro.swift
@@ -229,7 +229,13 @@ extension SQLQueryBuilder {
                 arguments.append(value)
             }
             else {
-                arguments.append("\(parameter.firstName.text): \(value)")
+                // The call-site label must be unescaped even when the
+                // parameter's own spelling is backtick-escaped (a reserved
+                // keyword like `class`): Swift call-site argument labels are
+                // never backtick-escaped, only the referenced local variable
+                // is. `value` keeps its original (possibly escaped) spelling.
+                let label = normalizedIdentifier(parameter.firstName.text)
+                arguments.append("\(label): \(value)")
             }
         }
         let argumentList = arguments.joined(separator: ", ")

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -661,10 +661,14 @@ internal struct SQLQueryBuilder {
         case .exactlyOne:
             return [
                 "let __xlRows = try \(requestVariable).fetchAtMost(2, bindings: \(packetVariable))",
-                "guard __xlRows.count == 1 else {",
-                "    throw XLQueryCardinalityError.exactlyOneRowExpected(actual: __xlRows.count)",
+                "switch __xlRows.count {",
+                "case 0:",
+                "    throw XLQueryCardinalityError.noRowsMatched",
+                "case 1:",
+                "    return __xlRows[0]",
+                "default:",
+                "    throw XLQueryCardinalityError.moreThanOneRowMatched",
                 "}",
-                "return __xlRows[0]",
             ]
         }
     }

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -1,0 +1,1114 @@
+//
+//  SQLQueryMacro.swift
+//  SwiftQL
+//
+//  Issues #18/#26: attached peer macro that rewrites a query-specification
+//  function into a value-free statement builder plus an executor whose fetch
+//  (`fetchAll` / `fetchOne` / exactly-one) is dispatched from the return
+//  annotation. Ported from the milestone #28 spike on
+//  `experiment/sqlquery-peer-macro`.
+//
+
+import Foundation
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+
+///
+/// Declares a query-specification function as a reusable prepared query.
+///
+/// The attached function builds a `SELECT` statement from its parameters. The
+/// macro generates two peers: a value-free statement builder in which every
+/// parameter reference is replaced by a typed `XLNamedBindingReference`, and an
+/// executor that renders the statement once per call through the enclosing
+/// database's `makeRequest(with:)`, binds the parameter values into an
+/// immutable invocation packet, and fetches the result. The fetch is dispatched
+/// from the function's return annotation: `[Row]` (or the legacy
+/// `any/some XLQueryStatement<Row>`) fetches all rows, `Row?` fetches one, and
+/// a bare `Row` fetches exactly one row, throwing if the query matches zero or
+/// more than one row.
+///
+public struct SQLQueryMacro {
+}
+
+extension SQLQueryMacro: PeerMacro {
+
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        let builder = try SQLQueryBuilder(node: node, declaration: declaration)
+        return [
+            DeclSyntax(stringLiteral: builder.makeStatementFunction()),
+            DeclSyntax(stringLiteral: builder.makeRenderOnceCacheDeclaration()),
+            DeclSyntax(stringLiteral: builder.makeExecutorFunction()),
+        ]
+    }
+}
+
+
+///
+/// One named function parameter that participates in the signature-driven body
+/// rewrite.
+///
+internal struct SQLQueryParameter {
+
+    /// The internal parameter name exactly as written, including any escaping
+    /// backticks. Used where generated code passes the parameter value.
+    var swiftName: String
+
+    /// The internal parameter name without escaping backticks. Doubles as the
+    /// SQL placeholder name and as the rewrite-matching key.
+    var placeholderName: String
+
+    /// The type annotation exactly as written in the signature.
+    var type: String
+
+    /// The typed named-binding reference that replaces every reference to the
+    /// parameter inside the statement body.
+    var bindingReference: String {
+        "XLNamedBindingReference<\(type)>(name: \"\(placeholderName)\")"
+    }
+}
+
+
+///
+/// Removes the escaping backticks from an identifier spelling, so escaped and
+/// unescaped references to the same declaration compare equal.
+///
+internal func normalizedIdentifier(_ text: String) -> String {
+    guard text.count >= 2, text.hasPrefix("`"), text.hasSuffix("`") else {
+        return text
+    }
+    return String(text.dropFirst().dropLast())
+}
+
+
+///
+/// Result cardinality derived from the attached function's return type.
+///
+/// With a direct-result signature the return annotation is the only source of
+/// cardinality. `[Row]` maps to `fetchAll`, `Row?` to `fetchOne`, and a bare
+/// `Row` to `exactlyOne` (fetch all, then validate the count is exactly one).
+///
+internal enum SQLQueryCardinality {
+    case many        // [Row]  -> fetchAll
+    case one         // Row?   -> fetchOne
+    case exactlyOne  // Row    -> fetchAll, then validate count == 1
+}
+
+
+///
+/// The row element type, cardinality, and spelling style extracted from the
+/// return clause.
+///
+internal struct SQLQueryReturnShape {
+
+    /// The element type the executor decodes (e.g. `Person`).
+    var rowType: String
+
+    /// Whether the executor fetches all rows, an optional single row, or
+    /// exactly one row.
+    var cardinality: SQLQueryCardinality
+
+    /// `true` when the function declares its result directly (`[Row]` /
+    /// `Row?` / `Row`); `false` for the legacy `XLQueryStatement<Row>`
+    /// spelling. In the direct-result case the statement-builder peer must
+    /// swap the trapping `sqlResult` entry point for the real `sql` builder.
+    var isDirectResult: Bool
+}
+
+
+///
+/// Parses the attached function and generates the statement-builder and
+/// executor peers for the `@SQLQuery` macro.
+///
+internal struct SQLQueryBuilder {
+
+    let function: FunctionDeclSyntax
+
+    let parameters: [SQLQueryParameter]
+
+    let returnShape: SQLQueryReturnShape
+
+    var rowType: String { returnShape.rowType }
+
+    let rewrittenBodyText: String
+
+    /// The user-facing attribute name used in diagnostics — `@SQLQuery` for
+    /// the per-function peer macro, `@SQLQueries` when specifications are
+    /// parsed out of a container by the member macro.
+    let macroName: String
+
+    init(
+        node: AttributeSyntax,
+        declaration: some DeclSyntaxProtocol,
+        macroName: String = "@SQLQuery"
+    ) throws {
+        self.macroName = macroName
+        guard let function = declaration.as(FunctionDeclSyntax.self) else {
+            throw DiagnosticsError(diagnostics: [
+                Diagnostic(
+                    node: node,
+                    id: "sqlquery-function-only",
+                    message: "'\(macroName)' can only be applied to a function."
+                )
+            ])
+        }
+        self.function = function
+
+        var diagnostics: [Diagnostic] = []
+
+        if let typeLevelModifier = function.modifiers.first(where: { modifier in
+            modifier.name.tokenKind == .keyword(.static)
+                || modifier.name.tokenKind == .keyword(.class)
+        }) {
+            diagnostics.append(
+                Diagnostic(
+                    node: typeLevelModifier,
+                    id: "sqlquery-instance-method-only",
+                    message: "'\(macroName)' can only be applied to an instance method. The generated executor prepares its request through 'self.makeRequest(with:)'."
+                )
+            )
+        }
+
+        if let genericParameterClause = function.genericParameterClause {
+            diagnostics.append(
+                Diagnostic(
+                    node: genericParameterClause,
+                    id: "sqlquery-generic-function",
+                    message: "'\(macroName)' cannot be applied to a generic function. The generated statement builder takes no arguments, so generic parameters cannot be inferred."
+                )
+            )
+        }
+
+        if let effectSpecifiers = function.signature.effectSpecifiers {
+            diagnostics.append(
+                Diagnostic(
+                    node: effectSpecifiers,
+                    id: "sqlquery-effect-specifiers",
+                    message: "'\(macroName)' requires a nonthrowing, synchronous function. Statement builders only construct a value-free statement."
+                )
+            )
+        }
+
+        self.parameters = Self.makeParameters(
+            of: function,
+            macroName: macroName,
+            diagnostics: &diagnostics
+        )
+        self.returnShape = Self.makeReturnShape(
+            of: function,
+            macroName: macroName,
+            diagnostics: &diagnostics
+        )
+
+        guard let body = function.body else {
+            diagnostics.append(
+                Diagnostic(
+                    node: Syntax(function.signature),
+                    id: "sqlquery-body-required",
+                    message: "'\(macroName)' requires a function body that returns the query statement."
+                )
+            )
+            throw DiagnosticsError(diagnostics: diagnostics)
+        }
+
+        let shadowingVisitor = SQLQueryShadowingVisitor(parameters: parameters, macroName: macroName)
+        shadowingVisitor.walk(body)
+        diagnostics.append(contentsOf: shadowingVisitor.diagnostics)
+
+        if shadowingVisitor.diagnostics.isEmpty {
+            // A shadowed name makes lexical parameter analysis unreliable, so
+            // member-access checking waits until the shadowing is resolved.
+            let memberAccessVisitor = SQLQueryParameterMemberAccessVisitor(parameters: parameters, macroName: macroName)
+            memberAccessVisitor.walk(body)
+            diagnostics.append(contentsOf: memberAccessVisitor.diagnostics)
+
+            // Run the strict reference checks only on an otherwise-valid
+            // declaration: a structural, parameter, return-type, shadowing, or
+            // member-access problem already reported means the body cannot be
+            // analyzed cleanly, so piling on frozen-literal diagnostics would
+            // just add noise.
+            if diagnostics.isEmpty {
+                // With shadowing and member access clean, every remaining
+                // reference to a parameter must sit in a position the rewrite
+                // can turn into a named binding. The frozen-literal guard
+                // reports the reference shapes that would otherwise let a value
+                // escape the rewrite and freeze into the cached SQL text, and
+                // records which parameters were actually referenced so an
+                // unused parameter can be flagged too.
+                let frozenLiteralGuard = SQLQueryFrozenLiteralGuard(parameters: parameters, macroName: macroName)
+                frozenLiteralGuard.walk(body)
+                diagnostics.append(contentsOf: frozenLiteralGuard.diagnostics)
+
+                let bindableNames = Set(parameters.map(\.placeholderName))
+                for signatureParameter in function.signature.parameterClause.parameters {
+                    let nameToken = signatureParameter.secondName ?? signatureParameter.firstName
+                    let normalized = normalizedIdentifier(nameToken.text)
+                    guard bindableNames.contains(normalized),
+                          !frozenLiteralGuard.referencedParameterNames.contains(normalized) else {
+                        continue
+                    }
+                    diagnostics.append(
+                        Diagnostic(
+                            node: nameToken,
+                            id: "sqlquery-unused-parameter",
+                            message: "'\(normalized)' is never referenced in the '\(macroName)' body, so it cannot bind a placeholder. A standalone bindings struct defers this to execution time, but the signature-driven rewrite can catch it here: reference the parameter in the statement, or remove it."
+                        )
+                    )
+                }
+            }
+        }
+
+        guard diagnostics.isEmpty else {
+            throw DiagnosticsError(diagnostics: diagnostics)
+        }
+
+        // In the direct-result case the spec body calls the trapping `sqlResult`
+        // entry point (so the user's `-> [Row]` / `-> Row?` / `-> Row` function
+        // type-checks without executing). The generated statement builder must
+        // call the real `sql` builder instead, so the rewriter renames that
+        // callee too. (`sqlResult` is provisional — `sqlQuery` and `sql` are
+        // already statement builders in `SQLFunctionalSyntax.swift`.)
+        let calleeRenames = returnShape.isDirectResult ? ["sqlResult": "sql"] : [:]
+
+        if returnShape.isDirectResult {
+            // The rename is lexical and applies only to an unqualified callee.
+            // A qualified spelling (`SwiftQL.sqlResult`) cannot be told apart
+            // from another object's member of the same name, so it is rejected
+            // rather than silently left to trap in the generated builder.
+            let qualifiedVisitor = SQLQueryQualifiedEntryPointVisitor(
+                entryPointNames: Set(calleeRenames.keys),
+                macroName: macroName
+            )
+            qualifiedVisitor.walk(body)
+            guard qualifiedVisitor.diagnostics.isEmpty else {
+                throw DiagnosticsError(diagnostics: qualifiedVisitor.diagnostics)
+            }
+        }
+        let rewriter = SQLQueryParameterRewriter(
+            parameters: parameters,
+            calleeRenames: calleeRenames
+        )
+        self.rewrittenBodyText = Self.makeBodyText(rewriter.visit(body))
+    }
+
+    ///
+    /// Removes the source-column indentation from the rewritten body so the
+    /// generated peer is independent of how deeply the attached function is
+    /// nested. The closing brace's column measures the indentation to strip.
+    ///
+    private static func makeBodyText(_ body: CodeBlockSyntax) -> String {
+        let text = body.trimmedDescription
+        var lines = text.components(separatedBy: "\n")
+        guard lines.count > 1, let closingLine = lines.last else {
+            return text
+        }
+        let indentation = closingLine.prefix { $0 == " " }.count
+        guard indentation > 0 else {
+            return text
+        }
+        for index in 1 ..< lines.count {
+            var line = lines[index]
+            var removed = 0
+            while removed < indentation, line.first == " " {
+                line.removeFirst()
+                removed += 1
+            }
+            lines[index] = line
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    ///
+    /// Parameter names that collide with a statement-builder entry point. The
+    /// rewrite replaces every reference to a parameter, so a parameter with one
+    /// of these names would corrupt the builder call in the generated code.
+    ///
+    private static let reservedParameterNames: Set<String> = [
+        "sql", "sqlQuery", "sqlResult",
+    ]
+
+    ///
+    /// Classifies the function parameters, reporting shapes that cannot be
+    /// rewritten to a named binding.
+    ///
+    private static func makeParameters(
+        of function: FunctionDeclSyntax,
+        macroName: String,
+        diagnostics: inout [Diagnostic]
+    ) -> [SQLQueryParameter] {
+        var parameters: [SQLQueryParameter] = []
+        for parameter in function.signature.parameterClause.parameters {
+            if let ellipsis = parameter.ellipsis {
+                diagnostics.append(
+                    Diagnostic(
+                        node: ellipsis,
+                        id: "sqlquery-variadic-parameter",
+                        message: "'\(macroName)' cannot bind a variadic parameter to a single named placeholder."
+                    )
+                )
+                continue
+            }
+            if let attributedType = parameter.type.as(AttributedTypeSyntax.self),
+               let specifier = attributedType.specifier {
+                diagnostics.append(
+                    Diagnostic(
+                        node: attributedType,
+                        id: "sqlquery-parameter-specifier",
+                        message: "'\(macroName)' cannot bind a '\(specifier.text)' parameter to a named placeholder."
+                    )
+                )
+                continue
+            }
+            let name = parameter.secondName ?? parameter.firstName
+            guard name.tokenKind != .wildcard else {
+                diagnostics.append(
+                    Diagnostic(
+                        node: name,
+                        id: "sqlquery-unnamed-parameter",
+                        message: "'\(macroName)' requires every parameter to have a name. The name identifies the SQL placeholder."
+                    )
+                )
+                continue
+            }
+            if reservedParameterNames.contains(normalizedIdentifier(name.text)) {
+                // The rewrite replaces every reference to a parameter, and the
+                // builder callee is itself a plain identifier reference — a
+                // parameter with the same name would corrupt the builder call
+                // in the generated peer.
+                diagnostics.append(
+                    Diagnostic(
+                        node: name,
+                        id: "sqlquery-reserved-parameter-name",
+                        message: "'\(macroName)' cannot bind a parameter named '\(normalizedIdentifier(name.text))'. The name collides with a statement-builder entry point, so rewriting its references would corrupt the builder call in the generated peer. Rename the parameter."
+                    )
+                )
+                continue
+            }
+            if let collection = collectionDescription(of: parameter.type) {
+                // A collection parameter would render a variable-length `IN`
+                // list, so the SQL text changes with the element count. That
+                // breaks the stable-SQL premise the render-once prepared query
+                // depends on, and a single named placeholder cannot bind a
+                // list, so the shape is rejected at the declaration site.
+                diagnostics.append(
+                    Diagnostic(
+                        node: parameter.type,
+                        id: "sqlquery-collection-parameter",
+                        message: "'\(macroName)' cannot bind the \(collection) parameter '\(normalizedIdentifier(name.text))' to a single named placeholder. A variable-length list renders SQL whose text changes with the element count, which breaks the stable-SQL premise the prepared query relies on. Spell the elements in the statement with the 'in(_:)' expression forms, or pass a fixed set of scalar parameters."
+                    )
+                )
+                continue
+            }
+            parameters.append(
+                SQLQueryParameter(
+                    swiftName: name.text,
+                    placeholderName: normalizedIdentifier(name.text),
+                    type: parameter.type.trimmedDescription
+                )
+            )
+        }
+        return parameters
+    }
+
+    ///
+    /// Derives the row type and cardinality from the return annotation.
+    ///
+    /// Four spellings are accepted:
+    ///   * `[Row]`                                 → `.many`, direct result
+    ///   * `Row?`                                   → `.one`, direct result
+    ///   * a bare `Row` (no generic wrapper)        → `.exactlyOne`, direct result
+    ///   * `any/some XLQueryStatement<Row>` (legacy) → `.many`, legacy statement
+    ///
+    private static func makeReturnShape(
+        of function: FunctionDeclSyntax,
+        macroName: String,
+        diagnostics: inout [Diagnostic]
+    ) -> SQLQueryReturnShape {
+        let returnType = function.signature.returnClause?.type.trimmed
+
+        // `[Row]` and `Array<Row>` -> fetchAll, direct result.
+        if let arrayType = returnType?.as(ArrayTypeSyntax.self) {
+            return SQLQueryReturnShape(
+                rowType: arrayType.element.trimmedDescription,
+                cardinality: .many,
+                isDirectResult: true
+            )
+        }
+        // `Row?` and `Optional<Row>` -> fetchOne, direct result.
+        if let optionalType = returnType?.as(OptionalTypeSyntax.self) {
+            return SQLQueryReturnShape(
+                rowType: optionalType.wrappedType.trimmedDescription,
+                cardinality: .one,
+                isDirectResult: true
+            )
+        }
+        if let (name, arguments) = genericConstraint(of: returnType),
+           name == "Array", let element = singleGenericArgument(arguments) {
+            return SQLQueryReturnShape(rowType: element, cardinality: .many, isDirectResult: true)
+        }
+        if let (name, arguments) = genericConstraint(of: returnType),
+           name == "Optional", let element = singleGenericArgument(arguments) {
+            return SQLQueryReturnShape(rowType: element, cardinality: .one, isDirectResult: true)
+        }
+
+        // Legacy spelling: `any/some XLQueryStatement<Row>` -> fetchAll.
+        var constraint = returnType
+        if let someOrAny = constraint?.as(SomeOrAnyTypeSyntax.self) {
+            constraint = someOrAny.constraint.trimmed
+        }
+        if let (name, arguments) = genericConstraint(of: constraint),
+           name == "XLQueryStatement", let rowType = singleGenericArgument(arguments) {
+            return SQLQueryReturnShape(rowType: rowType, cardinality: .many, isDirectResult: false)
+        }
+
+        // A bare, non-generic `Row` (e.g. `Person`, `Module.Person`) -> fetch
+        // exactly one row, direct result. `Void`/`()` is excluded so an
+        // explicit-Void return still falls through to the diagnostic below
+        // instead of being treated as a nonsensical `Void` row type. Any type
+        // with a generic argument clause (`Dictionary<K, V>`, an unrelated
+        // `Wrapper<Row>`, ...) is excluded too — only Array/Optional carry
+        // cardinality meaning, and every other generic shape is ambiguous.
+        if let returnType,
+           returnType.trimmedDescription != "Void",
+           returnType.trimmedDescription != "()",
+           let (_, arguments) = genericConstraint(of: returnType),
+           arguments == nil {
+            return SQLQueryReturnShape(
+                rowType: returnType.trimmedDescription,
+                cardinality: .exactlyOne,
+                isDirectResult: true
+            )
+        }
+
+        diagnostics.append(
+            Diagnostic(
+                node: Syntax(function.signature.returnClause?.type) ?? Syntax(function.signature),
+                id: "sqlquery-return-type",
+                message: "'\(macroName)' requires the function to return '[Row]' (fetch all), 'Row?' (fetch one), 'Row' (fetch exactly one), or the legacy 'any/some XLQueryStatement<Row>', with an explicit row type. The row type declares the executor's result element and the shape selects the fetch."
+            )
+        )
+        return SQLQueryReturnShape(rowType: "", cardinality: .many, isDirectResult: false)
+    }
+
+    ///
+    /// Splits a nominal type into its name token and generic argument clause,
+    /// handling both a bare identifier (`Array<Row>`) and a member type
+    /// (`Swift.Array<Row>`).
+    ///
+    private static func genericConstraint(
+        of type: TypeSyntax?
+    ) -> (name: String, arguments: GenericArgumentClauseSyntax?)? {
+        if let identifierType = type?.as(IdentifierTypeSyntax.self) {
+            return (identifierType.name.text, identifierType.genericArgumentClause)
+        }
+        if let memberType = type?.as(MemberTypeSyntax.self) {
+            return (memberType.name.text, memberType.genericArgumentClause)
+        }
+        return nil
+    }
+
+    private static func singleGenericArgument(
+        _ arguments: GenericArgumentClauseSyntax?
+    ) -> String? {
+        guard let arguments, arguments.arguments.count == 1 else {
+            return nil
+        }
+        return arguments.arguments.first?.argument.trimmedDescription
+    }
+
+    ///
+    /// Describes a parameter type that spells a collection form (`[T]`,
+    /// `[K: V]`, `Array<…>`, `Set<…>`, `Dictionary<…>`), peeling one layer of
+    /// optionality. Returns `nil` for scalar types. A single leading optional is
+    /// unwrapped so `[T]?` (and the `[T]!` / `Optional<[T]>` spellings) is still
+    /// recognized as a collection.
+    ///
+    private static func collectionDescription(of type: TypeSyntax) -> String? {
+        let type = unwrappingSingleOptional(type.trimmed)
+        if type.is(ArrayTypeSyntax.self) {
+            return "array"
+        }
+        if type.is(DictionaryTypeSyntax.self) {
+            return "dictionary"
+        }
+        if let (name, arguments) = genericConstraint(of: type), arguments != nil {
+            switch name {
+            case "Array":
+                return "array"
+            case "Set":
+                return "set"
+            case "Dictionary":
+                return "dictionary"
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+
+    ///
+    /// Unwraps a single layer of optionality in any spelling — postfix `T?`,
+    /// implicitly-unwrapped `T!`, and generic `Optional<T>` / `Swift.Optional<T>`
+    /// — so an optional collection is still recognized as a collection.
+    ///
+    private static func unwrappingSingleOptional(_ type: TypeSyntax) -> TypeSyntax {
+        if let optional = type.as(OptionalTypeSyntax.self) {
+            return optional.wrappedType.trimmed
+        }
+        if let unwrapped = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return unwrapped.wrappedType.trimmed
+        }
+        if let (name, arguments) = genericConstraint(of: type),
+           name == "Optional",
+           let arguments,
+           arguments.arguments.count == 1,
+           let inner = arguments.arguments.first?.argument.as(TypeSyntax.self) {
+            return inner.trimmed
+        }
+        return type
+    }
+
+    private var modifierPrefix: String {
+        let modifiers = function.modifiers.trimmedDescription
+        if modifiers.isEmpty {
+            return ""
+        }
+        return modifiers + " "
+    }
+
+    private var statementFunctionName: String {
+        "\(function.name.text)Statement"
+    }
+
+    private var executorFunctionName: String {
+        "fetch\(function.name.text.prefix(1).uppercased())\(function.name.text.dropFirst())"
+    }
+
+    private var renderOnceCacheName: String {
+        "__xl\(function.name.text.prefix(1).uppercased())\(function.name.text.dropFirst())Cache"
+    }
+
+    ///
+    /// Generates the per-declaration render-once cache. It is a `static` peer so
+    /// one cache is shared across every invocation of the specification, letting
+    /// the executor render the statement once per database/dialect and reuse the
+    /// request.
+    ///
+    func makeRenderOnceCacheDeclaration() -> String {
+        "private static let \(renderOnceCacheName) = XLRenderOnceCache<\(rowType)>()"
+    }
+
+    ///
+    /// Generates the value-free statement builder. The rewritten body renders
+    /// named placeholders instead of inline value literals, so the SQL text is
+    /// identical for every invocation.
+    ///
+    func makeStatementFunction() -> String {
+        // The value-free statement is always an `XLQueryStatement<Row>`. In the
+        // legacy spelling the function already declared exactly that, so the
+        // written return type is reused. In the direct-result case the function
+        // declared `[Row]` / `Row?` / `Row`, so the statement builder's return
+        // type is synthesized from the extracted row type instead.
+        let returnType: String
+        if returnShape.isDirectResult {
+            returnType = "any XLQueryStatement<\(rowType)>"
+        }
+        else {
+            returnType = function.signature.returnClause?.type.trimmedDescription ?? ""
+        }
+        return "\(modifierPrefix)func \(statementFunctionName)() -> \(returnType) \(rewrittenBodyText)"
+    }
+
+    ///
+    /// Generates the executor peer. The executor prepares a request from the
+    /// value-free statement, encodes the parameter values into one immutable
+    /// invocation packet, and fetches the result.
+    ///
+    /// The executor's declared result type, derived from the cardinality.
+    var executorResultType: String {
+        switch returnShape.cardinality {
+        case .many:
+            return "[\(rowType)]"
+        case .one:
+            return "\(rowType)?"
+        case .exactlyOne:
+            return rowType
+        }
+    }
+
+    ///
+    /// Generates the lines that fetch the result and return it from an
+    /// executor body, dispatched from ``SQLQueryReturnShape/cardinality``.
+    ///
+    /// `.exactlyOne` fetches every matching row and validates the count itself,
+    /// because no `XLRequest` fetch operation enforces "zero or many is an
+    /// error" on its own.
+    ///
+    func makeFetchLines(requestVariable: String, packetVariable: String) -> [String] {
+        switch returnShape.cardinality {
+        case .many:
+            return ["return try \(requestVariable).fetchAll(bindings: \(packetVariable))"]
+        case .one:
+            return ["return try \(requestVariable).fetchOne(bindings: \(packetVariable))"]
+        case .exactlyOne:
+            return [
+                "let __xlRows = try \(requestVariable).fetchAll(bindings: \(packetVariable))",
+                "guard __xlRows.count == 1 else {",
+                "    throw XLQueryCardinalityError.exactlyOneRowExpected(actual: __xlRows.count)",
+                "}",
+                "return __xlRows[0]",
+            ]
+        }
+    }
+
+    func makeExecutorFunction() -> String {
+        let parameterClause = function.signature.parameterClause.trimmedDescription
+        let resultType = executorResultType
+        var lines: [String] = []
+        lines.append("\(modifierPrefix)func \(executorFunctionName)\(parameterClause) throws -> \(resultType) {")
+        lines.append("    let __xlRequest = Self.\(renderOnceCacheName).request(for: self) {")
+        lines.append("        \(statementFunctionName)()")
+        lines.append("    }")
+        lines.append("    let __xlLayout = __xlRequest.parameterLayout")
+        if parameters.isEmpty {
+            lines.append("    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()")
+        }
+        else {
+            lines.append("    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(")
+            lines.append("        layout: __xlLayout,")
+            lines.append("        bindings: [")
+            for parameter in parameters {
+                lines.append("            try _xlQueryParameterBinding(\(parameter.swiftName), named: \"\(parameter.placeholderName)\", in: __xlLayout),")
+            }
+            lines.append("        ]")
+            lines.append("    ).validatingComplete()")
+        }
+        for fetchLine in makeFetchLines(requestVariable: "__xlRequest", packetVariable: "__xlPacket") {
+            lines.append("    " + fetchLine)
+        }
+        lines.append("}")
+        return lines.joined(separator: "\n")
+    }
+}
+
+
+///
+/// Replaces every expression reference to a function parameter with the
+/// parameter's typed named-binding reference.
+///
+/// Member names are never rewritten: `person.name` keeps its member `name`
+/// while a parameter also called `name` is still rewritten wherever it appears
+/// as the base of a member access or as a standalone reference.
+///
+internal final class SQLQueryParameterRewriter: SyntaxRewriter {
+
+    private let replacements: [String: String]
+
+    /// Identifier renames applied only to the called expression of a function
+    /// call — used to swap the trapping `sqlResult` spec entry point for the
+    /// real `sql` builder in the direct-result encoding. References outside
+    /// callee position are never renamed.
+    private let calleeRenames: [String: String]
+
+    init(parameters: [SQLQueryParameter], calleeRenames: [String: String] = [:]) {
+        var replacements: [String: String] = [:]
+        for parameter in parameters {
+            replacements[parameter.placeholderName] = parameter.bindingReference
+        }
+        self.replacements = replacements
+        self.calleeRenames = calleeRenames
+        super.init()
+    }
+
+    override func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
+        guard let replacement = replacements[normalizedIdentifier(node.baseName.text)] else {
+            return ExprSyntax(node)
+        }
+        var expression = ExprSyntax("\(raw: replacement)")
+        expression.leadingTrivia = node.leadingTrivia
+        expression.trailingTrivia = node.trailingTrivia
+        return expression
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+        // A callee rename applies only in callee position: a reference that
+        // merely *names* the entry point elsewhere in the body is left alone.
+        var node = node
+        if let callee = node.calledExpression.as(DeclReferenceExprSyntax.self),
+           let renamed = calleeRenames[normalizedIdentifier(callee.baseName.text)] {
+            let token = TokenSyntax.identifier(renamed)
+                .with(\.leadingTrivia, callee.baseName.leadingTrivia)
+                .with(\.trailingTrivia, callee.baseName.trailingTrivia)
+            node = node.with(\.calledExpression, ExprSyntax(callee.with(\.baseName, token)))
+        }
+        return super.visit(node)
+    }
+
+    override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
+        guard let base = node.base else {
+            return ExprSyntax(node)
+        }
+        return ExprSyntax(node.with(\.base, visit(base)))
+    }
+}
+
+
+///
+/// Rejects qualified calls to a spec entry point in a direct-result body.
+///
+/// The `sqlResult` -> `sql` swap is lexical and matches only an unqualified
+/// callee. A qualified spelling such as `SwiftQL.sqlResult { … }` cannot be
+/// distinguished from another object's member of the same name, so it is
+/// diagnosed instead of being left to trap at runtime in the generated
+/// statement builder.
+///
+internal final class SQLQueryQualifiedEntryPointVisitor: SyntaxVisitor {
+
+    private let entryPointNames: Set<String>
+
+    private let macroName: String
+
+    private(set) var diagnostics: [Diagnostic] = []
+
+    init(entryPointNames: Set<String>, macroName: String) {
+        self.entryPointNames = entryPointNames
+        self.macroName = macroName
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        guard let callee = node.calledExpression.as(MemberAccessExprSyntax.self) else {
+            return .visitChildren
+        }
+        let name = normalizedIdentifier(callee.declName.baseName.text)
+        guard entryPointNames.contains(name) else {
+            return .visitChildren
+        }
+        diagnostics.append(
+            Diagnostic(
+                node: Syntax(callee),
+                id: "sqlquery-qualified-entry-point",
+                message: "'\(name)' must be called unqualified in a '\(macroName)' specification. The macro rewrites the entry point lexically and cannot distinguish a module qualifier from another object's member of the same name."
+            )
+        )
+        return .visitChildren
+    }
+}
+
+
+///
+/// Rejects declarations inside the attached body that shadow a query
+/// parameter.
+///
+/// The rewrite is lexical: every expression reference whose name matches a
+/// parameter becomes a named binding. A local binding, closure parameter, or
+/// nested function parameter with the same name would make those references
+/// mean something else, so the collision is reported instead of silently
+/// rewriting the shadowed uses.
+///
+internal final class SQLQueryShadowingVisitor: SyntaxVisitor {
+
+    private let parameterNames: Set<String>
+
+    private let macroName: String
+
+    private(set) var diagnostics: [Diagnostic] = []
+
+    init(parameters: [SQLQueryParameter], macroName: String = "@SQLQuery") {
+        self.parameterNames = Set(parameters.map(\.placeholderName))
+        self.macroName = macroName
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
+        check(node.identifier)
+        return .visitChildren
+    }
+
+    override func visit(_ node: ClosureShorthandParameterSyntax) -> SyntaxVisitorContinueKind {
+        check(node.name)
+        return .visitChildren
+    }
+
+    override func visit(_ node: ClosureParameterSyntax) -> SyntaxVisitorContinueKind {
+        check(node.secondName ?? node.firstName)
+        return .visitChildren
+    }
+
+    override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
+        check(node.secondName ?? node.firstName)
+        return .visitChildren
+    }
+
+    private func check(_ name: TokenSyntax) {
+        let identifier = normalizedIdentifier(name.text)
+        guard parameterNames.contains(identifier) else {
+            return
+        }
+        diagnostics.append(
+            Diagnostic(
+                node: name,
+                id: "sqlquery-shadowed-parameter",
+                message: "'\(identifier)' shadows a query parameter inside the '\(macroName)' body. The macro rewrites every reference to '\(identifier)' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration."
+            )
+        )
+    }
+}
+
+
+///
+/// Rejects member access whose base is a query parameter.
+///
+/// A parameter reference must be rewriteable to a named binding as a whole
+/// expression. An access such as `name.lowercased()` transforms the value in
+/// Swift, which no placeholder can represent, so the generated peer would fail
+/// to type-check.
+///
+internal final class SQLQueryParameterMemberAccessVisitor: SyntaxVisitor {
+
+    private let parameterNames: Set<String>
+
+    private let macroName: String
+
+    private(set) var diagnostics: [Diagnostic] = []
+
+    init(parameters: [SQLQueryParameter], macroName: String = "@SQLQuery") {
+        self.parameterNames = Set(parameters.map(\.placeholderName))
+        self.macroName = macroName
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+        guard let base = node.base?.as(DeclReferenceExprSyntax.self) else {
+            return .visitChildren
+        }
+        let identifier = normalizedIdentifier(base.baseName.text)
+        guard parameterNames.contains(identifier) else {
+            return .visitChildren
+        }
+        diagnostics.append(
+            Diagnostic(
+                node: base,
+                id: "sqlquery-parameter-member-access",
+                message: "'\(identifier)' cannot be used through member access in a '\(macroName)' body. A parameter reference is rewritten to a named binding as a whole expression; compute the derived value before building the statement, or pass it as a separate parameter."
+            )
+        )
+        return .visitChildren
+    }
+}
+
+
+///
+/// The frozen-literal guard.
+///
+/// The generated executor renders SQL once per declaration and reuses that
+/// text on every call, so any parameter value that escapes the rewrite is
+/// baked into the cached SQL on the first invocation and every later call
+/// silently returns results for the first call's argument — a silent
+/// wrong-results bug. The rewrite can only turn a parameter reference into a
+/// named binding when the reference sits directly in a query-expression
+/// position (an operand of a comparison such as `column == name`). This guard
+/// reports the reference shapes that place a parameter somewhere the rewrite
+/// cannot reach, so the hazard becomes a declaration-site error instead.
+///
+/// Every parameter reference actually seen is recorded in
+/// ``referencedParameterNames`` so the builder can additionally flag a
+/// parameter that is never referenced at all.
+///
+internal final class SQLQueryFrozenLiteralGuard: SyntaxVisitor {
+
+    private let parameterNames: Set<String>
+
+    private let macroName: String
+
+    private(set) var diagnostics: [Diagnostic] = []
+
+    /// The normalized names of every parameter referenced anywhere in the body,
+    /// including references in hazardous positions.
+    private(set) var referencedParameterNames: Set<String> = []
+
+    init(parameters: [SQLQueryParameter], macroName: String = "@SQLQuery") {
+        self.parameterNames = Set(parameters.map(\.placeholderName))
+        self.macroName = macroName
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        // A hand-constructed binding reference bypasses the signature contract:
+        // the macro is the sole authority for the placeholder name and type, so
+        // building one by hand can disagree with the rendered layout. A callee
+        // that is itself a parameter of the same name (a function-typed
+        // parameter) is not manual binding construction — it falls to the
+        // compiler like any other callee-is-a-parameter case, so it is skipped.
+        if let calleeName = Self.calledBaseName(of: node.calledExpression),
+           !parameterNames.contains(calleeName),
+           calleeName == "XLNamedBindingReference" || calleeName == "contextualBinding" {
+            diagnostics.append(
+                Diagnostic(
+                    node: Syntax(node.calledExpression),
+                    id: "sqlquery-manual-binding",
+                    message: "'\(macroName)' derives every named binding from the function signature, so '\(calleeName)' must not be constructed by hand in the body. A hand-built binding can disagree with the rendered parameter layout. Reference the parameter directly and let the macro generate the binding."
+                )
+            )
+        }
+        return .visitChildren
+    }
+
+    override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+        let identifier = normalizedIdentifier(node.baseName.text)
+        guard parameterNames.contains(identifier) else {
+            return .visitChildren
+        }
+        // A member name (`person.name`) is not a reference to the parameter, so
+        // it neither counts as a use nor is a hazard — the member-access guard
+        // owns the base-of-member-access case.
+        if let memberAccess = node.parent?.as(MemberAccessExprSyntax.self),
+           memberAccess.declName == node {
+            return .visitChildren
+        }
+        referencedParameterNames.insert(identifier)
+        classify(reference: node, identifier: identifier)
+        return .visitChildren
+    }
+
+    ///
+    /// Reports the first recognized hazardous position for a parameter
+    /// reference. A reference that matches none of these is left for the
+    /// rewrite (typically a comparison operand) and any residual type mismatch
+    /// is caught by the compiler on the generated code.
+    ///
+    private func classify(reference node: DeclReferenceExprSyntax, identifier: String) {
+        if hasAncestor(node, upToEnclosingFunction: { $0.is(ExpressionSegmentSyntax.self) }) {
+            diagnostics.append(
+                Diagnostic(
+                    node: node,
+                    id: "sqlquery-parameter-string-interpolation",
+                    message: "'\(identifier)' is used inside a string interpolation in the '\(macroName)' body, which renders its value into the string rather than binding a placeholder. Build the value into the statement with a comparison against a column, not an interpolated string."
+                )
+            )
+            return
+        }
+        if closureDepth(of: node) >= 2 {
+            diagnostics.append(
+                Diagnostic(
+                    node: node,
+                    id: "sqlquery-parameter-nested-closure",
+                    message: "'\(identifier)' is captured by a nested closure in the '\(macroName)' body. The rewrite only reaches references in the statement builder itself, so a value captured deeper can escape into the cached SQL as a frozen literal. Reference the parameter directly in the statement."
+                )
+            )
+            return
+        }
+        if isDirectCallArgument(node) {
+            diagnostics.append(
+                Diagnostic(
+                    node: node,
+                    id: "sqlquery-parameter-call-argument",
+                    message: "'\(identifier)' is passed as an argument to a function call in the '\(macroName)' body. The rewrite cannot see through the call, so the value would be frozen into the cached SQL on the first invocation. Use the parameter directly as a comparison operand (for example 'column == \(identifier)') instead of passing it to a helper."
+                )
+            )
+            return
+        }
+        if isVariableInitializer(node) {
+            diagnostics.append(
+                Diagnostic(
+                    node: node,
+                    id: "sqlquery-parameter-local-binding",
+                    message: "'\(identifier)' is used to initialize a local binding in the '\(macroName)' body. The binding's later uses are outside the rewrite's reach, so the value can freeze into the cached SQL. Reference the parameter directly in the statement instead of storing it in a local."
+                )
+            )
+            return
+        }
+    }
+
+    ///
+    /// The base identifier of a called expression, peeling a generic
+    /// specialization (`XLNamedBindingReference<String>(…)`) and reading the
+    /// member name of a member-access callee (`x.contextualBinding(…)`).
+    ///
+    private static func calledBaseName(of expression: ExprSyntax) -> String? {
+        if let declReference = expression.as(DeclReferenceExprSyntax.self) {
+            return normalizedIdentifier(declReference.baseName.text)
+        }
+        if let specialization = expression.as(GenericSpecializationExprSyntax.self) {
+            return calledBaseName(of: specialization.expression)
+        }
+        if let memberAccess = expression.as(MemberAccessExprSyntax.self) {
+            return normalizedIdentifier(memberAccess.declName.baseName.text)
+        }
+        return nil
+    }
+
+    ///
+    /// Whether an ancestor up to (but not into) the enclosing specification
+    /// function satisfies the predicate.
+    ///
+    private func hasAncestor(
+        _ node: SyntaxProtocol,
+        upToEnclosingFunction predicate: (Syntax) -> Bool
+    ) -> Bool {
+        var current = node.parent
+        while let ancestor = current {
+            if ancestor.is(FunctionDeclSyntax.self) {
+                return false
+            }
+            if predicate(ancestor) {
+                return true
+            }
+            current = ancestor.parent
+        }
+        return false
+    }
+
+    ///
+    /// The number of closures enclosing the reference within the specification
+    /// function. The statement builder is itself a closure, so a value of one
+    /// is the normal case and two or more means a further-nested closure.
+    ///
+    private func closureDepth(of node: SyntaxProtocol) -> Int {
+        var depth = 0
+        var current = node.parent
+        while let ancestor = current {
+            if ancestor.is(FunctionDeclSyntax.self) {
+                break
+            }
+            if ancestor.is(ClosureExprSyntax.self) {
+                depth += 1
+            }
+            current = ancestor.parent
+        }
+        return depth
+    }
+
+    ///
+    /// Whether the reference is a direct argument expression of a function
+    /// call. A comparison operand's parent is an infix operator expression, and
+    /// a parenthesized operand's argument list belongs to a tuple, so neither is
+    /// mistaken for a call argument.
+    ///
+    private func isDirectCallArgument(_ node: DeclReferenceExprSyntax) -> Bool {
+        guard let labeled = node.parent?.as(LabeledExprSyntax.self),
+              let list = labeled.parent?.as(LabeledExprListSyntax.self) else {
+            return false
+        }
+        return list.parent?.is(FunctionCallExprSyntax.self) == true
+    }
+
+    ///
+    /// Whether the reference is the initializer value of a local `let`/`var`
+    /// binding (`let alias = name`).
+    ///
+    private func isVariableInitializer(_ node: DeclReferenceExprSyntax) -> Bool {
+        hasAncestor(node, upToEnclosingFunction: { ancestor in
+            guard let initializer = ancestor.as(InitializerClauseSyntax.self) else {
+                return false
+            }
+            return initializer.parent?.is(PatternBindingSyntax.self) == true
+        })
+    }
+}

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -477,6 +477,7 @@ internal struct SQLQueryBuilder {
         if let returnType,
            returnType.trimmedDescription != "Void",
            returnType.trimmedDescription != "()",
+           returnType.trimmedDescription != "Swift.Void",
            let (_, arguments) = genericConstraint(of: returnType),
            arguments == nil {
             return SQLQueryReturnShape(
@@ -646,9 +647,10 @@ internal struct SQLQueryBuilder {
     /// Generates the lines that fetch the result and return it from an
     /// executor body, dispatched from ``SQLQueryReturnShape/cardinality``.
     ///
-    /// `.exactlyOne` fetches every matching row and validates the count itself,
-    /// because no `XLRequest` fetch operation enforces "zero or many is an
-    /// error" on its own.
+    /// `.exactlyOne` fetches at most two matching rows via `fetchAtMost(_:bindings:)` and validates
+    /// the count itself, because no `XLRequest` fetch operation enforces "zero or many is an error" on
+    /// its own. Fetching at most two rows (rather than every row) keeps a query that accidentally
+    /// matches many rows cheap to reject.
     ///
     func makeFetchLines(requestVariable: String, packetVariable: String) -> [String] {
         switch returnShape.cardinality {
@@ -658,7 +660,7 @@ internal struct SQLQueryBuilder {
             return ["return try \(requestVariable).fetchOne(bindings: \(packetVariable))"]
         case .exactlyOne:
             return [
-                "let __xlRows = try \(requestVariable).fetchAll(bindings: \(packetVariable))",
+                "let __xlRows = try \(requestVariable).fetchAtMost(2, bindings: \(packetVariable))",
                 "guard __xlRows.count == 1 else {",
                 "    throw XLQueryCardinalityError.exactlyOneRowExpected(actual: __xlRows.count)",
                 "}",

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -20,15 +20,16 @@ import SwiftSyntaxMacros
 /// Declares a query-specification function as a reusable prepared query.
 ///
 /// The attached function builds a `SELECT` statement from its parameters. The
-/// macro generates two peers: a value-free statement builder in which every
-/// parameter reference is replaced by a typed `XLNamedBindingReference`, and an
-/// executor that renders the statement once per call through the enclosing
-/// database's `makeRequest(with:)`, binds the parameter values into an
-/// immutable invocation packet, and fetches the result. The fetch is dispatched
-/// from the function's return annotation: `[Row]` (or the legacy
-/// `any/some XLQueryStatement<Row>`) fetches all rows, `Row?` fetches one, and
-/// a bare `Row` fetches exactly one row, throwing if the query matches zero or
-/// more than one row.
+/// macro generates three peers: a value-free statement builder in which every
+/// parameter reference is replaced by a typed `XLNamedBindingReference`, a
+/// per-declaration `XLRenderOnceCache` that renders the statement once per
+/// `(databaseIdentifier, dialectIdentifier)` and reuses that rendered request
+/// on every later call, and an executor that binds the parameter values into
+/// an immutable invocation packet per call and fetches the result. The fetch
+/// is dispatched from the function's return annotation: `[Row]` (or the
+/// legacy `any/some XLQueryStatement<Row>`) fetches all rows, `Row?` fetches
+/// one, and a bare `Row` fetches exactly one row, throwing if the query
+/// matches zero or more than one row.
 ///
 public struct SQLQueryMacro {
 }

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -593,7 +593,9 @@ internal struct SQLQueryBuilder {
         "fetch\(function.name.text.prefix(1).uppercased())\(function.name.text.dropFirst())"
     }
 
-    private var renderOnceCacheName: String {
+    // Not `private`: shared with the `@SQLQueries` container executor
+    // generation in `SQLQueriesMacro.swift`, a different file in this target.
+    var renderOnceCacheName: String {
         "__xl\(function.name.text.prefix(1).uppercased())\(function.name.text.dropFirst())Cache"
     }
 

--- a/Sources/SQLMacros/SQLQueryMacro.swift
+++ b/Sources/SQLMacros/SQLQueryMacro.swift
@@ -92,12 +92,13 @@ internal func normalizedIdentifier(_ text: String) -> String {
 ///
 /// With a direct-result signature the return annotation is the only source of
 /// cardinality. `[Row]` maps to `fetchAll`, `Row?` to `fetchOne`, and a bare
-/// `Row` to `exactlyOne` (fetch all, then validate the count is exactly one).
+/// `Row` to `exactlyOne` (fetch at most two rows, then validate the count is
+/// exactly one, without decoding/retaining every matching row).
 ///
 internal enum SQLQueryCardinality {
     case many        // [Row]  -> fetchAll
     case one         // Row?   -> fetchOne
-    case exactlyOne  // Row    -> fetchAll, then validate count == 1
+    case exactlyOne  // Row    -> fetchAtMost(2), then validate count == 1
 }
 
 

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -331,6 +331,7 @@ struct GRDBRequest<Row>: XLRequest {
         limit: Int,
         in connection: inout GRDBDatabaseDriverConnection
     ) throws -> [Row] {
+        precondition(limit >= 0, "fetchAtMost(_:bindings:) requires limit >= 0, got \(limit).")
         guard limit > 0 else {
             return []
         }

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -345,7 +345,7 @@ struct GRDBRequest<Row>: XLRequest {
                 return items.count < limit ? .advance : .stop
             }
             catch {
-                logger?.error("fetchAtMost : Cannot decode entity: \(error)")
+                logger?.error("fetchAtMost(\(limit)): Cannot decode entity: \(error)")
                 throw error
             }
         }

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -897,7 +897,20 @@ public struct GRDBDatabase: XLDatabase {
         self.liveQueryRetryPolicy = liveQueryRetryPolicy
         self.liveQueryRetryScheduler = liveQueryRetryScheduler
     }
-    
+
+    /// Scopes render-once cache entries (issues #18/#26) to this database and
+    /// dialect. Rendering depends only on the dialect; the database identifier
+    /// keeps a per-declaration `static` cache from binding one database's
+    /// request to another. The driver assigns a fresh identifier per init, so
+    /// the scope is per `GRDBDatabase` instance rather than per `DatabasePool`
+    /// (see ``XLPreparedQueryCacheKey``).
+    public var preparedQueryCacheKey: XLPreparedQueryCacheKey? {
+        XLPreparedQueryCacheKey(
+            databaseIdentifier: driver.databaseIdentifier,
+            dialectIdentifier: dialect.descriptor.identity
+        )
+    }
+
     public func makeRequest<Row>(with statement: any XLQueryStatement<Row>) -> any XLRequest<Row> {
         let encoding = encoder.makeSQL(statement)
         return GRDBRequest(

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -306,6 +306,51 @@ struct GRDBRequest<Row>: XLRequest {
         return items
     }
     
+    func fetchAtMost(
+        _ limit: Int,
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [Row] {
+        let packet = try executor.sqlitePacket(bindings)
+        logger?.debug(
+            "fetchAtMost(\(limit)): <<<\(executor.logicalStatement.sql)>>> parameters: <<<\(packet.bindings)>>>")
+        return try decodeRows(packet: packet, limit: limit)
+    }
+
+    private func decodeRows(
+        packet: XLInvocationBindings<XLSQLiteValue>,
+        limit: Int
+    ) throws -> [Row] {
+        var driver = executor.driver
+        return try driver.withReadConnection { connection in
+            try decodeRows(packet: packet, limit: limit, in: &connection)
+        }
+    }
+
+    private func decodeRows(
+        packet: XLInvocationBindings<XLSQLiteValue>,
+        limit: Int,
+        in connection: inout GRDBDatabaseDriverConnection
+    ) throws -> [Row] {
+        guard limit > 0 else {
+            return []
+        }
+        let rowDecoder = GRDBRowDecoder(reader: reader)
+        var items: [Row] = []
+
+        try executor.forEachRow(packet: packet, in: &connection) { values in
+            do {
+                let item = try rowDecoder.decode(values: values)
+                items.append(item)
+                return items.count < limit ? .advance : .stop
+            }
+            catch {
+                logger?.error("fetchAtMost : Cannot decode entity: \(error)")
+                throw error
+            }
+        }
+        return items
+    }
+
     func fetchOne() throws -> Row? {
         try fetchOne(bindings: compatibilityPacket())
     }

--- a/Sources/SwiftQL/SQL.swift
+++ b/Sources/SwiftQL/SQL.swift
@@ -11,3 +11,39 @@ public macro SQLTable(name: String? = nil) = #externalMacro(module: "SQLMacros",
 @attached(member, names: arbitrary)
 @attached(extension, conformances: XLResult, names: arbitrary)
 public macro SQLResult() = #externalMacro(module: "SQLMacros", type: "SQLResultMacro")
+
+///
+/// Defines the `@SQLQuery` macro.
+///
+/// Issues #18/#26 (ported from the milestone #28 spike): attaches to a
+/// query-specification function in a database extension and generates two
+/// peers — a value-free statement builder whose parameter references are
+/// rewritten to typed `XLNamedBindingReference` placeholders, and an executor
+/// that binds the parameter values through an immutable invocation packet.
+/// The fetch is dispatched from the function's return annotation: `[Row]`
+/// fetches all rows, `Row?` fetches one, a bare `Row` fetches exactly one
+/// (throwing if the query matches zero or more than one row), and the legacy
+/// `any/some XLQueryStatement<Row>` spelling fetches all rows. A direct-result
+/// specification (`[Row]` / `Row?` / `Row`) writes its body with the trapping
+/// `sqlResult {}` entry point instead of `sql {}`. See
+/// <doc:DeclaredQueries> for the frozen-literal guard and render-once caching
+/// this macro relies on.
+///
+@attached(peer, names: arbitrary)
+public macro SQLQuery() = #externalMacro(module: "SQLMacros", type: "SQLQueryMacro")
+
+///
+/// Defines the `@SQLQueries` macro.
+///
+/// Issues #18/#26 (ported from the milestone #28 spike, container encoding):
+/// attaches to a database extension holding a nested `Query` container of
+/// specification functions, and generates the executors as members of the
+/// database — a connection-scoped `Context` with one executor per
+/// specification, an `execute(_:)` entry point, and one database-level
+/// convenience executor per specification (sugar over `execute`). Executors
+/// carry the specification's own name; the `Query` container is never
+/// referenced by generated code, so it may be declared `private` to hide the
+/// trapping specs from the visible API. See <doc:DeclaredQueries>.
+///
+@attached(member, names: arbitrary)
+public macro SQLQueries() = #externalMacro(module: "SQLMacros", type: "SQLQueriesMacro")

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -242,6 +242,9 @@ extension XLRequest {
         bindings: any XLInvocationBindingPacket
     ) throws -> [Row] {
         precondition(limit >= 0, "fetchAtMost(_:bindings:) requires limit >= 0, got \(limit).")
+        guard limit > 0 else {
+            return []
+        }
         return Array(try fetchAll(bindings: bindings).prefix(limit))
     }
 

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -241,7 +241,8 @@ extension XLRequest {
         _ limit: Int,
         bindings: any XLInvocationBindingPacket
     ) throws -> [Row] {
-        Array(try fetchAll(bindings: bindings).prefix(limit))
+        precondition(limit >= 0, "fetchAtMost(_:bindings:) requires limit >= 0, got \(limit).")
+        return Array(try fetchAll(bindings: bindings).prefix(limit))
     }
 
     /// Compatibility default for existing adapters. Invalid packets fail on

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -404,6 +404,16 @@ public protocol XLDatabase {
     /// Creates a prepared delete request from a delete statement.
     ///
     func makeRequest(with statement: any XLDeleteStatement) -> any XLWriteRequest
+
+    ///
+    /// The identity a render-once cache keys on, or `nil` to opt out.
+    ///
+    /// A macro-generated `@SQLQuery`/`@SQLQueries` executor (issues #18/#26)
+    /// renders its statement once per declaration and reuses the request; this
+    /// key scopes that reuse. Returning `nil` (the default) renders on every
+    /// call. See ``XLPreparedQueryCacheKey``.
+    ///
+    var preparedQueryCacheKey: XLPreparedQueryCacheKey? { get }
 }
 
 extension XLDatabase {
@@ -430,5 +440,14 @@ extension XLDatabase {
             "\(type(of: self)) does not support RETURNING statements. Override "
             + "XLDatabase.makeRequest(with: any XLReturningStatement) to add support."
         )
+    }
+
+    ///
+    /// Default render-once opt-out for adapters that do not render SQL
+    /// deterministically per dialect, or that predate ``XLPreparedQueryCacheKey``.
+    /// A macro-generated executor renders on every call exactly as before.
+    ///
+    public var preparedQueryCacheKey: XLPreparedQueryCacheKey? {
+        nil
     }
 }

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -160,6 +160,7 @@ public protocol XLRequest<Row> {
     /// Use this to check a query's cardinality (e.g. "zero, one, or more than one row?") without paying
     /// to decode and retain every row when many might match.
     ///
+    /// - Precondition: `limit >= 0`.
     /// - Throws: The original query-execution or row-decoding error.
     ///
     func fetchAtMost(_ limit: Int, bindings: any XLInvocationBindingPacket) throws -> [Row]

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -152,7 +152,18 @@ public protocol XLRequest<Row> {
 
     /// Fetches all rows with one immutable per-invocation binding packet.
     func fetchAll(bindings: any XLInvocationBindingPacket) throws -> [Row]
-    
+
+    ///
+    /// Fetches at most `limit` rows with one immutable per-invocation binding packet, stopping as soon
+    /// as `limit` rows have been decoded rather than materializing every matching row.
+    ///
+    /// Use this to check a query's cardinality (e.g. "zero, one, or more than one row?") without paying
+    /// to decode and retain every row when many might match.
+    ///
+    /// - Throws: The original query-execution or row-decoding error.
+    ///
+    func fetchAtMost(_ limit: Int, bindings: any XLInvocationBindingPacket) throws -> [Row]
+
     ///
     /// Fetches the first row returned by the query.
     ///
@@ -220,6 +231,16 @@ extension XLRequest {
     ) throws -> Row? {
         try validateCompatibilityBindings(bindings)
         return try fetchOne()
+    }
+
+    /// Compatibility default for adapters that do not implement early-stopping decode: fetches every
+    /// row and truncates. Adapters that can decode incrementally (e.g. `GRDBRequest`) override this to
+    /// actually stop after `limit` rows.
+    public func fetchAtMost(
+        _ limit: Int,
+        bindings: any XLInvocationBindingPacket
+    ) throws -> [Row] {
+        Array(try fetchAll(bindings: bindings).prefix(limit))
     }
 
     /// Compatibility default for existing adapters. Invalid packets fail on

--- a/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
+++ b/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
@@ -135,9 +135,14 @@ public enum XLQueryCardinalityError: Error, Equatable, Sendable, LocalizedError 
 
     public var errorDescription: String? {
         switch self {
-        case .exactlyOneRowExpected(let actual):
+        case .exactlyOneRowExpected(0):
             return "'@SQLQuery'/'@SQLQueries' declared a result of exactly one row, "
-                + "but the query matched \(actual) row(s)."
+                + "but the query matched 0 rows."
+        case .exactlyOneRowExpected:
+            // The executor fetches at most two rows to reject a many-row match cheaply, so any
+            // count above 1 here means "more than one" rather than an exact total.
+            return "'@SQLQuery'/'@SQLQueries' declared a result of exactly one row, "
+                + "but the query matched more than one row."
         }
     }
 }

--- a/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
+++ b/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
@@ -1,0 +1,143 @@
+//
+//  SQLQueryPeerMacroSupport.swift
+//  SwiftQL
+//
+//  Runtime support for `@SQLQuery` / `@SQLQueries` macro-generated executors
+//  (issues #18/#26, ported from the milestone #28 spike on
+//  `experiment/sqlquery-peer-macro`).
+//
+
+import Foundation
+
+
+///
+/// Captures one normalized SQLite value from an `XLBindable` conformer.
+///
+private struct XLSQLiteValueCaptureContext: XLBindingContext {
+
+    var value: XLSQLiteValue = .null
+
+    mutating func bindNull() {
+        self.value = .null
+    }
+
+    mutating func bindInteger(value: Int) {
+        self.value = .integer(Int64(value))
+    }
+
+    mutating func bindReal(value: Double) {
+        self.value = .real(value)
+    }
+
+    mutating func bindText(value: String) {
+        self.value = .text(value)
+    }
+
+    mutating func bindBlob(value: Data) {
+        self.value = .blob(value)
+    }
+}
+
+
+///
+/// Encodes one intrinsic literal parameter value for a named placeholder in a
+/// prepared parameter layout.
+///
+/// Support for `@SQLQuery`/`@SQLQueries` macro-generated executors. The macro
+/// rewrites function-parameter references into typed `XLNamedBindingReference`
+/// placeholders, and the generated executor calls this function to encode each
+/// runtime value into the immutable invocation packet. The static metadata
+/// derived from `T` must match the rendered slot exactly, mirroring the
+/// validation performed by the request `set` compatibility shim.
+///
+public func _xlQueryParameterBinding<T>(
+    _ value: T,
+    named name: XLName,
+    in layout: XLParameterLayout
+) throws -> XLInvocationBinding<XLSQLiteValue> where T: XLBindable & XLLiteral {
+    let declaration = _xlLegacyParameterDeclaration(
+        for: T.self,
+        key: .named(name.rawValue)
+    )
+    guard let slot = layout.slot(for: declaration.key) else {
+        throw XLInvocationBindingError.parameterDeclarationNotInLayout(
+            declaration: declaration
+        )
+    }
+    guard slot.declaration == declaration else {
+        throw XLInvocationBindingError.parameterMetadataMismatch(
+            expected: slot,
+            actual: declaration.slot(at: slot.index)
+        )
+    }
+    var context: any XLBindingContext = XLSQLiteValueCaptureContext()
+    value.bind(context: &context)
+    guard let capture = context as? XLSQLiteValueCaptureContext else {
+        // `bind(context:)` receives the context `inout`, so a conformer could
+        // replace it with a different type. Intrinsic literal conformers never
+        // do; fail with a diagnostic that names the offender if one does.
+        preconditionFailure(
+            "\(T.self).bind(context:) replaced the binding context with "
+            + "\(type(of: context)); expected it to write the value into the "
+            + "provided XLSQLiteValueCaptureContext."
+        )
+    }
+    let sqliteValue = capture.value
+    if sqliteValue == .null, slot.nullability == .required {
+        throw XLInvocationBindingError.nullForRequiredParameter(slot: slot)
+    }
+    return try XLInvocationBinding(slot: slot, value: sqliteValue)
+}
+
+
+///
+/// The trapping direct-result entry point for `@SQLQuery`/`@SQLQueries`
+/// specifications.
+///
+/// A specification written with a direct result type (`[Row]` / `Row?` /
+/// `Row`) calls this instead of `sql {}` so the function type-checks without
+/// the `XLQueryStatement` return-type boilerplate. `Result` appears only in
+/// return position, so it is inferred from the enclosing function's declared
+/// return type — one entry point satisfies every cardinality with no overload
+/// ambiguity.
+///
+/// This function is only a type-check anchor and a syntax source for the
+/// macro; invoking it directly traps loudly, because the real work happens in
+/// the macro-generated executor peer. The macro rewrites this callee back to
+/// `sql {}` when it emits the value-free statement builder.
+///
+/// The name is provisional — `sqlQuery` and `sql` are already statement
+/// builders in `SQLFunctionalSyntax.swift` / the query expression builder, so
+/// the direct-result anchor needs its own name.
+///
+public func sqlResult<Row, Result>(
+    @XLQueryExpressionBuilder _ builder: (XLSchema) -> any XLQueryStatement<Row>
+) -> Result {
+    fatalError(
+        "'sqlResult' marks a @SQLQuery/@SQLQueries specification, not an "
+        + "executor. Call the macro-generated executor peer instead."
+    )
+}
+
+
+///
+/// Thrown by a macro-generated executor when the declaration's return
+/// annotation requires exactly one row (a bare, non-optional, non-array
+/// `Row` result) but the rendered query matched zero rows or more than one.
+///
+/// No `XLRequest` fetch operation enforces "zero or many is an error" on its
+/// own, so the generated executor fetches every matching row and validates
+/// the count itself before returning the single element.
+///
+public enum XLQueryCardinalityError: Error, Equatable, Sendable, LocalizedError {
+
+    case exactlyOneRowExpected(actual: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .exactlyOneRowExpected(let actual):
+            return "'@SQLQuery'/'@SQLQueries' declared a result of exactly one row, "
+                + "but the query matched \(actual) row(s)."
+        }
+    }
+}

--- a/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
+++ b/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
@@ -115,7 +115,9 @@ public func sqlResult<Row, Result>(
 ) -> Result {
     fatalError(
         "'sqlResult' marks a @SQLQuery/@SQLQueries specification, not an "
-        + "executor. Call the macro-generated executor peer instead."
+        + "executor. Call the macro-generated executor instead -- a peer "
+        + "function for @SQLQuery, or a member of the database/Context for "
+        + "@SQLQueries."
     )
 }
 
@@ -126,21 +128,29 @@ public func sqlResult<Row, Result>(
 /// `Row` result) but the rendered query matched zero rows or more than one.
 ///
 /// No `XLRequest` fetch operation enforces "zero or many is an error" on its
-/// own, so the generated executor fetches every matching row and validates
-/// the count itself before returning the single element.
+/// own, so the generated executor calls `fetchAtMost(2, bindings:)` and
+/// validates the count itself before returning the single element. Fetching
+/// at most two rows -- rather than every matching row -- means a query that
+/// accidentally matches many rows is rejected cheaply, but also means the
+/// "more than one" case never has an exact matched-row count to report:
+/// there are separate cases below instead of one case carrying a
+/// possibly-misleading `Int`.
 ///
 public enum XLQueryCardinalityError: Error, Equatable, Sendable, LocalizedError {
 
-    case exactlyOneRowExpected(actual: Int)
+    /// The query matched zero rows.
+    case noRowsMatched
+
+    /// The query matched more than one row. The exact count is unknown --
+    /// the executor stops fetching as soon as a second row is seen.
+    case moreThanOneRowMatched
 
     public var errorDescription: String? {
         switch self {
-        case .exactlyOneRowExpected(0):
+        case .noRowsMatched:
             return "'@SQLQuery'/'@SQLQueries' declared a result of exactly one row, "
                 + "but the query matched 0 rows."
-        case .exactlyOneRowExpected:
-            // The executor fetches at most two rows to reject a many-row match cheaply, so any
-            // count above 1 here means "more than one" rather than an exact total.
+        case .moreThanOneRowMatched:
             return "'@SQLQuery'/'@SQLQueries' declared a result of exactly one row, "
                 + "but the query matched more than one row."
         }

--- a/Sources/SwiftQL/SQLQueryRenderOnceCache.swift
+++ b/Sources/SwiftQL/SQLQueryRenderOnceCache.swift
@@ -1,0 +1,104 @@
+//
+//  SQLQueryRenderOnceCache.swift
+//  SwiftQL
+//
+//  Render-once caching for `@SQLQuery` / `@SQLQueries` macro-generated
+//  executors (issues #18/#26, ported from the milestone #28 spike on
+//  `experiment/sqlquery-peer-macro`).
+//
+//  The generated executor renders its value-free statement to SQL once per
+//  declaration and reuses that request on every call, so per-call work is only
+//  packet construction plus execution. Because the SQL text is identical across
+//  invocations (parameters are placeholders, not inline literals), GRDB's
+//  per-connection `cachedStatement(sql:)` reuses the physical prepared
+//  statement. This is the runtime seam the macro emits a cache against.
+//
+
+import Foundation
+
+
+///
+/// Identity that scopes a render-once cache entry.
+///
+/// Rendering a statement to SQL depends only on the **dialect**, so the dialect
+/// identifier is the render-relevant component. The **database identifier** is
+/// included so a cache shared across databases (the macro emits the cache as a
+/// per-declaration `static`) never hands one database's request to another:
+/// each database renders into its own entry, while repeated calls on the same
+/// database reuse one rendered request. In the GRDB adapter the identifier is a
+/// fresh value per `GRDBDatabase` (its driver assigns one per init), so the
+/// scope is per-instance — two `GRDBDatabase` values wrapping the same
+/// `DatabasePool` render independently rather than sharing an entry.
+///
+/// Today there is a single dialect; keying on the dialect identifier rather than
+/// assuming one means a second dialect renders into its own entry rather than
+/// colliding with the first.
+///
+public struct XLPreparedQueryCacheKey: Hashable, Sendable {
+
+    /// Identifies the database the cached request is bound to (per-instance in
+    /// the GRDB adapter — a fresh identifier per driver init).
+    public let databaseIdentifier: XLDatabaseIdentifier
+
+    /// Identifies the dialect the SQL was rendered for.
+    public let dialectIdentifier: XLDialectIdentifier
+
+    public init(
+        databaseIdentifier: XLDatabaseIdentifier,
+        dialectIdentifier: XLDialectIdentifier
+    ) {
+        self.databaseIdentifier = databaseIdentifier
+        self.dialectIdentifier = dialectIdentifier
+    }
+}
+
+
+///
+/// A lazily-populated, thread-safe cache of one rendered request per
+/// declaration, scoped by ``XLPreparedQueryCacheKey``.
+///
+/// The macro emits one instance per query specification as a `static` peer, so
+/// the rendered request is shared across every invocation of that declaration.
+/// The first call for a given key renders the statement (building the request
+/// through the database's existing `makeRequest(with:)` path) while holding the
+/// lock, so concurrent first callers render exactly once; later calls read the
+/// cached request. The cached request is value-free — parameters are bound per
+/// call through an immutable invocation packet — so reusing it across threads is
+/// safe.
+///
+public final class XLRenderOnceCache<Row>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var requests: [XLPreparedQueryCacheKey: any XLRequest<Row>] = [:]
+
+    public init() {}
+
+    ///
+    /// Returns the request for `database`, rendering the statement built by
+    /// `build` on first use and reusing it afterward.
+    ///
+    /// - Parameter database: The database the request is prepared against; its
+    ///   ``XLDatabase/preparedQueryCacheKey`` scopes the cache entry.
+    /// - Parameter build: Builds the value-free statement. Invoked at most once
+    ///   per key — never on a cache hit.
+    ///
+    public func request(
+        for database: some XLDatabase,
+        statement build: () -> any XLQueryStatement<Row>
+    ) -> any XLRequest<Row> {
+        guard let key = database.preparedQueryCacheKey else {
+            // The adapter opts out of render-once caching, so render per call
+            // exactly as the un-cached executor did.
+            return database.makeRequest(with: build())
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = requests[key] {
+            return existing
+        }
+        let request = database.makeRequest(with: build())
+        requests[key] = request
+        return request
+    }
+}

--- a/Sources/SwiftQL/SQLQueryRenderOnceCache.swift
+++ b/Sources/SwiftQL/SQLQueryRenderOnceCache.swift
@@ -66,6 +66,17 @@ public struct XLPreparedQueryCacheKey: Hashable, Sendable {
 /// call through an immutable invocation packet — so reusing it across threads is
 /// safe.
 ///
+/// Retention trade-off: for the GRDB adapter, a cached `XLRequest` retains its
+/// `GRDBInvocationExecutor` → `GRDBDatabaseDriver` → `DatabasePool` chain. Since
+/// the macro emits one cache as a `static` peer per declaration, invoking a
+/// declared query keeps that database pool alive for the process lifetime, even
+/// if every other reference to the owning database is released. This mirrors an
+/// accepted trade-off from the milestone #28 spike (long-lived databases pay
+/// nothing extra; a short-lived database that only ever calls declared queries
+/// once is retained longer than it otherwise would be). A per-instance store or
+/// an eviction/weak-referencing scheme is future work if that trade-off proves
+/// wrong for a real workload; there is no correctness issue today.
+///
 public final class XLRenderOnceCache<Row>: @unchecked Sendable {
 
     private let lock = NSLock()

--- a/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
@@ -107,7 +107,7 @@ extension GRDBDatabase {
 }
 
 let matches = try database.personByName(name: "John Doe")
-// Equivalent explicit, connection-scoped form:
+// Equivalent explicit form:
 let sameMatches = try database.execute { context in
     try context.personByName(name: "John Doe")
 }
@@ -115,7 +115,11 @@ let sameMatches = try database.execute { context in
 
 `execute(_:)` and the generated `Context` type let you run more than one
 declared query in the same scope without repeating a database lookup per
-call.
+call. This scope does not by itself pin one physical connection --
+`context`'s executors still check out their own connection from the pool per
+call, the same as calling `database.personByName(name:)` directly. A scope
+that pins every operation to one connection, with atomic commit/rollback, is
+a separate capability (issue #284).
 
 ## Render-once caching
 

--- a/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
@@ -1,0 +1,251 @@
+# Declared queries
+
+Generate a nominal, database-bound prepared-query handle from a function
+signature: labeled parameters, result cardinality, statement caching, and a
+frozen-literal guard, all derived by a macro instead of hand-written.
+
+## Overview
+
+Introduced in v1.5.1 (issues [#18](https://github.com/lukevanin/swiftql/issues/18)
+and [#26](https://github.com/lukevanin/swiftql/issues/26)), `@SQLQuery` and
+`@SQLQueries` are attached macros that turn a **query-specification
+function** — an ordinary Swift function whose body builds a `sql { }`
+statement from its own parameters — into a callable, cached, database-bound
+query. Both macros lower to the same generated shape; they differ only in
+where the specification lives and what the generated executor is named:
+
+| Form | Specification lives | Executor name | Call site |
+| --- | --- | --- | --- |
+| `@SQLQuery` | a database extension, one function per query | `fetch` + capitalized spec name | `try database.fetchPersonByName(name:)` |
+| `@SQLQueries` | a nested `private struct Query` inside a `@SQLQueries`-attached extension | the spec's own name | `try database.personByName(name:)` |
+
+`@SQLQueries` is the recommended form for product code: because the
+specification lives in a `private` container that generated code never
+references, the container's own (trapping) functions never appear in the
+public API. `@SQLQuery` is retained as a smaller, independently useful
+building block and as the encoding both forms share underneath.
+
+Both macros need only the stable Swift 5.9 attached-macro roles (`@attached(peer)`
+and `@attached(member)`) — no experimental function-body macro and no Swift 6
+compiler floor. The vestigial specification function that a peer or member
+macro cannot remove is unreachable in the `@SQLQueries` form because of its
+container's access control, and it traps loudly if called directly in the
+`@SQLQuery` form (see [Why a trapping entry point](#why-a-trapping-entry-point)
+below).
+
+## Declare a query
+
+Write an instance method on a database extension whose body is a `sql { }`
+statement builder over the method's own parameters, and attach `@SQLQuery`.
+The **return type**, not the body, tells the macro what to generate: a bare
+row type fetches exactly one row, an optional row type fetches zero-or-one,
+and an array fetches every match.
+
+<!-- test: XLDocumentationTests.testDocumentationDeclaredQueries -->
+```swift
+extension GRDBDatabase {
+
+    @SQLQuery
+    func personByExactName(name: String) -> Person? {
+        sqlResult { schema in
+            let person = schema.table(Person.self)
+            Select(person)
+            From(person)
+            Where(person.name == name)
+        }
+    }
+}
+
+let match = try database.fetchPersonByExactName(name: "John Doe")
+```
+
+The macro derives everything from the signature:
+
+- **Labeled parameters** come straight from the function's own parameter list
+  — `fetchPersonByExactName(name:)` keeps the argument label, so callers get
+  the same compiler-checked labels and useful type errors a normal Swift
+  function would give. This is why the encoding must be a macro: a bare
+  closure loses argument labels entirely.
+- **Result cardinality** comes from the return annotation:
+
+  | Return annotation | Fetch | Executor result |
+  | --- | --- | --- |
+  | `[Row]` | fetch all | `[Row]` |
+  | `Row?` | fetch first-or-none | `Row?` |
+  | `Row` (bare, non-optional, non-array) | fetch exactly one | `Row`, throws `XLQueryCardinalityError.exactlyOneRowExpected` on zero or many rows |
+  | legacy `any/some XLQueryStatement<Row>` | fetch all | `[Row]` |
+
+  The legacy `XLQueryStatement<Row>` spelling from the encoding's original
+  form is still accepted and dispatches like `[Row]`; new declarations should
+  prefer the direct result shapes.
+- A **fresh, immutable binding packet** is constructed on every call from the
+  arguments you pass — callers never construct or mutate an `XLParameter` or
+  `XLNamedBindingReference` themselves, and never bind by textual SQL
+  substitution. Two invocations with different arguments are two independent
+  packets built against the one cached request; a bound value is never part
+  of the query's static identity.
+
+Container form (`@SQLQueries`) generates the same executor shape, but reads
+every specification out of a nested container in one expansion and gives the
+executor its own name instead of a `fetch`-prefixed one:
+
+<!-- test: XLDocumentationTests.testDocumentationDeclaredQueries -->
+```swift
+@SQLQueries
+extension GRDBDatabase {
+
+    private struct Query {
+        func personByName(name: String) -> [Person] {
+            sqlResult { schema in
+                let person = schema.table(Person.self)
+                Select(person)
+                From(person)
+                Where(person.name == name)
+            }
+        }
+    }
+}
+
+let matches = try database.personByName(name: "John Doe")
+// Equivalent explicit, connection-scoped form:
+let sameMatches = try database.execute { context in
+    try context.personByName(name: "John Doe")
+}
+```
+
+`execute(_:)` and the generated `Context` type let you run more than one
+declared query in the same scope without repeating a database lookup per
+call.
+
+## Render-once caching
+
+The generated executor does not render SQL on every call. Each declaration
+gets one `XLRenderOnceCache`, and the **first** call for a given database
+renders the value-free statement (parameters are named placeholders, never
+inline literals) and caches the resulting request; every later call —
+including concurrent first calls racing on an empty cache — reuses that
+cached request and only builds a fresh invocation packet. Because the
+rendered SQL text never changes between calls, the underlying GRDB
+connection's own statement cache reuses one physical prepared statement too.
+
+The cache key is `(databaseIdentifier, dialectIdentifier)`
+(``XLPreparedQueryCacheKey``): rendering depends only on the dialect, so a
+second dialect would render into its own entry, and the database identifier
+keeps one static cache from ever handing one database's prepared request to
+another. `GRDBDatabase.preparedQueryCacheKey` supplies a fresh identifier per
+instance — two `GRDBDatabase` values wrapping the same connection pool render
+independently. An adapter that has not opted into render-once caching
+returns `nil` from `preparedQueryCacheKey` (the `XLDatabase` default), and the
+executor simply renders on every call, exactly as it would without the cache.
+
+### Concurrency and `Sendable`
+
+`XLRenderOnceCache` is `Sendable`; its single lock only ever guards the
+render-once population of one dictionary, so many threads can safely race to
+call a declared query for the first time — the statement renders exactly
+once, and every caller (including the ones that arrived first) gets the same
+cached request back. Each call still builds its own invocation packet and
+executes independently, so concurrent invocations with different argument
+values never share mutable state and never share a physical `sqlite3_stmt`
+across connections: the existing `XLRequest`/connection-pool contracts still
+apply per call.
+
+## Why a trapping entry point
+
+A specification function is still a real, callable Swift function — a peer
+or member macro cannot delete or rewrite the declaration it is attached to.
+To keep that vestigial function from silently doing the wrong thing if it is
+ever called directly (which would execute the query with inline value
+literals baked in, defeating the cached request's whole purpose), a
+direct-result specification calls `sqlResult { }` instead of `sql { }`.
+`sqlResult` type-checks identically to `sql` but **traps** if actually
+invoked; the macro rewrites the call back to the real `sql { }` builder only
+inside the generated statement peer. In the `@SQLQueries` container form this
+residual function is additionally unreachable from outside the file, because
+generated code never references the container and you are free to mark it
+`private`.
+
+## The frozen-literal guard
+
+The render-once cache's central hazard is a parameter value that escapes the
+signature-driven rewrite: if the macro cannot turn every reference to a
+parameter into a named placeholder, that value could freeze into the cached
+SQL text on the very first call, and every later call would silently reuse
+the first call's value. The macro closes this by rejecting, at the
+declaration site, every reference shape it cannot rewrite:
+
+- a parameter used inside a **string interpolation** (renders into the SQL
+  text instead of binding a placeholder),
+- a parameter **captured by a nested closure** (outside the rewrite's reach),
+- a parameter passed as a **direct argument to a function call** (the
+  rewrite cannot see through the call — `matches(name)` is rejected; write
+  `column == name` instead),
+- a parameter used to **initialize a local binding** (`let alias = name`;
+  the binding's later uses are unreachable),
+- a **hand-constructed** `XLNamedBindingReference` or `contextualBinding` (the
+  macro is the sole authority for a placeholder's name and type),
+- a declaration that **shadows** a parameter name, or accesses a parameter
+  **through member access** (`name.uppercased()`),
+- a **collection-typed parameter** (`[T]`, `Set`, `Dictionary`) — a
+  variable-length `IN` list would change the rendered SQL text with the
+  element count, breaking the stable-SQL premise the cache relies on, and
+  a single named placeholder cannot bind a list anyway,
+- a parameter that is **never referenced** at all.
+
+Every one of these is a compile-time diagnostic at the declaration, not a
+runtime failure, and every remaining reference shape the guard accepts — a
+comparison operand such as `column == name` — is the one shape the rewrite
+can always turn into a named placeholder. This means the encoding has **no
+silent-freeze path**: a parameter value either becomes a placeholder, or the
+declaration fails to compile.
+
+Two shapes are not lexically detectable and are intentionally left to the
+compiler as loud type errors on the generated code rather than silently
+accepted: a parameter used as the *callee* of a call (`predicate(x)`), and a
+parenthesized member-access base (`(name).lowercased()`). Neither produces a
+silently wrong result.
+
+## Diagnostics point at the declaration
+
+Every diagnostic above — and every structural one (non-function declaration,
+static/class method, generic function, throwing/async function, variadic or
+unnamed parameter, missing or unsupported return type, missing body) — is
+reported on the specification's own source location, not on the generated
+code. A malformed declaration therefore never produces a confusing error deep
+inside macro-expanded output.
+
+## v1.5 transitional syntax and the v2 migration path
+
+The v1.5.1 prototype builds its value-free statement with the existing
+`sql { }` / `XLQueryStatement` / `makeRequest(with:)` v1 path — the same
+statement construction every other SwiftQL query already uses. It
+deliberately does **not** build on the newer `XLStaticQueryDescriptor` /
+`XLQueryCapture` catalog machinery described in <doc:StaticQueries>; that
+stable-v2 catalog integration is out of scope until the catalog-facing issues
+it depends on land. Existing `@SQLQuery`/`@SQLQueries` declarations are
+expected to keep compiling once that integration ships — the migration is
+expected to be a change to what the macro generates internally, not to how
+you write a specification function.
+
+## Current limitations
+
+- **Read-only.** Only `SELECT`-shaped specifications are supported. A
+  write statement (`INSERT`/`UPDATE`/`DELETE`, with or without `RETURNING`)
+  is not yet an accepted return shape; write declarations remain a possible
+  future cardinality (a `.command` shape dispatching to
+  `XLWriteRequest.execute`), not implemented in v1.5.1.
+- **No collection parameters.** A fixed set of scalar parameters or the
+  `in(_:)` expression forms are today's alternative to a variable-length
+  `IN` list.
+- **No async executor yet.** The generated executor is synchronous and
+  throwing; an `async` variant is additive future work, not a breaking
+  change to what exists today.
+- **Same-name overloads collide.** Generated peer and member names are
+  derived from the specification's base name only, so two `@SQLQuery`
+  functions that share a base name but differ only in parameter list
+  generate colliding peer declarations. This fails loudly as a
+  duplicate-declaration compile error, not silently.
+- **One `@SQLQueries` extension per database type.** A second
+  `@SQLQueries`-attached extension of the same database type would
+  redeclare `Context` and `execute(_:)`. Declare every specification for one
+  database type in a single `@SQLQueries` extension's `Query` container.

--- a/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
@@ -72,7 +72,7 @@ The macro derives everything from the signature:
   | --- | --- | --- |
   | `[Row]` | fetch all | `[Row]` |
   | `Row?` | fetch first-or-none | `Row?` |
-  | `Row` (bare, non-optional, non-array) | fetch exactly one | `Row`, throws `XLQueryCardinalityError.exactlyOneRowExpected` on zero or many rows |
+  | `Row` (bare, non-optional, non-array) | fetch exactly one | `Row`, throws `XLQueryCardinalityError.noRowsMatched` on zero rows or `.moreThanOneRowMatched` on more than one |
   | legacy `any/some XLQueryStatement<Row>` | fetch all | `[Row]` |
 
   The legacy `XLQueryStatement<Row>` spelling from the encoding's original

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -130,6 +130,7 @@ replacing SQLite's runtime type rules.
 - <doc:GettingStarted>
 - <doc:Queries>
 - <doc:StaticQueries>
+- <doc:DeclaredQueries>
 - <doc:LiveQueries>
 - <doc:Expressions>
 - <doc:RealValues>

--- a/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
@@ -145,6 +145,82 @@ final class SQLQueriesMacroExpansionTests: XCTestCase {
             macros: makeTestMacros()
         )
     }
+
+    ///
+    /// A backtick-escaped parameter label (a Swift reserved keyword, e.g.
+    /// `class`) must not carry its backticks into the generated database-level
+    /// executor's call-site argument label -- Swift call-site labels are never
+    /// backtick-escaped, only the referenced local variable is (Copilot
+    /// review, PR #381).
+    ///
+    func test_escapedKeywordParameterLabel_databaseExecutorUsesUnescapedLabel() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            extension MyDatabase {
+                private struct Query {
+                    func peopleByClass(`class`: String) -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.name == `class`)
+                        }
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                private struct Query {
+                    func peopleByClass(`class`: String) -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.name == `class`)
+                        }
+                    }
+                }
+
+                struct Context {
+                    let database: MyDatabase
+
+                    func peopleByClass(`class`: String) throws -> [Person] {
+                        let __xlStatement: any XLQueryStatement<Person> = {
+                            sql { schema in
+                                let person = schema.table(Person.self)
+                                Select(person)
+                                From(person)
+                                Where(person.name == XLNamedBindingReference<String>(name: "class"))
+                            }
+                        }()
+                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlLayout = __xlRequest.parameterLayout
+                        let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                            layout: __xlLayout,
+                            bindings: [
+                                try _xlQueryParameterBinding(`class`, named: "class", in: __xlLayout),
+                            ]
+                        ).validatingComplete()
+                        return try __xlRequest.fetchAll(bindings: __xlPacket)
+                    }
+                }
+
+                func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {
+                    try __xlWork(Context(database: self))
+                }
+
+                func peopleByClass(`class`: String) throws -> [Person] {
+                    try execute { __xlContext in
+                        try __xlContext.peopleByClass(class: `class`)
+                    }
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
 }
 
 

--- a/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
@@ -1,0 +1,311 @@
+//
+//  SQLQueriesMacroTests.swift
+//  SwiftQL
+//
+//  Tests for the `@SQLQueries` member macro (issues #18/#26, container
+//  encoding): the macro reads specifications from a nested `Query` container
+//  and generates a connection-scoped `Context`, the `execute` entry point, and
+//  database-level convenience executors. Ported from the milestone #28 spike
+//  on `experiment/sqlquery-peer-macro`.
+//
+
+import SwiftDiagnostics
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import SQLMacros
+
+
+private func makeTestMacros() -> [String: Macro.Type] {
+    [
+        "SQLQueries": SQLQueriesMacro.self,
+    ]
+}
+
+
+final class SQLQueriesMacroExpansionTests: XCTestCase {
+
+    ///
+    /// The container's specifications become executors carrying the
+    /// specification's own name: connection-scoped on `Context`, one-shot
+    /// sugar on the database. `[Row]` dispatches `fetchAll`, `Row?` dispatches
+    /// `fetchOne`. The `Query` container itself is left untouched and is never
+    /// referenced by the generated members.
+    ///
+    func test_container_generatesContextExecuteAndDatabaseExecutors() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            extension MyDatabase {
+                private struct Query {
+                    func personByName(name: String) -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.name == name)
+                        }
+                    }
+                    func personById(id: String) -> Person? {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.id == id)
+                        }
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                private struct Query {
+                    func personByName(name: String) -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.name == name)
+                        }
+                    }
+                    func personById(id: String) -> Person? {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.id == id)
+                        }
+                    }
+                }
+
+                struct Context {
+                    let database: MyDatabase
+
+                    func personByName(name: String) throws -> [Person] {
+                        let __xlStatement: any XLQueryStatement<Person> = {
+                            sql { schema in
+                                let person = schema.table(Person.self)
+                                Select(person)
+                                From(person)
+                                Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                            }
+                        }()
+                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlLayout = __xlRequest.parameterLayout
+                        let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                            layout: __xlLayout,
+                            bindings: [
+                                try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                            ]
+                        ).validatingComplete()
+                        return try __xlRequest.fetchAll(bindings: __xlPacket)
+                    }
+
+                    func personById(id: String) throws -> Person? {
+                        let __xlStatement: any XLQueryStatement<Person> = {
+                            sql { schema in
+                                let person = schema.table(Person.self)
+                                Select(person)
+                                From(person)
+                                Where(person.id == XLNamedBindingReference<String>(name: "id"))
+                            }
+                        }()
+                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlLayout = __xlRequest.parameterLayout
+                        let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                            layout: __xlLayout,
+                            bindings: [
+                                try _xlQueryParameterBinding(id, named: "id", in: __xlLayout),
+                            ]
+                        ).validatingComplete()
+                        return try __xlRequest.fetchOne(bindings: __xlPacket)
+                    }
+                }
+
+                func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {
+                    try __xlWork(Context(database: self))
+                }
+
+                func personByName(name: String) throws -> [Person] {
+                    try execute { __xlContext in
+                        try __xlContext.personByName(name: name)
+                    }
+                }
+
+                func personById(id: String) throws -> Person? {
+                    try execute { __xlContext in
+                        try __xlContext.personById(id: id)
+                    }
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+}
+
+
+final class SQLQueriesMacroAccessLevelTests: XCTestCase {
+
+    ///
+    /// The extension's access level propagates to every generated member, so a
+    /// `public extension` exposes `Context`, `execute`, and the database-level
+    /// executors to outside-module callers.
+    ///
+    func test_publicExtension_propagatesAccessLevelToGeneratedMembers() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            public extension MyDatabase {
+                private struct Query {
+                    func allPeople() -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                        }
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            public extension MyDatabase {
+                private struct Query {
+                    func allPeople() -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                        }
+                    }
+                }
+
+                public struct Context {
+                    let database: MyDatabase
+
+                    public func allPeople() throws -> [Person] {
+                        let __xlStatement: any XLQueryStatement<Person> = {
+                            sql { schema in
+                                let person = schema.table(Person.self)
+                                Select(person)
+                                From(person)
+                            }
+                        }()
+                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlLayout = __xlRequest.parameterLayout
+                        let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()
+                        return try __xlRequest.fetchAll(bindings: __xlPacket)
+                    }
+                }
+
+                public func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {
+                    try __xlWork(Context(database: self))
+                }
+
+                public func allPeople() throws -> [Person] {
+                    try execute { __xlContext in
+                        try __xlContext.allPeople()
+                    }
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+}
+
+
+final class SQLQueriesMacroDiagnosticTests: XCTestCase {
+
+    ///
+    /// A malformed specification inside the container is diagnosed with the
+    /// container macro's own name, not '@SQLQuery' (which the user never
+    /// wrote).
+    ///
+    func test_malformedContainerSpec_diagnosticNamesSQLQueries() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            extension MyDatabase {
+                struct Query {
+                    func allPeople() throws -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                        }
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                struct Query {
+                    func allPeople() throws -> [Person] {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                        }
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQueries' requires a nonthrowing, synchronous function. Statement builders only construct a value-free statement.",
+                    line: 4,
+                    column: 26
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_nonExtensionDeclaration_emitsError() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            struct MyDatabase {
+            }
+            """,
+            expandedSource: """
+            struct MyDatabase {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQueries' can only be applied to an extension of a database type. The generated executors prepare requests through the extended type's 'makeRequest(with:)'.",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_missingQueryContainer_emitsError() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            extension MyDatabase {
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQueries' requires a nested 'struct Query' container declaring the query specifications.",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+}

--- a/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
@@ -308,4 +308,72 @@ final class SQLQueriesMacroDiagnosticTests: XCTestCase {
             macros: makeTestMacros()
         )
     }
+
+    ///
+    /// Two `Query` containers in the same extension would otherwise silently
+    /// merge their specifications into one generated executor set with no
+    /// indication which container a given executor came from (Copilot
+    /// review, PR #381).
+    ///
+    func test_multipleQueryContainers_emitsError() {
+        assertMacroExpansion(
+            """
+            @SQLQueries
+            extension MyDatabase {
+                private struct Query {
+                    func personByName(name: String) -> Person? {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.name == name)
+                        }
+                    }
+                }
+                private struct Query {
+                    func personByAge(age: Int) -> Person? {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.age == age)
+                        }
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                private struct Query {
+                    func personByName(name: String) -> Person? {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.name == name)
+                        }
+                    }
+                }
+                private struct Query {
+                    func personByAge(age: Int) -> Person? {
+                        sqlResult { schema in
+                            let person = schema.table(Person.self)
+                            Select(person)
+                            From(person)
+                            Where(person.age == age)
+                        }
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQueries' found more than one nested 'struct Query' container in this extension. Declare every query specification in a single 'Query' container.",
+                    line: 13,
+                    column: 5
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
 }

--- a/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
@@ -84,16 +84,19 @@ final class SQLQueriesMacroExpansionTests: XCTestCase {
                 struct Context {
                     let database: MyDatabase
 
+                    private static let __xlPersonByNameCache = XLRenderOnceCache<Person>()
+
                     func personByName(name: String) throws -> [Person] {
-                        let __xlStatement: any XLQueryStatement<Person> = {
-                            sql { schema in
-                                let person = schema.table(Person.self)
-                                Select(person)
-                                From(person)
-                                Where(person.name == XLNamedBindingReference<String>(name: "name"))
-                            }
-                        }()
-                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlRequest = Self.__xlPersonByNameCache.request(for: database) {
+                            {
+                                sql { schema in
+                                    let person = schema.table(Person.self)
+                                    Select(person)
+                                    From(person)
+                                    Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                                }
+                            }()
+                        }
                         let __xlLayout = __xlRequest.parameterLayout
                         let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
                             layout: __xlLayout,
@@ -104,16 +107,19 @@ final class SQLQueriesMacroExpansionTests: XCTestCase {
                         return try __xlRequest.fetchAll(bindings: __xlPacket)
                     }
 
+                    private static let __xlPersonByIdCache = XLRenderOnceCache<Person>()
+
                     func personById(id: String) throws -> Person? {
-                        let __xlStatement: any XLQueryStatement<Person> = {
-                            sql { schema in
-                                let person = schema.table(Person.self)
-                                Select(person)
-                                From(person)
-                                Where(person.id == XLNamedBindingReference<String>(name: "id"))
-                            }
-                        }()
-                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlRequest = Self.__xlPersonByIdCache.request(for: database) {
+                            {
+                                sql { schema in
+                                    let person = schema.table(Person.self)
+                                    Select(person)
+                                    From(person)
+                                    Where(person.id == XLNamedBindingReference<String>(name: "id"))
+                                }
+                            }()
+                        }
                         let __xlLayout = __xlRequest.parameterLayout
                         let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
                             layout: __xlLayout,
@@ -186,16 +192,19 @@ final class SQLQueriesMacroExpansionTests: XCTestCase {
                 struct Context {
                     let database: MyDatabase
 
+                    private static let __xlPeopleByClassCache = XLRenderOnceCache<Person>()
+
                     func peopleByClass(`class`: String) throws -> [Person] {
-                        let __xlStatement: any XLQueryStatement<Person> = {
-                            sql { schema in
-                                let person = schema.table(Person.self)
-                                Select(person)
-                                From(person)
-                                Where(person.name == XLNamedBindingReference<String>(name: "class"))
-                            }
-                        }()
-                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlRequest = Self.__xlPeopleByClassCache.request(for: database) {
+                            {
+                                sql { schema in
+                                    let person = schema.table(Person.self)
+                                    Select(person)
+                                    From(person)
+                                    Where(person.name == XLNamedBindingReference<String>(name: "class"))
+                                }
+                            }()
+                        }
                         let __xlLayout = __xlRequest.parameterLayout
                         let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
                             layout: __xlLayout,
@@ -262,15 +271,18 @@ final class SQLQueriesMacroAccessLevelTests: XCTestCase {
                 public struct Context {
                     let database: MyDatabase
 
+                    private static let __xlAllPeopleCache = XLRenderOnceCache<Person>()
+
                     public func allPeople() throws -> [Person] {
-                        let __xlStatement: any XLQueryStatement<Person> = {
-                            sql { schema in
-                                let person = schema.table(Person.self)
-                                Select(person)
-                                From(person)
-                            }
-                        }()
-                        let __xlRequest = database.makeRequest(with: __xlStatement)
+                        let __xlRequest = Self.__xlAllPeopleCache.request(for: database) {
+                            {
+                                sql { schema in
+                                    let person = schema.table(Person.self)
+                                    Select(person)
+                                    From(person)
+                                }
+                            }()
+                        }
                         let __xlLayout = __xlRequest.parameterLayout
                         let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()
                         return try __xlRequest.fetchAll(bindings: __xlPacket)

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -536,7 +536,7 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
                             try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
                         ]
                     ).validatingComplete()
-                    let __xlRows = try __xlRequest.fetchAll(bindings: __xlPacket)
+                    let __xlRows = try __xlRequest.fetchAtMost(2, bindings: __xlPacket)
                     guard __xlRows.count == 1 else {
                         throw XLQueryCardinalityError.exactlyOneRowExpected(actual: __xlRows.count)
                     }
@@ -699,6 +699,47 @@ final class SQLQueryMacroDiagnosticTests: XCTestCase {
             expandedSource: """
             extension MyDatabase {
                 func allPeople() -> Void {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' requires the function to return '[Row]' (fetch all), 'Row?' (fetch one), 'Row' (fetch exactly one), or the legacy 'any/some XLQueryStatement<Row>', with an explicit row type. The row type declares the executor's result element and the shape selects the fetch.",
+                    line: 3,
+                    column: 25
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// `Swift.Void` is the same type as the bare `Void` spelling covered by
+    /// `test_voidReturn_emitsMissingRowTypeError` above, and must be excluded
+    /// from the bare-`Row` fallback the same way (Copilot review, PR #381).
+    ///
+    func test_moduleQualifiedVoidReturn_emitsMissingRowTypeError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() -> Swift.Void {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() -> Swift.Void {
                     sql { schema in
                         let person = schema.table(Person.self)
                         Select(person)

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -485,7 +485,7 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
     ///
     /// A bare `Row` direct-result signature (v1.5.1 extension) dispatches to a
     /// fetch-all-then-validate-count executor that throws
-    /// `XLQueryCardinalityError.exactlyOneRowExpected` when the query does not
+    /// `XLQueryCardinalityError.noRowsMatched/.moreThanOneRowMatched` when the query does not
     /// match exactly one row.
     ///
     func test_directResultBareRow_dispatchesExactlyOne() {
@@ -537,10 +537,14 @@ final class SQLQueryMacroExpansionTests: XCTestCase {
                         ]
                     ).validatingComplete()
                     let __xlRows = try __xlRequest.fetchAtMost(2, bindings: __xlPacket)
-                    guard __xlRows.count == 1 else {
-                        throw XLQueryCardinalityError.exactlyOneRowExpected(actual: __xlRows.count)
+                    switch __xlRows.count {
+                    case 0:
+                        throw XLQueryCardinalityError.noRowsMatched
+                    case 1:
+                        return __xlRows[0]
+                    default:
+                        throw XLQueryCardinalityError.moreThanOneRowMatched
                     }
-                    return __xlRows[0]
                 }
             }
             """,

--- a/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueryMacroTests.swift
@@ -1,0 +1,1470 @@
+//
+//  SQLQueryMacroTests.swift
+//  SwiftQL
+//
+//  Tests for the `@SQLQuery` peer macro (issues #18/#26): signature-driven
+//  body rewriting, executor generation, and diagnostics for unsupported
+//  declaration shapes. Ported from the milestone #28 spike on
+//  `experiment/sqlquery-peer-macro`, extended with the `.exactlyOne`
+//  cardinality added for v1.5.1.
+//
+
+import SwiftDiagnostics
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import SQLMacros
+
+
+private func makeTestMacros() -> [String: Macro.Type] {
+    [
+        "SQLQuery": SQLQueryMacro.self,
+    ]
+}
+
+
+final class SQLQueryMacroExpansionTests: XCTestCase {
+
+    func test_oneParameter_rewritesReferenceAndGeneratesExecutor() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+
+                func personByNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                    }
+                }
+
+                private static let __xlPersonByNameCache = XLRenderOnceCache<Person>()
+
+                func fetchPersonByName(name: String) throws -> [Person] {
+                    let __xlRequest = Self.__xlPersonByNameCache.request(for: self) {
+                        personByNameStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_twoParameters_rewritesEveryReferenceWithItsOwnType() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                public func peopleInCohort(name: String, minimumAge: Int) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name && person.age >= minimumAge)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                public func peopleInCohort(name: String, minimumAge: Int) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name && person.age >= minimumAge)
+                    }
+                }
+
+                public func peopleInCohortStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name") && person.age >= XLNamedBindingReference<Int>(name: "minimumAge"))
+                    }
+                }
+
+                private static let __xlPeopleInCohortCache = XLRenderOnceCache<Person>()
+
+                public func fetchPeopleInCohort(name: String, minimumAge: Int) throws -> [Person] {
+                    let __xlRequest = Self.__xlPeopleInCohortCache.request(for: self) {
+                        peopleInCohortStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                            try _xlQueryParameterBinding(minimumAge, named: "minimumAge", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_optionalParameter_bindsThroughOptionalReference() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func peopleByNickname(nickname: String?) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.nickname == nickname)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func peopleByNickname(nickname: String?) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.nickname == nickname)
+                    }
+                }
+
+                func peopleByNicknameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.nickname == XLNamedBindingReference<String?>(name: "nickname"))
+                    }
+                }
+
+                private static let __xlPeopleByNicknameCache = XLRenderOnceCache<Person>()
+
+                func fetchPeopleByNickname(nickname: String?) throws -> [Person] {
+                    let __xlRequest = Self.__xlPeopleByNicknameCache.request(for: self) {
+                        peopleByNicknameStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(nickname, named: "nickname", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_memberNameMatchingParameterName_isNotRewritten() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name && name == person.name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name && name == person.name)
+                    }
+                }
+
+                func personByNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name") && XLNamedBindingReference<String>(name: "name") == person.name)
+                    }
+                }
+
+                private static let __xlPersonByNameCache = XLRenderOnceCache<Person>()
+
+                func fetchPersonByName(name: String) throws -> [Person] {
+                    let __xlRequest = Self.__xlPersonByNameCache.request(for: self) {
+                        personByNameStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_backtickedParameter_stripsEscapingFromPlaceholderName() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func rowsForKind(`class`: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.kind == `class`)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func rowsForKind(`class`: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.kind == `class`)
+                    }
+                }
+
+                func rowsForKindStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.kind == XLNamedBindingReference<String>(name: "class"))
+                    }
+                }
+
+                private static let __xlRowsForKindCache = XLRenderOnceCache<Person>()
+
+                func fetchRowsForKind(`class`: String) throws -> [Person] {
+                    let __xlRequest = Self.__xlRowsForKindCache.request(for: self) {
+                        rowsForKindStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(`class`, named: "class", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_zeroParameters_generatesEmptyPacketExecutor() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+
+                func allPeopleStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+
+                private static let __xlAllPeopleCache = XLRenderOnceCache<Person>()
+
+                func fetchAllPeople() throws -> [Person] {
+                    let __xlRequest = Self.__xlAllPeopleCache.request(for: self) {
+                        allPeopleStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(layout: __xlLayout, bindings: []).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    // MARK: - Direct-result signatures + return-shape dispatch
+
+    ///
+    /// A `[Row]` direct-result signature (no `XLQueryStatement` boilerplate)
+    /// dispatches to `fetchAll`. The spec calls the trapping `sqlResult` entry
+    /// point; the generated statement builder swaps it for the real `sql`
+    /// builder and declares the value-free `any XLQueryStatement<Row>` result.
+    ///
+    func test_directResultArray_dispatchesFetchAll() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> [Person] {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> [Person] {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+
+                func personByNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                    }
+                }
+
+                private static let __xlPersonByNameCache = XLRenderOnceCache<Person>()
+
+                func fetchPersonByName(name: String) throws -> [Person] {
+                    let __xlRequest = Self.__xlPersonByNameCache.request(for: self) {
+                        personByNameStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A `Row?` direct-result signature dispatches to `fetchOne` and returns an
+    /// optional row. This is the only source of the cardinality — the return
+    /// annotation — since the macro is declaration-local.
+    ///
+    func test_directResultOptional_dispatchesFetchOne() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByExactName(name: String) -> Person? {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByExactName(name: String) -> Person? {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+
+                func personByExactNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                    }
+                }
+
+                private static let __xlPersonByExactNameCache = XLRenderOnceCache<Person>()
+
+                func fetchPersonByExactName(name: String) throws -> Person? {
+                    let __xlRequest = Self.__xlPersonByExactNameCache.request(for: self) {
+                        personByExactNameStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchOne(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A bare `Row` direct-result signature (v1.5.1 extension) dispatches to a
+    /// fetch-all-then-validate-count executor that throws
+    /// `XLQueryCardinalityError.exactlyOneRowExpected` when the query does not
+    /// match exactly one row.
+    ///
+    func test_directResultBareRow_dispatchesExactlyOne() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func theOnlyPerson(name: String) -> Person {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func theOnlyPerson(name: String) -> Person {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+
+                func theOnlyPersonStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                    }
+                }
+
+                private static let __xlTheOnlyPersonCache = XLRenderOnceCache<Person>()
+
+                func fetchTheOnlyPerson(name: String) throws -> Person {
+                    let __xlRequest = Self.__xlTheOnlyPersonCache.request(for: self) {
+                        theOnlyPersonStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    let __xlRows = try __xlRequest.fetchAll(bindings: __xlPacket)
+                    guard __xlRows.count == 1 else {
+                        throw XLQueryCardinalityError.exactlyOneRowExpected(actual: __xlRows.count)
+                    }
+                    return __xlRows[0]
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// The `sqlResult` -> `sql` swap applies only in callee position. A
+    /// reference that merely names the entry point elsewhere in the body is
+    /// left untouched. (The expansion is syntactic, so the contrived non-callee
+    /// reference needs no runtime meaning.)
+    ///
+    func test_directResult_calleeRenameAppliesOnlyInCalleePosition() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func auditedPersonByName(name: String) -> [Person] {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                        audit(sqlResult)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func auditedPersonByName(name: String) -> [Person] {
+                    sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                        audit(sqlResult)
+                    }
+                }
+
+                func auditedPersonByNameStatement() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == XLNamedBindingReference<String>(name: "name"))
+                        audit(sqlResult)
+                    }
+                }
+
+                private static let __xlAuditedPersonByNameCache = XLRenderOnceCache<Person>()
+
+                func fetchAuditedPersonByName(name: String) throws -> [Person] {
+                    let __xlRequest = Self.__xlAuditedPersonByNameCache.request(for: self) {
+                        auditedPersonByNameStatement()
+                    }
+                    let __xlLayout = __xlRequest.parameterLayout
+                    let __xlPacket = try XLInvocationBindings<XLSQLiteValue>(
+                        layout: __xlLayout,
+                        bindings: [
+                            try _xlQueryParameterBinding(name, named: "name", in: __xlLayout),
+                        ]
+                    ).validatingComplete()
+                    return try __xlRequest.fetchAll(bindings: __xlPacket)
+                }
+            }
+            """,
+            macros: makeTestMacros()
+        )
+    }
+}
+
+
+final class SQLQueryMacroDiagnosticTests: XCTestCase {
+
+    func test_nonFunctionDeclaration_emitsError() {
+        assertMacroExpansion(
+            """
+            @SQLQuery
+            struct Sample {
+            }
+            """,
+            expandedSource: """
+            struct Sample {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' can only be applied to a function.",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_missingRowType_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() -> any XLQueryStatement {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() -> any XLQueryStatement {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' requires the function to return '[Row]' (fetch all), 'Row?' (fetch one), 'Row' (fetch exactly one), or the legacy 'any/some XLQueryStatement<Row>', with an explicit row type. The row type declares the executor's result element and the shape selects the fetch.",
+                    line: 3,
+                    column: 25
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// An explicit `Void` return is excluded from the bare-`Row`
+    /// (`.exactlyOne`) fallback, so it still falls through to the same
+    /// missing-row-type diagnostic rather than being treated as a nonsensical
+    /// `Void` row type. `.command` (write statements) is out of scope for
+    /// v1.5.1; see the DeclaredQueries.md limitations section.
+    ///
+    func test_voidReturn_emitsMissingRowTypeError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() -> Void {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() -> Void {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' requires the function to return '[Row]' (fetch all), 'Row?' (fetch one), 'Row' (fetch exactly one), or the legacy 'any/some XLQueryStatement<Row>', with an explicit row type. The row type declares the executor's result element and the shape selects the fetch.",
+                    line: 3,
+                    column: 25
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_throwingFunction_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() throws -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() throws -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' requires a nonthrowing, synchronous function. Statement builders only construct a value-free statement.",
+                    line: 3,
+                    column: 22
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_variadicParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func peopleNamed(names: String...) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func peopleNamed(names: String...) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' cannot bind a variadic parameter to a single named placeholder.",
+                    line: 3,
+                    column: 35
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_genericFunction_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func rows<Value>(value: Value) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func rows<Value>(value: Value) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' cannot be applied to a generic function. The generated statement builder takes no arguments, so generic parameters cannot be inferred.",
+                    line: 3,
+                    column: 14
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_staticFunction_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                static func allPeople() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                static func allPeople() -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' can only be applied to an instance method. The generated executor prepares its request through 'self.makeRequest(with:)'.",
+                    line: 3,
+                    column: 5
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_shadowingLocalBinding_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        let name = "frozen"
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        let name = "frozen"
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' shadows a query parameter inside the '@SQLQuery' body. The macro rewrites every reference to 'name' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration.",
+                    line: 6,
+                    column: 17
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_shadowingClosureParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { name in
+                        let person = name.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { name in
+                        let person = name.table(Person.self)
+                        Select(person)
+                        From(person)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' shadows a query parameter inside the '@SQLQuery' body. The macro rewrites every reference to 'name' into a named binding, so a shadowing declaration would change what those references mean. Rename the declaration.",
+                    line: 4,
+                    column: 15
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_parameterMemberAccess_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name.uppercased())
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name.uppercased())
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' cannot be used through member access in a '@SQLQuery' body. A parameter reference is rewritten to a named binding as a whole expression; compute the derived value before building the statement, or pass it as a separate parameter.",
+                    line: 8,
+                    column: 34
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    func test_missingBody_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func allPeople() -> any XLQueryStatement<Person>
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func allPeople() -> any XLQueryStatement<Person>
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' requires a function body that returns the query statement.",
+                    line: 3,
+                    column: 19
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A parameter named after a statement-builder entry point would be
+    /// rewritten wherever the builder is called, corrupting the generated code.
+    ///
+    func test_reservedParameterName_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func rowsMatching(sql: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == sql)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func rowsMatching(sql: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == sql)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' cannot bind a parameter named 'sql'. The name collides with a statement-builder entry point, so rewriting its references would corrupt the builder call in the generated peer. Rename the parameter.",
+                    line: 3,
+                    column: 23
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// The `sqlResult` -> `sql` swap matches only an unqualified callee, so a
+    /// qualified spelling is rejected rather than left to trap at runtime in
+    /// the generated statement builder.
+    ///
+    func test_qualifiedEntryPoint_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> [Person] {
+                    SwiftQL.sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> [Person] {
+                    SwiftQL.sqlResult { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == name)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'sqlResult' must be called unqualified in a '@SQLQuery' specification. The macro rewrites the entry point lexically and cannot distinguish a module qualifier from another object's member of the same name.",
+                    line: 4,
+                    column: 9
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    // MARK: - Frozen-literal guard
+
+    ///
+    /// A collection parameter would render a variable-length `IN` list, so the
+    /// SQL text changes with the element count and the render-once cache breaks.
+    ///
+    func test_collectionParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func peopleByNames(names: [String]) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == names)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func peopleByNames(names: [String]) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == names)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' cannot bind the array parameter 'names' to a single named placeholder. A variable-length list renders SQL whose text changes with the element count, which breaks the stable-SQL premise the prepared query relies on. Spell the elements in the statement with the 'in(_:)' expression forms, or pass a fixed set of scalar parameters.",
+                    line: 3,
+                    column: 31
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// An optional collection in the generic `Optional<[T]>` spelling is still a
+    /// collection and is rejected, not just the postfix `[T]?` spelling.
+    ///
+    func test_genericOptionalCollectionParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func peopleByNames(names: Optional<[String]>) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == names)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func peopleByNames(names: Optional<[String]>) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == names)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' cannot bind the array parameter 'names' to a single named placeholder. A variable-length list renders SQL whose text changes with the element count, which breaks the stable-SQL premise the prepared query relies on. Spell the elements in the statement with the 'in(_:)' expression forms, or pass a fixed set of scalar parameters.",
+                    line: 3,
+                    column: 31
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A parameter inside a string interpolation renders its value into the
+    /// string rather than binding a placeholder.
+    ///
+    func test_stringInterpolationParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == "prefix\\(name)")
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.name == "prefix\\(name)")
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' is used inside a string interpolation in the '@SQLQuery' body, which renders its value into the string rather than binding a placeholder. Build the value into the statement with a comparison against a column, not an interpolated string.",
+                    line: 8,
+                    column: 43
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A parameter captured by a nested closure escapes the rewrite, which only
+    /// reaches the statement builder itself.
+    ///
+    func test_nestedClosureParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.tags.contains { $0 == name })
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.tags.contains { $0 == name })
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' is captured by a nested closure in the '@SQLQuery' body. The rewrite only reaches references in the statement builder itself, so a value captured deeper can escape into the cached SQL as a frozen literal. Reference the parameter directly in the statement.",
+                    line: 8,
+                    column: 48
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A parameter passed to a helper call is invisible to the rewrite, so its
+    /// value freezes into the cached SQL on the first invocation.
+    ///
+    func test_helperCallArgumentParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(matches(name))
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(matches(name))
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' is passed as an argument to a function call in the '@SQLQuery' body. The rewrite cannot see through the call, so the value would be frozen into the cached SQL on the first invocation. Use the parameter directly as a comparison operand (for example 'column == name') instead of passing it to a helper.",
+                    line: 8,
+                    column: 27
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A parameter used to initialize a local binding escapes the rewrite
+    /// through the binding's later uses.
+    ///
+    func test_parameterInLocalBindingInitializer_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        let alias = name
+                        Select(person)
+                        From(person)
+                        Where(person.name == alias)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func personByName(name: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        let alias = name
+                        Select(person)
+                        From(person)
+                        Where(person.name == alias)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'name' is used to initialize a local binding in the '@SQLQuery' body. The binding's later uses are outside the rewrite's reach, so the value can freeze into the cached SQL. Reference the parameter directly in the statement instead of storing it in a local.",
+                    line: 6,
+                    column: 25
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A hand-constructed binding reference bypasses the signature contract and
+    /// can disagree with the rendered parameter layout.
+    ///
+    func test_manualBindingReference_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func rows(id: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.id == id && person.other == XLNamedBindingReference<String>(name: "x"))
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func rows(id: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.id == id && person.other == XLNamedBindingReference<String>(name: "x"))
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' derives every named binding from the function signature, so 'XLNamedBindingReference' must not be constructed by hand in the body. A hand-built binding can disagree with the rendered parameter layout. Reference the parameter directly and let the macro generate the binding.",
+                    line: 8,
+                    column: 54
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// The manual-binding guard also covers the `contextualBinding(_:)`
+    /// spelling, so the unqualified-callee match is exercised alongside the
+    /// generic `XLNamedBindingReference<…>(…)` form.
+    ///
+    func test_manualContextualBinding_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func rows(id: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.id == id && person.other == contextualBinding("x"))
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func rows(id: String) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.id == id && person.other == contextualBinding("x"))
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'@SQLQuery' derives every named binding from the function signature, so 'contextualBinding' must not be constructed by hand in the body. A hand-built binding can disagree with the rendered parameter layout. Reference the parameter directly and let the macro generate the binding.",
+                    line: 8,
+                    column: 54
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    ///
+    /// A parameter never referenced in the body cannot bind a placeholder, and
+    /// the signature-driven rewrite can catch it at the declaration site.
+    ///
+    func test_unusedParameter_emitsError() {
+        assertMacroExpansion(
+            """
+            extension MyDatabase {
+                @SQLQuery
+                func rows(id: String, unused: Int) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.id == id)
+                    }
+                }
+            }
+            """,
+            expandedSource: """
+            extension MyDatabase {
+                func rows(id: String, unused: Int) -> any XLQueryStatement<Person> {
+                    sql { schema in
+                        let person = schema.table(Person.self)
+                        Select(person)
+                        From(person)
+                        Where(person.id == id)
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'unused' is never referenced in the '@SQLQuery' body, so it cannot bind a placeholder. A standalone bindings struct defers this to execution time, but the signature-driven rewrite can catch it here: reference the parameter in the statement, or remove it.",
+                    line: 3,
+                    column: 27
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+}

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -445,7 +445,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         let firstReleaseHeading = changelog
             .components(separatedBy: .newlines)
             .first(where: { $0.hasPrefix("## [") })
-        XCTAssertEqual(firstReleaseHeading, "## [1.4.6] - 2026-07-25")
+        XCTAssertEqual(firstReleaseHeading, "## [1.5.1] - 2026-07-24")
     }
 
     func testREADMERepositoryLinksResolveWithExactCase() throws {

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -107,6 +107,10 @@ private let documentationTests = [
         "XLDocumentationTests.testDocumentationLiveQueryPublishers",
         XLDocumentationTests.testDocumentationLiveQueryPublishers
     ),
+    DocumentationTestReference(
+        "XLDocumentationTests.testDocumentationDeclaredQueries",
+        XLDocumentationTests.testDocumentationDeclaredQueries
+    ),
 ]
 
 
@@ -116,6 +120,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         "BuiltinFunctions.md": "XLDocumentationTests.testDocumentationConditionalAndScalarFunctions",
         "CustomFunctions.md": "XLDocumentationTests.testDocumentationCustomFunctionRegistrationAndExecution",
         "CustomTypes.md": "XLDocumentationTests.testDocumentationCustomTypeRoundTrips",
+        "DeclaredQueries.md": "XLDocumentationTests.testDocumentationDeclaredQueries",
         "Enums.md": "XLDocumentationTests.testDocumentationEnumValues",
         "Expressions.md": "XLDocumentationTests.testDocumentationExpressions",
         "FunctionalSyntax.md": "XLDocumentationTests.testDocumentationFunctionalQueriesAndMutations",

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -529,6 +529,23 @@ public struct HaversineDistance: XLCustomFunction {
 }
 
 
+// Compiled scenario for <doc:DeclaredQueries> (issues #18/#26): a `@SQLQuery`
+// declaration lowers the signature-driven specification into a value-free
+// statement builder and a cached, cardinality-dispatched executor.
+extension GRDBDatabase {
+
+    @SQLQuery
+    func personByExactName(name: String) -> Person? {
+        sqlResult { schema in
+            let person = schema.table(Person.self)
+            Select(person)
+            From(person)
+            Where(person.name == name)
+        }
+    }
+}
+
+
 final class XLDocumentationTests: XCTestCase {
     
     var encoder: XLiteEncoder!
@@ -2168,5 +2185,19 @@ extension XLDocumentationTests {
         let _: (XLGRDBLiveQueryRetryTests) -> () throws -> Void =
             XLGRDBLiveQueryRetryTests
                 .testRealGRDBObservationRecoversFromInjectedBusyAndKeepsObserving
+    }
+
+    func testDocumentationDeclaredQueries() throws {
+        XCTAssertEqual(try database.fetchPersonByExactName(name: "John Doe"), johnDoe)
+        XCTAssertNil(try database.fetchPersonByExactName(name: "Nobody"))
+
+        let _: (XLQueryPeerMacroTests) -> () throws -> Void =
+            XLQueryPeerMacroTests.testDirectResultOptionalExecutorFetchesSingleRow
+        let _: (XLQueryPeerMacroTests) -> () throws -> Void =
+            XLQueryPeerMacroTests.testBareRowExecutorThrowsWhenMultipleRowsMatch
+        let _: (XLQueriesContainerTests) -> () throws -> Void =
+            XLQueriesContainerTests.testExecuteClosureRunsMultipleQueriesInOneScope
+        let _: (XLQueryRenderOnceCacheTests) -> () throws -> Void =
+            XLQueryRenderOnceCacheTests.testCachedExecutorServesDifferentArgumentsWithStablePlaceholderSQL
     }
 }

--- a/Tests/SQLTests/SQLQueriesContainerTests.swift
+++ b/Tests/SQLTests/SQLQueriesContainerTests.swift
@@ -55,6 +55,26 @@ extension GRDBDatabase {
 }
 
 
+/// Captures logged SQL text so a test can inspect what was actually rendered
+/// and executed, without any internal render-count hook.
+private final class RecordingLogger: XLLogger {
+    private let lock = NSLock()
+    private var messages: [String] = []
+
+    func log(level: XLLogLevel, message: String) {
+        lock.lock()
+        messages.append(message)
+        lock.unlock()
+    }
+
+    var allMessages: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return messages
+    }
+}
+
+
 final class XLQueriesContainerTests: XCTestCase {
 
     var databasePool: DatabasePool!
@@ -150,6 +170,48 @@ final class XLQueriesContainerTests: XCTestCase {
         }
         XCTAssertEqual(all, [TestTable(id: "alpha", value: 1)])
         XCTAssertEqual(one, TestTable(id: "beta", value: 9))
+    }
+
+
+    // MARK: - Render-once caching
+
+    ///
+    /// The container form's `Context` executor is prepared through its own
+    /// `XLRenderOnceCache` (Copilot review, PR #386) the same way the
+    /// `@SQLQuery` peer macro's executor is, rather than re-rendering SQL on
+    /// every call. Proven the same way `SQLQueryRenderOnceCacheTests` proves
+    /// it for the peer form: the executed SQL text is byte-identical across
+    /// calls with different argument values and carries a named placeholder,
+    /// never an inlined literal -- a re-rendering-per-call implementation
+    /// would inline each call's `id` value into the SQL text instead.
+    ///
+    func testContextExecutorRendersOnceAcrossCallsWithDifferentArguments() throws {
+        let logger = RecordingLogger()
+        let formatter = XLiteFormatter(identifierFormattingOptions: .mysqlCompatible)
+        let loggingDatabase = try GRDBDatabase(databasePool: databasePool, formatter: formatter, logger: logger)
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 9))
+
+        _ = try loggingDatabase.containerRowsMatchingID(id: "alpha")
+        _ = try loggingDatabase.containerRowsMatchingID(id: "beta")
+        _ = try loggingDatabase.containerRowsMatchingID(id: "alpha")
+
+        let fetchLogs = logger.allMessages.filter { $0.contains("fetchAll:") }
+        XCTAssertEqual(fetchLogs.count, 3, "expected one log line per call")
+        let renderedSQLTexts = Set(
+            fetchLogs.compactMap { message -> String? in
+                guard let start = message.range(of: "<<<"), let end = message.range(of: ">>>") else {
+                    return nil
+                }
+                return String(message[start.upperBound..<end.lowerBound])
+            }
+        )
+        XCTAssertEqual(renderedSQLTexts.count, 1, "every call must reuse the same rendered SQL text")
+        let renderedSQL = try XCTUnwrap(renderedSQLTexts.first)
+        XCTAssertTrue(renderedSQL.contains(":id"), "the reused SQL must bind a placeholder")
+        XCTAssertFalse(renderedSQL.contains("'alpha'"), "no call's argument may be inlined as a literal")
+        XCTAssertFalse(renderedSQL.contains("'beta'"), "no call's argument may be inlined as a literal")
     }
 
 

--- a/Tests/SQLTests/SQLQueriesContainerTests.swift
+++ b/Tests/SQLTests/SQLQueriesContainerTests.swift
@@ -117,7 +117,7 @@ final class XLQueriesContainerTests: XCTestCase {
         XCTAssertThrowsError(try database.containerTheOnlyRowMatchingID(id: "gamma")) { error in
             XCTAssertEqual(
                 error as? XLQueryCardinalityError,
-                .exactlyOneRowExpected(actual: 0)
+                .noRowsMatched
             )
         }
     }

--- a/Tests/SQLTests/SQLQueriesContainerTests.swift
+++ b/Tests/SQLTests/SQLQueriesContainerTests.swift
@@ -74,6 +74,7 @@ final class XLQueriesContainerTests: XCTestCase {
     }
 
     override func tearDown() {
+        try? databasePool?.close()
         databasePool = nil
         database = nil
     }

--- a/Tests/SQLTests/SQLQueriesContainerTests.swift
+++ b/Tests/SQLTests/SQLQueriesContainerTests.swift
@@ -1,0 +1,164 @@
+//
+//  SQLQueriesContainerTests.swift
+//  SwiftQL
+//
+//  Runtime tests for the `@SQLQueries` member macro (issues #18/#26,
+//  container encoding): the macro attaches to a database extension on the
+//  v1.x toolchain floor, reads the specifications from the nested
+//  (fileprivate) `Query` container, and generates working executors —
+//  connection-scoped on `Context` and one-shot on the database. Ported from
+//  the milestone #28 spike on `experiment/sqlquery-peer-macro`, extended with
+//  `.exactlyOne` cardinality coverage added for v1.5.1.
+//
+
+import Foundation
+import XCTest
+import GRDB
+import SwiftQL
+
+
+@SQLQueries
+extension GRDBDatabase {
+
+    // The container is deliberately `fileprivate`: generated code never
+    // references it, so the trapping specification functions are invisible
+    // outside this file. Only the generated executors are callable.
+    fileprivate struct Query {
+
+        func containerRowsMatchingID(id: String) -> [TestTable] {
+            sqlResult { schema in
+                let table = schema.table(TestTable.self)
+                Select(table)
+                From(table)
+                Where(table.id == id)
+            }
+        }
+
+        func containerRowMatchingID(id: String) -> TestTable? {
+            sqlResult { schema in
+                let table = schema.table(TestTable.self)
+                Select(table)
+                From(table)
+                Where(table.id == id)
+            }
+        }
+
+        func containerTheOnlyRowMatchingID(id: String) -> TestTable {
+            sqlResult { schema in
+                let table = schema.table(TestTable.self)
+                Select(table)
+                From(table)
+                Where(table.id == id)
+            }
+        }
+    }
+}
+
+
+final class XLQueriesContainerTests: XCTestCase {
+
+    var databasePool: DatabasePool!
+    var database: GRDBDatabase!
+
+    override func setUp() {
+        let formatter = XLiteFormatter(
+            identifierFormattingOptions: .mysqlCompatible
+        )
+        let directory = FileManager.default.temporaryDirectory
+        let filename = UUID().uuidString
+        let fileURL = directory
+            .appendingPathComponent(filename, isDirectory: false)
+            .appendingPathExtension("sqlite")
+        databasePool = try! DatabasePool(path: fileURL.path)
+        database = try! GRDBDatabase(databasePool: databasePool, formatter: formatter, logger: nil)
+    }
+
+    override func tearDown() {
+        databasePool = nil
+        database = nil
+    }
+
+
+    // MARK: - Database-level executors (implicit, one-shot)
+
+    func testDatabaseExecutorFetchesAllMatchingRows() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "alpha", value: 5))
+        try insert(TestTable(id: "beta", value: 9))
+
+        XCTAssertEqual(try database.containerRowsMatchingID(id: "alpha").count, 2)
+        XCTAssertEqual(
+            try database.containerRowsMatchingID(id: "beta"),
+            [TestTable(id: "beta", value: 9)]
+        )
+        XCTAssertEqual(try database.containerRowsMatchingID(id: "gamma"), [])
+    }
+
+    func testDatabaseExecutorFetchesSingleOptionalRow() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+
+        XCTAssertEqual(
+            try database.containerRowMatchingID(id: "alpha"),
+            TestTable(id: "alpha", value: 1)
+        )
+        XCTAssertNil(try database.containerRowMatchingID(id: "gamma"))
+    }
+
+    func testDatabaseExecutorFetchesExactlyOneRow() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+
+        XCTAssertEqual(
+            try database.containerTheOnlyRowMatchingID(id: "alpha"),
+            TestTable(id: "alpha", value: 1)
+        )
+        XCTAssertThrowsError(try database.containerTheOnlyRowMatchingID(id: "gamma")) { error in
+            XCTAssertEqual(
+                error as? XLQueryCardinalityError,
+                .exactlyOneRowExpected(actual: 0)
+            )
+        }
+    }
+
+
+    // MARK: - Context-scoped execution (explicit)
+
+    func testExecuteClosureProvidesContextScopedExecutors() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 9))
+
+        let rows = try database.execute { context in
+            try context.containerRowsMatchingID(id: "alpha")
+        }
+        XCTAssertEqual(rows, [TestTable(id: "alpha", value: 1)])
+    }
+
+    func testExecuteClosureRunsMultipleQueriesInOneScope() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 9))
+
+        let (all, one) = try database.execute { context in
+            (
+                try context.containerRowsMatchingID(id: "alpha"),
+                try context.containerRowMatchingID(id: "beta")
+            )
+        }
+        XCTAssertEqual(all, [TestTable(id: "alpha", value: 1)])
+        XCTAssertEqual(one, TestTable(id: "beta", value: 9))
+    }
+
+
+    // MARK: - Helpers
+
+    private func createTestTable() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+    }
+
+    private func insert(_ row: TestTable) throws {
+        try database.makeRequest(with: sqlInsert(row)).execute()
+    }
+}

--- a/Tests/SQLTests/SQLQueryPeerMacroTests.swift
+++ b/Tests/SQLTests/SQLQueryPeerMacroTests.swift
@@ -1,0 +1,321 @@
+//
+//  SQLQueryPeerMacroTests.swift
+//  SwiftQL
+//
+//  Runtime tests for the `@SQLQuery` peer macro (issues #18/#26): the
+//  generated statement builders render placeholder SQL with a typed parameter
+//  layout, and the generated executors bind invocation values and fetch rows
+//  from a GRDB database. Ported from the milestone #28 spike on
+//  `experiment/sqlquery-peer-macro`, extended with `.exactlyOne` cardinality
+//  coverage added for v1.5.1.
+//
+
+import Foundation
+import XCTest
+import GRDB
+import SwiftQL
+
+
+extension GRDBDatabase {
+
+    @SQLQuery
+    func rowsMatchingID(id: String) -> any XLQueryStatement<TestTable> {
+        sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id)
+        }
+    }
+
+    // Direct-result specs — no `XLQueryStatement` boilerplate. `[TestTable]`
+    // dispatches to fetchAll; `TestTable?` dispatches to fetchOne; a bare
+    // `TestTable` dispatches to the v1.5.1 `.exactlyOne` cardinality.
+
+    @SQLQuery
+    func directRowsMatchingID(id: String) -> [TestTable] {
+        sqlResult { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id)
+        }
+    }
+
+    @SQLQuery
+    func directRowMatchingID(id: String) -> TestTable? {
+        sqlResult { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id)
+        }
+    }
+
+    @SQLQuery
+    func theOnlyRowMatchingID(id: String) -> TestTable {
+        sqlResult { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id)
+        }
+    }
+
+    @SQLQuery
+    func rowsMatchingIDAndMinimumValue(id: String, minimumValue: Int) -> any XLQueryStatement<TestTable> {
+        sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id && table.value >= minimumValue)
+        }
+    }
+
+    @SQLQuery
+    func nullableRowsMatchingValue(value: Int?) -> any XLQueryStatement<TestNullablesTable> {
+        sql { schema in
+            let table = schema.table(TestNullablesTable.self)
+            Select(table)
+            From(table)
+            Where(table.value == value)
+        }
+    }
+}
+
+
+final class XLQueryPeerMacroTests: XCTestCase {
+
+    var encoder: XLiteEncoder!
+    var databasePool: DatabasePool!
+    var database: GRDBDatabase!
+
+    override func setUp() {
+        let formatter = XLiteFormatter(
+            identifierFormattingOptions: .mysqlCompatible
+        )
+        let directory = FileManager.default.temporaryDirectory
+        let filename = UUID().uuidString
+        let fileURL = directory
+            .appendingPathComponent(filename, isDirectory: false)
+            .appendingPathExtension("sqlite")
+        encoder = XLiteEncoder(formatter: formatter)
+        databasePool = try! DatabasePool(path: fileURL.path)
+        database = try! GRDBDatabase(databasePool: databasePool, formatter: formatter, logger: nil)
+    }
+
+    override func tearDown() {
+        encoder = nil
+        databasePool = nil
+        database = nil
+    }
+
+
+    // MARK: - Placeholder rendering
+
+    func testOneParameterStatementRendersNamedPlaceholderSQL() throws {
+        let encoding = encoder.makeSQL(database.rowsMatchingIDStatement())
+
+        XCTAssertEqual(
+            encoding.sql,
+            "SELECT `t0`.`id` AS `id`, `t0`.`value` AS `value` FROM `Test` AS `t0` WHERE (`t0`.`id` == :id)"
+        )
+        XCTAssertNil(encoding.parameterLayoutError)
+        XCTAssertEqual(encoding.parameterLayout.slots.map(\.key), [.named("id")])
+        XCTAssertEqual(encoding.parameterLayout.slots.map(\.nullability), [.required])
+    }
+
+    func testTwoParameterStatementRendersNamedPlaceholderSQL() throws {
+        let encoding = encoder.makeSQL(database.rowsMatchingIDAndMinimumValueStatement())
+
+        XCTAssertTrue(encoding.sql.contains(":id"), "expected ':id' placeholder in \(encoding.sql)")
+        XCTAssertTrue(encoding.sql.contains(":minimumValue"), "expected ':minimumValue' placeholder in \(encoding.sql)")
+        XCTAssertFalse(encoding.sql.contains("'"), "expected no inline value literal in \(encoding.sql)")
+        XCTAssertNil(encoding.parameterLayoutError)
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.key),
+            [.named("id"), .named("minimumValue")]
+        )
+        XCTAssertEqual(
+            encoding.parameterLayout.slots.map(\.nullability),
+            [.required, .required]
+        )
+    }
+
+    func testOptionalParameterStatementRendersNullableSlot() throws {
+        let encoding = encoder.makeSQL(database.nullableRowsMatchingValueStatement())
+
+        XCTAssertTrue(encoding.sql.contains(":value"), "expected ':value' placeholder in \(encoding.sql)")
+        XCTAssertNil(encoding.parameterLayoutError)
+        XCTAssertEqual(encoding.parameterLayout.slots.map(\.key), [.named("value")])
+        XCTAssertEqual(encoding.parameterLayout.slots.map(\.nullability), [.nullable])
+    }
+
+    func testStatementBuilderRendersIdenticalSQLOnRepeatedCalls() throws {
+        let first = encoder.makeSQL(database.rowsMatchingIDStatement())
+        let second = encoder.makeSQL(database.rowsMatchingIDStatement())
+
+        XCTAssertEqual(first.sql, second.sql)
+        XCTAssertEqual(first.parameterLayout, second.parameterLayout)
+    }
+
+
+    // MARK: - Execution
+
+    func testOneParameterExecutorFetchesMatchingRowsForEachInvocation() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 2))
+
+        XCTAssertEqual(
+            try database.fetchRowsMatchingID(id: "alpha"),
+            [TestTable(id: "alpha", value: 1)]
+        )
+        XCTAssertEqual(
+            try database.fetchRowsMatchingID(id: "beta"),
+            [TestTable(id: "beta", value: 2)]
+        )
+        XCTAssertEqual(try database.fetchRowsMatchingID(id: "gamma"), [])
+    }
+
+    func testTwoParameterExecutorFetchesMatchingRows() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "alpha", value: 5))
+        try insert(TestTable(id: "beta", value: 9))
+
+        XCTAssertEqual(
+            try database.fetchRowsMatchingIDAndMinimumValue(id: "alpha", minimumValue: 2),
+            [TestTable(id: "alpha", value: 5)]
+        )
+        XCTAssertEqual(
+            try database.fetchRowsMatchingIDAndMinimumValue(id: "alpha", minimumValue: 0).count,
+            2
+        )
+        XCTAssertEqual(
+            try database.fetchRowsMatchingIDAndMinimumValue(id: "beta", minimumValue: 10),
+            []
+        )
+    }
+
+    func testOptionalParameterExecutorBindsValueAndSQLNull() throws {
+        try createNullablesTable()
+        try insert(TestNullablesTable(id: "with-value", value: 42))
+        try insert(TestNullablesTable(id: "without-value", value: nil))
+
+        XCTAssertEqual(
+            try database.fetchNullableRowsMatchingValue(value: 42),
+            [TestNullablesTable(id: "with-value", value: 42)]
+        )
+        // Optional equality renders as SQL `IS`, which is null-safe: a nil
+        // binding matches the row whose column is NULL.
+        XCTAssertEqual(
+            try database.fetchNullableRowsMatchingValue(value: nil),
+            [TestNullablesTable(id: "without-value", value: nil)]
+        )
+    }
+
+
+    // MARK: - Direct-result execution
+
+    func testDirectResultArrayExecutorFetchesAllMatchingRows() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "alpha", value: 5))
+        try insert(TestTable(id: "beta", value: 9))
+
+        // `-> [TestTable]` dispatched to fetchAll and returned every match.
+        XCTAssertEqual(
+            try database.fetchDirectRowsMatchingID(id: "alpha").count,
+            2
+        )
+        XCTAssertEqual(
+            try database.fetchDirectRowsMatchingID(id: "beta"),
+            [TestTable(id: "beta", value: 9)]
+        )
+        XCTAssertEqual(try database.fetchDirectRowsMatchingID(id: "gamma"), [])
+    }
+
+    func testDirectResultOptionalExecutorFetchesSingleRow() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 9))
+
+        // `-> TestTable?` dispatched to fetchOne and returned an optional row.
+        XCTAssertEqual(
+            try database.fetchDirectRowMatchingID(id: "beta"),
+            TestTable(id: "beta", value: 9)
+        )
+        XCTAssertNil(try database.fetchDirectRowMatchingID(id: "gamma"))
+    }
+
+    func testDirectResultStatementRendersSamePlaceholderSQLAsLegacyForm() throws {
+        // The direct-result spec produces the same value-free statement as the
+        // legacy XLQueryStatement spelling: a named placeholder, no inline
+        // literal. The `sqlResult` -> `sql` callee swap is transparent.
+        let direct = encoder.makeSQL(database.directRowsMatchingIDStatement())
+        let legacy = encoder.makeSQL(database.rowsMatchingIDStatement())
+
+        XCTAssertEqual(direct.sql, legacy.sql)
+        XCTAssertTrue(direct.sql.contains(":id"))
+        XCTAssertFalse(direct.sql.contains("'"))
+        XCTAssertEqual(direct.parameterLayout.slots.map(\.key), [.named("id")])
+    }
+
+
+    // MARK: - Exactly-one cardinality (v1.5.1)
+
+    func testBareRowExecutorReturnsTheSingleMatchingRow() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 9))
+
+        XCTAssertEqual(
+            try database.fetchTheOnlyRowMatchingID(id: "alpha"),
+            TestTable(id: "alpha", value: 1)
+        )
+    }
+
+    func testBareRowExecutorThrowsWhenNoRowMatches() throws {
+        try createTestTable()
+
+        XCTAssertThrowsError(try database.fetchTheOnlyRowMatchingID(id: "missing")) { error in
+            XCTAssertEqual(
+                error as? XLQueryCardinalityError,
+                .exactlyOneRowExpected(actual: 0)
+            )
+        }
+    }
+
+    func testBareRowExecutorThrowsWhenMultipleRowsMatch() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "alpha", value: 2))
+
+        XCTAssertThrowsError(try database.fetchTheOnlyRowMatchingID(id: "alpha")) { error in
+            XCTAssertEqual(
+                error as? XLQueryCardinalityError,
+                .exactlyOneRowExpected(actual: 2)
+            )
+        }
+    }
+
+
+    // MARK: - Helpers
+
+    private func createTestTable() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+    }
+
+    private func createNullablesTable() throws {
+        try database.makeRequest(with: sqlCreate(TestNullablesTable.self)).execute()
+    }
+
+    private func insert(_ row: TestTable) throws {
+        try database.makeRequest(with: sqlInsert(row)).execute()
+    }
+
+    private func insert(_ row: TestNullablesTable) throws {
+        try database.makeRequest(with: sqlInsert(row)).execute()
+    }
+}

--- a/Tests/SQLTests/SQLQueryPeerMacroTests.swift
+++ b/Tests/SQLTests/SQLQueryPeerMacroTests.swift
@@ -105,6 +105,7 @@ final class XLQueryPeerMacroTests: XCTestCase {
     }
 
     override func tearDown() {
+        try? databasePool?.close()
         encoder = nil
         databasePool = nil
         database = nil

--- a/Tests/SQLTests/SQLQueryPeerMacroTests.swift
+++ b/Tests/SQLTests/SQLQueryPeerMacroTests.swift
@@ -282,7 +282,7 @@ final class XLQueryPeerMacroTests: XCTestCase {
         XCTAssertThrowsError(try database.fetchTheOnlyRowMatchingID(id: "missing")) { error in
             XCTAssertEqual(
                 error as? XLQueryCardinalityError,
-                .exactlyOneRowExpected(actual: 0)
+                .noRowsMatched
             )
         }
     }
@@ -295,7 +295,7 @@ final class XLQueryPeerMacroTests: XCTestCase {
         XCTAssertThrowsError(try database.fetchTheOnlyRowMatchingID(id: "alpha")) { error in
             XCTAssertEqual(
                 error as? XLQueryCardinalityError,
-                .exactlyOneRowExpected(actual: 2)
+                .moreThanOneRowMatched
             )
         }
     }

--- a/Tests/SQLTests/SQLQueryRenderOnceCacheTests.swift
+++ b/Tests/SQLTests/SQLQueryRenderOnceCacheTests.swift
@@ -30,6 +30,7 @@ private final class ConcurrentRenderProbe: @unchecked Sendable {
 
     private let lock = NSLock()
     private var count = 0
+    private var mismatchedSlotKeys: [[XLBindingKey]] = []
 
     init(database: GRDBDatabase) {
         self.database = database
@@ -45,6 +46,23 @@ private final class ConcurrentRenderProbe: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return count
+    }
+
+    /// Records a request's slot keys if they don't match the expected shape.
+    /// XCTest's failure recording isn't thread-safe, so a concurrent racing
+    /// caller records here instead of asserting directly; the test asserts
+    /// once, after `DispatchQueue.concurrentPerform` returns.
+    func recordIfMismatched(_ slotKeys: [XLBindingKey], expected: [XLBindingKey]) {
+        guard slotKeys != expected else { return }
+        lock.lock()
+        mismatchedSlotKeys.append(slotKeys)
+        lock.unlock()
+    }
+
+    var allMismatchedSlotKeys: [[XLBindingKey]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return mismatchedSlotKeys
     }
 }
 
@@ -137,12 +155,24 @@ final class XLQueryRenderOnceCacheTests: XCTestCase {
                 return probe.database.rowsMatchingIDStatement()
             }
             // Every racing caller receives a usable request with the layout.
-            XCTAssertEqual(request.parameterLayout.slots.map(\.key), [.named("id")])
+            // XCTest's failure recording isn't thread-safe across
+            // concurrentPerform's worker threads, so mismatches are recorded
+            // on the lock-guarded probe and asserted once below instead of
+            // asserting directly from each racing closure.
+            probe.recordIfMismatched(
+                request.parameterLayout.slots.map(\.key),
+                expected: [.named("id")]
+            )
         }
         XCTAssertEqual(
             probe.buildCount,
             1,
             "concurrent first use must render the statement exactly once"
+        )
+        XCTAssertEqual(
+            probe.allMismatchedSlotKeys,
+            [],
+            "every racing caller must receive a usable request with the expected layout"
         )
     }
 

--- a/Tests/SQLTests/SQLQueryRenderOnceCacheTests.swift
+++ b/Tests/SQLTests/SQLQueryRenderOnceCacheTests.swift
@@ -63,6 +63,7 @@ final class XLQueryRenderOnceCacheTests: XCTestCase {
     }
 
     override func tearDown() {
+        try? databasePool?.close()
         encoder = nil
         databasePool = nil
         database = nil

--- a/Tests/SQLTests/SQLQueryRenderOnceCacheTests.swift
+++ b/Tests/SQLTests/SQLQueryRenderOnceCacheTests.swift
@@ -1,0 +1,308 @@
+//
+//  SQLQueryRenderOnceCacheTests.swift
+//  SwiftQL
+//
+//  Runtime tests for the render-once cache (issues #18/#26): the generated
+//  executor renders its value-free statement to SQL once per declaration and
+//  reuses the request across calls, binding parameter values per call through
+//  an immutable invocation packet. The rendered SQL is byte-identical across
+//  calls (parameters are placeholders, not inline literals), and concurrent
+//  first use renders once. Ported from the milestone #28 spike on
+//  `experiment/sqlquery-peer-macro`.
+//
+
+import Foundation
+import XCTest
+import GRDB
+import SwiftQL
+
+
+///
+/// Lock-guarded shared state for the concurrent first-use test. The database is
+/// not `Sendable`, so it is reached only through this holder, which vouches for
+/// its own thread safety.
+///
+private final class ConcurrentRenderProbe: @unchecked Sendable {
+
+    let cache = XLRenderOnceCache<TestTable>()
+
+    let database: GRDBDatabase
+
+    private let lock = NSLock()
+    private var count = 0
+
+    init(database: GRDBDatabase) {
+        self.database = database
+    }
+
+    func recordBuild() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var buildCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
+
+
+final class XLQueryRenderOnceCacheTests: XCTestCase {
+
+    var encoder: XLiteEncoder!
+    var databasePool: DatabasePool!
+    var database: GRDBDatabase!
+
+    override func setUp() {
+        encoder = XLiteEncoder(
+            formatter: XLiteFormatter(identifierFormattingOptions: .mysqlCompatible)
+        )
+        (databasePool, database) = Self.makeDatabase()
+    }
+
+    override func tearDown() {
+        encoder = nil
+        databasePool = nil
+        database = nil
+    }
+
+    private static func makeDatabase() -> (DatabasePool, GRDBDatabase) {
+        let formatter = XLiteFormatter(identifierFormattingOptions: .mysqlCompatible)
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: false)
+            .appendingPathExtension("sqlite")
+        let pool = try! DatabasePool(path: fileURL.path)
+        let database = try! GRDBDatabase(databasePool: pool, formatter: formatter, logger: nil)
+        return (pool, database)
+    }
+
+
+    // MARK: - Render-once
+
+    ///
+    /// The render-once premise: the value-free statement is rendered exactly
+    /// once per declaration and reused, regardless of how many times the query
+    /// is invoked. The build closure — which constructs the statement the cache
+    /// renders — runs only on the first call. Render count is the allocation
+    /// anchor: rendering a statement is a fixed allocation set, so one render for
+    /// N calls amortizes that cost to zero per call.
+    ///
+    func testCacheBuildsStatementExactlyOnceAcrossManyCalls() {
+        let cache = XLRenderOnceCache<TestTable>()
+        var buildCount = 0
+        for _ in 0 ..< 1_000 {
+            _ = cache.request(for: database) {
+                buildCount += 1
+                return database.rowsMatchingIDStatement()
+            }
+        }
+        XCTAssertEqual(
+            buildCount,
+            1,
+            "the render-once cache must render the statement exactly once"
+        )
+    }
+
+    ///
+    /// A cache hit returns the previously rendered request without rebuilding.
+    ///
+    func testCacheReturnsSameRequestWithoutRebuildingOnHit() {
+        let cache = XLRenderOnceCache<TestTable>()
+        _ = cache.request(for: database) { database.rowsMatchingIDStatement() }
+        _ = cache.request(for: database) {
+            XCTFail("a cache hit must not rebuild the statement")
+            return database.rowsMatchingIDStatement()
+        }
+    }
+
+
+    // MARK: - Concurrent first use (cache race)
+
+    ///
+    /// Many threads racing on the first use of one declaration must render
+    /// exactly once. The cache renders under its lock, so concurrent first
+    /// callers block until the single render completes, then reuse it.
+    ///
+    func testConcurrentFirstUseBuildsExactlyOnce() {
+        // The shared state crosses a `@Sendable` concurrent closure, so it is
+        // routed through one lock-guarded holder rather than capturing `self`
+        // or the non-Sendable database directly.
+        let probe = ConcurrentRenderProbe(database: database)
+        DispatchQueue.concurrentPerform(iterations: 128) { _ in
+            let request = probe.cache.request(for: probe.database) {
+                probe.recordBuild()
+                return probe.database.rowsMatchingIDStatement()
+            }
+            // Every racing caller receives a usable request with the layout.
+            XCTAssertEqual(request.parameterLayout.slots.map(\.key), [.named("id")])
+        }
+        XCTAssertEqual(
+            probe.buildCount,
+            1,
+            "concurrent first use must render the statement exactly once"
+        )
+    }
+
+
+    // MARK: - Stable placeholder SQL across calls with different values
+
+    ///
+    /// One rendered request serves every parameter value: the cached executor
+    /// returns the rows for each distinct argument, proving the SQL binds a
+    /// placeholder rather than freezing the first call's value as an inline
+    /// literal. The rendered SQL is byte-identical and value-free.
+    ///
+    func testCachedExecutorServesDifferentArgumentsWithStablePlaceholderSQL() throws {
+        try createTestTable()
+        try insert(TestTable(id: "alpha", value: 1))
+        try insert(TestTable(id: "beta", value: 2))
+
+        // Different values through the same rendered request → different rows.
+        XCTAssertEqual(
+            try database.fetchRowsMatchingID(id: "alpha"),
+            [TestTable(id: "alpha", value: 1)]
+        )
+        XCTAssertEqual(
+            try database.fetchRowsMatchingID(id: "beta"),
+            [TestTable(id: "beta", value: 2)]
+        )
+        XCTAssertEqual(
+            try database.fetchRowsMatchingID(id: "alpha"),
+            [TestTable(id: "alpha", value: 1)]
+        )
+
+        // The rendered SQL carries a named placeholder and no inline literal,
+        // and is byte-identical across renders — the property the cache reuses.
+        let first = encoder.makeSQL(database.rowsMatchingIDStatement())
+        let second = encoder.makeSQL(database.rowsMatchingIDStatement())
+        XCTAssertEqual(first.sql, second.sql)
+        XCTAssertTrue(first.sql.contains(":id"))
+        XCTAssertFalse(first.sql.contains("'"))
+    }
+
+
+    // MARK: - Cache keying
+
+    ///
+    /// The cache key includes the database identity, so a per-declaration
+    /// `static` cache shared across databases never binds one database's request
+    /// to another: two distinct `GRDBDatabase` instances render independently,
+    /// while the same database reuses its rendered request.
+    ///
+    func testDistinctDatabasesRenderIndependentlyAndSameDatabaseReuses() {
+        let cache = XLRenderOnceCache<TestTable>()
+        let (poolA, databaseA) = Self.makeDatabase()
+        let (poolB, databaseB) = Self.makeDatabase()
+        withExtendedLifetime((poolA, poolB)) {
+            var buildCount = 0
+            _ = cache.request(for: databaseA) {
+                buildCount += 1
+                return databaseA.rowsMatchingIDStatement()
+            }
+            _ = cache.request(for: databaseB) {
+                buildCount += 1
+                return databaseB.rowsMatchingIDStatement()
+            }
+            XCTAssertEqual(
+                buildCount,
+                2,
+                "distinct databases must not share one cached request"
+            )
+            // The first database reuses its entry rather than rendering again.
+            _ = cache.request(for: databaseA) {
+                buildCount += 1
+                return databaseA.rowsMatchingIDStatement()
+            }
+            XCTAssertEqual(buildCount, 2)
+        }
+    }
+
+    ///
+    /// The keys of the two databases differ in their database identifier and
+    /// agree on the dialect identifier — the documented keying decision.
+    ///
+    func testCacheKeyScopesByDatabaseAndDialect() {
+        let (poolA, databaseA) = Self.makeDatabase()
+        let (poolB, databaseB) = Self.makeDatabase()
+        withExtendedLifetime((poolA, poolB)) {
+            guard let keyA = databaseA.preparedQueryCacheKey,
+                  let keyB = databaseB.preparedQueryCacheKey else {
+                return XCTFail("the GRDB adapter opts into render-once caching")
+            }
+            XCTAssertNotEqual(keyA, keyB)
+            XCTAssertNotEqual(keyA.databaseIdentifier, keyB.databaseIdentifier)
+            XCTAssertEqual(keyA.dialectIdentifier, keyB.dialectIdentifier)
+        }
+    }
+
+
+    // MARK: - Benchmark (allocation-anchored)
+
+    ///
+    /// Micro-benchmark: render-once reuse vs. per-call rebuild. The conclusion
+    /// is anchored on the deterministic render count (render-once renders once
+    /// for N calls; per-call renders N times) rather than the wall-clock delta,
+    /// which is unreliable on a noisy machine. The timing is printed as
+    /// corroborating evidence only.
+    ///
+    func testRenderOnceVsPerCallRebuildBenchmark() {
+        // Kept small so the benchmark doesn't add noticeable wall-clock time to
+        // the unit-test suite on slower CI runners. The deterministic anchor
+        // (render count) is exact at any iteration count; a few thousand calls
+        // is already enough for the per-call rebuild cost to dominate visibly
+        // in the corroborating timing.
+        let iterations = 3_000
+
+        // Deterministic anchor: render-once renders exactly once for N calls.
+        let cache = XLRenderOnceCache<TestTable>()
+        var renderOnceBuildCount = 0
+        let renderOnceStart = DispatchTime.now()
+        for _ in 0 ..< iterations {
+            _ = cache.request(for: database) {
+                renderOnceBuildCount += 1
+                return database.rowsMatchingIDStatement()
+            }
+        }
+        let renderOnceElapsed = elapsedSeconds(since: renderOnceStart)
+
+        // Per-call rebuild renders on every call (the pre-cache behavior).
+        var perCallBuildCount = 0
+        let perCallStart = DispatchTime.now()
+        for _ in 0 ..< iterations {
+            perCallBuildCount += 1
+            _ = database.makeRequest(with: database.rowsMatchingIDStatement())
+        }
+        let perCallElapsed = elapsedSeconds(since: perCallStart)
+
+        XCTAssertEqual(renderOnceBuildCount, 1)
+        XCTAssertEqual(perCallBuildCount, iterations)
+
+        let ratio = perCallElapsed / max(renderOnceElapsed, .leastNonzeroMagnitude)
+        print(
+            """
+            [render-once benchmark] iterations=\(iterations)
+              render-once: renders=1        wall=\(String(format: "%.4f", renderOnceElapsed))s
+              per-call:    renders=\(iterations)  wall=\(String(format: "%.4f", perCallElapsed))s
+              wall-clock speedup (noisy, corroborating only): \(String(format: "%.1f", ratio))x
+              allocation anchor: render-once avoids \(iterations - 1) of \(iterations) renders
+            """
+        )
+    }
+
+    private func elapsedSeconds(since start: DispatchTime) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
+    }
+
+
+    // MARK: - Helpers
+
+    private func createTestTable() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+    }
+
+    private func insert(_ row: TestTable) throws {
+        try database.makeRequest(with: sqlInsert(row)).execute()
+    }
+}


### PR DESCRIPTION
Closes #18. Closes #26.

Delivered together: milestone #28's spike (concluded **GO**, 2026-07-24) proved these are the same code path — the callable-handle generation mechanism (#18) *is* the declaration macro's output (#26). The spike branch (`experiment/sqlquery-peer-macro`) was deliberately not merged as-is; this PR ports and adapts its validated design onto current `main`/`version/1.5.1`, extending cardinality coverage per the issues' "Done When" criteria.

## Summary

Two forms, both stable-Swift-5.9 attached macros (no experimental body macros, no Swift 6 floor — the spike's central finding):

- **`@SQLQuery`** — a peer macro on a query-specification function; generates a value-free statement builder + a render-once-cached executor. `fetchPersonByName(name:)`.
- **`@SQLQueries`** — the recommended packaging: a member macro on a container of nested specs, generating clean-named executors as database members: `try database.personByName(name:)`.

Cardinality is dispatched from the function's return annotation: `[Row]` → `fetchAll`, `Row?` → `fetchOne`, and (new, beyond the spike) bare `Row` → `.exactlyOne`, calling `fetchAtMost(2, bindings:)` and throwing `XLQueryCardinalityError.noRowsMatched` / `.moreThanOneRowMatched` (two cases, not one carrying a matched-row count — the bounded fetch means "more than one" never has an exact count to report).

## Correctness-critical pieces

- **Frozen-literal guard**: the executor renders SQL once and reuses it, so a parameter value that escapes the rewrite would freeze into cached SQL — a silent wrong-results bug. Every parameter reference is either rewritten to a placeholder or produces a loud compile error (collection params, string interpolation, closure capture, call-argument position, local-binding initialization, hand-constructed binding references, unused parameters — all diagnosed at the declaration site).
- **Render-once cache** (`XLRenderOnceCache<Row>`): one rendered request per declaration, thread-safe, keyed on `(databaseIdentifier, dialectIdentifier)` — reusing `GRDBDatabaseDriver`'s existing `databaseIdentifier` rather than introducing a new identity type. Documented retention trade-off: a cached request keeps its `DatabasePool` alive for the process lifetime once invoked (carried over from the spike, not a new regression).
- **`fetchAtMost(_:bindings:)`**: new `XLRequest` requirement so `.exactlyOne` doesn't decode/retain every matching row just to reject a many-row match; the GRDB override stops decoding after 2 rows via the existing `forEachRow` stream-control seam.
- **`@SQLQueries`** now diagnoses more than one nested `Query` container instead of silently merging their specifications.

## Changes

- `Sources/SQLMacros/SQLQueryMacro.swift`, `SQLQueriesMacro.swift` (new).
- `Sources/SwiftQL/SQLQueryPeerMacroSupport.swift`, `SQLQueryRenderOnceCache.swift` (new).
- `Sources/SwiftQL/SQLDatabase.swift` — `XLDatabase.preparedQueryCacheKey`, `XLRequest.fetchAtMost(_:bindings:)` (both default-implemented, source-compatible).
- `Sources/SwiftQL/GRDBSQLDatabase.swift` — `GRDBDatabase.preparedQueryCacheKey`, `GRDBRequest.fetchAtMost`.
- `Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md` (new) — both forms, the frozen-literal-guard hazard, render-once/concurrency semantics, v1.5-transitional vs. v2-catalog migration note.
- `IntegrationTests/Swift5Client/` — downstream Swift-5-language-mode consumer exercising both forms (fulfills #26's downstream-package requirement).
- `CHANGELOG.md`.

## Tests

`Tests/SQLMacrosTests/SQLQueryMacroTests.swift`, `SQLQueriesMacroTests.swift`, `Tests/SQLTests/SQLQueryPeerMacroTests.swift`, `SQLQueryRenderOnceCacheTests.swift`, `SQLQueriesContainerTests.swift` — expansion/diagnostic tests, real-GRDB repeated/concurrent-invocation tests, a 128-thread render-once race test.

`swift test` (full suite): **808/808 pass**. Downstream Swift 5 fixture builds and runs.

## Explicitly deferred (not silently dropped)

- **`.command` cardinality** (write statements) — the spike judged this "feasibility only"; building it now meant a materially different, untested code path (`XLWriteRequest.execute`, no shared `Row` generic) under time pressure. Cut in favor of shipping `.exactlyOne` (implemented and tested) rather than rushing an unproven write path.
- `async` executors, collection/`IN` parameters — out of scope per the spike write-up, additive future work.
- A dedicated "each pooled connection owns its physical statement" test wasn't added separately; render-once's SQL-text-stability tests plus GRDB's existing per-connection `cachedStatement` coverage cover this indirectly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)