### PR TITLE
Add typed multi-statement transaction scopes (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,25 @@
 - Added the `DeclaredQueries` DocC article covering the `@SQLQuery` and
   `@SQLQueries` forms, the frozen-literal guard, render-once caching and its
   concurrency/`Sendable` story, and the v1.5 transitional-syntax note.
+- Added typed multi-statement transaction scopes (issue #284):
+  `XLTransactionalDatabase.withTransaction(_:)` runs an ordered sequence of
+  typed `XLRequest`/`XLWriteRequest` invocations — reads and writes alike —
+  on one pinned GRDB connection as a single atomic unit, committing only
+  after the whole body succeeds and rolling back every write on a
+  preparation, binding, execution, decoding, or user-thrown failure, with no
+  GRDB type anywhere in the contract. `@SQLQueries`'s generated `execute(_:)`
+  is now sugar over this same primitive, so declared-query calls and
+  `makeRequest(with:)` calls in one `execute(_:)` closure commit or roll back
+  together. Calling `withTransaction(_:)` again from inside an active body —
+  whether on the scope it was given or on the original database captured
+  from the enclosing closure — is rejected with a catchable
+  `XLTransactionScopeError.nestedTransactionUnsupported` before any pool
+  access, instead of the uncatchable crash GRDB's own reentrant-write guard
+  would otherwise raise. A scope value used after its body returns throws
+  `.scopeEscaped`; `publish()`/`publishOne()` inside a transaction throws
+  `.liveQueriesUnsupportedInTransaction`; an already-cancelled task throws
+  `CancellationError` before the transaction opens. Documented in
+  `GettingStarted`'s "Typed multi-statement transaction scopes".
 
 ### Migration
 
@@ -69,6 +88,13 @@ including third-party `XLDatabase` adapters, source-compatible.
   duplicate-declaration compile error, not a silent one.
 - Only one `@SQLQueries`-attached extension is supported per database type; a
   second would redeclare `Context` and `execute(_:)`.
+- `withTransaction(_:)` does not support nested transactions or savepoints —
+  a nested call is rejected outright rather than silently composed — and
+  cancellation is checked only once, before the transaction opens; the
+  synchronous body has no cooperative mid-transaction cancellation point.
+  Both remain tracked by v2 issue #113, matching the disposition the shared
+  `SQLiteTransactionConformanceFixtures` capability table (issue #253)
+  already recorded for the driver-level contract.
 
 ## [1.4.6] - 2026-07-25
 

--- a/Sources/SQLMacros/SQLQueriesMacro.swift
+++ b/Sources/SQLMacros/SQLQueriesMacro.swift
@@ -154,14 +154,22 @@ extension SQLQueriesMacro: MemberMacro {
     }
 
     ///
-    /// Generates the `execute` entry point. The current implementation binds
-    /// the context straight to the database; connection checkout and
-    /// transaction scoping are runtime design left for future work.
+    /// Generates the `execute` entry point. `execute(_:)` runs `__xlWork`
+    /// inside a real transaction (issue #284) by delegating to
+    /// `withTransaction(_:)` (``XLTransactionalDatabase``): the extended
+    /// database type must conform to `XLTransactionalDatabase` for the
+    /// generated code to compile, exactly as it must already conform to
+    /// `XLDatabase` for `makeRequest(with:)`. `Context` binds to the pinned
+    /// scope `withTransaction(_:)` hands back, so every generated executor
+    /// the closure calls — and any `execute` calls it makes on the outer
+    /// database convenience form — commits or rolls back together.
     ///
     private static func makeExecuteFunction(modifierPrefix: String) -> String {
         var lines: [String] = []
         lines.append("\(modifierPrefix)func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {")
-        lines.append("    try __xlWork(Context(database: self))")
+        lines.append("    try withTransaction { __xlScope in")
+        lines.append("        try __xlWork(Context(database: __xlScope))")
+        lines.append("    }")
         lines.append("}")
         return lines.joined(separator: "\n")
     }

--- a/Sources/SQLMacros/SQLQueriesMacro.swift
+++ b/Sources/SQLMacros/SQLQueriesMacro.swift
@@ -28,9 +28,11 @@ import SwiftSyntaxMacros
 ///
 /// Generated members:
 ///   * `struct Context` — connection-scoped executors; one per specification.
-///   * `execute(_:)` — runs a closure against a context. The current
-///     implementation binds the context directly to the database; connection
-///     pooling and transaction scoping remain future runtime-design work.
+///   * `execute(_:)` — runs a closure against a context pinned to one
+///     transaction (issue #284's `XLTransactionalDatabase.withTransaction(_:)`):
+///     every declared-query call and `context.database.makeRequest(with:)`
+///     call inside the closure runs on one pinned connection, committing
+///     together on success and rolling back together on any failure.
 ///   * One database-level convenience executor per specification, defined as
 ///     sugar over `execute`, so the implicit form is transparently the
 ///     explicit one.

--- a/Sources/SwiftQL/GRDBDatabaseDriver.swift
+++ b/Sources/SwiftQL/GRDBDatabaseDriver.swift
@@ -10,7 +10,15 @@ import GRDB
 ///
 /// The driver is internal to the v1 compatibility facade. Public code depends
 /// on the adapter-neutral contracts from `SwiftQLCore`.
-struct GRDBDatabaseDriver: XLDatabaseDriver, Sendable {
+///
+/// A driver is either pool-backed (the default: every connection access
+/// leases from the `DatabasePool`, exactly as before issue #284) or pinned to
+/// one already-open connection for the duration of one
+/// ``XLTransactionalDatabase/withTransaction(_:)`` scope. Pinned-mode
+/// connection access never touches the pool, so it cannot re-enter it and
+/// cannot deadlock waiting on a writer access the enclosing scope already
+/// holds.
+struct GRDBDatabaseDriver: XLDatabaseDriver, @unchecked Sendable {
 
     typealias Dialect = XLSQLiteDialect
 
@@ -22,23 +30,95 @@ struct GRDBDatabaseDriver: XLDatabaseDriver, Sendable {
 
     let dialect: XLSQLiteDialect
 
-    let databasePool: DatabasePool
+    private enum Access {
+        case pool(DatabasePool)
+        case pinned(GRDBPinnedConnectionBox)
+    }
+
+    private let access: Access
+
+    /// The pool backing this driver, or `nil` when pinned to one transaction
+    /// scope's connection. `ValueObservation`-backed live queries need a
+    /// stable pool to track, so a pinned-mode caller must fail explicitly
+    /// instead of observing a connection that is about to be invalidated.
+    var databasePool: DatabasePool? {
+        if case .pool(let pool) = access {
+            return pool
+        }
+        return nil
+    }
+
+    /// `true` once this driver has been pinned to one transaction scope's
+    /// connection. Used to reject a nested `withTransaction(_:)` call before
+    /// it touches the pool, instead of silently opening a second scope.
+    var isPinned: Bool {
+        if case .pinned = access {
+            return true
+        }
+        return false
+    }
 
     init(
         databasePool: DatabasePool,
         dialect: XLSQLiteDialect,
         databaseIdentifier: XLDatabaseIdentifier = XLDatabaseIdentifier(rawValue: UUID())
     ) {
-        self.databasePool = databasePool
+        self.access = .pool(databasePool)
         self.dialect = dialect
         self.databaseIdentifier = databaseIdentifier
+    }
+
+    private init(
+        access: Access,
+        dialect: XLSQLiteDialect,
+        databaseIdentifier: XLDatabaseIdentifier
+    ) {
+        self.access = access
+        self.dialect = dialect
+        self.databaseIdentifier = databaseIdentifier
+    }
+
+    ///
+    /// Produces a driver pinned to `box`'s connection for the duration of one
+    /// transaction scope. Every connection access on the returned driver
+    /// reuses that connection directly instead of leasing one from the pool.
+    ///
+    /// Deliberately assigns a **fresh** `databaseIdentifier` rather than
+    /// reusing this driver's own: a `@SQLQuery`/`@SQLQueries` render-once
+    /// cache entry (``XLPreparedQueryCacheKey``) caches a fully-built
+    /// `GRDBRequest`/`GRDBWriteRequest` — which closes over one specific
+    /// driver — not just the rendered SQL text. Sharing the pool-backed
+    /// database's identifier would let a declared query first populated
+    /// outside a transaction permanently bind that entry to the pool driver
+    /// (silently re-entering the pool from inside every later transaction
+    /// instead of using the pinned connection), or let a declared query first
+    /// populated *inside* one transaction hand a later, unrelated call a
+    /// `GRDBRequest` bound to that transaction's already-invalidated pinned
+    /// box. A fresh identifier per scope gives every transaction its own
+    /// cache entry instead: one extra render the first time a declared query
+    /// is used inside a given transaction, in exchange for never reusing a
+    /// request built for a different connection.
+    ///
+    func pinned(to box: GRDBPinnedConnectionBox) -> GRDBDatabaseDriver {
+        GRDBDatabaseDriver(
+            access: .pinned(box),
+            dialect: dialect,
+            databaseIdentifier: XLDatabaseIdentifier(rawValue: UUID())
+        )
     }
 
     mutating func withReadConnection<Result>(
         _ operation: (inout GRDBDatabaseDriverConnection) throws -> Result
     ) throws -> Result {
-        try databasePool.read { database in
-            var connection = makeConnection(database)
+        switch access {
+        case .pool(let pool):
+            try preconditionNotRootReentrant()
+            return try pool.read { database in
+                var connection = makeConnection(database)
+                return try operation(&connection)
+            }
+        case .pinned(let box):
+            var connection = try box.connection(makeConnection: makeConnection)
             return try operation(&connection)
         }
     }
@@ -46,8 +126,15 @@ struct GRDBDatabaseDriver: XLDatabaseDriver, Sendable {
     mutating func withWriteConnection<Result>(
         _ operation: (inout GRDBDatabaseDriverConnection) throws -> Result
     ) throws -> Result {
-        try databasePool.writeWithoutTransaction { database in
-            var connection = makeConnection(database)
+        switch access {
+        case .pool(let pool):
+            try preconditionNotRootReentrant()
+            return try pool.writeWithoutTransaction { database in
+                var connection = makeConnection(database)
+                return try operation(&connection)
+            }
+        case .pinned(let box):
+            var connection = try box.connection(makeConnection: makeConnection)
             return try operation(&connection)
         }
     }
@@ -55,9 +142,45 @@ struct GRDBDatabaseDriver: XLDatabaseDriver, Sendable {
     mutating func withTransaction<Result>(
         _ operation: (inout GRDBDatabaseDriverConnection) throws -> Result
     ) throws -> Result {
-        try databasePool.write { database in
-            var connection = makeConnection(database)
+        switch access {
+        case .pool(let pool):
+            try preconditionNotRootReentrant()
+            return try pool.write { database in
+                var connection = makeConnection(database)
+                return try operation(&connection)
+            }
+        case .pinned(let box):
+            // Already running inside the one real transaction that the
+            // owning `XLTransactionalDatabase.withTransaction(_:)` scope
+            // opened with `databasePool.write`. A write statement executed
+            // through the ordinary v1 request path calls this method once
+            // per statement, so reuse the pinned connection directly instead
+            // of asking GRDB for a second write access — GRDB's own writer
+            // queue is not reentrant, and a second `databasePool.write` here
+            // would deadlock instead of composing as a nested transaction.
+            var connection = try box.connection(makeConnection: makeConnection)
             return try operation(&connection)
+        }
+    }
+
+    ///
+    /// Rejects "root-executor re-entry" (issue #284): any pool-mode
+    /// connection access — read *or* write — issued through this driver's
+    /// `databaseIdentifier` while a ``XLTransactionalDatabase/withTransaction(_:)``
+    /// scope for that same identifier is already active on the calling
+    /// thread. This is what protects a plain `SELECT` issued through the
+    /// captured root database from inside an active transaction body, not
+    /// just a second `withTransaction(_:)` call: GRDB's reader pool is not
+    /// reentrant-locked with its writer, so a stray read like that would not
+    /// crash or deadlock — it would just silently lease a different
+    /// connection and return the database's last *committed* state, missing
+    /// the transaction's own uncommitted writes, exactly the "lease another
+    /// connection... and break the transaction boundary" hazard the hard
+    /// constraints call out. See ``GRDBTransactionScopeTracker``.
+    ///
+    private func preconditionNotRootReentrant() throws {
+        guard !GRDBTransactionScopeTracker.shared.isActive(databaseIdentifier) else {
+            throw XLTransactionScopeError.nestedTransactionUnsupported
         }
     }
 
@@ -68,6 +191,50 @@ struct GRDBDatabaseDriver: XLDatabaseDriver, Sendable {
             driverIdentifier: driverIdentifier,
             dialect: dialect
         )
+    }
+}
+
+
+///
+/// Holds the one physical connection lent to a
+/// ``XLTransactionalDatabase/withTransaction(_:)`` scope for its entire
+/// duration, and invalidates it the instant that scope's body returns.
+///
+/// GRDB's `Database` is explicitly *not* `Sendable` — it must only be used
+/// from the serialized writer access that owns it (see
+/// `GRDB/Core/Database.swift`'s `@available(*, unavailable) extension
+/// Database: Sendable`). This box is created inside that writer access,
+/// read only synchronously from the same dynamic extent by the transaction
+/// body, and invalidated before that access returns; `@unchecked Sendable`
+/// documents and contains that invariant instead of ever exposing `Database`
+/// through public API.
+///
+/// Invalidation is what turns an escaped transaction-scoped value into a
+/// predictable ``XLTransactionScopeError/scopeEscaped`` instead of a data
+/// race or a crash: once `invalidate()` runs, every later `connection(...)`
+/// call throws rather than touching a connection GRDB may already have
+/// reused for unrelated work.
+final class GRDBPinnedConnectionBox: @unchecked Sendable {
+
+    private var database: Database?
+
+    init(_ database: Database) {
+        self.database = database
+    }
+
+    /// Invalidates the box. Called once, when the owning
+    /// `databasePool.write` access is about to return (commit or rollback).
+    func invalidate() {
+        database = nil
+    }
+
+    func connection(
+        makeConnection: (Database) -> GRDBDatabaseDriverConnection
+    ) throws -> GRDBDatabaseDriverConnection {
+        guard let database else {
+            throw XLTransactionScopeError.scopeEscaped
+        }
+        return makeConnection(database)
     }
 }
 
@@ -616,6 +783,68 @@ private extension XLBindingKey {
             return name
         case .indexed(let index):
             return String(index)
+        }
+    }
+}
+
+
+///
+/// Detects "root-executor re-entry" (issue #284): a second
+/// `withTransaction(_:)` call, reached from inside an already-active body,
+/// on the *original, unpinned* database value rather than the pinned scope
+/// `body` was given.
+///
+/// `GRDBDatabaseDriver.isPinned` alone cannot catch this, because the
+/// captured root database's own driver was never marked pinned — only the
+/// scope handed to `body` was. And the crash this guards against cannot be
+/// caught after the fact: GRDB's writer access is not reentrant, and a
+/// reentrant `DatabasePool.write`/`writeWithoutTransaction` call traps with
+/// an unconditional `fatalError` ("Database methods are not reentrant.")
+/// before a single line of SwiftQL runs. This tracker must reject the call
+/// *before* it reaches `databasePool.write` at all.
+///
+/// Scoped per-`Thread` rather than per-pool: `body` runs synchronously to
+/// completion, so a call nested inside it is necessarily on the same thread
+/// as the active scope. Two independent, concurrent `withTransaction(_:)`
+/// calls from different threads are unrelated activations — each has its own
+/// thread dictionary — and both must succeed, serialized safely by GRDB's own
+/// writer queue.
+final class GRDBTransactionScopeTracker: @unchecked Sendable {
+
+    static let shared = GRDBTransactionScopeTracker()
+
+    private let key = "swiftql.grdb.activeTransactionScopeDatabaseIdentifiers"
+
+    private init() {}
+
+    func isActive(_ databaseIdentifier: XLDatabaseIdentifier) -> Bool {
+        activeIdentifiers.contains(databaseIdentifier)
+    }
+
+    /// Marks `databaseIdentifier` active on the calling thread for the
+    /// duration of `body`, and always clears it again afterward — including
+    /// when `body` throws.
+    func withActive<Result>(
+        _ databaseIdentifier: XLDatabaseIdentifier,
+        _ body: () throws -> Result
+    ) throws -> Result {
+        var identifiers = activeIdentifiers
+        identifiers.insert(databaseIdentifier)
+        activeIdentifiers = identifiers
+        defer {
+            var identifiers = activeIdentifiers
+            identifiers.remove(databaseIdentifier)
+            activeIdentifiers = identifiers
+        }
+        return try body()
+    }
+
+    private var activeIdentifiers: Set<XLDatabaseIdentifier> {
+        get {
+            Thread.current.threadDictionary[key] as? Set<XLDatabaseIdentifier> ?? []
+        }
+        set {
+            Thread.current.threadDictionary[key] = newValue
         }
     }
 }

--- a/Sources/SwiftQL/GRDBDatabaseDriver.swift
+++ b/Sources/SwiftQL/GRDBDatabaseDriver.swift
@@ -821,6 +821,14 @@ private extension XLBindingKey {
 /// calls from different threads are unrelated activations — each has its own
 /// thread dictionary — and both must succeed, serialized safely by GRDB's own
 /// writer queue.
+///
+/// Callers must enter `withActive(_:_:)` on the same thread that will run
+/// `body` -- for the GRDB adapter, that means *inside* the
+/// `databasePool.write(_:)` closure, not around it. GRDB dispatches that
+/// closure onto its own writer thread, which is not necessarily the caller's
+/// thread; marking active before calling `databasePool.write` would leave a
+/// reentrant call made from inside `body` unable to see the marker, silently
+/// defeating this guard.
 final class GRDBTransactionScopeTracker: @unchecked Sendable {
 
     static let shared = GRDBTransactionScopeTracker()

--- a/Sources/SwiftQL/GRDBDatabaseDriver.swift
+++ b/Sources/SwiftQL/GRDBDatabaseDriver.swift
@@ -216,6 +216,7 @@ struct GRDBDatabaseDriver: XLDatabaseDriver, @unchecked Sendable {
 /// reused for unrelated work.
 final class GRDBPinnedConnectionBox: @unchecked Sendable {
 
+    private let lock = NSLock()
     private var database: Database?
 
     init(_ database: Database) {
@@ -224,13 +225,24 @@ final class GRDBPinnedConnectionBox: @unchecked Sendable {
 
     /// Invalidates the box. Called once, when the owning
     /// `databasePool.write` access is about to return (commit or rollback).
+    ///
+    /// Synchronized against `connection(makeConnection:)` so a scope value
+    /// that escapes to another thread reads a consistent, already-invalidated
+    /// `database` instead of racing this write -- a scope value used after
+    /// its body returns must reliably throw `.scopeEscaped`, never trip a
+    /// data race.
     func invalidate() {
+        lock.lock()
+        defer { lock.unlock() }
         database = nil
     }
 
     func connection(
         makeConnection: (Database) -> GRDBDatabaseDriverConnection
     ) throws -> GRDBDatabaseDriverConnection {
+        lock.lock()
+        let database = self.database
+        lock.unlock()
         guard let database else {
             throw XLTransactionScopeError.scopeEscaped
         }

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -1276,8 +1276,15 @@ extension GRDBDatabase: XLTransactionalDatabase {
         if Task.isCancelled {
             throw CancellationError()
         }
-        return try GRDBTransactionScopeTracker.shared.withActive(driver.databaseIdentifier) {
-            try databasePool.write { database in
+        // `withActive` must be entered *inside* `databasePool.write`'s
+        // closure, not around it: GRDB runs that closure on its own writer
+        // thread, not necessarily the caller's thread, and the tracker marks
+        // a thread active via `Thread.current.threadDictionary`. A reentrant
+        // call from inside `body` runs on this same writer thread (it is
+        // still on the same call stack), so marking active here is what
+        // `preconditionNotRootReentrant()` actually observes.
+        return try databasePool.write { database in
+            try GRDBTransactionScopeTracker.shared.withActive(driver.databaseIdentifier) {
                 let box = GRDBPinnedConnectionBox(database)
                 defer { box.invalidate() }
                 let scope = GRDBDatabase(

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -446,18 +446,26 @@ struct GRDBRequest<Row>: XLRequest {
     }
     
     private func publisher<T>(fetch: @escaping (Database) throws -> T) -> AnyPublisher<T, Error> {
+        // A transaction-scoped driver (issue #284) has no pool to track: its
+        // connection is invalidated the instant the `withTransaction(_:)`
+        // body returns, so there is nothing a `ValueObservation` could keep
+        // observing. Fail predictably instead of crashing on a `nil` pool.
+        guard let databasePool = executor.driver.databasePool else {
+            return Fail(error: XLTransactionScopeError.liveQueriesUnsupportedInTransaction)
+                .eraseToAnyPublisher()
+        }
         let makeSource = {
 #if canImport(Combine)
             ValueObservation
                 .tracking(fetch)
-                .publisher(in: executor.driver.databasePool)
+                .publisher(in: databasePool)
                 .eraseToAnyPublisher()
 #else
             GRDBOpenCombineValuePublisher { onError, onChange in
                 ValueObservation
                     .tracking(fetch)
                     .start(
-                        in: executor.driver.databasePool,
+                        in: databasePool,
                         onError: onError,
                         onChange: onChange
                     )
@@ -944,6 +952,23 @@ public struct GRDBDatabase: XLDatabase {
         self.liveQueryRetryScheduler = liveQueryRetryScheduler
     }
 
+    /// Constructs a transaction-scoped copy of this database (issue #284),
+    /// pinned to `pinnedDriver`'s connection. Every other field is copied
+    /// unchanged, so a pinned scope renders through the same encoder,
+    /// dialect, coding snapshot, logger, and live-query retry policy as the
+    /// database ``withTransaction(_:)`` was called on.
+    private init(pinnedDriver: GRDBDatabaseDriver, pinnedFrom other: GRDBDatabase) {
+        self.dialect = other.dialect
+        self.encoder = other.encoder
+        self.codingConfiguration = other.codingConfiguration
+        self.databasePool = other.databasePool
+        self.driverIdentifier = other.driverIdentifier
+        self.driver = pinnedDriver
+        self.logger = other.logger
+        self.liveQueryRetryPolicy = other.liveQueryRetryPolicy
+        self.liveQueryRetryScheduler = other.liveQueryRetryScheduler
+    }
+
     /// Scopes render-once cache entries (issues #18/#26) to this database and
     /// dialect. Rendering depends only on the dialect; the database identifier
     /// keeps a per-declaration `static` cache from binding one database's
@@ -1211,5 +1236,56 @@ public struct GRDBDatabase: XLDatabase {
             entities: encoding.entities,
             parameterLayout: encoding.parameterLayout
         )
+    }
+}
+
+
+extension GRDBDatabase: XLTransactionalDatabase {
+
+    /// Runs `body` against one pinned `DatabasePool` connection inside one
+    /// real GRDB transaction (issue #284): `databasePool.write(_:)` opens the
+    /// transaction, hands `body` a `GRDBDatabase` pinned to that connection,
+    /// commits when `body` returns normally, and rolls back — preserving the
+    /// original error — when `body` throws. See ``XLTransactionalDatabase``
+    /// for the full ordering, atomicity, and lifetime contract.
+    ///
+    /// Rejects two cases before any transaction work happens:
+    /// - calling `withTransaction(_:)` again from inside an already-active
+    ///   body on this database throws
+    ///   ``XLTransactionScopeError/nestedTransactionUnsupported`` without
+    ///   touching the pool;
+    /// - a task that is already cancelled when this is called throws
+    ///   `CancellationError` before opening the transaction. The body itself
+    ///   runs synchronously to completion once started, so there is no later
+    ///   cooperative cancellation point.
+    public func withTransaction<Result>(
+        _ body: (GRDBDatabase) throws -> Result
+    ) throws -> Result {
+        // Rejects reentry on the pinned scope itself (fast, value-level,
+        // thread-independent) and reentry through the original, unpinned
+        // database captured from inside an active body (thread-scoped; see
+        // `GRDBTransactionScopeTracker`). Both checks run before touching
+        // `databasePool.write`, because GRDB's own reentrant-write guard is
+        // an uncatchable `fatalError`.
+        guard !driver.isPinned else {
+            throw XLTransactionScopeError.nestedTransactionUnsupported
+        }
+        guard !GRDBTransactionScopeTracker.shared.isActive(driver.databaseIdentifier) else {
+            throw XLTransactionScopeError.nestedTransactionUnsupported
+        }
+        if Task.isCancelled {
+            throw CancellationError()
+        }
+        return try GRDBTransactionScopeTracker.shared.withActive(driver.databaseIdentifier) {
+            try databasePool.write { database in
+                let box = GRDBPinnedConnectionBox(database)
+                defer { box.invalidate() }
+                let scope = GRDBDatabase(
+                    pinnedDriver: driver.pinned(to: box),
+                    pinnedFrom: self
+                )
+                return try body(scope)
+            }
+        }
     }
 }

--- a/Sources/SwiftQL/SQLTransactionScope.swift
+++ b/Sources/SwiftQL/SQLTransactionScope.swift
@@ -1,0 +1,133 @@
+//
+//  SQLTransactionScope.swift
+//  SwiftQL
+//
+//  Typed multi-statement transaction scopes (issue #284): a database that
+//  lends one pinned connection to an ordered sequence of typed
+//  `XLRequest`/`XLWriteRequest` invocations, committing only after the whole
+//  body succeeds and rolling back every write on any failure. Built on the
+//  `XLDatabase` contract that issues #18/#26 already generate `Context`
+//  executors against, so a `@SQLQueries` declaration composes with
+//  `withTransaction(_:)` without a second query or binding runtime.
+//
+
+import Foundation
+
+
+///
+/// A database capable of running an ordered sequence of typed requests as one
+/// atomic transaction on a single pinned connection.
+///
+/// `withTransaction(_:)` is the typed, adapter-neutral multi-statement
+/// executor required by issue #284. It differs from calling
+/// `XLDatabaseDriver.withTransaction` directly in three ways:
+///
+/// - the body receives another value of `Self` — an ordinary `XLDatabase` —
+///   instead of a driver connection, so it composes with `makeRequest(with:)`,
+///   `execute()`, `fetchAll()`, and every other typed v1 request API, and
+///   with a `@SQLQueries`-generated `Context`;
+/// - no adapter connection, statement handle, or pool type is ever exposed;
+/// - the scope is invalidated the instant `body` returns, so a request or
+///   scope value that escapes the closure fails predictably instead of
+///   touching a connection that may already be reused for other work.
+///
+/// ## Ordering, atomicity, and results
+///
+/// Every request `body` executes runs, in source order, against the same
+/// physical connection `withTransaction(_:)` pinned for this call. Because
+/// Swift closures execute their statements in program order, an ordinary
+/// local variable is enough to carry one operation's typed result to a later
+/// one, or out to the transaction's own return value — no extra plumbing is
+/// required.
+///
+/// The whole body is one commit unit: `withTransaction(_:)` commits only
+/// after `body` returns normally, and rolls back every write `body` performed
+/// — preparation, binding, execution, decoding, and user-thrown failures
+/// alike — before rethrowing the original, unmodified error.
+///
+/// ## Unsupported: nesting, savepoints, and mid-flight cancellation
+///
+/// Calling `withTransaction(_:)` again from inside an active body throws
+/// ``XLTransactionScopeError/nestedTransactionUnsupported`` before any nested
+/// work runs — the v1 driver has no savepoint hook, so a nested call cannot
+/// prove correct partial-rollback semantics, and re-entering the root
+/// connection pool from inside an open transaction can deadlock or hand two
+/// operations different connections. Cancellation is checked only once, at
+/// the very start of `withTransaction(_:)`, because the body itself runs
+/// synchronously to completion and has no cooperative cancellation point
+/// while committed or rolled-back writes are underway.
+///
+/// See <doc:GettingStarted> for the isolation and lifetime rules, and for
+/// concrete examples of the durable-state guarantees this API makes.
+///
+public protocol XLTransactionalDatabase: XLDatabase {
+
+    ///
+    /// Runs `body` against one pinned connection inside one real database
+    /// transaction and returns its result.
+    ///
+    /// - Parameter body: Receives a database-shaped scope pinned to this
+    ///   transaction's connection. Use it exactly like the enclosing
+    ///   database — `makeRequest(with:)`, the v1 fetch/execute methods, and
+    ///   any `@SQLQueries`-generated `Context` all work unchanged.
+    /// - Returns: `body`'s result, after the transaction has committed.
+    /// - Throws: The original error `body` threw (preparation, binding,
+    ///   execution, decoding, or user-thrown) after rolling back every write
+    ///   it performed; ``XLTransactionScopeError/nestedTransactionUnsupported``
+    ///   if called again from inside an active `body`, before touching the
+    ///   connection pool; or `CancellationError` if the calling task was
+    ///   already cancelled before the transaction began.
+    ///
+    func withTransaction<Result>(
+        _ body: (Self) throws -> Result
+    ) throws -> Result
+}
+
+
+///
+/// Failures at the transaction-scope boundary itself, distinct from errors a
+/// scoped operation's preparation, binding, execution, or decoding raises.
+///
+public enum XLTransactionScopeError: Error, Equatable, Sendable, LocalizedError {
+
+    ///
+    /// A request, write request, or scope value created inside a
+    /// ``XLTransactionalDatabase/withTransaction(_:)`` body was used after
+    /// that body returned. The body's connection is no longer pinned by the
+    /// time this is thrown — the transaction already committed or rolled
+    /// back — so continuing would silently operate on a connection reused
+    /// for unrelated work instead of the one the caller believed it still
+    /// held.
+    ///
+    case scopeEscaped
+
+    ///
+    /// `withTransaction(_:)` was called again from inside an already-active
+    /// transaction body on the same database. The v1 driver has no
+    /// savepoint hook, so a nested call cannot commit or roll back only its
+    /// own writes; re-entering the connection pool from inside an open
+    /// transaction can also deadlock. Rejected before any nested work runs,
+    /// so no partial state exists to roll back.
+    ///
+    case nestedTransactionUnsupported
+
+    ///
+    /// A request's live-query `publish()`/`publishOne()` was called on a
+    /// transaction-scoped database. Live observation tracks a connection
+    /// pool across commits over time; a transaction-scoped connection is
+    /// invalidated the instant the body returns, so there is no stable pool
+    /// to observe.
+    ///
+    case liveQueriesUnsupportedInTransaction
+
+    public var errorDescription: String? {
+        switch self {
+        case .scopeEscaped:
+            return "A transaction-scoped database, request, or write request was used after its 'withTransaction(_:)' body returned. Transaction-scoped values must not escape the closure."
+        case .nestedTransactionUnsupported:
+            return "'withTransaction(_:)' was called again from inside an active transaction body. Nested transactions and savepoints are not supported; perform every operation in one body instead."
+        case .liveQueriesUnsupportedInTransaction:
+            return "Live-query 'publish()'/'publishOne()' is not supported inside a 'withTransaction(_:)' body. Fetch with 'fetchAll()'/'fetchOne()' instead, or observe outside the transaction."
+        }
+    }
+}

--- a/Sources/SwiftQL/SQLTransactionScope.swift
+++ b/Sources/SwiftQL/SQLTransactionScope.swift
@@ -102,12 +102,15 @@ public enum XLTransactionScopeError: Error, Equatable, Sendable, LocalizedError 
     case scopeEscaped
 
     ///
-    /// `withTransaction(_:)` was called again from inside an already-active
-    /// transaction body on the same database. The v1 driver has no
-    /// savepoint hook, so a nested call cannot commit or roll back only its
-    /// own writes; re-entering the connection pool from inside an open
-    /// transaction can also deadlock. Rejected before any nested work runs,
-    /// so no partial state exists to roll back.
+    /// Either `withTransaction(_:)` was called again from inside an
+    /// already-active transaction body, or the original (root, unpinned)
+    /// database was used from inside an active body instead of the pinned
+    /// scope value it was given -- both re-enter the same connection pool
+    /// while a transaction is open. The v1 driver has no savepoint hook, so
+    /// a nested call cannot commit or roll back only its own writes; pool
+    /// re-entry can also deadlock or hand two operations different
+    /// connections. Rejected before any nested work runs, so no partial
+    /// state exists to roll back.
     ///
     case nestedTransactionUnsupported
 
@@ -125,7 +128,7 @@ public enum XLTransactionScopeError: Error, Equatable, Sendable, LocalizedError 
         case .scopeEscaped:
             return "A transaction-scoped database, request, or write request was used after its 'withTransaction(_:)' body returned. Transaction-scoped values must not escape the closure."
         case .nestedTransactionUnsupported:
-            return "'withTransaction(_:)' was called again from inside an active transaction body. Nested transactions and savepoints are not supported; perform every operation in one body instead."
+            return "'withTransaction(_:)' was called again from inside an active transaction body, or the original (root) database was used instead of the pinned scope value the body was given -- both re-enter the connection pool while a transaction is open. Nested transactions and savepoints are not supported; perform every operation in one body using the scope value it receives instead."
         case .liveQueriesUnsupportedInTransaction:
             return "Live-query 'publish()'/'publishOne()' is not supported inside a 'withTransaction(_:)' body. Fetch with 'fetchAll()'/'fetchOne()' instead, or observe outside the transaction."
         }

--- a/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
@@ -115,11 +115,15 @@ let sameMatches = try database.execute { context in
 
 `execute(_:)` and the generated `Context` type let you run more than one
 declared query in the same scope without repeating a database lookup per
-call. This scope does not by itself pin one physical connection --
-`context`'s executors still check out their own connection from the pool per
-call, the same as calling `database.personByName(name:)` directly. A scope
-that pins every operation to one connection, with atomic commit/rollback, is
-a separate capability (issue #284).
+call. Since issue #284, `execute(_:)` is sugar over the adapter-neutral typed
+transaction scope described in <doc:GettingStarted>'s "Typed multi-statement
+transaction scopes": it commits only after the whole closure returns and
+rolls back everything the closure did on any failure, so
+`context.database.makeRequest(with:)` calls interleaved with declared-query
+calls in the same closure commit or roll back together. `Context.database` is
+the pinned scope, not the original database — pass it to `makeRequest(with:)`
+for any operation the closure needs beyond the container's own declared
+queries.
 
 ## Render-once caching
 

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -322,6 +322,87 @@ Execute the request whenever it is needed:
 let workingAgePeople = try workingAgeRequest.fetchAll()
 ```
 
+#### Typed multi-statement transaction scopes
+
+`GRDBDatabase.withTransaction(_:)` (issue #284, `XLTransactionalDatabase`) runs
+an ordered sequence of typed requests — reads and writes alike — as one atomic
+unit on a single pinned connection, without ever naming a GRDB type. It is the
+typed counterpart to the driver-level `withTransaction` described above: where
+the driver hands an adapter integration a raw connection, this hands ordinary
+application code another `GRDBDatabase`, so the body is just more
+`makeRequest(with:)` calls (and, inside a `@SQLQueries` extension, more
+`Context` calls — `execute(_:)` is sugar over this same primitive).
+
+<!-- test: XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings -->
+```swift
+let (workingAgeCount, insertedID) = try database.withTransaction { scope in
+    let newHire = Person(id: "txn-scope-a", occupationId: nil, name: "Grace", age: 29)
+    try scope.makeRequest(with: sqlInsert(newHire)).execute()
+    let promoted = Person(id: "txn-scope-b", occupationId: nil, name: "Harold", age: 45)
+    try scope.makeRequest(with: sqlInsert(promoted)).execute()
+    let matches = try scope.makeRequest(with: workingAgeQuery).fetchAll()
+    return (matches.count, newHire.id)
+}
+```
+
+Ordering, atomicity, and lifetime work exactly as the driver-level contract
+above describes, plus the guarantees a typed, adapter-neutral surface adds:
+
+- **Order and results.** Every request the body issues runs in source order
+  on the one connection `withTransaction(_:)` pinned for this call; an
+  ordinary local variable carries one operation's result to a later one or to
+  the transaction's own return value.
+- **Commit and rollback.** The whole body is one commit unit: it commits only
+  after the body returns normally, and rolls back every write the body
+  performed — on a preparation, binding, execution, decoding, or user-thrown
+  failure alike — before rethrowing the original, unmodified error.
+- **Read-your-writes.** A read issued from the scope observes an earlier,
+  still-uncommitted write from the same body, because both run on the same
+  pinned connection.
+- **No GRDB type in the contract.** The scope handed to the body is another
+  `GRDBDatabase` — the exact same type the rest of this article uses — never a
+  GRDB `Database`, `DatabasePool`, or statement handle.
+
+Three cases are rejected before any transaction work happens, each with a
+predictable, catchable `XLTransactionScopeError` rather than a crash or silent
+wrong answer:
+
+- **Nested transactions and savepoints are not supported.** Calling
+  `withTransaction(_:)` again from inside an active body — on the scope it was
+  given, *or* on the original database captured from the enclosing scope —
+  throws `.nestedTransactionUnsupported`. The v1 driver has no savepoint hook,
+  so a nested call cannot prove it would only commit or roll back its own
+  writes; re-entering the connection pool from inside an open transaction can
+  also deadlock or silently lease a different connection that only sees the
+  database's last *committed* state, missing the transaction's own
+  uncommitted writes.
+- **The scope must not escape the body.** A request, write request, or scope
+  value used after `withTransaction(_:)` returns throws `.scopeEscaped`: the
+  pinned connection is invalidated the instant the body returns, so
+  continuing would silently touch a connection GRDB may already be reusing
+  for unrelated work.
+- **Live queries are not supported inside a transaction.** `publish()` /
+  `publishOne()` on a transaction-scoped request throws
+  `.liveQueriesUnsupportedInTransaction`: `ValueObservation` tracks a
+  connection pool across commits over time, and a transaction-scoped
+  connection is invalidated before there is anything to observe.
+
+Cancellation is checked once, at the very start of `withTransaction(_:)`: a
+task that is already cancelled throws `CancellationError` before opening the
+transaction. The body itself runs synchronously to completion once started —
+there is no later cooperative cancellation point, so mid-transaction
+cancellation is not a supported capability of this v1 surface, not a silently
+ignored one.
+
+`withTransaction(_:)` is a non-macro v1 compatibility API: a plain closure
+over `XLTransactionalDatabase`, available on the same Swift 5.9 floor as the
+rest of this article, independent of the `@SQLQuery`/`@SQLQueries` macros
+described in <doc:DeclaredQueries>. Composing with those macros needs no
+separate transaction-aware spelling — a `@SQLQueries` extension's generated
+`execute(_:)` already calls `withTransaction(_:)` internally, so every
+declared query it runs shares the same pinned connection as any
+`makeRequest(with:)` call alongside it in the same body.
+
 ## Named bindings
 
 Use `XLNamedBindingReference` to add a type-safe named placeholder to a query.

--- a/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
@@ -132,7 +132,9 @@ final class SQLQueriesMacroExpansionTests: XCTestCase {
                 }
 
                 func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {
-                    try __xlWork(Context(database: self))
+                    try withTransaction { __xlScope in
+                        try __xlWork(Context(database: __xlScope))
+                    }
                 }
 
                 func personByName(name: String) throws -> [Person] {
@@ -290,7 +292,9 @@ final class SQLQueriesMacroAccessLevelTests: XCTestCase {
                 }
 
                 public func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {
-                    try __xlWork(Context(database: self))
+                    try withTransaction { __xlScope in
+                        try __xlWork(Context(database: __xlScope))
+                    }
                 }
 
                 public func allPeople() throws -> [Person] {

--- a/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLQueriesMacroTests.swift
@@ -219,7 +219,9 @@ final class SQLQueriesMacroExpansionTests: XCTestCase {
                 }
 
                 func execute<__XLResult>(_ __xlWork: (Context) throws -> __XLResult) throws -> __XLResult {
-                    try __xlWork(Context(database: self))
+                    try withTransaction { __xlScope in
+                        try __xlWork(Context(database: __xlScope))
+                    }
                 }
 
                 func peopleByClass(`class`: String) throws -> [Person] {

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1202,6 +1202,18 @@ extension XLDocumentationTests {
         let workingAgeRequest = database.makeRequest(with: workingAgeQuery)
         XCTAssertEqual(try workingAgeRequest.fetchAll().count, 3)
 
+        let (workingAgeCount, insertedID) = try database.withTransaction { scope in
+            let newHire = Person(id: "txn-scope-a", occupationId: nil, name: "Grace", age: 29)
+            try scope.makeRequest(with: sqlInsert(newHire)).execute()
+            let promoted = Person(id: "txn-scope-b", occupationId: nil, name: "Harold", age: 45)
+            try scope.makeRequest(with: sqlInsert(promoted)).execute()
+            let matches = try scope.makeRequest(with: workingAgeQuery).fetchAll()
+            return (matches.count, newHire.id)
+        }
+        XCTAssertEqual(workingAgeCount, 5)
+        XCTAssertEqual(insertedID, "txn-scope-a")
+        XCTAssertEqual(try workingAgeRequest.fetchAll().count, 5)
+
         let nameParameter = XLNamedBindingReference<String>(name: "name")
         let peopleByNameQuery = sql { schema in
             let person = schema.table(Person.self)

--- a/Tests/SQLTests/SQLTransactionScopeTests.swift
+++ b/Tests/SQLTests/SQLTransactionScopeTests.swift
@@ -14,6 +14,11 @@
 //
 
 import Foundation
+#if canImport(Combine)
+import Combine
+#else
+import OpenCombine
+#endif
 import XCTest
 import GRDB
 import SwiftQL

--- a/Tests/SQLTests/SQLTransactionScopeTests.swift
+++ b/Tests/SQLTests/SQLTransactionScopeTests.swift
@@ -1,0 +1,638 @@
+//
+//  SQLTransactionScopeTests.swift
+//  SwiftQL
+//
+//  Typed multi-statement transaction scopes (issue #284):
+//  `XLTransactionalDatabase.withTransaction(_:)` runs an ordered sequence of
+//  typed `XLRequest`/`XLWriteRequest` invocations on one pinned GRDB
+//  connection, committing only after the whole body succeeds and rolling
+//  back every write on any failure. These tests are state-oracle tests: every
+//  commit/rollback assertion re-opens a brand-new `DatabasePool` against the
+//  same SQLite file instead of reusing anything from inside the transaction,
+//  so a broken implementation that merely avoided throwing could not pass by
+//  accident.
+//
+
+import Foundation
+import XCTest
+import GRDB
+import SwiftQL
+
+
+// A peer `@SQLQuery` declaration (not `@SQLQueries`, which would redeclare
+// the `Context`/`execute(_:)` pair `SQLQueriesContainerTests.swift` already
+// generates once for `GRDBDatabase` in this same test target) — enough to
+// prove a declared-query executor composes with `withTransaction(_:)`: it
+// dispatches through whatever `self` it is called on, pinned scope or root
+// database alike, with no separate query or binding runtime of its own.
+extension GRDBDatabase {
+
+    @SQLQuery
+    fileprivate func transactionScopeRowByID(id: String) -> [TestTable] {
+        sqlResult { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == id)
+        }
+    }
+}
+
+
+final class SQLTransactionScopeTests: XCTestCase {
+
+    private struct UserError: Error, Equatable {
+        let reason: String
+    }
+
+    var fileURL: URL!
+    var databasePool: DatabasePool!
+    var database: GRDBDatabase!
+
+    override func setUp() {
+        let directory = FileManager.default.temporaryDirectory
+        fileURL = directory
+            .appendingPathComponent(UUID().uuidString, isDirectory: false)
+            .appendingPathExtension("sqlite")
+        databasePool = try! DatabasePool(path: fileURL.path)
+        database = try! GRDBDatabase(
+            databasePool: databasePool,
+            formatter: XLiteFormatter(identifierFormattingOptions: .mysqlCompatible),
+            logger: nil
+        )
+    }
+
+    override func tearDown() {
+        try? databasePool.close()
+        if let fileURL {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+        fileURL = nil
+        databasePool = nil
+        database = nil
+    }
+
+    // MARK: - Schema helpers
+
+    /// The default `sqlCreate`-derived schema: no primary key, so it never
+    /// enforces a uniqueness constraint. Used by every test that is not
+    /// specifically exercising a constraint failure.
+    private func createTestTable() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+    }
+
+    /// A schema with a real `PRIMARY KEY`, created with raw SQL exactly like
+    /// the shared issue #253 transaction-invariant fixtures do, so a
+    /// duplicate `id` insert fails with `SQLITE_CONSTRAINT`. SwiftQL's typed
+    /// `TestTable` statement builders only need the table and column names to
+    /// match; they do not care how the table was declared.
+    private func createConstrainedTestTable() throws {
+        try databasePool.write { db in
+            try db.execute(sql: "CREATE TABLE Test (id TEXT PRIMARY KEY, value INTEGER NOT NULL)")
+        }
+    }
+
+    private func selectAllTestRowsQuery() -> any XLQueryStatement<TestTable> {
+        sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+        }
+    }
+
+    /// Reads durable state from a **fresh read boundary**: a brand-new
+    /// `DatabasePool`/`GRDBDatabase` pair opened against the same file, not
+    /// anything retained from `database` or from inside a transaction. A
+    /// broken commit/rollback implementation that merely avoided throwing
+    /// could not fool this.
+    private func freshRows() throws -> [TestTable] {
+        let freshPool = try DatabasePool(path: fileURL.path)
+        defer { try? freshPool.close() }
+        let freshDatabase = try GRDBDatabase(
+            databasePool: freshPool,
+            formatter: XLiteFormatter(identifierFormattingOptions: .mysqlCompatible),
+            logger: nil
+        )
+        return try freshDatabase.makeRequest(with: selectAllTestRowsQuery()).fetchAll()
+    }
+
+    /// Reads only the `id` column from a fresh read boundary, bypassing
+    /// `TestTable`'s typed row reader. Used by the decode-failure test, whose
+    /// table intentionally contains one row that a typed reader cannot
+    /// decode.
+    private func freshRowIDs() throws -> [String] {
+        let freshPool = try DatabasePool(path: fileURL.path)
+        defer { try? freshPool.close() }
+        return try freshPool.read { db in
+            try String.fetchAll(db, sql: "SELECT id FROM Test ORDER BY id")
+        }
+    }
+
+    // MARK: - Public typed example: two writes and a read, committed atomically
+
+    /// The public typed example required by issue #284's "Done When": at
+    /// least two writes and one read, executed against a real temporary
+    /// SQLite database, returning the expected typed result with no GRDB
+    /// type anywhere in the call site.
+    func testTwoWritesAndAReadExecuteInOrderAndCommitAtomically() throws {
+        try createTestTable()
+
+        let (insertedCount, alphaRows) = try database.withTransaction { scope in
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "beta", value: 2))).execute()
+            let rows = try scope.makeRequest(with: self.selectAllTestRowsQuery()).fetchAll()
+            return (rows.count, rows)
+        }
+
+        XCTAssertEqual(insertedCount, 2)
+        XCTAssertEqual(
+            alphaRows.sorted { $0.id < $1.id },
+            [TestTable(id: "alpha", value: 1), TestTable(id: "beta", value: 2)]
+        )
+
+        // Fresh read boundary after commit.
+        XCTAssertEqual(
+            try freshRows().sorted { $0.id < $1.id },
+            [TestTable(id: "alpha", value: 1), TestTable(id: "beta", value: 2)]
+        )
+    }
+
+    func testReadWithinTheTransactionObservesAnEarlierWriteInTheSameScope() throws {
+        try createTestTable()
+
+        let visibleBeforeCommit = try database.withTransaction { scope in
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+            return try scope.makeRequest(with: self.selectAllTestRowsQuery()).fetchAll()
+        }
+
+        XCTAssertEqual(visibleBeforeCommit, [TestTable(id: "alpha", value: 1)])
+        XCTAssertEqual(try freshRows(), [TestTable(id: "alpha", value: 1)])
+    }
+
+    // MARK: - Composition with declared queries (issues #18/#26)
+
+    /// A `@SQLQuery`-declared executor dispatches through whatever `self` it
+    /// is called on. Calling it on the pinned `scope` runs it against the
+    /// same pinned connection as every other operation in the body, so it
+    /// observes an earlier write from the same transaction.
+    func testDeclaredQueryExecutorCallableFromTheScopeObservesAWriteFromTheSameTransaction() throws {
+        try createTestTable()
+
+        let matches = try database.withTransaction { scope in
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+            return try scope.fetchTransactionScopeRowByID(id: "alpha")
+        }
+
+        XCTAssertEqual(matches, [TestTable(id: "alpha", value: 1)])
+        XCTAssertEqual(try freshRows(), [TestTable(id: "alpha", value: 1)])
+    }
+
+    /// The `@SQLQueries` `execute(_:)`/`Context` pair (`SQLQueriesContainerTests.swift`,
+    /// same test target) now runs its closure inside a real transaction too:
+    /// `execute(_:)` is sugar over `withTransaction(_:)`. `context.database`
+    /// is the pinned scope, so a write made through it and a later declared
+    /// read both land on the same connection and commit together.
+    func testDeclaredQueriesExecuteEntryPointRunsInARealCommittingTransaction() throws {
+        try createTestTable()
+
+        let rows = try database.execute { context -> [TestTable] in
+            try context.database.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+            return try context.database.fetchTransactionScopeRowByID(id: "alpha")
+        }
+
+        XCTAssertEqual(rows, [TestTable(id: "alpha", value: 1)])
+        XCTAssertEqual(try freshRows(), [TestTable(id: "alpha", value: 1)])
+    }
+
+    func testDeclaredQueriesExecuteEntryPointRollsBackOnFailure() throws {
+        try createTestTable()
+
+        struct SpecFailure: Error, Equatable {}
+
+        XCTAssertThrowsError(
+            try database.execute { context -> Void in
+                try context.database.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+                throw SpecFailure()
+            }
+        ) { error in
+            XCTAssertEqual(error as? SpecFailure, SpecFailure())
+        }
+
+        XCTAssertEqual(try freshRows(), [])
+    }
+
+    // MARK: - Edge cases: empty body, single operation, repeated parameters
+
+    func testEmptyBodyCommitsWithoutError() throws {
+        try createTestTable()
+
+        let result = try database.withTransaction { _ in
+            42
+        }
+
+        XCTAssertEqual(result, 42)
+        XCTAssertEqual(try freshRows(), [])
+    }
+
+    func testSingleOperationBodyCommits() throws {
+        try createTestTable()
+
+        try database.withTransaction { scope in
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "solo", value: 7))).execute()
+        }
+
+        XCTAssertEqual(try freshRows(), [TestTable(id: "solo", value: 7)])
+    }
+
+    /// One prepared read request, invoked twice with different immutable
+    /// binding packets in the same scope. Each invocation must bind and
+    /// fetch independently — no shared mutable binding state leaks a
+    /// parameter value from the first call into the second.
+    func testRepeatedParametersAcrossOperationsDoNotShareMutableBindingState() throws {
+        try createTestTable()
+
+        let idParameter = XLNamedBindingReference<String>(name: "id")
+        let query = sql { schema -> any XLQueryStatement<TestTable> in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            Where(table.id == idParameter)
+        }
+
+        let (first, second) = try database.withTransaction { scope -> ([TestTable], [TestTable]) in
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "first", value: 1))).execute()
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "second", value: 2))).execute()
+
+            let request = scope.makeRequest(with: query)
+            let slot = try XCTUnwrap(request.parameterLayout.slot(for: .named("id")))
+
+            let firstBindings = try XLInvocationBindings<XLSQLiteValue>(
+                layout: request.parameterLayout,
+                bindings: [try XLInvocationBinding(slot: slot, value: .text("first"))]
+            ).validatingComplete()
+            let firstResult = try request.fetchAll(bindings: firstBindings)
+
+            let secondBindings = try XLInvocationBindings<XLSQLiteValue>(
+                layout: request.parameterLayout,
+                bindings: [try XLInvocationBinding(slot: slot, value: .text("second"))]
+            ).validatingComplete()
+            let secondResult = try request.fetchAll(bindings: secondBindings)
+
+            return (firstResult, secondResult)
+        }
+
+        XCTAssertEqual(first, [TestTable(id: "first", value: 1)])
+        XCTAssertEqual(second, [TestTable(id: "second", value: 2)])
+    }
+
+    // MARK: - Source ordering: an earlier typed result feeds a later operation
+
+    func testEarlierTypedResultFeedsALaterOperationAndTheReturnValue() throws {
+        try createTestTable()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "seed-1", value: 1))).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "seed-2", value: 2))).execute()
+
+        let (countBefore, insertedID) = try database.withTransaction { scope -> (Int, String) in
+            let existing = try scope.makeRequest(with: self.selectAllTestRowsQuery()).fetchAll()
+            let nextID = "seed-\(existing.count + 1)"
+            try scope.makeRequest(with: sqlInsert(TestTable(id: nextID, value: existing.count + 1))).execute()
+            return (existing.count, nextID)
+        }
+
+        XCTAssertEqual(countBefore, 2)
+        XCTAssertEqual(insertedID, "seed-3")
+        XCTAssertEqual(try freshRows().map(\.id).sorted(), ["seed-1", "seed-2", "seed-3"])
+    }
+
+    // MARK: - Failure boundaries: every write in the body rolls back together
+
+    func testMidSequenceConstraintFailureRollsBackEveryEarlierWriteInTheSameTransaction() throws {
+        try createConstrainedTestTable()
+
+        XCTAssertThrowsError(
+            try database.withTransaction { scope in
+                try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+                try scope.makeRequest(with: sqlInsert(TestTable(id: "beta", value: 2))).execute()
+                // Duplicate primary key: SQLITE_CONSTRAINT.
+                try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 999))).execute()
+            }
+        ) { error in
+            XCTAssertEqual((error as? DatabaseError)?.resultCode, .SQLITE_CONSTRAINT)
+        }
+
+        XCTAssertEqual(try freshRows(), [], "alpha and beta must both roll back with the failing statement.")
+    }
+
+    func testPreparationFailureRollsBackEarlierWritesAndPreservesTheOriginalError() throws {
+        try createTestTable()
+
+        XCTAssertThrowsError(
+            try database.withTransaction { scope in
+                try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+                // `TestNullablesTable` maps to a table that was never
+                // created in this database: "no such table" at prepare time.
+                _ = try scope.makeRequest(
+                    with: sql { schema -> any XLQueryStatement<TestNullablesTable> in
+                        let table = schema.table(TestNullablesTable.self)
+                        Select(table)
+                        From(table)
+                    }
+                ).fetchAll()
+            }
+        ) { error in
+            XCTAssertEqual((error as? DatabaseError)?.resultCode, .SQLITE_ERROR)
+        }
+
+        XCTAssertEqual(try freshRows(), [])
+    }
+
+    func testBindingFailureRollsBackEarlierWritesAndPreservesTheOriginalError() throws {
+        try database.makeRequest(with: sqlCreate(DoubleTest.self)).execute()
+
+        let valueParameter = XLNamedBindingReference<Double>(name: "value")
+        let query = sql { schema -> any XLQueryStatement<DoubleTest> in
+            let table = schema.table(DoubleTest.self)
+            Select(table)
+            From(table)
+            Where(table.value == valueParameter)
+        }
+
+        XCTAssertThrowsError(
+            try database.withTransaction { scope in
+                try scope.makeRequest(with: sqlInsert(DoubleTest(id: "alpha", value: 1.5))).execute()
+
+                let request = scope.makeRequest(with: query)
+                let slot = try XCTUnwrap(request.parameterLayout.slot(for: .named("value")))
+                let bindings = try XLInvocationBindings<XLSQLiteValue>(
+                    layout: request.parameterLayout,
+                    bindings: [try XLInvocationBinding(slot: slot, value: .real(.nan))]
+                ).validatingComplete()
+                _ = try request.fetchAll(bindings: bindings)
+            }
+        ) { error in
+            XCTAssertEqual(
+                error as? XLSQLValueEncodingError,
+                .realBindingWouldBecomeNull(
+                    value: .notANumber,
+                    valueType: String(reflecting: Double.self),
+                    context: XLValueCodingContext(
+                        site: .parameter,
+                        path: XLValueCodingPath("value")
+                    )
+                )
+            )
+        }
+
+        let freshPool = try DatabasePool(path: fileURL.path)
+        defer { try? freshPool.close() }
+        let freshDatabase = try GRDBDatabase(
+            databasePool: freshPool,
+            formatter: XLiteFormatter(identifierFormattingOptions: .mysqlCompatible),
+            logger: nil
+        )
+        let remaining = try freshDatabase.makeRequest(
+            with: sql { schema -> any XLQueryStatement<DoubleTest> in
+                let table = schema.table(DoubleTest.self)
+                Select(table)
+                From(table)
+            }
+        ).fetchAll()
+        XCTAssertEqual(remaining, [])
+    }
+
+    func testDecodeFailureAfterAWriteRollsBackThatWriteAndPreservesTheOriginalError() throws {
+        try createTestTable()
+        // Seed a row outside the transaction under test whose `value` column
+        // holds TEXT instead of the INTEGER `TestTable.value` expects. The
+        // default `sqlCreate`-derived schema declares no column type, so
+        // SQLite stores this value with its own affinity instead of
+        // coercing it, and a typed `TestTable` read of it decode-fails.
+        try databasePool.write { db in
+            try db.execute(
+                sql: "INSERT INTO Test (id, value) VALUES ('corrupt', 'not-a-number')"
+            )
+        }
+
+        XCTAssertThrowsError(
+            try database.withTransaction { scope in
+                try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+                _ = try scope.makeRequest(with: self.selectAllTestRowsQuery()).fetchAll()
+            }
+        ) { error in
+            XCTAssertTrue(error is XLColumnReadError, "Expected a decode failure, got \(error)")
+        }
+
+        // The pre-existing corrupt row is untouched (it was never part of
+        // this transaction); the in-transaction insert must not survive.
+        XCTAssertEqual(try freshRowIDs(), ["corrupt"])
+    }
+
+    func testUserThrownFailureRollsBackEarlierWritesAndPreservesTheOriginalError() throws {
+        try createTestTable()
+
+        XCTAssertThrowsError(
+            try database.withTransaction { scope in
+                try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+                throw UserError(reason: "caller decided to abort")
+            }
+        ) { error in
+            XCTAssertEqual(error as? UserError, UserError(reason: "caller decided to abort"))
+        }
+
+        XCTAssertEqual(try freshRows(), [])
+    }
+
+    // MARK: - Escaped scope
+
+    func testUsingTheScopeAfterTheBodyReturnsThrowsScopeEscaped() throws {
+        try createTestTable()
+
+        var escapedScope: GRDBDatabase?
+        try database.withTransaction { scope in
+            escapedScope = scope
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+        }
+
+        let scope = try XCTUnwrap(escapedScope)
+        XCTAssertThrowsError(
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "beta", value: 2))).execute()
+        ) { error in
+            XCTAssertEqual(error as? XLTransactionScopeError, .scopeEscaped)
+        }
+
+        // The committed write from inside the body is unaffected; only the
+        // escaped use fails.
+        XCTAssertEqual(try freshRows(), [TestTable(id: "alpha", value: 1)])
+    }
+
+    // MARK: - Live queries are rejected, not crashed, inside a transaction
+
+    func testPublishInsideATransactionFailsPredictablyInsteadOfObservingAnInvalidatedConnection() throws {
+        try createTestTable()
+
+        try database.withTransaction { scope in
+            let expectation = self.expectation(description: "publish fails")
+            var receivedError: Error?
+            let cancellable = scope.makeRequest(with: self.selectAllTestRowsQuery())
+                .publish()
+                .sink(
+                    receiveCompletion: { completion in
+                        if case .failure(let error) = completion {
+                            receivedError = error
+                        }
+                        expectation.fulfill()
+                    },
+                    receiveValue: { _ in }
+                )
+            self.wait(for: [expectation], timeout: 5)
+            cancellable.cancel()
+            XCTAssertEqual(
+                receivedError as? XLTransactionScopeError,
+                .liveQueriesUnsupportedInTransaction
+            )
+        }
+    }
+
+    // MARK: - Nesting and root-executor re-entry are rejected before any pool access
+
+    func testNestedWithTransactionOnTheScopeIsRejectedBeforeTouchingThePool() throws {
+        try createTestTable()
+
+        XCTAssertThrowsError(
+            try database.withTransaction { scope in
+                try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+                try scope.withTransaction { _ in }
+            }
+        ) { error in
+            XCTAssertEqual(error as? XLTransactionScopeError, .nestedTransactionUnsupported)
+        }
+
+        XCTAssertEqual(try freshRows(), [], "The outer body's write must roll back too.")
+    }
+
+    /// The dangerous case: `body` captures and calls back into the
+    /// *original, unpinned* `database` value instead of the `scope` it was
+    /// given — for example, by using the database-level convenience executor
+    /// sugar the `@SQLQueries` macro generates over `execute`/
+    /// `withTransaction`. Without the thread-scoped tracker in
+    /// `GRDBDatabase.withTransaction`, this reaches GRDB's own reentrant-write
+    /// guard, which is an uncatchable `fatalError` — so this test is the
+    /// actual proof that root-executor re-entry is rejected, not merely that
+    /// nesting on the scope value is.
+    func testRootExecutorReentryThroughTheCapturedDatabaseIsRejectedBeforeTouchingThePool() throws {
+        try createTestTable()
+
+        XCTAssertThrowsError(
+            try database.withTransaction { scope in
+                try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+                // Deliberately re-enters through `self.database`, not `scope`.
+                _ = try self.database.fetchTransactionScopeRowByID(id: "alpha")
+            }
+        ) { error in
+            XCTAssertEqual(error as? XLTransactionScopeError, .nestedTransactionUnsupported)
+        }
+
+        XCTAssertEqual(try freshRows(), [], "The outer body's write must roll back too.")
+    }
+
+    // MARK: - Cancellation
+
+    func testWithTransactionThrowsCancellationErrorWhenTheTaskIsAlreadyCancelledBeforeStarting() async throws {
+        try createTestTable()
+
+        let task = Task {
+            try self.database.withTransaction { scope in
+                try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+            }
+        }
+        task.cancel()
+
+        do {
+            try await task.value
+            XCTFail("Expected CancellationError")
+        }
+        catch is CancellationError {
+            // Expected.
+        }
+
+        XCTAssertEqual(try freshRows(), [])
+    }
+
+    // MARK: - Concurrency: independent transactions and pool isolation
+
+    func testConcurrentIndependentTransactionsBothCommitWithoutCorruptingEachOther() throws {
+        try createTestTable()
+
+        let group = DispatchGroup()
+        var firstError: Error?
+        var secondError: Error?
+
+        group.enter()
+        DispatchQueue.global().async {
+            do {
+                try self.database.withTransaction { scope in
+                    try scope.makeRequest(with: sqlInsert(TestTable(id: "first", value: 1))).execute()
+                }
+            }
+            catch {
+                firstError = error
+            }
+            group.leave()
+        }
+
+        group.enter()
+        DispatchQueue.global().async {
+            do {
+                try self.database.withTransaction { scope in
+                    try scope.makeRequest(with: sqlInsert(TestTable(id: "second", value: 2))).execute()
+                }
+            }
+            catch {
+                secondError = error
+            }
+            group.leave()
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + 10), .success)
+        XCTAssertNil(firstError)
+        XCTAssertNil(secondError)
+        XCTAssertEqual(try freshRows().map(\.id).sorted(), ["first", "second"])
+    }
+
+    /// Instrumented proof of one pinned connection and one transaction
+    /// boundary: while a transaction body is paused after an uncommitted
+    /// write, a concurrent one-shot read through the ordinary pool-backed
+    /// request path must not observe that write. Regular `DatabasePool`
+    /// readers only ever see committed state; observing the write here would
+    /// mean the "transaction" was not really pinned to one isolated
+    /// connection (or had already committed early).
+    func testConcurrentPoolReadDuringAnOpenTransactionDoesNotObserveTheUncommittedWrite() throws {
+        try createTestTable()
+
+        let writeIsVisible = DispatchSemaphore(value: 0)
+        let readIsDone = DispatchSemaphore(value: 0)
+        var observedDuringTransaction: [TestTable] = []
+
+        let readerQueue = DispatchQueue(label: "transaction-scope-concurrent-reader")
+        readerQueue.async {
+            writeIsVisible.wait()
+            observedDuringTransaction = (try? self.database.makeRequest(
+                with: self.selectAllTestRowsQuery()
+            ).fetchAll()) ?? []
+            readIsDone.signal()
+        }
+
+        try database.withTransaction { scope in
+            try scope.makeRequest(with: sqlInsert(TestTable(id: "alpha", value: 1))).execute()
+            writeIsVisible.signal()
+            XCTAssertEqual(readIsDone.wait(timeout: .now() + 10), .success)
+        }
+
+        XCTAssertEqual(
+            observedDuringTransaction,
+            [],
+            "A concurrent pool reader must not see an uncommitted write from a pinned transaction."
+        )
+        XCTAssertEqual(try freshRows(), [TestTable(id: "alpha", value: 1)])
+    }
+}


### PR DESCRIPTION
Closes #284.

**Stacked on #381 (`claude/18-26-sqlquery-declaration-macro`).** Depends on #18/#26 per the issue text. Until #381 merges into `version/1.5.1`, this diff also shows its commits. Merge order: **#381 → #284**.

## Summary

`XLTransactionalDatabase.withTransaction<Result>(_ body: (Self) throws -> Result) throws -> Result` — a plain synchronous closure, not a macro or result-builder. `body` receives another `GRDBDatabase` pinned to one connection for the scope's duration, so it composes with existing `makeRequest(with:)` calls and an `@SQLQueries` extension's `Context` unchanged. Documented as a non-macro v1 compatibility API, no Swift 6 gating needed.

`@SQLQueries`'s generated `execute(_:)` (previously a stub calling the closure directly against `self`) now calls `withTransaction(_:)` internally.

## Correctness

- Real GRDB `databasePool.write` transaction (BEGIN/COMMIT/ROLLBACK) with a pinned connection box invalidated the instant the body returns.
- **Nested transactions/savepoints**: always rejected before any pool access (`XLTransactionScopeError.nestedTransactionUnsupported`). GRDB's reentrant-write guard is an uncatchable `fatalError`, and a value-level pinned check alone misses a body that calls back through the *original* unpinned database (returns stale committed state instead of crashing) — a thread-scoped `GRDBTransactionScopeTracker` closes both gaps.
- **Mid-transaction cancellation**: checked once before the transaction opens; the synchronous body has no later cooperative cancellation point.
- Both match #253's `SQLiteTransactionConformanceFixtures` capability table already recorded at the driver level (blocked on v2 #113).
- **Render-once cache fix**: a pinned scope gets a fresh `databaseIdentifier` rather than reusing the root database's, so a declared-query render-once cache entry can't bind across transaction/pool boundaries (would otherwise let a cached request silently re-enter the pool driver, or hand a later call a request bound to an already-invalidated connection).

## Changes

- `Sources/SwiftQL/SQLTransactionScope.swift` (new).
- `Sources/SwiftQL/GRDBDatabaseDriver.swift` — pinned driver mode, `GRDBPinnedConnectionBox`, `GRDBTransactionScopeTracker`.
- `Sources/SwiftQL/GRDBSQLDatabase.swift` — `withTransaction`, pinned-copy init.
- `Sources/SQLMacros/SQLQueriesMacro.swift` — `execute(_:)` codegen calls `withTransaction`.
- `Sources/SwiftQL/SwiftQL.docc/GettingStarted.md`, `DeclaredQueries.md`, `CHANGELOG.md`.

## Tests

`Tests/SQLTests/SQLTransactionScopeTests.swift` (new, 21 tests) — state-oracle atomicity tests (fresh-`DatabasePool`-per-assertion commit/rollback verification from a clean read boundary), concurrent-pool-read isolation, root-executor-reentry proof.

`swift test --filter 'SQLDriverContractTests|SQLiteTransactionInvariantGRDBTests|GRDBDriverContractTests'` — 27/27 pass (existing suite, unchanged). Full `swift test`: **828/828 pass**.

## Deferred (by design, matching #253's precedent)

Nested transactions, savepoints, mid-transaction cancellation — explicitly rejected with clear diagnostics rather than half-implemented, tracked under v2 #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)