### PR TITLE
Add #row macro for ad hoc row projections (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,18 @@ render unchanged.
 
 ### Added
 
+- Added the `#row(...)` freestanding expression macro (issue #20). It builds an ad hoc, unnamed
+  row projection from one to six column expressions without requiring a declared `@SQLResult`
+  type first, mirroring what `Type.columns(...)` already does for a named result: `#row(a)`
+  decodes into `SQLScalarResult`, and `#row(a, b, ...)` (up to six columns) decodes into the new
+  `SQLRow2`...`SQLRow6` types, whose fields are named positionally (`_0`, `_1`, ...). Investigation
+  for this issue found its original premise — replacing `result { SomeResult.SQLReader(...) }` —
+  already stale: that helper is deprecated and superseded by `Type.columns(...)`, which is already
+  minimal and cannot be shortened further while preserving per-property labels (a freestanding
+  macro's parameter labels are fixed at its declaration and cannot vary per call site to match an
+  arbitrary result type's property names). `#row` instead targets the gap that remains: a quick,
+  one-off projection that does not deserve a declared result type.
+
 - Added `INSERT OR ROLLBACK/ABORT/FAIL/IGNORE/REPLACE` through `Insert(_:or:)`
   and the functional `insert(_:or:)`. The conflict algorithm is part of the
   `INSERT` keyword and applies to every uniqueness constraint the statement

--- a/Sources/SQLMacros/SQLMacro.swift
+++ b/Sources/SQLMacros/SQLMacro.swift
@@ -158,5 +158,6 @@ extension SQLResultMacro: ExtensionMacro {
         SQLQueryMacro.self,
         SQLQueriesMacro.self,
         SQLFunctionMacro.self,
+        SQLRowMacro.self,
     ]
 }

--- a/Sources/SQLMacros/SQLRowMacro.swift
+++ b/Sources/SQLMacros/SQLRowMacro.swift
@@ -1,0 +1,76 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+
+///
+/// Implements the `#row(...)` freestanding expression macro.
+///
+/// The public overloads declared in `Sources/SwiftQL/SQLRowMacro.swift` fix the arity (one to
+/// six unlabeled column expressions) and the resulting ad hoc row type (`SQLScalarResult` for one
+/// column, `SQLRow2`...`SQLRow6` for two to six), so the only work left here is rewriting
+/// `#row(a, b, ...)` into the equivalent `Type.columns(...)` call the caller would otherwise have
+/// to spell out by hand:
+///
+///     #row(person.id, person.name)
+///     // -> SQLRow2.columns(_0: person.id, _1: person.name)
+///
+/// Because the public overloads already fix the arity and reject labeled arguments before this
+/// macro ever runs, the diagnostics below are unreachable through the declared `#row` overloads
+/// and only matter for direct `assertMacroExpansion` coverage or a future overload that relaxes
+/// those constraints.
+///
+public struct SQLRowMacro: ExpressionMacro {
+
+    static let fieldNames = ["_0", "_1", "_2", "_3", "_4", "_5"]
+
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        let arguments = Array(node.argumentList)
+
+        guard !arguments.isEmpty else {
+            context.diagnose(
+                Diagnostic(
+                    node: node,
+                    id: "row.emptyArgumentList",
+                    message: "'#row' requires at least one column expression, such as '#row(person.id)'."
+                )
+            )
+            return "()"
+        }
+
+        guard arguments.count <= fieldNames.count else {
+            context.diagnose(
+                Diagnostic(
+                    node: node,
+                    id: "row.tooManyArguments",
+                    message: "'#row' supports at most \(fieldNames.count) columns; declare a named result with '@SQLResult' for wider projections."
+                )
+            )
+            return "()"
+        }
+
+        for argument in arguments where argument.label != nil {
+            context.diagnose(
+                Diagnostic(
+                    node: argument,
+                    id: "row.labeledArgument",
+                    message: "'#row' does not accept labeled arguments; pass column expressions positionally, such as '#row(person.id, person.name)'."
+                )
+            )
+        }
+
+        if arguments.count == 1 {
+            let column = arguments[0].expression
+            return "SQLScalarResult.columns(scalarValue: \(column))"
+        }
+
+        let typeName = "SQLRow\(arguments.count)"
+        let columnArguments = arguments.enumerated().map { index, argument in
+            "\(fieldNames[index]): \(argument.expression)"
+        }.joined(separator: ", ")
+        return "\(raw: typeName).columns(\(raw: columnArguments))"
+    }
+}

