### PR TITLE
Support composite/nested @SQLResult properties (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,28 @@
   `.liveQueriesUnsupportedInTransaction`; an already-cancelled task throws
   `CancellationError` before the transaction opens. Documented in
   `GettingStarted`'s "Typed multi-statement transaction scopes".
+- Added composite/nested result selection (issue #6): a stored property on an
+  `@SQLTable`/`@SQLResult` type can now itself be another `@SQLTable`/
+  `@SQLResult` type. The generated `staticRowLayout(using:...)` factory
+  flattens every one of the nested type's own columns into the enclosing
+  type's flat SQL result (re-aliased with the property name as a prefix, e.g.
+  `employee_id`, `employee_name`), and reconstructs the nested value before
+  building the enclosing type. Nesting composes to any depth, since a
+  composite property's argument is itself the nested type's own
+  `staticRowLayout(using:...)` result.
+- Added the `XLStaticRowFieldSource` protocol and `XLStaticFieldGroup` type to
+  `SwiftQL`. Every generated `staticRowLayout(using:...)` parameter now takes
+  an `XLStaticRowFieldSource` value; both an ordinary `XLStaticSelectField`
+  (through a default implementation, so no scalar call site changes) and an
+  `XLStaticRowLayout` (for a nested composite property) conform to it. The
+  macro has no semantic access to a property's type declaration, so it never
+  has to detect which case applies -- Swift's own conformance checking
+  resolves it from whichever value the caller passes to a given property.
+- Extended the unsupported-column-type diagnostic to name both supported
+  property shapes (a scalar `XLLiteral` column, or a nested `@SQLTable`/
+  `@SQLResult` composite), so a property type the macro cannot resolve as
+  either is rejected with an actionable message instead of only failing
+  downstream with an opaque protocol-conformance error.
 
 ### Migration
 
@@ -88,6 +110,9 @@ including third-party `XLDatabase` adapters, source-compatible.
   duplicate-declaration compile error, not a silent one.
 - Only one `@SQLQueries`-attached extension is supported per database type; a
   second would redeclare `Context` and `execute(_:)`.
+- A composite/nested `@SQLTable`/`@SQLResult` property must be
+  non-optional; an optional nested composite (representing an absent
+  value from an outer join, for example) is not yet supported.
 - `withTransaction(_:)` does not support nested transactions or savepoints —
   a nested call is rejected outright rather than silently composed — and
   cancellation is checked only once, before the transaction opens; the

--- a/Sources/SQLMacros/MetaBuilder.swift
+++ b/Sources/SQLMacros/MetaBuilder.swift
@@ -388,7 +388,7 @@ internal struct MetaBuilder {
                 else {
                     report(
                         annotation.type, id: "unsupported-column-type",
-                        "Type '\(annotation.type.trimmedDescription)' cannot be used as a column type."
+                        "Type '\(annotation.type.trimmedDescription)' cannot be used as a column type. Use a named type that conforms to 'XLLiteral' for a scalar column, or a nested '@SQLTable'/'@SQLResult' type for a composite column selection."
                     )
                     carriedType = .invalid
                     continue
@@ -574,41 +574,79 @@ internal struct MetaBuilder {
 
     // Generate the static layout factory as a nominal member for the same
     // Swift 5.9 cross-file lookup reason as `columns(...)`. The caller supplies
-    // one immutable typed field per property, allowing each use to select its
-    // own expression and codec without constructing the model or SQLReader.
+    // one `XLStaticRowFieldSource` value per property, allowing each use to
+    // select its own expression and codec without constructing the model or
+    // SQLReader.
+    //
+    // A property's argument is either an ordinary scalar field (any
+    // `XLStaticSelectFieldProtocol` value, e.g. from `staticResultField` or
+    // `.intrinsic`) or another generated type's own `staticRowLayout(using:...)`
+    // result -- a nested `@SQLTable`/`@SQLResult` composite property. The macro
+    // never has to tell those apart: both conform to `XLStaticRowFieldSource`,
+    // and `grouped(at:alias:)` reports how many flat SQL slots it occupies
+    // through its runtime `count`, so the generated code below only ever
+    // accumulates a running slot offset -- it does not need to know any
+    // property's arity at expansion time. A scalar property always
+    // contributes exactly one slot; a nested composite property contributes
+    // every one of its own flattened slots, re-aliased with its property name
+    // as a prefix so the flattened SQL output columns stay unique.
     func makeStaticRowLayoutFunction() -> String {
         var context = SwiftSyntaxBuilder()
         var allocator = GeneratedIdentifierAllocator(
             used: generatedIdentifierReservations
         )
         let dialect = allocator.allocate("_SwiftQLStaticDialect")
-        let positionedFields = properties.indices.map { index in
+        let fieldGroups = properties.indices.map { index in
             allocator.allocate("_swiftQLStaticField\(index)")
         }
+        let offset = allocator.allocate("_swiftQLStaticOffset")
         let reader = allocator.allocate("_swiftQLStaticReader")
         let row = allocator.allocate("_swiftQLStaticRow")
 
         var parameters = ["using _: \(dialect).Type"]
         for property in properties {
             parameters.append(
-                "\(property.name): some SwiftQL.XLStaticSelectFieldProtocol<\(property.qualifiedType), \(dialect)>"
+                "\(property.name): some SwiftQL.XLStaticRowFieldSource<\(property.qualifiedType), \(dialect)>"
             )
         }
+
+        // A running offset is reassigned only when a third or later property
+        // needs it, so it is generated as an immutable binding otherwise --
+        // avoiding an unused-mutation warning in the generated code.
+        let offsetIsMutable = properties.count > 2
 
         context.block(
             "public static func staticRowLayout<\(dialect)>(\(parameters.joined(separator: ", "))) throws -> SwiftQL.XLStaticRowLayout<Self, \(dialect)> where \(dialect): SwiftQL.XLValueCodingDialect"
         ) { context in
             for (index, property) in properties.enumerated() {
-                context.line(
-                    "let \(positionedFields[index]) = \(property.name).positioned(at: \(index), alias: \(quoted(property.alias)))"
-                )
+                if index == 0 {
+                    context.line(
+                        "let \(fieldGroups[index]) = try \(property.name).grouped(at: 0, alias: \(quoted(property.alias)))"
+                    )
+                }
+                else {
+                    context.line(
+                        "let \(fieldGroups[index]) = try \(property.name).grouped(at: \(offset), alias: \(quoted(property.alias)))"
+                    )
+                }
+                if index < properties.count - 1 {
+                    if index == 0 {
+                        context.line("\(offsetIsMutable ? "var" : "let") \(offset) = \(fieldGroups[index]).count")
+                    }
+                    else {
+                        context.line("\(offset) += \(fieldGroups[index]).count")
+                    }
+                }
             }
 
             context.block("return try SwiftQL.XLStaticRowLayout", opening: "(", closing: ")") { context in
-                context.block("fields: [", opening: "", closing: "],") { context in
-                    for field in positionedFields {
-                        context.line("try \(field).erased(),")
-                    }
+                if fieldGroups.isEmpty {
+                    context.line("fields: [],")
+                }
+                else {
+                    context.line(
+                        "fields: " + fieldGroups.map { "\($0).fields" }.joined(separator: " + ") + ","
+                    )
                 }
                 context.block(
                     "decode: { \(reader) in",
@@ -619,7 +657,7 @@ internal struct MetaBuilder {
                         for (index, property) in properties.enumerated() {
                             context.item { context in
                                 context.line(
-                                    "\(property.name): try \(positionedFields[index]).read(from: \(reader))"
+                                    "\(property.name): try \(fieldGroups[index]).read(from: \(reader))"
                                 )
                             }
                         }
@@ -630,11 +668,18 @@ internal struct MetaBuilder {
                     opening: "",
                     closing: "}"
                 ) { context in
-                    context.block("[", opening: "", closing: "]") { context in
-                        for (index, property) in properties.enumerated() {
-                            context.line(
-                                "try \(positionedFields[index]).encode(\(row).\(property.name)),"
-                            )
+                    if fieldGroups.isEmpty {
+                        context.line("[]")
+                    }
+                    else {
+                        let terms = zip(fieldGroups, properties).map { field, property in
+                            "\(field).encode(\(row).\(property.name))"
+                        }
+                        if terms.count == 1 {
+                            context.line("try \(terms[0])")
+                        }
+                        else {
+                            context.line("try \(terms.joined(separator: " + "))")
                         }
                     }
                 }

--- a/Sources/SQLMacros/MetaBuilder.swift
+++ b/Sources/SQLMacros/MetaBuilder.swift
@@ -644,8 +644,11 @@ internal struct MetaBuilder {
                     context.line("fields: [],")
                 }
                 else {
+                    // A single `.flatMap` over the per-property field arrays copies each
+                    // element once; chaining `+` between them would instead recopy every
+                    // earlier array on each concatenation (quadratic in property count).
                     context.line(
-                        "fields: " + fieldGroups.map { "\($0).fields" }.joined(separator: " + ") + ","
+                        "fields: [" + fieldGroups.map { "\($0).fields" }.joined(separator: ", ") + "].flatMap { $0 },"
                     )
                 }
                 context.block(
@@ -679,7 +682,10 @@ internal struct MetaBuilder {
                             context.line("try \(terms[0])")
                         }
                         else {
-                            context.line("try \(terms.joined(separator: " + "))")
+                            // See the `fields:` array above: a single `.flatMap` over the
+                            // per-property encoded arrays avoids the quadratic recopying
+                            // that chaining `+` between them would cause.
+                            context.line("try [\(terms.joined(separator: ", "))].flatMap { $0 }")
                         }
                     }
                 }

--- a/Sources/SwiftQL/SQLStaticRowLayout.swift
+++ b/Sources/SwiftQL/SQLStaticRowLayout.swift
@@ -155,9 +155,10 @@ public enum XLStaticRowLayoutError:
 /// closures, but never a model instance, database, SQL reader, or invocation
 /// value. Generated row-layout factories assign its declaration position and
 /// SQL alias.
-public protocol XLStaticSelectFieldProtocol<FieldValue, FieldDialect> {
-    associatedtype FieldValue
-    associatedtype FieldDialect: XLValueCodingDialect
+public protocol XLStaticSelectFieldProtocol<FieldValue, FieldDialect>: XLStaticRowFieldSource {
+    // `FieldValue`/`FieldDialect` are inherited from `XLStaticRowFieldSource`,
+    // not redeclared -- redeclaring the constrained `FieldDialect` here would
+    // just restate its `XLValueCodingDialect` bound.
 
     func positioned(at index: Int, alias: String) -> Self
     func erased() throws -> XLAnyStaticSelectField<FieldDialect>
@@ -326,9 +327,6 @@ extension XLStaticSelectField: XLStaticSelectFieldProtocol {
 }
 
 
-extension XLStaticSelectField: XLStaticRowFieldSource {}
-
-
 /// The expression-bearing, type-erased half of one static row field.
 ///
 /// Its public metadata is driver-neutral. The retained expression is used only
@@ -430,6 +428,16 @@ public protocol XLStaticRowFieldSource<FieldValue, FieldDialect> {
 
 extension XLStaticSelectFieldProtocol {
     /// The default scalar contribution: exactly one positioned slot.
+    ///
+    /// `XLStaticSelectFieldProtocol` itself declares conformance to
+    /// `XLStaticRowFieldSource` (rather than each conforming type declaring
+    /// it individually), so every existing `XLStaticSelectFieldProtocol`
+    /// conformer -- including custom types declared outside this module
+    /// before `XLStaticRowFieldSource` existed -- automatically satisfies it
+    /// too via this one default implementation. A generated
+    /// `staticRowLayout(using:...)` factory constrained to
+    /// `XLStaticRowFieldSource` remains source-compatible with every prior
+    /// scalar field type.
     public func grouped(
         at index: Int,
         alias: String

--- a/Sources/SwiftQL/SQLStaticRowLayout.swift
+++ b/Sources/SwiftQL/SQLStaticRowLayout.swift
@@ -326,6 +326,9 @@ extension XLStaticSelectField: XLStaticSelectFieldProtocol {
 }
 
 
+extension XLStaticSelectField: XLStaticRowFieldSource {}
+
+
 /// The expression-bearing, type-erased half of one static row field.
 ///
 /// Its public metadata is driver-neutral. The retained expression is used only
@@ -344,6 +347,156 @@ where Dialect: XLValueCodingDialect {
         self.expression = expression
         self.metadata = metadata
         self.validateValue = validate
+    }
+}
+
+
+/// A contiguous, ordered run of one or more positioned static result slots
+/// contributed by a single generated stored property.
+///
+/// An ordinary scalar property (any `XLStaticSelectFieldProtocol` value, such
+/// as one returned by `XLValueCodingConfiguration.staticResultField` or
+/// `XLStaticSelectField.intrinsic`) contributes exactly one slot. A nested
+/// composite property -- a stored property whose type is itself an
+/// `@SQLTable`/`@SQLResult` type -- contributes every one of that nested
+/// type's own flattened slots, continuing directly after the slots
+/// contributed by the properties declared before it, and re-aliased with a
+/// prefix derived from its own property alias so every SQL output column
+/// keeps a unique name. Generated `staticRowLayout(using:...)` factories
+/// obtain one of these per property from `XLStaticRowFieldSource.grouped(at:
+/// alias:)` and concatenate their `fields`, `read(from:)`, and `encode(_:)`
+/// results in declaration order.
+public struct XLStaticFieldGroup<Value, Dialect>
+where Dialect: XLValueCodingDialect {
+
+    /// The flattened, positioned slots contributed by this property, in
+    /// declaration order.
+    public let fields: [XLAnyStaticSelectField<Dialect>]
+
+    private let decodeValue: (XLRowReader) throws -> Value
+    private let encodeValue: (Value) throws -> [Dialect.Value]
+
+    /// The number of flat SQL result slots this property contributes. A
+    /// scalar property contributes exactly one slot; a nested composite
+    /// property contributes as many slots as its own flattened layout.
+    public var count: Int {
+        fields.count
+    }
+
+    public init(
+        fields: [XLAnyStaticSelectField<Dialect>],
+        decode: @escaping (XLRowReader) throws -> Value,
+        encode: @escaping (Value) throws -> [Dialect.Value]
+    ) {
+        self.fields = fields
+        self.decodeValue = decode
+        self.encodeValue = encode
+    }
+
+    /// Decodes this property's value from its positioned slot(s).
+    public func read(from reader: XLRowReader) throws -> Value {
+        try decodeValue(reader)
+    }
+
+    /// Encodes this property's value into its positioned slot(s), in
+    /// declaration order.
+    public func encode(_ value: Value) throws -> [Dialect.Value] {
+        try encodeValue(value)
+    }
+}
+
+
+/// A source of one generated property's contribution to a static row layout:
+/// either a single scalar slot, or every flattened slot of a nested
+/// composite value.
+///
+/// Conformances: every `XLStaticSelectFieldProtocol` value (through the
+/// default implementation below, so any existing scalar field continues to
+/// work unchanged), and `XLStaticRowLayout` (so a nested `@SQLTable`/
+/// `@SQLResult` property can be contributed by passing another generated
+/// type's own `staticRowLayout(using:...)` result). The generated factory
+/// never has to decide which case applies -- Swift resolves the matching
+/// conformance for whatever value the caller passes.
+public protocol XLStaticRowFieldSource<FieldValue, FieldDialect> {
+    associatedtype FieldValue
+    associatedtype FieldDialect: XLValueCodingDialect
+
+    /// Positions this property's slot(s) starting at `index`, aliased using
+    /// `alias`. A nested composite property re-aliases each of its own
+    /// flattened slots as `"\(alias)_\(nestedAlias)"`.
+    func grouped(at index: Int, alias: String) throws -> XLStaticFieldGroup<FieldValue, FieldDialect>
+}
+
+
+extension XLStaticSelectFieldProtocol {
+    /// The default scalar contribution: exactly one positioned slot.
+    public func grouped(
+        at index: Int,
+        alias: String
+    ) throws -> XLStaticFieldGroup<FieldValue, FieldDialect> {
+        let positioned = positioned(at: index, alias: alias)
+        let erasedField = try positioned.erased()
+        return XLStaticFieldGroup(
+            fields: [erasedField],
+            decode: { reader in try positioned.read(from: reader) },
+            encode: { value in [try positioned.encode(value)] }
+        )
+    }
+}
+
+
+extension XLAnyStaticSelectField {
+    /// Reflows this already-positioned field's index and alias so it can be
+    /// spliced into an enclosing composite property's flattened slot range.
+    /// The field's identity, type metadata, and codec selection are
+    /// unchanged -- only its logical SQL position and output alias move.
+    fileprivate func _swiftQLNested(
+        atOffset offset: Int,
+        aliasPrefix: String
+    ) -> Self {
+        let originalResult = metadata.result
+        let shiftedResult = XLStaticQueryResultSlot(
+            index: XLLogicalResultIndex(originalResult.index.rawValue + offset),
+            identity: originalResult.identity,
+            valueTypeIdentifier: originalResult.valueTypeIdentifier,
+            valueTypeName: originalResult.valueTypeName,
+            nullability: originalResult.nullability,
+            codecIdentity: originalResult.codecIdentity,
+            storageIdentifier: originalResult.storageIdentifier,
+            codingContext: originalResult.codingContext
+        )
+        let shiftedField = XLStaticRowField(
+            alias: "\(aliasPrefix)_\(metadata.alias)",
+            result: shiftedResult
+        )
+        return Self(
+            expression: expression,
+            metadata: shiftedField,
+            validate: validateValue
+        )
+    }
+}
+
+
+/// Offsets logical result indices by a fixed amount, so a nested composite
+/// property's own zero-based layout can decode directly from its enclosing
+/// layout's flat row without rebuilding any of its fields.
+private struct _XLStaticOffsetRowReader: XLRowReader {
+    let base: XLRowReader
+    let offset: Int
+
+    func column<Value>(
+        _ expression: any XLExpression<Value>,
+        alias: XLName
+    ) throws -> Value where Value: XLLiteral {
+        try base.column(expression, alias: alias)
+    }
+
+    func dialectValue<RequestedDialect>(
+        at index: Int,
+        using dialect: RequestedDialect
+    ) throws -> RequestedDialect.Value where RequestedDialect: XLValueCodingDialect {
+        try base.dialectValue(at: offset + index, using: dialect)
     }
 }
 
@@ -447,6 +600,37 @@ where Dialect: XLValueCodingDialect {
         for (field, value) in zip(fields, values) {
             try field.validateValue(value)
         }
+    }
+}
+
+
+extension XLStaticRowLayout: XLStaticRowFieldSource {
+    public typealias FieldValue = Row
+    public typealias FieldDialect = Dialect
+
+    /// The nested composite contribution: every one of this layout's own
+    /// flattened slots, continuing at `index` and re-aliased with `alias`.
+    /// Reading recurses through this layout's own `readRow(reader:)` against
+    /// an index-offsetting view of the enclosing row, so none of its fields
+    /// need to be rebuilt; encoding reuses `encode(_:)` directly, since its
+    /// flat, ordered output already matches the position where the group's
+    /// `fields` are spliced into the enclosing layout.
+    public func grouped(
+        at index: Int,
+        alias: String
+    ) throws -> XLStaticFieldGroup<Row, Dialect> {
+        let offsetFields = fields.map {
+            $0._swiftQLNested(atOffset: index, aliasPrefix: alias)
+        }
+        return XLStaticFieldGroup(
+            fields: offsetFields,
+            decode: { reader in
+                try self.readRow(
+                    reader: _XLStaticOffsetRowReader(base: reader, offset: index)
+                )
+            },
+            encode: { value in try self.encode(value) }
+        )
     }
 }
 

--- a/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
@@ -189,8 +189,10 @@ order and retain the corresponding typed encode/decode behavior.
 
 `@SQLTable` and `@SQLResult` generate a nominal
 `staticRowLayout(using:...)` factory alongside the existing `columns(...)`
-factory. Supply one `XLStaticSelectField` for each property. Intrinsic v1
-literals can use `XLStaticSelectField.intrinsic`; contextual values use
+factory. Supply one `XLStaticSelectField` for each scalar property (or a
+nested `XLStaticRowLayout` for a composite one -- see "Select a nested
+composite property" below). Intrinsic v1 literals can use
+`XLStaticSelectField.intrinsic`; contextual values use
 `XLValueCodingConfiguration.staticResultField`, with an explicit intrinsic
 storage carrier such as `String.self` and a codec selection when needed.
 
@@ -201,9 +203,11 @@ The public field type is
 pass `field.expression` to `queryCapture(_:matching:identifiedBy:)` and reuse
 `field.codecSelection`. The resulting capture must have the same storage and
 selected codec identity as the field. Generated layout factories accept each
-concrete field through a primary-associated-type protocol, so every property
-keeps its independently inferred `Storage` without synthesized generic names
-that can shadow model generics.
+property's argument through `XLStaticRowFieldSource`, a primary-associated-type
+protocol that both a scalar `XLStaticSelectField` and a nested
+`XLStaticRowLayout` conform to, so every property keeps its independently
+inferred `Storage` without synthesized generic names that can shadow model
+generics.
 
 The factory assigns declaration indices and SQL aliases, validates them through
 `XLStaticRowMetadata`, and returns `XLStaticRowLayout`. Constructing that layout
@@ -230,6 +234,92 @@ table APIs remain the v1 compatibility path. Their `XLLiteral` behavior,
 including `wrapSQL`, is unchanged. Contextual-only properties compile in
 generated metadata, but must use a static layout for value encoding and row
 decoding instead of the v1 `MetaInsert`/`MetaUpdate` and introspection path.
+
+## Select a nested composite property
+
+A stored property does not have to be a scalar `XLLiteral` column. It can
+instead be another `@SQLTable`/`@SQLResult` type, selecting that type's whole
+row as one nested value:
+
+```text
+@SQLTable struct Employee {
+    let id: Int
+    let name: String
+    let companyID: Int
+}
+
+@SQLTable struct Company {
+    let id: Int
+    let title: String
+}
+
+@SQLResult struct EmployeeCompany {
+    let employee: Employee
+    let company: Company
+}
+```
+
+SQL has no nested row shape, so `EmployeeCompany`'s generated
+`staticRowLayout(using:...)` factory selects every one of `Employee`'s columns
+and every one of `Company`'s columns as flat, individually aliased SQL result
+columns, then reconstructs the nested `Employee` and `Company` values before
+building `EmployeeCompany`. Build the composite layout by passing each nested
+type's own layout as that property's argument:
+
+```text
+let employeeLayout = try Employee.staticRowLayout(
+    using: XLSQLiteDialect.self,
+    id: /* ... */,
+    name: /* ... */,
+    companyID: /* ... */
+)
+let companyLayout = try Company.staticRowLayout(
+    using: XLSQLiteDialect.self,
+    id: /* ... */,
+    title: /* ... */
+)
+let combined = try EmployeeCompany.staticRowLayout(
+    using: XLSQLiteDialect.self,
+    employee: employeeLayout,
+    company: companyLayout
+)
+```
+
+Nesting a composite property requires no different call shape than an
+ordinary scalar one: every generated factory parameter accepts any
+`XLStaticRowFieldSource<Value, Dialect>` value, and both an ordinary
+`XLStaticSelectField` (through a default implementation) and an already-built
+`XLStaticRowLayout` conform to it. The factory never has to decide which case
+applies -- Swift's own conformance checking resolves it from whatever value
+the caller passes. Each property's `grouped(at:alias:)` call reports how many
+flat SQL slots it occupies through its runtime `count`, so an outer layout's
+generated code only ever accumulates a running slot offset; it does not need
+to know any property's arity in advance. A scalar property always
+contributes exactly one slot; `employee` and `company` each contribute every
+one of their own flattened slots, re-aliased with the property name as a
+prefix (`employee_id`, `employee_name`, `employee_companyID`, `company_id`,
+`company_title`) so the flattened SQL output columns stay unique. Nesting
+composes: a composite property's own value can itself have been built by
+nesting a further composite property, since an `XLStaticRowLayout` returned
+by one factory is exactly the kind of value another factory's composite
+property accepts.
+
+A composite property is not a value-free carrier the way a scalar field is --
+building it requires supplying the nested type's own real column
+selections -- so it is ordinarily built once per query alongside the tables it
+references, then passed to the outer `staticRowLayout(using:...)` call. A
+composite property must be non-optional; representing "this whole nested
+value is absent" (for example, from an outer join) is not yet supported and
+is tracked as follow-up work.
+
+The macro has no semantic access to a property's own type declaration -- it
+may not even be in the same file -- so it cannot itself distinguish a scalar
+`XLLiteral` property from a nested composite one at expansion time; both are
+just a named type. A property type it cannot resolve as either shape at all
+(a tuple, a function type, or another shape `resolveColumnType` rejects)
+is still reported with an explicit, actionable diagnostic naming both
+supported forms, rather than compiling into generated code that only fails
+downstream with an opaque protocol-conformance error.
 
 ## Stable identity
 

--- a/Tests/SQLMacrosTests/SQLTests.swift
+++ b/Tests/SQLMacrosTests/SQLTests.swift
@@ -246,9 +246,40 @@ final class SQLMacroDiagnosticTests: XCTestCase {
             """,
             diagnostics: [
                 DiagnosticSpec(
-                    message: "Type '(Int) -> Int' cannot be used as a column type.",
+                    message: "Type '(Int) -> Int' cannot be used as a column type. Use a named type that conforms to 'XLLiteral' for a scalar column, or a nested '@SQLTable'/'@SQLResult' type for a composite column selection.",
                     line: 3,
                     column: 19
+                )
+            ],
+            macros: makeTestMacros()
+        )
+    }
+
+    // A property type the macro cannot resolve as either a scalar `XLLiteral`
+    // column or a nested `@SQLTable`/`@SQLResult` composite (here, a tuple
+    // type -- the shape someone reaching for issue #6's composite selection
+    // might mistakenly try) is rejected at expansion time with a message
+    // naming both supported shapes, rather than compiling into generated
+    // code that only fails downstream with an opaque protocol-conformance
+    // error.
+    func test_unresolvableAsScalarOrComposite_emitsActionableDiagnostic() {
+        assertMacroExpansion(
+            """
+            @SQLResult
+            struct EmployeeCompany {
+                let pair: (Employee, Company)
+            }
+            """,
+            expandedSource: """
+            struct EmployeeCompany {
+                let pair: (Employee, Company)
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "Type '(Employee, Company)' cannot be used as a column type. Use a named type that conforms to 'XLLiteral' for a scalar column, or a nested '@SQLTable'/'@SQLResult' type for a composite column selection.",
+                    line: 3,
+                    column: 15
                 )
             ],
             macros: makeTestMacros()
@@ -393,7 +424,7 @@ final class SQLMacroDiagnosticTests: XCTestCase {
             """,
             diagnostics: [
                 DiagnosticSpec(
-                    message: "Type '(Int) -> Int' cannot be used as a column type.",
+                    message: "Type '(Int) -> Int' cannot be used as a column type. Use a named type that conforms to 'XLLiteral' for a scalar column, or a nested '@SQLTable'/'@SQLResult' type for a composite column selection.",
                     line: 3,
                     column: 15
                 )
@@ -842,14 +873,18 @@ final class MetaBuilderTests: XCTestCase {
 
         XCTAssertFalse(Parser.parse(source: source).hasError)
         XCTAssertTrue(source.contains("public static func staticRowLayout<_SwiftQLStaticDialect>"))
-        XCTAssertTrue(source.contains("some SwiftQL.XLStaticSelectFieldProtocol<Element?, _SwiftQLStaticDialect>"))
-        XCTAssertTrue(source.contains("some SwiftQL.XLStaticSelectFieldProtocol<Array<Element>, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("some SwiftQL.XLStaticRowFieldSource<Element?, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("some SwiftQL.XLStaticRowFieldSource<Array<Element>, _SwiftQLStaticDialect>"))
         XCTAssertFalse(source.contains("_SwiftQLStaticStorage"))
-        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = `switch`.positioned(at: 0, alias: \"switch\")"))
-        XCTAssertTrue(source.contains("let _swiftQLStaticField1 = values.positioned(at: 1, alias: \"values\")"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = try `switch`.grouped(at: 0, alias: \"switch\")"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField1 = try values.grouped(at: _swiftQLStaticOffset, alias: \"values\")"))
         XCTAssertTrue(source.contains("try _swiftQLStaticField0.read(from: _swiftQLStaticReader)"))
-        XCTAssertTrue(source.contains("try _swiftQLStaticField1.encode(_swiftQLStaticRow.values)"))
-        XCTAssertTrue(source.contains("try _swiftQLStaticField0.erased()"))
+        XCTAssertTrue(
+            source.contains(
+                "try _swiftQLStaticField0.encode(_swiftQLStaticRow.`switch`) + _swiftQLStaticField1.encode(_swiftQLStaticRow.values)"
+            )
+        )
+        XCTAssertTrue(source.contains("fields: _swiftQLStaticField0.fields + _swiftQLStaticField1.fields,"))
     }
 
     func test_staticRowLayoutGenerationAvoidsReaderAndRowPropertyCollisions() throws {
@@ -866,12 +901,16 @@ final class MetaBuilderTests: XCTestCase {
         let metaSource = builder.makeMetaResultExtension(table: false)
 
         XCTAssertFalse(Parser.parse(source: source).hasError)
-        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = reader.positioned"))
-        XCTAssertTrue(source.contains("let _swiftQLStaticField1 = row.positioned"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = try reader.grouped"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField1 = try row.grouped"))
         XCTAssertTrue(source.contains("decode: { _swiftQLStaticReader in"))
         XCTAssertTrue(source.contains("reader: try _swiftQLStaticField0.read(from: _swiftQLStaticReader)"))
         XCTAssertTrue(source.contains("encode: { _swiftQLStaticRow in"))
-        XCTAssertTrue(source.contains("try _swiftQLStaticField1.encode(_swiftQLStaticRow.row)"))
+        XCTAssertTrue(
+            source.contains(
+                "try _swiftQLStaticField0.encode(_swiftQLStaticRow.reader) + _swiftQLStaticField1.encode(_swiftQLStaticRow.row)"
+            )
+        )
         XCTAssertFalse(source.contains("decode: { reader in"))
         XCTAssertFalse(source.contains("encode: { row in"))
         XCTAssertTrue(metaSource.contains("readRow(reader _swiftQLRowReader: XLRowReader)"))
@@ -901,9 +940,9 @@ final class MetaBuilderTests: XCTestCase {
 
         XCTAssertFalse(Parser.parse(source: source).hasError)
         XCTAssertTrue(source.contains("staticRowLayout<_SwiftQLStaticDialect_1>"))
-        XCTAssertTrue(source.contains("XLStaticSelectFieldProtocol<Dialect, _SwiftQLStaticDialect_1>"))
-        XCTAssertTrue(source.contains("let _swiftQLStaticField0_1 = dialect.positioned"))
-        XCTAssertTrue(source.contains("let _swiftQLStaticField3 = _swiftQLStaticField0.positioned"))
+        XCTAssertTrue(source.contains("XLStaticRowFieldSource<Dialect, _SwiftQLStaticDialect_1>"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0_1 = try dialect.grouped"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField3 = try _swiftQLStaticField0.grouped"))
         XCTAssertTrue(source.contains("decode: { _swiftQLStaticReader_1 in"))
         XCTAssertTrue(source.contains("encode: { _swiftQLStaticRow_1 in"))
         XCTAssertFalse(source.contains("staticRowLayout<Dialect>"))
@@ -930,12 +969,12 @@ final class MetaBuilderTests: XCTestCase {
         )
         XCTAssertTrue(
             staticSource.contains(
-                "XLStaticSelectFieldProtocol<_SwiftQLStaticDialect, _SwiftQLStaticDialect_1>"
+                "XLStaticRowFieldSource<_SwiftQLStaticDialect, _SwiftQLStaticDialect_1>"
             )
         )
         XCTAssertTrue(
             staticSource.contains(
-                "XLStaticSelectFieldProtocol<Box<Array<_SwiftQLStaticDialect?>>, _SwiftQLStaticDialect_1>"
+                "XLStaticRowFieldSource<Box<Array<_SwiftQLStaticDialect?>>, _SwiftQLStaticDialect_1>"
             )
         )
         XCTAssertTrue(
@@ -943,6 +982,138 @@ final class MetaBuilderTests: XCTestCase {
                 "readRow(reader _swiftQLRowReader_1: XLRowReader) throws -> _swiftQLRowReader"
             )
         )
+    }
+
+    // MARK: - Composite (nested `@SQLTable`/`@SQLResult`) properties
+    //
+    // A stored property whose type is itself a generated `@SQLTable`/
+    // `@SQLResult` type is, from `MetaBuilder`'s point of view, syntactically
+    // indistinguishable from any other nominal-type property: the macro has
+    // no semantic access to the property type's own declaration (it may not
+    // even be in the same file), so it cannot tell "nested composite" apart
+    // from "scalar `XLLiteral`" at expansion time. Composite support is
+    // therefore uniform code generation, not macro-side detection: every
+    // property -- scalar or composite -- goes through the same
+    // `some SwiftQL.XLStaticRowFieldSource<Type, Dialect>` parameter and the
+    // same `.grouped(at:alias:)` / running-offset accumulation. Whether a
+    // given call site actually supplies a scalar field or a nested
+    // `XLStaticRowLayout` is resolved later, by Swift's own conformance
+    // checking. These tests pin the exact generated shape for the
+    // property-count patterns issue #6 calls out; `StaticRowLayoutGRDBTests`
+    // exercises the same generated code with a real nested composite value
+    // and a real SQLite database.
+
+    func test_staticRowLayoutGeneration_singleCompositeProperty() throws {
+        let builder = try makeBuilder(
+            """
+            @SQLResult
+            struct EmployeeOnly {
+                let employee: Employee
+            }
+            """
+        )
+        let source = builder.makeStaticRowLayoutFunction()
+
+        XCTAssertFalse(Parser.parse(source: source).hasError)
+        XCTAssertTrue(source.contains("some SwiftQL.XLStaticRowFieldSource<Employee, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = try employee.grouped(at: 0, alias: \"employee\")"))
+        XCTAssertFalse(source.contains("_swiftQLStaticOffset"))
+        XCTAssertTrue(source.contains("fields: _swiftQLStaticField0.fields,"))
+        XCTAssertTrue(source.contains("employee: try _swiftQLStaticField0.read(from: _swiftQLStaticReader)"))
+        XCTAssertTrue(source.contains("encode: { _swiftQLStaticRow in"))
+        XCTAssertTrue(source.contains("try _swiftQLStaticField0.encode(_swiftQLStaticRow.employee)"))
+    }
+
+    func test_staticRowLayoutGeneration_multipleCompositeProperties() throws {
+        let builder = try makeBuilder(
+            """
+            @SQLResult
+            struct EmployeeCompany {
+                let employee: Employee
+                let company: Company
+            }
+            """
+        )
+        let source = builder.makeStaticRowLayoutFunction()
+
+        XCTAssertFalse(Parser.parse(source: source).hasError)
+        XCTAssertTrue(source.contains("employee: some SwiftQL.XLStaticRowFieldSource<Employee, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("company: some SwiftQL.XLStaticRowFieldSource<Company, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = try employee.grouped(at: 0, alias: \"employee\")"))
+        XCTAssertTrue(source.contains("_swiftQLStaticOffset = _swiftQLStaticField0.count"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField1 = try company.grouped(at: _swiftQLStaticOffset, alias: \"company\")"))
+        XCTAssertTrue(source.contains("fields: _swiftQLStaticField0.fields + _swiftQLStaticField1.fields,"))
+        XCTAssertTrue(source.contains("employee: try _swiftQLStaticField0.read(from: _swiftQLStaticReader)"))
+        XCTAssertTrue(source.contains("company: try _swiftQLStaticField1.read(from: _swiftQLStaticReader)"))
+        XCTAssertTrue(
+            source.contains(
+                "try _swiftQLStaticField0.encode(_swiftQLStaticRow.employee) + _swiftQLStaticField1.encode(_swiftQLStaticRow.company)"
+            )
+        )
+    }
+
+    func test_staticRowLayoutGeneration_mixOfScalarAndCompositeProperties() throws {
+        let builder = try makeBuilder(
+            """
+            @SQLResult
+            struct EmployeeWithBadge {
+                let badgeNumber: Int
+                let employee: Employee
+                let company: Company
+            }
+            """
+        )
+        let source = builder.makeStaticRowLayoutFunction()
+
+        XCTAssertFalse(Parser.parse(source: source).hasError)
+        // Every property -- scalar or composite -- gets the identical
+        // parameter shape; there is no macro-side branch between them.
+        XCTAssertTrue(source.contains("badgeNumber: some SwiftQL.XLStaticRowFieldSource<Int, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("employee: some SwiftQL.XLStaticRowFieldSource<Employee, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("company: some SwiftQL.XLStaticRowFieldSource<Company, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = try badgeNumber.grouped(at: 0, alias: \"badgeNumber\")"))
+        // A third property means the running offset is genuinely
+        // reassigned, so it is generated as `var`.
+        XCTAssertTrue(source.contains("var _swiftQLStaticOffset = _swiftQLStaticField0.count"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField1 = try employee.grouped(at: _swiftQLStaticOffset, alias: \"employee\")"))
+        XCTAssertTrue(source.contains("_swiftQLStaticOffset += _swiftQLStaticField1.count"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField2 = try company.grouped(at: _swiftQLStaticOffset, alias: \"company\")"))
+        XCTAssertTrue(
+            source.contains(
+                "fields: _swiftQLStaticField0.fields + _swiftQLStaticField1.fields + _swiftQLStaticField2.fields,"
+            )
+        )
+    }
+
+    func test_staticRowLayoutGeneration_nestedInsideNestedComposite() throws {
+        // `Department` is itself a composite result nesting `Employee` and
+        // `Company` (mirroring `EmployeeCompany` above); `DepartmentReport`
+        // then nests `Department` a further level deep alongside a scalar
+        // property. `MetaBuilder` only ever sees `DepartmentReport`'s own
+        // declared properties, so the generated code is identical in shape
+        // to any other single-composite-plus-scalar case -- depth is
+        // handled entirely by `XLStaticRowLayout.grouped(at:alias:)`
+        // recursing through however many nested layouts are passed to it at
+        // the call site, not by anything the macro generates differently
+        // here. `StaticRowLayoutGRDBTests` proves the recursive flattening
+        // actually works end to end against a real database.
+        let builder = try makeBuilder(
+            """
+            @SQLResult
+            struct DepartmentReport {
+                let headcount: Int
+                let department: Department
+            }
+            """
+        )
+        let source = builder.makeStaticRowLayoutFunction()
+
+        XCTAssertFalse(Parser.parse(source: source).hasError)
+        XCTAssertTrue(source.contains("headcount: some SwiftQL.XLStaticRowFieldSource<Int, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("department: some SwiftQL.XLStaticRowFieldSource<Department, _SwiftQLStaticDialect>"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField0 = try headcount.grouped(at: 0, alias: \"headcount\")"))
+        XCTAssertTrue(source.contains("let _swiftQLStaticField1 = try department.grouped(at: _swiftQLStaticOffset, alias: \"department\")"))
+        XCTAssertTrue(source.contains("fields: _swiftQLStaticField0.fields + _swiftQLStaticField1.fields,"))
     }
 
     func test_emptyStaticRowLayoutGenerationDefersInitializerToDecodeClosure() throws {

--- a/Tests/SQLMacrosTests/SQLTests.swift
+++ b/Tests/SQLMacrosTests/SQLTests.swift
@@ -881,10 +881,10 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains("try _swiftQLStaticField0.read(from: _swiftQLStaticReader)"))
         XCTAssertTrue(
             source.contains(
-                "try _swiftQLStaticField0.encode(_swiftQLStaticRow.`switch`) + _swiftQLStaticField1.encode(_swiftQLStaticRow.values)"
+                "try [_swiftQLStaticField0.encode(_swiftQLStaticRow.`switch`), _swiftQLStaticField1.encode(_swiftQLStaticRow.values)].flatMap { $0 }"
             )
         )
-        XCTAssertTrue(source.contains("fields: _swiftQLStaticField0.fields + _swiftQLStaticField1.fields,"))
+        XCTAssertTrue(source.contains("fields: [_swiftQLStaticField0.fields, _swiftQLStaticField1.fields].flatMap { $0 },"))
     }
 
     func test_staticRowLayoutGenerationAvoidsReaderAndRowPropertyCollisions() throws {
@@ -908,7 +908,7 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains("encode: { _swiftQLStaticRow in"))
         XCTAssertTrue(
             source.contains(
-                "try _swiftQLStaticField0.encode(_swiftQLStaticRow.reader) + _swiftQLStaticField1.encode(_swiftQLStaticRow.row)"
+                "try [_swiftQLStaticField0.encode(_swiftQLStaticRow.reader), _swiftQLStaticField1.encode(_swiftQLStaticRow.row)].flatMap { $0 }"
             )
         )
         XCTAssertFalse(source.contains("decode: { reader in"))
@@ -1018,7 +1018,7 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains("some SwiftQL.XLStaticRowFieldSource<Employee, _SwiftQLStaticDialect>"))
         XCTAssertTrue(source.contains("let _swiftQLStaticField0 = try employee.grouped(at: 0, alias: \"employee\")"))
         XCTAssertFalse(source.contains("_swiftQLStaticOffset"))
-        XCTAssertTrue(source.contains("fields: _swiftQLStaticField0.fields,"))
+        XCTAssertTrue(source.contains("fields: [_swiftQLStaticField0.fields].flatMap { $0 },"))
         XCTAssertTrue(source.contains("employee: try _swiftQLStaticField0.read(from: _swiftQLStaticReader)"))
         XCTAssertTrue(source.contains("encode: { _swiftQLStaticRow in"))
         XCTAssertTrue(source.contains("try _swiftQLStaticField0.encode(_swiftQLStaticRow.employee)"))
@@ -1042,12 +1042,12 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains("let _swiftQLStaticField0 = try employee.grouped(at: 0, alias: \"employee\")"))
         XCTAssertTrue(source.contains("_swiftQLStaticOffset = _swiftQLStaticField0.count"))
         XCTAssertTrue(source.contains("let _swiftQLStaticField1 = try company.grouped(at: _swiftQLStaticOffset, alias: \"company\")"))
-        XCTAssertTrue(source.contains("fields: _swiftQLStaticField0.fields + _swiftQLStaticField1.fields,"))
+        XCTAssertTrue(source.contains("fields: [_swiftQLStaticField0.fields, _swiftQLStaticField1.fields].flatMap { $0 },"))
         XCTAssertTrue(source.contains("employee: try _swiftQLStaticField0.read(from: _swiftQLStaticReader)"))
         XCTAssertTrue(source.contains("company: try _swiftQLStaticField1.read(from: _swiftQLStaticReader)"))
         XCTAssertTrue(
             source.contains(
-                "try _swiftQLStaticField0.encode(_swiftQLStaticRow.employee) + _swiftQLStaticField1.encode(_swiftQLStaticRow.company)"
+                "try [_swiftQLStaticField0.encode(_swiftQLStaticRow.employee), _swiftQLStaticField1.encode(_swiftQLStaticRow.company)].flatMap { $0 }"
             )
         )
     }
@@ -1080,7 +1080,7 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains("let _swiftQLStaticField2 = try company.grouped(at: _swiftQLStaticOffset, alias: \"company\")"))
         XCTAssertTrue(
             source.contains(
-                "fields: _swiftQLStaticField0.fields + _swiftQLStaticField1.fields + _swiftQLStaticField2.fields,"
+                "fields: [_swiftQLStaticField0.fields, _swiftQLStaticField1.fields, _swiftQLStaticField2.fields].flatMap { $0 },"
             )
         )
     }
@@ -1113,7 +1113,7 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains("department: some SwiftQL.XLStaticRowFieldSource<Department, _SwiftQLStaticDialect>"))
         XCTAssertTrue(source.contains("let _swiftQLStaticField0 = try headcount.grouped(at: 0, alias: \"headcount\")"))
         XCTAssertTrue(source.contains("let _swiftQLStaticField1 = try department.grouped(at: _swiftQLStaticOffset, alias: \"department\")"))
-        XCTAssertTrue(source.contains("fields: _swiftQLStaticField0.fields + _swiftQLStaticField1.fields,"))
+        XCTAssertTrue(source.contains("fields: [_swiftQLStaticField0.fields, _swiftQLStaticField1.fields].flatMap { $0 },"))
     }
 
     func test_emptyStaticRowLayoutGenerationDefersInitializerToDecodeClosure() throws {

--- a/Tests/SwiftQLCodecIntegrationTests/StaticRowLayoutGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/StaticRowLayoutGRDBTests.swift
@@ -140,6 +140,35 @@ private struct TrappingDefaultRow: Equatable {
 }
 
 
+// MARK: - Composite (nested `@SQLTable`) result selection (issue #6)
+
+
+@SQLTable(name: "CompositeEmployee")
+private struct CompositeEmployeeRecord: Equatable {
+    let id: Int
+    let name: String
+    let companyId: Int
+}
+
+
+@SQLTable(name: "CompositeCompany")
+private struct CompositeCompanyRecord: Equatable {
+    let id: Int
+    let title: String
+}
+
+
+/// Selects whole nested tables in one result, per issue #6: every one of
+/// `CompositeEmployeeRecord`'s columns and every one of
+/// `CompositeCompanyRecord`'s columns are flattened at the SQL level, then
+/// reconstructed into their own nested values before building this type.
+@SQLResult
+private struct CompositeEmployeeCompanyRow: Equatable {
+    let employee: CompositeEmployeeRecord
+    let company: CompositeCompanyRecord
+}
+
+
 final class StaticRowLayoutGRDBTests: XCTestCase {
 
     func testGeneratedLayoutPreservesConcretePropertyTypeIdentifiers() throws {
@@ -568,6 +597,172 @@ final class StaticRowLayoutGRDBTests: XCTestCase {
         let bindings = try prepared.makeInvocationBindings()
 
         XCTAssertEqual(try prepared.fetchAll(bindings: bindings), [expected])
+    }
+
+    func testGeneratedCompositeLayoutFlattensNestedTablesAndReconstructsSubObjects() throws {
+        let fixture = try StaticRowLayoutFixture()
+        defer { fixture.tearDown() }
+
+        let database = try GRDBDatabase(
+            databasePool: fixture.pool,
+            codingConfiguration: XLValueCodingConfiguration(),
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
+
+        try fixture.pool.write { db in
+            try db.execute(
+                sql: """
+                    CREATE TABLE CompositeCompany (
+                        id INTEGER NOT NULL,
+                        title TEXT NOT NULL
+                    )
+                    """
+            )
+            try db.execute(
+                sql: """
+                    CREATE TABLE CompositeEmployee (
+                        id INTEGER NOT NULL,
+                        name TEXT NOT NULL,
+                        companyId INTEGER NOT NULL
+                    )
+                    """
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO CompositeCompany (id, title)
+                    VALUES (1, 'Acme'), (2, 'Globex')
+                    """
+            )
+            try db.execute(
+                sql: """
+                    INSERT INTO CompositeEmployee (id, name, companyId)
+                    VALUES (10, 'Alice', 1), (11, 'Bob', 2)
+                    """
+            )
+        }
+
+        let schema = XLSchema()
+        let employeeTable = schema.table(CompositeEmployeeRecord.self, as: "employee")
+        let companyTable = schema.table(CompositeCompanyRecord.self, as: "company")
+
+        // Each nested table builds its own layout exactly as it would as a
+        // top-level result -- nesting requires no different call shape.
+        let employeeLayout = try CompositeEmployeeRecord.staticRowLayout(
+            using: XLSQLiteDialect.self,
+            id: XLStaticSelectField<Int, Int, XLSQLiteDialect>.intrinsic(
+                selecting: employeeTable.id,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["composite", "employee", "id"]
+                )
+            ),
+            name: XLStaticSelectField<String, String, XLSQLiteDialect>.intrinsic(
+                selecting: employeeTable.name,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["composite", "employee", "name"]
+                )
+            ),
+            companyId: XLStaticSelectField<Int, Int, XLSQLiteDialect>.intrinsic(
+                selecting: employeeTable.companyId,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["composite", "employee", "companyId"]
+                )
+            )
+        )
+        let companyLayout = try CompositeCompanyRecord.staticRowLayout(
+            using: XLSQLiteDialect.self,
+            id: XLStaticSelectField<Int, Int, XLSQLiteDialect>.intrinsic(
+                selecting: companyTable.id,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["composite", "company", "id"]
+                )
+            ),
+            title: XLStaticSelectField<String, String, XLSQLiteDialect>.intrinsic(
+                selecting: companyTable.title,
+                identifiedBy: XLQuerySlotIdentity(
+                    path: ["composite", "company", "title"]
+                )
+            )
+        )
+
+        // Nesting: pass each nested table's own layout as the composite
+        // property's field source. `grouped(at:alias:)` flattens its three
+        // (then two) slots in place and re-aliases them with the property
+        // name as a prefix.
+        let combinedLayout = try CompositeEmployeeCompanyRow.staticRowLayout(
+            using: XLSQLiteDialect.self,
+            employee: employeeLayout,
+            company: companyLayout
+        )
+
+        XCTAssertEqual(
+            combinedLayout.metadata.fields.map(\.alias),
+            [
+                "employee_id", "employee_name", "employee_companyId",
+                "company_id", "company_title",
+            ]
+        )
+
+        let statement = sql { _ in
+            Select(combinedLayout)
+            From(employeeTable)
+            Join(companyTable, on: employeeTable.companyId == companyTable.id)
+            OrderBy(employeeTable.id.ascending())
+        }
+        let encoding = try XLiteEncoder(dialect: database.dialect)
+            .makeValidatedSQL(statement)
+        XCTAssertTrue(
+            encoding.sql.contains(
+                "\"employee\".\"id\" AS \"employee_id\""
+            )
+        )
+        XCTAssertTrue(
+            encoding.sql.contains(
+                "\"company\".\"id\" AS \"company_id\""
+            )
+        )
+
+        let descriptor = try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "static-layout", "composite-employee-company"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(validating: encoding),
+            parameters: [],
+            results: combinedLayout.metadata.results,
+            cardinality: .many
+        )
+        let prepared = try database.prepareInvocation(
+            with: XLTypedStaticQueryDescriptor(
+                descriptor: descriptor,
+                layout: combinedLayout
+            )
+        )
+        let rows = try prepared.fetchAll(
+            bindings: prepared.makeInvocationBindings()
+        )
+
+        XCTAssertEqual(
+            rows,
+            [
+                CompositeEmployeeCompanyRow(
+                    employee: CompositeEmployeeRecord(
+                        id: 10,
+                        name: "Alice",
+                        companyId: 1
+                    ),
+                    company: CompositeCompanyRecord(id: 1, title: "Acme")
+                ),
+                CompositeEmployeeCompanyRow(
+                    employee: CompositeEmployeeRecord(
+                        id: 11,
+                        name: "Bob",
+                        companyId: 2
+                    ),
+                    company: CompositeCompanyRecord(id: 2, title: "Globex")
+                ),
+            ]
+        )
     }
 
     func testTypedStaticFetchAllStopsSteppingAtMiddleRowDecodeFailure() throws {


### PR DESCRIPTION
Closes #6.

## Summary

A stored property on `@SQLTable`/`@SQLResult` can now itself be another `@SQLTable`/`@SQLResult` type, flattened at the SQL level and reconstructed on decode:

```swift
@SQLTable struct Company { ... }
@SQLTable struct Employee { ... }

@SQLResult struct EmployeeCompany {
    let employee: Employee
    let company: Company
}
```

**Call-site note:** the issue's literal `result { EmployeeCompany(...) }` syntax is the legacy, deprecated `XLResult`/`result{}` DSL (superseded by the macro-generated `staticRowLayout(using:...)` factory — the repo's own tests assert `"result {"` is absent from docs/generated code). This PR targets the current static-layout API instead and documents the mapping.

## Design

Macros have no semantic access to another type's declaration, so `MetaBuilder` can't itself distinguish a scalar `XLLiteral` property from a nested composite one at expansion time — both are just a named type. So this is uniform codegen, not macro-side type detection:

- New `XLStaticRowFieldSource` protocol (`grouped(at:alias:) -> XLStaticFieldGroup<Value, Dialect>`). Every existing scalar field gets a default implementation contributing one slot; `XLStaticRowLayout` gets a conformance that flattens its own fields at a given offset.
- `MetaBuilder.makeStaticRowLayoutFunction()` generates, for every property uniformly: `let fN = try prop.grouped(at: runningOffset, alias: "prop")`, accumulating offsets and concatenating `fields`/`encode`. Fully additive — existing scalar call sites are unaffected.

## Changes

- `Sources/SwiftQL/SQLStaticRowLayout.swift`, `Sources/SQLMacros/MetaBuilder.swift`.
- `Sources/SwiftQL/SwiftQL.docc/StaticQueries.md`, `CHANGELOG.md`.

## Tests

Macro-expansion tests: single/multiple/mixed scalar+composite/nested-inside-nested properties, plus a diagnostic test for an unresolvable property type. Real-GRDB execution test joining two `@SQLTable` types, selecting via a composite `@SQLResult`, decoding correctly reconstructed nested sub-objects.

Full `swift test`: **749/749 pass**.

## Scope cut

Composite properties must be non-optional — an absent nested value (e.g. from a LEFT JOIN) isn't supported yet; flagged as follow-up in the docs/changelog. The legacy `columns(...)`/`result{}` v1 path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)