--- a/Sources/SwiftQL/SQLRowMacro.swift
+++ b/Sources/SwiftQL/SQLRowMacro.swift
@@ -1,0 +1,65 @@
+///
+/// Defines the `#row` macro.
+///
+/// `#row(...)` builds an ad hoc, unnamed row projection from a short list of column
+/// expressions, the same way `Type.columns(...)` builds a named one for a declared
+/// `@SQLResult`/`@SQLTable` type. Use `#row` for a quick, one-off projection that does not
+/// deserve (or does not yet have) a declared result type; use `.columns(...)` on a declared
+/// `@SQLResult`/`@SQLTable` type when the columns have meaningful names that should appear in
+/// the decoded model.
+///
+/// `#row` accepts between one and six column expressions:
+///
+/// ```swift
+/// let row = #row(person.id, person.name)
+/// Select(row)
+/// From(person)
+/// ```
+///
+/// A single column expands to ``SQLScalarResult``; two to six columns expand to the matching
+/// ``SQLRow2``...``SQLRow6`` type, whose fields are named positionally (`_0`, `_1`, ...).
+///
+@freestanding(expression)
+public macro row<C0>(
+    _ c0: any XLExpression<C0>
+) -> SQLScalarResult<C0>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>
+) -> SQLRow2<C0, C1>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1, C2>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>,
+    _ c2: any XLExpression<C2>
+) -> SQLRow3<C0, C1, C2>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1, C2, C3>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>,
+    _ c2: any XLExpression<C2>,
+    _ c3: any XLExpression<C3>
+) -> SQLRow4<C0, C1, C2, C3>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1, C2, C3, C4>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>,
+    _ c2: any XLExpression<C2>,
+    _ c3: any XLExpression<C3>,
+    _ c4: any XLExpression<C4>
+) -> SQLRow5<C0, C1, C2, C3, C4>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression, C4: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1, C2, C3, C4, C5>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>,
+    _ c2: any XLExpression<C2>,
+    _ c3: any XLExpression<C3>,
+    _ c4: any XLExpression<C4>,
+    _ c5: any XLExpression<C5>
+) -> SQLRow6<C0, C1, C2, C3, C4, C5>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression, C4: XLLiteral & XLExpression, C5: XLLiteral & XLExpression

--- a/Sources/SwiftQL/SQLRowResult.swift
+++ b/Sources/SwiftQL/SQLRowResult.swift
@@ -1,0 +1,118 @@
+//
+//  SQLRowResult.swift
+//
+//
+//  Ad hoc row projections used by the `#row` macro (see SQLRowMacro.swift).
+//
+
+import Foundation
+
+
+///
+/// A two-column ad hoc row projection.
+///
+/// `SQLRow2` and its siblings (`SQLRow3`...`SQLRow6`) exist so `#row(...)` can build a result
+/// column set without requiring the caller to declare a named `@SQLResult` type first. Fields are
+/// exposed positionally as `_0`, `_1`, ... because the columns have no caller-chosen name; declare
+/// an `@SQLResult` type instead when the projection is reused or the columns deserve real names.
+///
+@SQLResult
+public struct SQLRow2<C0, C1> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+}
+
+extension SQLRow2: Equatable where C0: Equatable, C1: Equatable {
+
+}
+
+extension SQLRow2: Hashable where C0: Hashable, C1: Hashable {
+
+}
+
+
+///
+/// A three-column ad hoc row projection. See ``SQLRow2``.
+///
+@SQLResult
+public struct SQLRow3<C0, C1, C2> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+    public var _2: C2
+}
+
+extension SQLRow3: Equatable where C0: Equatable, C1: Equatable, C2: Equatable {
+
+}
+
+extension SQLRow3: Hashable where C0: Hashable, C1: Hashable, C2: Hashable {
+
+}
+
+
+///
+/// A four-column ad hoc row projection. See ``SQLRow2``.
+///
+@SQLResult
+public struct SQLRow4<C0, C1, C2, C3> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+    public var _2: C2
+    public var _3: C3
+}
+
+extension SQLRow4: Equatable where C0: Equatable, C1: Equatable, C2: Equatable, C3: Equatable {
+
+}
+
+extension SQLRow4: Hashable where C0: Hashable, C1: Hashable, C2: Hashable, C3: Hashable {
+
+}
+
+
+///
+/// A five-column ad hoc row projection. See ``SQLRow2``.
+///
+@SQLResult
+public struct SQLRow5<C0, C1, C2, C3, C4> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression, C4: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+    public var _2: C2
+    public var _3: C3
+    public var _4: C4
+}
+
+extension SQLRow5: Equatable where C0: Equatable, C1: Equatable, C2: Equatable, C3: Equatable, C4: Equatable {
+
+}
+
+extension SQLRow5: Hashable where C0: Hashable, C1: Hashable, C2: Hashable, C3: Hashable, C4: Hashable {
+
+}
+
+
+///
+/// A six-column ad hoc row projection. See ``SQLRow2``.
+///
+@SQLResult
+public struct SQLRow6<C0, C1, C2, C3, C4, C5> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression, C4: XLLiteral & XLExpression, C5: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+    public var _2: C2
+    public var _3: C3
+    public var _4: C4
+    public var _5: C5
+}
+
+extension SQLRow6: Equatable where C0: Equatable, C1: Equatable, C2: Equatable, C3: Equatable, C4: Equatable, C5: Equatable {
+
+}
+
+extension SQLRow6: Hashable where C0: Hashable, C1: Hashable, C2: Hashable, C3: Hashable, C4: Hashable, C5: Hashable {
+
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Queries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/Queries.md
@@ -168,6 +168,46 @@ let query = sql { schema in
 > Tip: Use `Join.Cross` or `Join.Inner` to perform a cross or inner 
 join respectively.
 
+### Ad hoc rows with `#row`
+
+Declaring a `@SQLResult` type is the right choice when a projection is reused
+or its columns deserve real names. For a quick, one-off projection that is
+used in a single query, the `#row(...)` macro builds the same kind of column
+set without declaring a type first:
+
+<!-- test: XLDocumentationTests.testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs -->
+```swift
+let query = sql { schema in
+    let person = schema.table(Person.self)
+    let occupation = schema.nullableTable(Occupation.self)
+    Select(#row(person.name, occupation.name))
+    From(person)
+    Join.Left(occupation, on: occupation.id == person.occupationId)
+}
+```
+
+`#row` accepts between one and six column expressions. A single column
+decodes into ``SQLScalarResult``; two to six columns decode into the matching
+`SQLRow2`...`SQLRow6` type, whose fields are named positionally (`_0`, `_1`,
+...) since the columns have no caller-chosen name:
+
+<!-- test: XLDocumentationTests.testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs -->
+```swift
+let query = sql { schema in
+    let person = schema.table(Person.self)
+    let occupation = schema.nullableTable(Occupation.self)
+    let row = #row(person.name, occupation.name)
+    Select(row)
+    From(person)
+    Join.Left(occupation, on: occupation.id == person.occupationId)
+    Where(row._0 != "Fred")
+}
+```
+
+> Tip: Reach for a named `@SQLResult` type once a projection's columns need
+> descriptive names, or once the projection is reused across more than one
+> query.
+
 ## Group By
 
 Use the group by clause to return aggregate results, or results where a single

--- a/Tests/SQLMacrosTests/SQLRowMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLRowMacroTests.swift
@@ -1,0 +1,151 @@
+//
+//  SQLRowMacroTests.swift
+//  SwiftQL
+//
+//  Macro-expansion tests for the `#row` freestanding expression macro: the supported one- through
+//  six-column shapes, and the diagnostics for misuse.
+//
+
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import SQLMacros
+
+
+private func makeRowTestMacros() -> [String: Macro.Type] {
+    ["row": SQLRowMacro.self]
+}
+
+
+final class SQLRowMacroExpansionTests: XCTestCase {
+
+    func test_oneColumn_expandsToScalarResultColumns() {
+        assertMacroExpansion(
+            """
+            let row = #row(person.id)
+            """,
+            expandedSource: """
+            let row = SQLScalarResult.columns(scalarValue: person.id)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_twoColumns_expandsToSQLRow2Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(person.id, person.name)
+            """,
+            expandedSource: """
+            let row = SQLRow2.columns(_0: person.id, _1: person.name)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_threeColumns_expandsToSQLRow3Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(person.id, person.name, person.age)
+            """,
+            expandedSource: """
+            let row = SQLRow3.columns(_0: person.id, _1: person.name, _2: person.age)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_fourColumns_expandsToSQLRow4Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(a, b, c, d)
+            """,
+            expandedSource: """
+            let row = SQLRow4.columns(_0: a, _1: b, _2: c, _3: d)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_fiveColumns_expandsToSQLRow5Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(a, b, c, d, e)
+            """,
+            expandedSource: """
+            let row = SQLRow5.columns(_0: a, _1: b, _2: c, _3: d, _4: e)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_sixColumns_expandsToSQLRow6Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(a, b, c, d, e, f)
+            """,
+            expandedSource: """
+            let row = SQLRow6.columns(_0: a, _1: b, _2: c, _3: d, _4: e, _5: f)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_zeroColumns_emitsDiagnostic() {
+        assertMacroExpansion(
+            """
+            let row = #row()
+            """,
+            expandedSource: """
+            let row = ()
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'#row' requires at least one column expression, such as '#row(person.id)'.",
+                    line: 1,
+                    column: 11
+                )
+            ],
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_tooManyColumns_emitsDiagnostic() {
+        assertMacroExpansion(
+            """
+            let row = #row(a, b, c, d, e, f, g)
+            """,
+            expandedSource: """
+            let row = ()
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'#row' supports at most 6 columns; declare a named result with '@SQLResult' for wider projections.",
+                    line: 1,
+                    column: 11
+                )
+            ],
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_labeledArgument_emitsDiagnostic() {
+        assertMacroExpansion(
+            """
+            let row = #row(scalarValue: person.id)
+            """,
+            expandedSource: """
+            let row = SQLScalarResult.columns(scalarValue: person.id)
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'#row' does not accept labeled arguments; pass column expressions positionally, such as '#row(person.id, person.name)'.",
+                    line: 1,
+                    column: 16
+                )
+            ],
+            macros: makeRowTestMacros()
+        )
+    }
+}

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -811,6 +811,37 @@ final class XLDocumentationTests: XCTestCase {
         ])
     }
 
+    func testExample_RowMacro() throws {
+        let statement = sql { schema in
+            let person = schema.table(Person.self)
+            let occupation = schema.nullableTable(Occupation.self)
+            Select(#row(person.name, occupation.name))
+            From(person)
+            Join.Left(occupation, on: occupation.id == person.occupationId)
+        }
+        let sql = encoder.makeSQL(statement).sql
+        XCTAssertEqual(sql, "SELECT t0.name AS _0, t1.name AS _1 FROM Person AS t0 LEFT JOIN Occupation AS t1 ON (t1.id IS t0.occupationId)")
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(rows.map { $0._0 }, ["John Doe", "Jane Doe", "Yogi Bear"])
+        XCTAssertEqual(rows.map { $0._1 }, ["Engineer", "Scientist", nil])
+    }
+
+    func testExample_RowMacro_ReferencedInWhereClause() throws {
+        let statement = sql { schema in
+            let person = schema.table(Person.self)
+            let occupation = schema.nullableTable(Occupation.self)
+            let row = #row(person.name, occupation.name)
+            Select(row)
+            From(person)
+            Join.Left(occupation, on: occupation.id == person.occupationId)
+            Where(row._0 != "Fred")
+        }
+        let sql = encoder.makeSQL(statement).sql
+        XCTAssertEqual(sql, "SELECT t0.name AS _0, t1.name AS _1 FROM Person AS t0 LEFT JOIN Occupation AS t1 ON (t1.id IS t0.occupationId) WHERE (_0 != 'Fred')")
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(rows.map { $0._0 }, ["John Doe", "Jane Doe", "Yogi Bear"])
+    }
+
     func testExample_LeftJoin_Functional_NullRows() throws {
         let statement = sqlQuery { schema in
             let person = schema.table(Person.self)
@@ -2167,6 +2198,8 @@ extension XLDocumentationTests {
 
     func testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs() throws {
         try testExample_LeftJoin_Statement_NullRows()
+        try testExample_RowMacro()
+        try testExample_RowMacro_ReferencedInWhereClause()
         try testExample_Subquery()
 
         let _: (XLExecutionTests) -> () throws -> Void = XLExecutionTests.testGroupConcatVariants

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -94,6 +94,39 @@ final class XLExecutionTests: XCTestCase {
         )
     }
 
+    /// `#row(...)` builds an ad hoc row projection without a declared `@SQLResult` type. This
+    /// exercises it against a real SQLite database: a two-column `#row` decodes into `SQLRow2`,
+    /// and a one-column `#row` decodes into `SQLScalarResult`.
+    func testRowMacroDecodesFromRealDatabase() throws {
+        try createTestTable()
+        try insertTest(TestTable(id: "bar", value: 42))
+
+        let id = XLNamedBindingReference<String>(name: "id")
+        let twoColumnStatement = sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(#row(table.id, table.value))
+            From(table)
+            Where(table.id == id)
+        }
+        var twoColumnRequest = database.makeRequest(with: twoColumnStatement)
+        twoColumnRequest.set(id, "bar")
+
+        let twoColumnResult = try twoColumnRequest.fetchOne()
+        XCTAssertEqual(twoColumnResult?._0, "bar")
+        XCTAssertEqual(twoColumnResult?._1, 42)
+
+        let scalarStatement = sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(#row(table.value))
+            From(table)
+            Where(table.id == id)
+        }
+        var scalarRequest = database.makeRequest(with: scalarStatement)
+        scalarRequest.set(id, "bar")
+
+        XCTAssertEqual(try scalarRequest.fetchOne()?.scalarValue, 42)
+    }
+
     func testNestedUnaryOperatorExecution() throws {
         let x = XLNamedBindingReference<Int>(name: "x")
         let doubleNegation = sql { _ in


### PR DESCRIPTION
Closes #20.

## Investigation: is `result { SomeResult.SQLReader(...) }` still live?

No — it's stale. `result(_:)` in `SQLFunctionalSyntax.swift` is `@available(*, deprecated, message: "Use the .columns() method on the table object instead.")`, fully superseded by the macro-generated `Type.columns(label: expr, ...)` factory. Tests actively assert `"result {"` is absent from docs/generated code.

Empirically verified `.columns(...)` can't be shortened further while preserving per-property labels: a freestanding macro's parameter labels are fixed at its own declaration and can't vary per call site to match an arbitrary target type's property names (a throwaway macro confirmed the compiler rejects mismatched labels *before* expansion runs).

## What `#row` actually delivers

Targets the real remaining gap: a quick, one-off row projection that doesn't deserve a declared `@SQLResult` type.

- `#row(a)` → `SQLScalarResult.columns(scalarValue: a)`
- `#row(a, b, ..., f)` (2–6 columns) → new generic ad hoc `SQLRow2`...`SQLRow6` types, positionally named fields.
- Diagnostics for 0 columns, >6 columns, and labeled arguments.

## Changes

- `Sources/SwiftQL/SQLRowResult.swift` (new) — `SQLRow2`...`SQLRow6`.
- `Sources/SwiftQL/SQLRowMacro.swift` (new) — public macro declarations, arities 1–6.
- `Sources/SQLMacros/SQLRowMacro.swift` (new) — `ExpressionMacro` implementation.
- `Sources/SwiftQL/SwiftQL.docc/Queries.md` — new "Ad hoc rows with `#row`" section.
- `CHANGELOG.md`.

## Tests

`Tests/SQLMacrosTests/SQLRowMacroTests.swift` — 9 expansion/diagnostic tests (all 6 arities + 3 diagnostics). Real-SQLite execution test decoding a 2-column + scalar row. Doc-example tests.

Full `swift test`: **777/777 pass**.

## Branch base note

This branch is based on `origin/main` (`1ef2c07f`), not the pre-sync `version/1.5.1` (`b0443b37`) — `version/1.5.1` was stale relative to `main` (missing v1.4.4 RETURNING/upsert work) and is being brought current in #380. Once #380 merges, this branch's base matches `version/1.5.1` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)