### PR TITLE
Add a versioned SQLite build-validation manifest for static query descriptors (#292)

### DIFF
--- a/Documentation/Architecture/SQLiteBuildValidation.md
+++ b/Documentation/Architecture/SQLiteBuildValidation.md
@@ -406,7 +406,10 @@ Three atomic v1.5 follow-ups are recommended:
    query descriptors.**](https://github.com/lukevanin/swiftql/issues/292)
    Specify versioned canonical JSON, query/descriptor identity,
    parameter/result/codec layout, schema identity, capabilities, and #190/#191
-   references. No database I/O, macro implementation, or query-identity change.
+   references. No database I/O, macro implementation, or query-identity
+   change. Delivered as `SwiftQLSQLiteBuildValidationManifest`; see
+   [SQLiteBuildValidationManifest.md](SQLiteBuildValidationManifest.md) for
+   the schema, determinism, and registry-resolution contract.
 2. [**#293: Ship a standalone SQLite static-query build
    validator.**](https://github.com/lukevanin/swiftql/issues/293) Consume the
    manifest and snapshot, own a read-only connection, call

--- a/Documentation/Architecture/SQLiteBuildValidationManifest.md
+++ b/Documentation/Architecture/SQLiteBuildValidationManifest.md
@@ -1,0 +1,139 @@
+# SQLite Build-Validation Manifest (#292)
+
+This is the versioned, deterministic sidecar contract recommended by the
+[#132 research](SQLiteBuildValidation.md) and produced by
+[#292](https://github.com/lukevanin/swiftql/issues/292). It is the input the
+standalone validator ([#293](https://github.com/lukevanin/swiftql/issues/293))
+and its SwiftPM build-tool plugin wrapper
+([#294](https://github.com/lukevanin/swiftql/issues/294)) consume. This module
+performs no SQLite database I/O, ships no build-tool plugin, and does not
+change the frozen `XLQueryIdentity` v1 representation or make
+`XLStaticQueryDescriptor` wholesale `Codable`.
+
+## Package surface
+
+`SwiftQLSQLiteBuildValidationManifest` (`Sources/SwiftQLSQLiteBuildValidationManifest`)
+is a regular library target depending only on `SwiftQLCore`. It intentionally
+does not depend on the test-only targets that own the #190 inventory, #191
+combinatorial cases, or #254 Northwind fixture (`SwiftQLSQLiteConformanceFixtures`,
+`SwiftQLSQLiteCombinatorialSupport`, `SwiftQLNorthwindFixtures`); a regular
+SwiftPM target cannot depend on a `.testTarget`, and this codebase's existing
+targets already follow that boundary (see `SwiftQLSQLiteBuildValidationPrototype`,
+which likewise avoids depending on them).
+
+## Schema
+
+`SQLiteBuildValidationManifest` (`format_version: 1`) carries:
+
+- `format_version` — the frozen manifest schema version (see below).
+- `conformance_inventory_version` — the #190 `inventory_version` the manifest
+  was authored against.
+- `combinatorial_manifest_version` — the #191 `generator_version` the manifest
+  was authored against.
+- `schema_snapshot` — the pinned checked-in SQLite database identity (SHA-256,
+  byte count, schema row count, schema fingerprint). Byte identity is
+  authoritative; the fingerprint is exact runtime provenance evidence (it
+  includes root pages and raw schema SQL) and is not a semantic migration or
+  catalog fingerprint.
+- `queries` — one `SQLiteBuildValidationQueryEntry` per static query,
+  canonically sorted by `id`.
+
+Each query entry records exact UTF-8 SQL, dialect identifier/minimum
+version/capabilities, cardinality, canonically ordered parameter and result
+entries (logical index, physical SQLite bind position, value type,
+nullability, storage identifier, optional codec identity, and — for results —
+a declared `AS` alias where one exists), required engine capabilities, and
+cross-references into #190 (`conformance_feature_ids`), #191
+(`conformance_case_ids`), and #254 (`northwind_anchor_case_ids`).
+
+`XLStaticQueryDescriptor` fields remain authoritative where they overlap. The
+manifest only adds fields the frozen `XLQueryIdentity` v1 identity
+deliberately excludes: physical placeholder positions (recovered by scanning
+the rendered SQL, since SwiftQL emits only `:name` and one-based `?N`),
+declared result aliases, pinned schema-snapshot identity, and the #190/#191/
+#254 cross-references.
+
+## Determinism and canonical JSON
+
+Canonical JSON is `[.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]`
+with exactly one trailing newline. Every set-like field (`conformance_feature_ids`,
+`conformance_case_ids`, `northwind_anchor_case_ids`, `required_capabilities`)
+is deduplicated and sorted at construction time, and `queries` is sorted by
+`id` at construction time — so two manifests built from the same content in a
+different order encode to byte-identical bytes. The schema has no timestamp,
+hostname, process ID, local path, or elapsed-time field anywhere; determinism
+is structural, not something callers must remember to exclude.
+
+## Validation is two separate, composable steps
+
+1. **`validating()`** — structural, registry-independent. Fails closed on: an
+   unsupported `format_version`; an empty inventory/manifest version; an
+   invalid schema snapshot (empty identifier, non-positive byte/row counts,
+   malformed SHA-256/fingerprint hex); a duplicate query id; noncontiguous or
+   physically-colliding parameter slots; a malformed indexed-parameter key;
+   and incomplete codec metadata. `SQLiteBuildValidationManifest.decode(_:)`
+   calls this automatically.
+2. **`validating(against:)`** — exhaustive reference resolution. Every
+   `conformance_feature_id`, `conformance_case_id`, and
+   `northwind_anchor_case_id` in every query must resolve against an injected
+   `SQLiteBuildValidationReferenceRegistry`; an unresolved reference throws
+   `.unresolvedReference` and fails closed.
+
+These are separate because registry membership is external data (the #190/
+#191/#254 JSON/enum sources), not part of the manifest's own bytes — decoding
+a manifest cannot, by itself, know whether an ID it references still exists.
+Treat a manifest as trustworthy input to the validator (#293) only after both
+steps succeed.
+
+### Wiring the real registries
+
+`SQLiteBuildValidationReferenceRegistry` is a protocol so the manifest module
+never depends on the concrete #190/#191/#254 sources. A caller that has loaded
+them (typically a test target, or eventually the standalone validator) wires:
+
+```swift
+let registry = SQLiteBuildValidationStaticReferenceRegistry(
+    conformanceFeatureIDs: Set(try SQLiteConformanceInventory.load().features.map(\.id)),
+    conformanceCaseIDs: Set(try SQLiteCombinatorialSuite.makeManifest().cases.map(\.id)),
+    northwindAnchorCaseIDs: Set(SQLiteNorthwindConformanceCaseID.allCases.map(\.rawValue))
+)
+try manifest.validating(against: registry)
+```
+
+This does not mint a parallel inventory: the registry only reports whether an
+ID appears in the canonical sources it was constructed from; it never curates
+or duplicates the ID lists themselves.
+
+## Versioning and upgrade policy
+
+`format_version: 1` is frozen, mirroring the `XLQueryIdentity` v1 policy this
+sidecar was designed to complement: field inclusion, field ordering, canonical
+JSON normalization, and the reference-kind vocabulary (`conformance_feature`,
+`conformance_case`, `northwind_anchor`) cannot change under version 1. A
+backward-incompatible schema change requires a new `format_version`.
+`SQLiteBuildValidationManifest.decode(_:)` rejects any format version other
+than `.current` — an unrecognized version fails closed rather than attempting
+best-effort compatibility.
+
+`conformance_inventory_version` and `combinatorial_manifest_version` are not
+manifest-schema versions; they record which #190/#191 snapshot a manifest was
+authored against, purely as provenance. A manifest referencing an older
+inventory/combinatorial version than what a validator's registry was built
+from is still structurally valid — `validating(against:)` only requires that
+the specific referenced IDs still resolve, not that the versions match
+exactly. Producers that want stricter drift detection can compare these
+fields themselves.
+
+## What this does not do
+
+Per the #132 research decision (§16-17), this module owns only the "freeze the
+sidecar manifest schema and deterministic serialization without database I/O"
+step. It does not:
+
+- open a SQLite connection, prepare a statement, or otherwise perform database
+  I/O (owned by #293);
+- provide a build-tool plugin or declare SwiftPM build-command inputs/outputs
+  (owned by #294);
+- implement or lower the `@SQLQuery` macro (owned by #26); or
+- change `XLQueryIdentity` v1, make `XLStaticQueryDescriptor` wholesale
+  `Codable`, or mint a competing #190/#191/#254 inventory.

--- a/IntegrationTests/Swift5Client/Package.swift
+++ b/IntegrationTests/Swift5Client/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftQLCore", package: "SwiftQL"),
                 .product(name: "SwiftQL", package: "SwiftQL"),
+                .product(name: "SwiftQLSQLiteBuildValidationManifest", package: "SwiftQL"),
             ]
         ),
     ],

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftQL
 import SwiftQLCore
+import SwiftQLSQLiteBuildValidationManifest
 
 #if compiler(<6.0)
 #error("The downstream compatibility fixture must use the supported Swift 6 compiler.")
@@ -350,10 +351,94 @@ private func executeFixture(
     return try request.fetchOne()
 }
 
+private func validateBuildValidationManifestFixture() throws {
+    let statement = XLStaticStatementDefinition(
+        sql: "SELECT :id AS id",
+        dialectRequirement: XLDialectRequirement(
+            identity: XLSQLiteDialect.identity,
+            capabilities: [.namedBindings]
+        ),
+        parameterLayout: try XLParameterLayout(slots: [
+            XLParameterSlot(
+                index: XLLogicalParameterIndex(0),
+                key: .named("id"),
+                valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.string"),
+                valueTypeName: "Swift.String",
+                nullability: .required,
+                codecIdentity: nil,
+                codingContext: XLValueCodingContext(
+                    site: .parameter,
+                    path: XLValueCodingPath(["parameter", "id"])
+                )
+            )
+        ])
+    )
+    let descriptor = try XLStaticQueryDescriptor(
+        definitionIdentity: XLQueryDefinitionIdentity(
+            path: ["downstream", "manifest-fixture"],
+            version: 1
+        ),
+        statement: statement,
+        parameters: [
+            XLStaticQueryParameterMetadata(
+                identity: try XLQuerySlotIdentity(path: ["parameter", "id"]),
+                slot: statement.parameterLayout.slot(
+                    at: XLLogicalParameterIndex(0)
+                )!,
+                storageIdentifier: XLValueStorageIdentifier(rawValue: "text")
+            )
+        ],
+        results: try XLStaticQueryResultMetadata(slots: [
+            XLStaticQueryResultSlot(
+                index: XLLogicalResultIndex(0),
+                identity: try XLQuerySlotIdentity(path: ["result", "id"]),
+                valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.string"),
+                valueTypeName: "Swift.String",
+                nullability: .required,
+                codecIdentity: nil,
+                storageIdentifier: XLValueStorageIdentifier(rawValue: "text"),
+                codingContext: XLValueCodingContext(
+                    site: .result,
+                    path: XLValueCodingPath(["result", "id"])
+                )
+            )
+        ]),
+        cardinality: .exactlyOne
+    )
+
+    let query = try SQLiteBuildValidationQueryEntry(
+        id: "downstream.manifest-fixture",
+        descriptor: descriptor,
+        declaredAliases: ["id"]
+    )
+    let manifest = SQLiteBuildValidationManifest(
+        conformanceInventoryVersion: "downstream-fixture",
+        combinatorialManifestVersion: "downstream-fixture",
+        schemaSnapshot: SQLiteBuildValidationSchemaSnapshot(
+            identifier: "downstream-fixture",
+            databaseSHA256: String(repeating: "a", count: 64),
+            databaseByteCount: 1,
+            schemaRowCount: 1,
+            schemaFingerprint: String(repeating: "b", count: 16)
+        ),
+        queries: [query]
+    )
+
+    let validated = try manifest.validating()
+    let data = try validated.canonicalJSONData()
+    let roundTripped = try SQLiteBuildValidationManifest.decode(data)
+    guard roundTripped == validated,
+          try roundTripped.canonicalJSONData() == data
+    else {
+        throw FixtureError.invalidCoreContract
+    }
+}
+
 private func runFixture() throws {
     try validateLiteralReaderCompatibility()
     try validateRowReaderCompatibility()
     try validateSeparatorCompatibility()
+    try validateBuildValidationManifestFixture()
     let codingConfiguration = try validateCoreContractProduct()
 
     let directory = FileManager.default.temporaryDirectory

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -373,6 +373,11 @@ private func validateBuildValidationManifestFixture() throws {
             )
         ])
     )
+    guard let idParameterSlot = statement.parameterLayout.slot(
+        at: XLLogicalParameterIndex(0)
+    ) else {
+        throw FixtureError.invalidCoreContract
+    }
     let descriptor = try XLStaticQueryDescriptor(
         definitionIdentity: XLQueryDefinitionIdentity(
             path: ["downstream", "manifest-fixture"],
@@ -382,9 +387,7 @@ private func validateBuildValidationManifestFixture() throws {
         parameters: [
             XLStaticQueryParameterMetadata(
                 identity: try XLQuerySlotIdentity(path: ["parameter", "id"]),
-                slot: statement.parameterLayout.slot(
-                    at: XLLogicalParameterIndex(0)
-                )!,
+                slot: idParameterSlot,
                 storageIdentifier: XLValueStorageIdentifier(rawValue: "text")
             )
         ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,10 @@ let package = Package(
             name: "SwiftQL",
             targets: ["SwiftQL"]
         ),
+        .library(
+            name: "SwiftQLSQLiteBuildValidationManifest",
+            targets: ["SwiftQLSQLiteBuildValidationManifest"]
+        ),
         .executable(
             name: "swiftql-benchmark",
             targets: ["SwiftQLBenchmarkCLI"]
@@ -110,6 +114,16 @@ let package = Package(
             path: "Benchmarks/Sources/SwiftQLBenchmarkCLI"
         ),
 
+        // Versioned, deterministic sidecar manifest for static SwiftQL query
+        // descriptors (#292). No SQLite I/O, no macro/plugin logic. #190/#191/
+        // #254 reference resolution is injected via
+        // SQLiteBuildValidationReferenceRegistry rather than depending on
+        // their test-only targets.
+        .target(
+            name: "SwiftQLSQLiteBuildValidationManifest",
+            dependencies: ["SwiftQLCore"]
+        ),
+
         // Package-private research engine for issue #132. This deliberately
         // remains outside the package's public products while the descriptor
         // sidecar and build lifecycle are being evaluated.
@@ -200,6 +214,19 @@ let package = Package(
             name: "SwiftQLBenchmarkTests",
             dependencies: ["SwiftQLBenchmarks"],
             path: "Benchmarks/Tests/SwiftQLBenchmarkTests"
+        ),
+
+        .testTarget(
+            name: "SwiftQLSQLiteBuildValidationManifestTests",
+            dependencies: [
+                "SwiftQLCore",
+                "SwiftQL",
+                "SwiftQLSQLiteBuildValidationManifest",
+                "SwiftQLSQLiteConformanceFixtures",
+                "SwiftQLSQLiteCombinatorialSupport",
+                "SwiftQLNorthwindFixtures",
+                .product(name: "GRDB", package: "GRDB.swift"),
+            ]
         ),
 
         .testTarget(

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftQLCore
 
 
 /// A versioned, deterministic sidecar for static SwiftQL query descriptors.
@@ -113,7 +114,7 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
     /// `northwind_anchor_case_id` in every query must resolve; an unresolved
     /// reference fails closed rather than passing silently.
     public func validating(
-        against registry: some SQLiteBuildValidationReferenceRegistry
+        against registry: any SQLiteBuildValidationReferenceRegistry
     ) throws -> Self {
         let validated = try validating()
         for query in validated.queries {
@@ -165,6 +166,12 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
             throw SQLiteBuildValidationManifestError.invalidQuery(
                 query.id,
                 "query identities and SQL must not be empty"
+            )
+        }
+        guard XLQueryCardinality(rawValue: query.cardinality) != nil else {
+            throw SQLiteBuildValidationManifestError.invalidQuery(
+                query.id,
+                "cardinality \(query.cardinality) is not a recognized XLQueryCardinality raw value"
             )
         }
         guard !query.conformanceFeatureIDs.contains(where: \.isEmpty),

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
@@ -160,10 +160,11 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
         guard !query.id.isEmpty,
               !query.definitionIdentity.isEmpty,
               !query.descriptorIdentity.isEmpty,
-              !query.dialectIdentifier.isEmpty else {
+              !query.dialectIdentifier.isEmpty,
+              !query.sql.isEmpty else {
             throw SQLiteBuildValidationManifestError.invalidQuery(
                 query.id,
-                "query and descriptor identities must not be empty"
+                "query identities and SQL must not be empty"
             )
         }
         guard !query.conformanceFeatureIDs.contains(where: \.isEmpty),
@@ -254,7 +255,7 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
 
     private static func isLowercaseHex(_ value: String, count: Int) -> Bool {
         value.count == count && value.allSatisfy {
-            $0.isNumber || ("a" ... "f").contains($0)
+            ("0" ... "9").contains($0) || ("a" ... "f").contains($0)
         }
     }
 

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
@@ -242,6 +242,7 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
                 "logical parameters must not share a physical SQLite slot"
             )
         }
+        try validatePlaceholders(for: query)
 
         for (offset, result) in query.results.enumerated() {
             guard result.index == offset,
@@ -257,6 +258,41 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
             }
             try validateNullability(result.nullability, queryID: query.id)
             try validateCodec(result.codec, queryID: query.id)
+        }
+    }
+
+    /// Cross-checks declared parameter metadata against the placeholders
+    /// actually present in `query.sql`. This is the check the `init(id:
+    /// descriptor:...)` projection satisfies by construction (it derives
+    /// physical indices from the same scanner) but that an externally
+    /// authored or hand-edited manifest — decoded straight from JSON — is
+    /// not otherwise forced to satisfy. Without it, a manifest could declare
+    /// a parameter absent from its own SQL, omit one the SQL actually uses,
+    /// or assign it a physical index SQLite's first-encounter placeholder
+    /// ordering would not produce, and still pass structural validation.
+    private static func validatePlaceholders(
+        for query: SQLiteBuildValidationQueryEntry
+    ) throws {
+        let placeholders = SQLiteBuildValidationManifestPlaceholderScanner.scan(
+            query.sql
+        )
+        let scannedPhysicalIndices = Set(placeholders.occurrences.map(\.physicalIndex))
+        let declaredPhysicalIndices = Set(query.parameters.map(\.physicalIndex))
+        guard scannedPhysicalIndices == declaredPhysicalIndices else {
+            throw SQLiteBuildValidationManifestError.invalidQuery(
+                query.id,
+                "declared parameter physical indices \(declaredPhysicalIndices.sorted()) do not match the placeholders found in SQL \(scannedPhysicalIndices.sorted())"
+            )
+        }
+        for parameter in query.parameters {
+            guard let occurrence = placeholders.occurrences.first(where: {
+                $0.physicalIndex == parameter.physicalIndex
+            }), occurrence.spelling == parameter.expectedSQLiteSpelling else {
+                throw SQLiteBuildValidationManifestError.invalidQuery(
+                    query.id,
+                    "parameter at physical index \(parameter.physicalIndex) declares spelling '\(parameter.expectedSQLiteSpelling)', which does not match its placeholder occurrence in SQL"
+                )
+            }
         }
     }
 

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
@@ -1,0 +1,275 @@
+import Foundation
+
+
+/// A versioned, deterministic sidecar for static SwiftQL query descriptors.
+///
+/// The manifest fills reproducible-build fields that intentionally do not
+/// belong in the frozen `XLQueryIdentity` v1 representation: physical
+/// placeholder positions, declared result aliases, pinned schema-snapshot
+/// identity, and cross-references into the #190 conformance inventory, #191
+/// combinatorial cases, and #254 Northwind anchors. Descriptor fields remain
+/// authoritative; this is a sidecar, not a second structural query model, and
+/// it performs no SQLite database I/O — that is the standalone validator's
+/// responsibility (#293).
+public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
+
+    public let formatVersion: SQLiteBuildValidationManifestFormatVersion
+    public let conformanceInventoryVersion: String
+    public let combinatorialManifestVersion: String
+    public let schemaSnapshot: SQLiteBuildValidationSchemaSnapshot
+    public let queries: [SQLiteBuildValidationQueryEntry]
+
+    public init(
+        formatVersion: SQLiteBuildValidationManifestFormatVersion = .current,
+        conformanceInventoryVersion: String,
+        combinatorialManifestVersion: String,
+        schemaSnapshot: SQLiteBuildValidationSchemaSnapshot,
+        queries: [SQLiteBuildValidationQueryEntry]
+    ) {
+        self.formatVersion = formatVersion
+        self.conformanceInventoryVersion = conformanceInventoryVersion
+        self.combinatorialManifestVersion = combinatorialManifestVersion
+        self.schemaSnapshot = schemaSnapshot
+        self.queries = queries.map { $0.normalized() }.sorted { $0.id < $1.id }
+    }
+
+    /// Decodes and structurally validates a manifest. Reference resolution
+    /// against #190/#191/#254 is a separate step; see
+    /// ``validating(against:)``.
+    public static func decode(_ data: Data) throws -> Self {
+        try JSONDecoder().decode(Self.self, from: data).validating()
+    }
+
+    public static func decode(contentsOf url: URL) throws -> Self {
+        try decode(Data(contentsOf: url))
+    }
+
+    /// Structural, registry-independent validation.
+    ///
+    /// Fails closed on an unsupported format version, empty inventory
+    /// versions, an invalid schema snapshot, duplicate query ids, malformed
+    /// physical parameter slots, and incomplete codec metadata. This alone
+    /// cannot detect an unresolved #190/#191/#254 reference, since resolving
+    /// one requires external registry data not present in the manifest bytes.
+    public func validating() throws -> Self {
+        guard formatVersion == .current else {
+            throw SQLiteBuildValidationManifestError.unsupportedFormatVersion(
+                formatVersion
+            )
+        }
+        guard !conformanceInventoryVersion.isEmpty else {
+            throw SQLiteBuildValidationManifestError.invalidManifest(
+                "conformance_inventory_version must not be empty"
+            )
+        }
+        guard !combinatorialManifestVersion.isEmpty else {
+            throw SQLiteBuildValidationManifestError.invalidManifest(
+                "combinatorial_manifest_version must not be empty"
+            )
+        }
+        guard !queries.isEmpty else {
+            throw SQLiteBuildValidationManifestError.invalidManifest(
+                "queries must not be empty"
+            )
+        }
+        guard !schemaSnapshot.identifier.isEmpty,
+              schemaSnapshot.databaseByteCount > 0,
+              schemaSnapshot.schemaRowCount > 0,
+              Self.isLowercaseHex(schemaSnapshot.databaseSHA256, count: 64),
+              Self.isLowercaseHex(schemaSnapshot.schemaFingerprint, count: 16) else {
+            throw SQLiteBuildValidationManifestError.invalidManifest(
+                "schema snapshot identifier, byte count, row count, SHA-256, and fingerprint are required"
+            )
+        }
+
+        let duplicateQueryID = Dictionary(grouping: queries, by: \.id)
+            .first { $0.value.count > 1 }?.key
+        if let duplicateQueryID {
+            throw SQLiteBuildValidationManifestError.duplicateQueryID(duplicateQueryID)
+        }
+        for query in queries {
+            try Self.validateStructure(query)
+        }
+        return Self(
+            formatVersion: formatVersion,
+            conformanceInventoryVersion: conformanceInventoryVersion,
+            combinatorialManifestVersion: combinatorialManifestVersion,
+            schemaSnapshot: schemaSnapshot,
+            queries: queries
+        )
+    }
+
+    /// Exhaustive reference resolution against the real #190/#191/#254
+    /// registries, in addition to structural validation.
+    ///
+    /// Every `conformance_feature_id`, `conformance_case_id`, and
+    /// `northwind_anchor_case_id` in every query must resolve; an unresolved
+    /// reference fails closed rather than passing silently.
+    public func validating(
+        against registry: some SQLiteBuildValidationReferenceRegistry
+    ) throws -> Self {
+        let validated = try validating()
+        for query in validated.queries {
+            for featureID in query.conformanceFeatureIDs
+            where !registry.resolvesConformanceFeatureID(featureID) {
+                throw SQLiteBuildValidationManifestError.unresolvedReference(
+                    queryID: query.id,
+                    kind: .conformanceFeature,
+                    id: featureID
+                )
+            }
+            for caseID in query.conformanceCaseIDs
+            where !registry.resolvesConformanceCaseID(caseID) {
+                throw SQLiteBuildValidationManifestError.unresolvedReference(
+                    queryID: query.id,
+                    kind: .conformanceCase,
+                    id: caseID
+                )
+            }
+            for anchorID in query.northwindAnchorCaseIDs
+            where !registry.resolvesNorthwindAnchorCaseID(anchorID) {
+                throw SQLiteBuildValidationManifestError.unresolvedReference(
+                    queryID: query.id,
+                    kind: .northwindAnchor,
+                    id: anchorID
+                )
+            }
+        }
+        return validated
+    }
+
+    /// Canonical JSON: pretty-printed, sorted keys, exactly one trailing
+    /// newline. Set-like fields and the query list are sorted at construction
+    /// time, so two manifests with the same reordered content encode to
+    /// byte-identical output. No timestamp, hostname, process ID, local path,
+    /// or elapsed-time field exists anywhere in this schema.
+    public func canonicalJSONData() throws -> Data {
+        try SQLiteBuildValidationManifestCanonicalJSON.encode(validating())
+    }
+
+    private static func validateStructure(
+        _ query: SQLiteBuildValidationQueryEntry
+    ) throws {
+        guard !query.id.isEmpty,
+              !query.definitionIdentity.isEmpty,
+              !query.descriptorIdentity.isEmpty,
+              !query.dialectIdentifier.isEmpty else {
+            throw SQLiteBuildValidationManifestError.invalidQuery(
+                query.id,
+                "query and descriptor identities must not be empty"
+            )
+        }
+        guard !query.conformanceFeatureIDs.contains(where: \.isEmpty),
+              !query.conformanceCaseIDs.contains(where: \.isEmpty),
+              !query.northwindAnchorCaseIDs.contains(where: \.isEmpty),
+              !query.requiredCapabilities.contains(where: { $0.id.isEmpty }) else {
+            throw SQLiteBuildValidationManifestError.invalidQuery(
+                query.id,
+                "reference and capability identifiers must not be empty"
+            )
+        }
+
+        for (offset, parameter) in query.parameters.enumerated() {
+            guard parameter.logicalIndex == offset,
+                  parameter.physicalIndex > 0,
+                  !parameter.identity.isEmpty,
+                  !parameter.valueTypeIdentifier.isEmpty,
+                  !parameter.valueTypeName.isEmpty,
+                  !parameter.storageIdentifier.isEmpty else {
+                throw SQLiteBuildValidationManifestError.invalidQuery(
+                    query.id,
+                    "parameter metadata must be contiguous and complete"
+                )
+            }
+            switch parameter.keyKind {
+            case .named:
+                guard let name = parameter.keyName, !name.isEmpty,
+                      parameter.keyIndex == nil else {
+                    throw SQLiteBuildValidationManifestError.invalidQuery(
+                        query.id,
+                        "named parameters require key_name and no key_index"
+                    )
+                }
+            case .indexed:
+                guard parameter.keyName == nil,
+                      let index = parameter.keyIndex,
+                      index >= 0,
+                      parameter.physicalIndex == index + 1 else {
+                    throw SQLiteBuildValidationManifestError.invalidQuery(
+                        query.id,
+                        "indexed parameters require a nonnegative key_index matching physical_index"
+                    )
+                }
+            }
+            try validateCodec(parameter.codec, queryID: query.id)
+        }
+        guard Set(query.parameters.map(\.physicalIndex)).count
+                == query.parameters.count else {
+            throw SQLiteBuildValidationManifestError.invalidQuery(
+                query.id,
+                "logical parameters must not share a physical SQLite slot"
+            )
+        }
+
+        for (offset, result) in query.results.enumerated() {
+            guard result.index == offset,
+                  !result.identity.isEmpty,
+                  !result.valueTypeIdentifier.isEmpty,
+                  !result.valueTypeName.isEmpty,
+                  !result.storageIdentifier.isEmpty,
+                  result.declaredAlias?.isEmpty != true else {
+                throw SQLiteBuildValidationManifestError.invalidQuery(
+                    query.id,
+                    "result metadata must be contiguous and complete"
+                )
+            }
+            try validateCodec(result.codec, queryID: query.id)
+        }
+    }
+
+    private static func validateCodec(
+        _ codec: SQLiteBuildValidationCodecReference?,
+        queryID: String
+    ) throws {
+        guard let codec else {
+            return
+        }
+        guard !codec.keyID.isEmpty,
+              !codec.valueTypeIdentifier.isEmpty,
+              !codec.dialectIdentifier.isEmpty,
+              !codec.storageIdentifier.isEmpty else {
+            throw SQLiteBuildValidationManifestError.invalidQuery(
+                queryID,
+                "codec metadata must be complete"
+            )
+        }
+    }
+
+    private static func isLowercaseHex(_ value: String, count: Int) -> Bool {
+        value.count == count && value.allSatisfy {
+            $0.isNumber || ("a" ... "f").contains($0)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case formatVersion = "format_version"
+        case conformanceInventoryVersion = "conformance_inventory_version"
+        case combinatorialManifestVersion = "combinatorial_manifest_version"
+        case schemaSnapshot = "schema_snapshot"
+        case queries
+    }
+}
+
+
+enum SQLiteBuildValidationManifestCanonicalJSON {
+    static func encode<Value: Encodable>(_ value: Value) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(value)
+        while data.last == 0x0A {
+            data.removeLast()
+        }
+        data.append(0x0A)
+        return data
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
@@ -82,8 +82,15 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
             )
         }
 
+        // Dictionary iteration order is not stable across processes, so pick
+        // the lexicographically smallest duplicated id rather than `.first`
+        // over an unordered grouping — the reported id must not vary between
+        // runs of the same input.
         let duplicateQueryID = Dictionary(grouping: queries, by: \.id)
-            .first { $0.value.count > 1 }?.key
+            .filter { $0.value.count > 1 }
+            .keys
+            .sorted()
+            .first
         if let duplicateQueryID {
             throw SQLiteBuildValidationManifestError.duplicateQueryID(duplicateQueryID)
         }

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
@@ -168,11 +168,27 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
                 "query identities and SQL must not be empty"
             )
         }
-        guard XLQueryCardinality(rawValue: query.cardinality) != nil else {
+        guard let cardinality = XLQueryCardinality(rawValue: query.cardinality) else {
             throw SQLiteBuildValidationManifestError.invalidQuery(
                 query.id,
                 "cardinality \(query.cardinality) is not a recognized XLQueryCardinality raw value"
             )
+        }
+        switch cardinality {
+        case .command:
+            guard query.results.isEmpty else {
+                throw SQLiteBuildValidationManifestError.invalidQuery(
+                    query.id,
+                    "command cardinality must not declare result slots"
+                )
+            }
+        case .exactlyOne, .zeroOrOne, .many:
+            guard !query.results.isEmpty else {
+                throw SQLiteBuildValidationManifestError.invalidQuery(
+                    query.id,
+                    "row cardinality requires at least one result slot"
+                )
+            }
         }
         guard !query.conformanceFeatureIDs.contains(where: \.isEmpty),
               !query.conformanceCaseIDs.contains(where: \.isEmpty),
@@ -196,6 +212,7 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
                     "parameter metadata must be contiguous and complete"
                 )
             }
+            try validateNullability(parameter.nullability, queryID: query.id)
             switch parameter.keyKind {
             case .named:
                 guard let name = parameter.keyName, !name.isEmpty,
@@ -238,7 +255,20 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
                     "result metadata must be contiguous and complete"
                 )
             }
+            try validateNullability(result.nullability, queryID: query.id)
             try validateCodec(result.codec, queryID: query.id)
+        }
+    }
+
+    private static func validateNullability(
+        _ nullability: String,
+        queryID: String
+    ) throws {
+        guard XLParameterNullability(rawValue: nullability) != nil else {
+            throw SQLiteBuildValidationManifestError.invalidQuery(
+                queryID,
+                "nullability '\(nullability)' is not a recognized XLParameterNullability raw value"
+            )
         }
     }
 

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifest.swift
@@ -83,11 +83,27 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
             )
         }
 
+        // `Codable`'s synthesized initializer decodes each stored property
+        // directly and never calls the canonicalizing memberwise
+        // initializer below, so a manifest fresh off `JSONDecoder` may still
+        // have unsorted/undeduplicated queries, parameters, results, or
+        // id-set fields even though it is otherwise semantically valid.
+        // Re-normalize before running structural checks against it so a
+        // reordered-but-valid manifest doesn't spuriously fail contiguity
+        // checks that assume canonical ordering.
+        let normalizedQueries = Self(
+            formatVersion: formatVersion,
+            conformanceInventoryVersion: conformanceInventoryVersion,
+            combinatorialManifestVersion: combinatorialManifestVersion,
+            schemaSnapshot: schemaSnapshot,
+            queries: queries
+        ).queries
+
         // Dictionary iteration order is not stable across processes, so pick
         // the lexicographically smallest duplicated id rather than `.first`
         // over an unordered grouping — the reported id must not vary between
         // runs of the same input.
-        let duplicateQueryID = Dictionary(grouping: queries, by: \.id)
+        let duplicateQueryID = Dictionary(grouping: normalizedQueries, by: \.id)
             .filter { $0.value.count > 1 }
             .keys
             .sorted()
@@ -95,7 +111,7 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
         if let duplicateQueryID {
             throw SQLiteBuildValidationManifestError.duplicateQueryID(duplicateQueryID)
         }
-        for query in queries {
+        for query in normalizedQueries {
             try Self.validateStructure(query)
         }
         return Self(
@@ -103,7 +119,7 @@ public struct SQLiteBuildValidationManifest: Codable, Equatable, Sendable {
             conformanceInventoryVersion: conformanceInventoryVersion,
             combinatorialManifestVersion: combinatorialManifestVersion,
             schemaSnapshot: schemaSnapshot,
-            queries: queries
+            queries: normalizedQueries
         )
     }
 

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestError.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestError.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+
+/// Deterministic, fail-closed failures constructing or validating a manifest.
+public enum SQLiteBuildValidationManifestError:
+    Error,
+    Equatable,
+    Sendable,
+    CustomStringConvertible
+{
+
+    public enum ReferenceKind: String, Equatable, Sendable {
+        case conformanceFeature = "#190 conformance feature"
+        case conformanceCase = "#191 conformance case"
+        case northwindAnchor = "#254 Northwind anchor"
+    }
+
+    case unsupportedFormatVersion(SQLiteBuildValidationManifestFormatVersion)
+    case invalidManifest(String)
+    case duplicateQueryID(String)
+    case invalidQuery(String, String)
+    case resultAliasCountMismatch(queryID: String, expected: Int, actual: Int)
+    case unresolvedReference(queryID: String, kind: ReferenceKind, id: String)
+
+    public var description: String {
+        switch self {
+        case .unsupportedFormatVersion(let version):
+            return "Unsupported build-validation manifest format version \(version)."
+        case .invalidManifest(let reason):
+            return "Invalid build-validation manifest: \(reason)."
+        case .duplicateQueryID(let id):
+            return "Build-validation query id '\(id)' is duplicated."
+        case .invalidQuery(let id, let reason):
+            return "Invalid build-validation query '\(id)': \(reason)."
+        case .resultAliasCountMismatch(let queryID, let expected, let actual):
+            return "Build-validation query '\(queryID)' supplied \(actual) result aliases for \(expected) result slots."
+        case .unresolvedReference(let queryID, let kind, let id):
+            return "Build-validation query '\(queryID)' references unknown \(kind.rawValue) '\(id)'."
+        }
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestFormatVersion.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestFormatVersion.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+
+/// The version of SwiftQL's build-validation manifest sidecar schema.
+///
+/// Version 1 is frozen. Changing field inclusion, ordering, canonical JSON
+/// normalization, or the identifiers used for #190/#191/#254 reference
+/// resolution requires a new format version. Decoding an unrecognized version
+/// fails closed rather than guessing at compatibility.
+public struct SQLiteBuildValidationManifestFormatVersion:
+    RawRepresentable,
+    Hashable,
+    Sendable,
+    CustomStringConvertible,
+    Codable
+{
+
+    public static let v1 = Self(rawValue: 1)
+
+    public static let current = Self.v1
+
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String {
+        String(rawValue)
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestModels.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestModels.swift
@@ -1,0 +1,464 @@
+import Foundation
+import SwiftQLCore
+
+
+/// The pinned, checked-in SQLite database a manifest's queries validate against.
+///
+/// Byte identity (`databaseSHA256`) is authoritative. `schemaFingerprint` is
+/// exact runtime provenance evidence (it includes root pages and raw schema
+/// SQL) and must not be treated as a semantic migration or catalog fingerprint.
+public struct SQLiteBuildValidationSchemaSnapshot: Codable, Equatable, Sendable {
+
+    public enum Kind: String, Codable, Sendable {
+        case checkedInSnapshot = "checked-in-snapshot"
+    }
+
+    public let kind: Kind
+    public let identifier: String
+    public let databaseSHA256: String
+    public let databaseByteCount: Int
+    public let schemaRowCount: Int
+    public let schemaFingerprint: String
+
+    public init(
+        kind: Kind = .checkedInSnapshot,
+        identifier: String,
+        databaseSHA256: String,
+        databaseByteCount: Int,
+        schemaRowCount: Int,
+        schemaFingerprint: String
+    ) {
+        self.kind = kind
+        self.identifier = identifier
+        self.databaseSHA256 = databaseSHA256.lowercased()
+        self.databaseByteCount = databaseByteCount
+        self.schemaRowCount = schemaRowCount
+        self.schemaFingerprint = schemaFingerprint.lowercased()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case identifier
+        case databaseSHA256 = "database_sha256"
+        case databaseByteCount = "database_byte_count"
+        case schemaRowCount = "schema_row_count"
+        case schemaFingerprint = "schema_fingerprint"
+    }
+}
+
+
+/// A JSON-friendly projection of ``XLValueCodecIdentity``.
+public struct SQLiteBuildValidationCodecReference:
+    Codable,
+    Equatable,
+    Hashable,
+    Sendable
+{
+
+    public let keyID: String
+    public let keyVersion: UInt
+    public let valueTypeIdentifier: String
+    public let dialectIdentifier: String
+    public let storageIdentifier: String
+
+    public init(
+        keyID: String,
+        keyVersion: UInt,
+        valueTypeIdentifier: String,
+        dialectIdentifier: String,
+        storageIdentifier: String
+    ) {
+        self.keyID = keyID
+        self.keyVersion = keyVersion
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.dialectIdentifier = dialectIdentifier
+        self.storageIdentifier = storageIdentifier
+    }
+
+    public init(_ identity: XLValueCodecIdentity) {
+        self.init(
+            keyID: identity.key.id,
+            keyVersion: identity.key.version,
+            valueTypeIdentifier: identity.valueTypeIdentifier.rawValue,
+            dialectIdentifier: identity.dialectIdentifier.rawValue,
+            storageIdentifier: identity.storageIdentifier.rawValue
+        )
+    }
+
+    /// Stable spelling for diagnostics and required-codec summaries. The
+    /// sidecar retains the structured fields; this is only a convenience.
+    public var stableIdentifier: String {
+        "\(keyID)@\(keyVersion)|\(valueTypeIdentifier)|\(dialectIdentifier)|\(storageIdentifier)"
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case keyID = "key_id"
+        case keyVersion = "key_version"
+        case valueTypeIdentifier = "value_type_identifier"
+        case dialectIdentifier = "dialect_identifier"
+        case storageIdentifier = "storage_identifier"
+    }
+}
+
+
+/// A required engine capability referenced by stable identifier (for example
+/// `function:FLOOR`). Capability evidence itself belongs to the validator (#293).
+public struct SQLiteBuildValidationCapabilityReference:
+    Codable,
+    Equatable,
+    Hashable,
+    Sendable
+{
+
+    public let id: String
+
+    public init(id: String) {
+        self.id = id
+    }
+}
+
+
+/// Sidecar metadata for one logical query parameter.
+///
+/// `logicalIndex` mirrors ``XLLogicalParameterIndex``. `physicalIndex` is the
+/// one-based SQLite bind position, which the frozen `XLQueryIdentity` v1
+/// representation deliberately excludes.
+public struct SQLiteBuildValidationParameterEntry: Codable, Equatable, Sendable {
+
+    public enum KeyKind: String, Codable, Sendable {
+        case named
+        case indexed
+    }
+
+    public let logicalIndex: Int
+    public let physicalIndex: Int
+    public let identity: String
+    public let keyKind: KeyKind
+    public let keyName: String?
+    public let keyIndex: Int?
+    public let valueTypeIdentifier: String
+    public let valueTypeName: String
+    public let nullability: String
+    public let codec: SQLiteBuildValidationCodecReference?
+    public let storageIdentifier: String
+
+    public init(
+        logicalIndex: Int,
+        physicalIndex: Int,
+        identity: String,
+        keyKind: KeyKind,
+        keyName: String?,
+        keyIndex: Int?,
+        valueTypeIdentifier: String,
+        valueTypeName: String,
+        nullability: String,
+        codec: SQLiteBuildValidationCodecReference?,
+        storageIdentifier: String
+    ) {
+        self.logicalIndex = logicalIndex
+        self.physicalIndex = physicalIndex
+        self.identity = identity
+        self.keyKind = keyKind
+        self.keyName = keyName
+        self.keyIndex = keyIndex
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.valueTypeName = valueTypeName
+        self.nullability = nullability
+        self.codec = codec
+        self.storageIdentifier = storageIdentifier
+    }
+
+    /// The SQLite placeholder spelling a validator should observe at prepare time.
+    public var expectedSQLiteSpelling: String {
+        switch keyKind {
+        case .named:
+            return ":\(keyName ?? "")"
+        case .indexed:
+            return "?\((keyIndex ?? -1) + 1)"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case logicalIndex = "logical_index"
+        case physicalIndex = "physical_index"
+        case identity
+        case keyKind = "key_kind"
+        case keyName = "key_name"
+        case keyIndex = "key_index"
+        case valueTypeIdentifier = "value_type_identifier"
+        case valueTypeName = "value_type_name"
+        case nullability
+        case codec
+        case storageIdentifier = "storage_identifier"
+    }
+}
+
+
+/// Sidecar metadata for one value in a returned row.
+///
+/// `declaredAlias` is the stable `AS` alias the query renders, when known.
+/// SQLite does not promise stable names for unaliased expressions, so this is
+/// `nil` for positional-only results.
+public struct SQLiteBuildValidationResultEntry: Codable, Equatable, Sendable {
+
+    public let index: Int
+    public let identity: String
+    public let declaredAlias: String?
+    public let valueTypeIdentifier: String
+    public let valueTypeName: String
+    public let nullability: String
+    public let codec: SQLiteBuildValidationCodecReference?
+    public let storageIdentifier: String
+
+    public init(
+        index: Int,
+        identity: String,
+        declaredAlias: String?,
+        valueTypeIdentifier: String,
+        valueTypeName: String,
+        nullability: String,
+        codec: SQLiteBuildValidationCodecReference?,
+        storageIdentifier: String
+    ) {
+        self.index = index
+        self.identity = identity
+        self.declaredAlias = declaredAlias
+        self.valueTypeIdentifier = valueTypeIdentifier
+        self.valueTypeName = valueTypeName
+        self.nullability = nullability
+        self.codec = codec
+        self.storageIdentifier = storageIdentifier
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case index
+        case identity
+        case declaredAlias = "declared_alias"
+        case valueTypeIdentifier = "value_type_identifier"
+        case valueTypeName = "value_type_name"
+        case nullability
+        case codec
+        case storageIdentifier = "storage_identifier"
+    }
+}
+
+
+/// One static query's complete sidecar entry.
+///
+/// Descriptor fields remain authoritative where they overlap; this only adds
+/// the reproducible-build fields the frozen `XLQueryIdentity` v1
+/// representation excludes: physical placeholder positions, declared result
+/// aliases, and cross-references into the #190 conformance inventory, #191
+/// combinatorial cases, and #254 Northwind anchors.
+public struct SQLiteBuildValidationQueryEntry: Codable, Equatable, Sendable {
+
+    public let id: String
+    public let definitionIdentity: String
+    public let descriptorIdentity: String
+    public let conformanceFeatureIDs: [String]
+    public let conformanceCaseIDs: [String]
+    public let northwindAnchorCaseIDs: [String]
+    public let sql: String
+    public let dialectIdentifier: String
+    public let minimumDialectVersion: String?
+    public let dialectCapabilitiesRawValue: UInt64
+    public let cardinality: UInt8
+    public let parameters: [SQLiteBuildValidationParameterEntry]
+    public let results: [SQLiteBuildValidationResultEntry]
+    public let requiredCapabilities: [SQLiteBuildValidationCapabilityReference]
+
+    public init(
+        id: String,
+        definitionIdentity: String,
+        descriptorIdentity: String,
+        conformanceFeatureIDs: [String] = [],
+        conformanceCaseIDs: [String] = [],
+        northwindAnchorCaseIDs: [String] = [],
+        sql: String,
+        dialectIdentifier: String,
+        minimumDialectVersion: String? = nil,
+        dialectCapabilitiesRawValue: UInt64 = 0,
+        cardinality: UInt8,
+        parameters: [SQLiteBuildValidationParameterEntry] = [],
+        results: [SQLiteBuildValidationResultEntry] = [],
+        requiredCapabilities: [String] = []
+    ) {
+        self.id = id
+        self.definitionIdentity = definitionIdentity
+        self.descriptorIdentity = descriptorIdentity
+        self.conformanceFeatureIDs = Self.sortedUnique(conformanceFeatureIDs)
+        self.conformanceCaseIDs = Self.sortedUnique(conformanceCaseIDs)
+        self.northwindAnchorCaseIDs = Self.sortedUnique(northwindAnchorCaseIDs)
+        self.sql = sql
+        self.dialectIdentifier = dialectIdentifier
+        self.minimumDialectVersion = minimumDialectVersion
+        self.dialectCapabilitiesRawValue = dialectCapabilitiesRawValue
+        self.cardinality = cardinality
+        self.parameters = parameters.sorted { $0.logicalIndex < $1.logicalIndex }
+        self.results = results.sorted { $0.index < $1.index }
+        self.requiredCapabilities = Self.sortedUniqueCapabilities(requiredCapabilities)
+    }
+
+    /// Projects an existing static query descriptor into sidecar form.
+    ///
+    /// Physical placeholder positions are recovered by scanning the rendered
+    /// SQL, since `XLStaticQueryDescriptor` intentionally carries only logical
+    /// parameter order.
+    public init(
+        id: String,
+        descriptor: XLStaticQueryDescriptor,
+        declaredAliases: [String?]? = nil,
+        conformanceFeatureIDs: [String] = [],
+        conformanceCaseIDs: [String] = [],
+        northwindAnchorCaseIDs: [String] = [],
+        requiredCapabilities: [String] = []
+    ) throws {
+        if let declaredAliases, declaredAliases.count != descriptor.results.count {
+            throw SQLiteBuildValidationManifestError.resultAliasCountMismatch(
+                queryID: id,
+                expected: descriptor.results.count,
+                actual: declaredAliases.count
+            )
+        }
+
+        let placeholders = SQLiteBuildValidationManifestPlaceholderScanner.scan(
+            descriptor.sql
+        )
+        var projectedParameters: [SQLiteBuildValidationParameterEntry] = []
+        for parameter in descriptor.parameters.sorted(by: {
+            $0.slot.index < $1.slot.index
+        }) {
+            let keyKind: SQLiteBuildValidationParameterEntry.KeyKind
+            let keyName: String?
+            let keyIndex: Int?
+            let physicalIndex: Int
+            switch parameter.slot.key {
+            case .named(let name):
+                keyKind = .named
+                keyName = name
+                keyIndex = nil
+                let spelling = ":\(name)"
+                guard let occurrence = placeholders.occurrences.first(
+                    where: { $0.spelling == spelling }
+                ) else {
+                    throw SQLiteBuildValidationManifestError.invalidQuery(
+                        id,
+                        "named parameter '\(spelling)' is absent from descriptor SQL"
+                    )
+                }
+                physicalIndex = occurrence.physicalIndex
+            case .indexed(let zeroBasedIndex):
+                keyKind = .indexed
+                keyName = nil
+                keyIndex = zeroBasedIndex
+                physicalIndex = zeroBasedIndex + 1
+            }
+            projectedParameters.append(SQLiteBuildValidationParameterEntry(
+                logicalIndex: parameter.slot.index.rawValue,
+                physicalIndex: physicalIndex,
+                identity: parameter.identity.description,
+                keyKind: keyKind,
+                keyName: keyName,
+                keyIndex: keyIndex,
+                valueTypeIdentifier: parameter.slot.valueTypeIdentifier.rawValue,
+                valueTypeName: parameter.slot.valueTypeName,
+                nullability: parameter.slot.nullability.rawValue,
+                codec: parameter.slot.codecIdentity.map(
+                    SQLiteBuildValidationCodecReference.init
+                ),
+                storageIdentifier: parameter.storageIdentifier.rawValue
+            ))
+        }
+
+        let aliases = declaredAliases
+            ?? Array<String?>(repeating: nil, count: descriptor.results.count)
+        let projectedResults = descriptor.results.slots.map { result in
+            SQLiteBuildValidationResultEntry(
+                index: result.index.rawValue,
+                identity: result.identity.description,
+                declaredAlias: aliases[result.index.rawValue],
+                valueTypeIdentifier: result.valueTypeIdentifier.rawValue,
+                valueTypeName: result.valueTypeName,
+                nullability: result.nullability.rawValue,
+                codec: result.codecIdentity.map(
+                    SQLiteBuildValidationCodecReference.init
+                ),
+                storageIdentifier: result.storageIdentifier.rawValue
+            )
+        }
+
+        self.init(
+            id: id,
+            definitionIdentity: descriptor.definitionIdentity.description,
+            descriptorIdentity: descriptor.identity.description,
+            conformanceFeatureIDs: conformanceFeatureIDs,
+            conformanceCaseIDs: conformanceCaseIDs,
+            northwindAnchorCaseIDs: northwindAnchorCaseIDs,
+            sql: descriptor.sql,
+            dialectIdentifier: descriptor.dialectRequirement.identity.rawValue,
+            minimumDialectVersion: descriptor.dialectRequirement.minimumVersion?.description,
+            dialectCapabilitiesRawValue: descriptor.dialectRequirement.capabilities.rawValue,
+            cardinality: descriptor.cardinality.rawValue,
+            parameters: projectedParameters,
+            results: projectedResults,
+            requiredCapabilities: requiredCapabilities
+        )
+    }
+
+    public var expectedPhysicalParameterCount: Int {
+        parameters.map(\.physicalIndex).max() ?? 0
+    }
+
+    public var requiredCodecIdentifiers: [String] {
+        let codecs = parameters.compactMap(\.codec) + results.compactMap(\.codec)
+        return Array(Set(codecs.map(\.stableIdentifier))).sorted()
+    }
+
+    /// Re-applies canonical ordering. Used when normalizing a decoded or
+    /// externally-constructed manifest.
+    func normalized() -> Self {
+        Self(
+            id: id,
+            definitionIdentity: definitionIdentity,
+            descriptorIdentity: descriptorIdentity,
+            conformanceFeatureIDs: conformanceFeatureIDs,
+            conformanceCaseIDs: conformanceCaseIDs,
+            northwindAnchorCaseIDs: northwindAnchorCaseIDs,
+            sql: sql,
+            dialectIdentifier: dialectIdentifier,
+            minimumDialectVersion: minimumDialectVersion,
+            dialectCapabilitiesRawValue: dialectCapabilitiesRawValue,
+            cardinality: cardinality,
+            parameters: parameters,
+            results: results,
+            requiredCapabilities: requiredCapabilities.map(\.id)
+        )
+    }
+
+    private static func sortedUnique(_ values: [String]) -> [String] {
+        Array(Set(values)).sorted()
+    }
+
+    private static func sortedUniqueCapabilities(
+        _ ids: [String]
+    ) -> [SQLiteBuildValidationCapabilityReference] {
+        Self.sortedUnique(ids).map(SQLiteBuildValidationCapabilityReference.init)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case definitionIdentity = "definition_identity"
+        case descriptorIdentity = "descriptor_identity"
+        case conformanceFeatureIDs = "conformance_feature_ids"
+        case conformanceCaseIDs = "conformance_case_ids"
+        case northwindAnchorCaseIDs = "northwind_anchor_case_ids"
+        case sql
+        case dialectIdentifier = "dialect_identifier"
+        case minimumDialectVersion = "minimum_dialect_version"
+        case dialectCapabilitiesRawValue = "dialect_capabilities_raw_value"
+        case cardinality
+        case parameters
+        case results
+        case requiredCapabilities = "required_capabilities"
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestModels.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestModels.swift
@@ -351,6 +351,15 @@ public struct SQLiteBuildValidationQueryEntry: Codable, Equatable, Sendable {
                 keyKind = .indexed
                 keyName = nil
                 keyIndex = zeroBasedIndex
+                let spelling = "?\(zeroBasedIndex + 1)"
+                guard placeholders.occurrences.contains(
+                    where: { $0.spelling == spelling }
+                ) else {
+                    throw SQLiteBuildValidationManifestError.invalidQuery(
+                        id,
+                        "indexed parameter '\(spelling)' is absent from descriptor SQL"
+                    )
+                }
                 physicalIndex = zeroBasedIndex + 1
             }
             projectedParameters.append(SQLiteBuildValidationParameterEntry(

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestPlaceholderScanner.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestPlaceholderScanner.swift
@@ -169,10 +169,15 @@ private extension SQLiteBuildValidationManifestPlaceholderScanner {
     static func skipBracketQuoted(startingAt index: Int, bytes: [UInt8]) -> Int {
         var index = index
         while index < bytes.count {
-            if bytes[index] == 0x5D {
-                return index + 1
+            guard bytes[index] == 0x5D else {
+                index += 1
+                continue
             }
-            index += 1
+            if byte(at: index + 1, in: bytes) == 0x5D {
+                index += 2
+                continue
+            }
+            return index + 1
         }
         return index
     }

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestPlaceholderScanner.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationManifestPlaceholderScanner.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+
+/// One SQL-text occurrence of a supported SwiftQL placeholder spelling.
+struct SQLiteBuildValidationManifestPlaceholderOccurrence: Equatable {
+    let spelling: String
+    let physicalIndex: Int
+}
+
+
+/// Quote/comment-aware evidence for SwiftQL's supported placeholder spellings.
+///
+/// This is deliberately smaller than SQLite's tokenizer. It recognizes only
+/// the two forms emitted by `XLSQLiteDialect`: `:name` and one-based `?N`.
+/// The physical index of a named token is its first-encounter position among
+/// all placeholders in the rendered SQL; repeated occurrences of the same
+/// name share that index, matching SQLite's own binding semantics.
+struct SQLiteBuildValidationManifestPlaceholderAnalysis: Equatable {
+    let occurrences: [SQLiteBuildValidationManifestPlaceholderOccurrence]
+    let largestPhysicalIndex: Int
+}
+
+
+enum SQLiteBuildValidationManifestPlaceholderScanner {
+
+    static func scan(
+        _ sql: String
+    ) -> SQLiteBuildValidationManifestPlaceholderAnalysis {
+        let bytes = Array(sql.utf8)
+        var physicalIndexByNamedToken: [String: Int] = [:]
+        var largestPhysicalIndex = 0
+        var occurrences: [SQLiteBuildValidationManifestPlaceholderOccurrence] = []
+        var index = 0
+
+        while index < bytes.count {
+            let currentByte = bytes[index]
+            if currentByte == 0x2D, byte(at: index + 1, in: bytes) == 0x2D {
+                index = skipLineComment(startingAt: index + 2, bytes: bytes)
+                continue
+            }
+            if currentByte == 0x2F, byte(at: index + 1, in: bytes) == 0x2A {
+                index = skipBlockComment(startingAt: index + 2, bytes: bytes)
+                continue
+            }
+            if currentByte == 0x27 || currentByte == 0x22 || currentByte == 0x60 {
+                index = skipQuoted(
+                    startingAt: index + 1,
+                    delimiter: currentByte,
+                    bytes: bytes
+                )
+                continue
+            }
+            if currentByte == 0x5B {
+                index = skipBracketQuoted(startingAt: index + 1, bytes: bytes)
+                continue
+            }
+
+            if currentByte == 0x3F { // ? or ?NNN
+                let tokenEnd = consumeDigits(startingAt: index + 1, bytes: bytes)
+                guard tokenEnd > index + 1 else {
+                    index += 1
+                    continue
+                }
+                let spelling = String(
+                    decoding: bytes[index..<tokenEnd],
+                    as: UTF8.self
+                )
+                guard let physicalIndex = Int(spelling.dropFirst()),
+                      physicalIndex > 0 else {
+                    index = tokenEnd
+                    continue
+                }
+                largestPhysicalIndex = max(largestPhysicalIndex, physicalIndex)
+                occurrences.append(
+                    SQLiteBuildValidationManifestPlaceholderOccurrence(
+                        spelling: spelling,
+                        physicalIndex: physicalIndex
+                    )
+                )
+                index = tokenEnd
+                continue
+            }
+
+            if currentByte == 0x3A { // :name
+                let tokenEnd = consumeName(startingAt: index + 1, bytes: bytes)
+                guard tokenEnd > index + 1 else {
+                    index += 1
+                    continue
+                }
+                let spelling = String(
+                    decoding: bytes[index..<tokenEnd],
+                    as: UTF8.self
+                )
+                let physicalIndex: Int
+                if let existing = physicalIndexByNamedToken[spelling] {
+                    physicalIndex = existing
+                }
+                else {
+                    physicalIndex = largestPhysicalIndex + 1
+                    largestPhysicalIndex = physicalIndex
+                    physicalIndexByNamedToken[spelling] = physicalIndex
+                }
+                occurrences.append(
+                    SQLiteBuildValidationManifestPlaceholderOccurrence(
+                        spelling: spelling,
+                        physicalIndex: physicalIndex
+                    )
+                )
+                index = tokenEnd
+                continue
+            }
+
+            index += 1
+        }
+
+        return SQLiteBuildValidationManifestPlaceholderAnalysis(
+            occurrences: occurrences,
+            largestPhysicalIndex: largestPhysicalIndex
+        )
+    }
+}
+
+
+private extension SQLiteBuildValidationManifestPlaceholderScanner {
+
+    static func byte(at index: Int, in bytes: [UInt8]) -> UInt8? {
+        bytes.indices.contains(index) ? bytes[index] : nil
+    }
+
+    static func skipLineComment(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count, bytes[index] != 0x0A, bytes[index] != 0x0D {
+            index += 1
+        }
+        return index
+    }
+
+    static func skipBlockComment(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count {
+            if bytes[index] == 0x2A, byte(at: index + 1, in: bytes) == 0x2F {
+                return index + 2
+            }
+            index += 1
+        }
+        return index
+    }
+
+    static func skipQuoted(
+        startingAt index: Int,
+        delimiter: UInt8,
+        bytes: [UInt8]
+    ) -> Int {
+        var index = index
+        while index < bytes.count {
+            guard bytes[index] == delimiter else {
+                index += 1
+                continue
+            }
+            if byte(at: index + 1, in: bytes) == delimiter {
+                index += 2
+                continue
+            }
+            return index + 1
+        }
+        return index
+    }
+
+    static func skipBracketQuoted(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count {
+            if bytes[index] == 0x5D {
+                return index + 1
+            }
+            index += 1
+        }
+        return index
+    }
+
+    static func consumeDigits(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count, (0x30...0x39).contains(bytes[index]) {
+            index += 1
+        }
+        return index
+    }
+
+    static func consumeName(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count, isNameByte(bytes[index]) {
+            index += 1
+        }
+        return index
+    }
+
+    static func isNameByte(_ byte: UInt8) -> Bool {
+        (0x30...0x39).contains(byte)
+            || (0x41...0x5A).contains(byte)
+            || byte == 0x5F
+            || (0x61...0x7A).contains(byte)
+            || byte >= 0x80
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationReferenceRegistry.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationManifest/SQLiteBuildValidationReferenceRegistry.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+
+/// External #190/#191/#254 registry membership.
+///
+/// The manifest model does not depend on the (test-only) targets that own the
+/// canonical #190 inventory, #191 combinatorial cases, or #254 Northwind
+/// fixture, so it cannot resolve references itself. Callers that have loaded
+/// those canonical sources inject a conformance here instead of the manifest
+/// minting a parallel copy of any of the three ID spaces.
+public protocol SQLiteBuildValidationReferenceRegistry: Sendable {
+    func resolvesConformanceFeatureID(_ id: String) -> Bool
+    func resolvesConformanceCaseID(_ id: String) -> Bool
+    func resolvesNorthwindAnchorCaseID(_ id: String) -> Bool
+}
+
+
+/// A registry backed by explicit in-memory ID sets.
+///
+/// Useful for tests, and for callers that have already loaded the canonical
+/// #190/#191/#254 sources and want a value-type conformance instead of
+/// implementing the protocol themselves.
+public struct SQLiteBuildValidationStaticReferenceRegistry:
+    SQLiteBuildValidationReferenceRegistry
+{
+
+    public let conformanceFeatureIDs: Set<String>
+    public let conformanceCaseIDs: Set<String>
+    public let northwindAnchorCaseIDs: Set<String>
+
+    public init(
+        conformanceFeatureIDs: Set<String>,
+        conformanceCaseIDs: Set<String>,
+        northwindAnchorCaseIDs: Set<String>
+    ) {
+        self.conformanceFeatureIDs = conformanceFeatureIDs
+        self.conformanceCaseIDs = conformanceCaseIDs
+        self.northwindAnchorCaseIDs = northwindAnchorCaseIDs
+    }
+
+    public func resolvesConformanceFeatureID(_ id: String) -> Bool {
+        conformanceFeatureIDs.contains(id)
+    }
+
+    public func resolvesConformanceCaseID(_ id: String) -> Bool {
+        conformanceCaseIDs.contains(id)
+    }
+
+    public func resolvesNorthwindAnchorCaseID(_ id: String) -> Bool {
+        northwindAnchorCaseIDs.contains(id)
+    }
+}

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTestSupport.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTestSupport.swift
@@ -1,0 +1,221 @@
+import Foundation
+import SwiftQLCore
+@testable import SwiftQLSQLiteBuildValidationManifest
+
+
+/// Shared fixture construction for the #292 manifest test suite.
+enum SQLiteBuildValidationManifestTestSupport {
+
+    static func schemaSnapshot(
+        identifier: String = "northwind-fixture",
+        databaseSHA256: String = String(repeating: "a", count: 64),
+        databaseByteCount: Int = 602112,
+        schemaRowCount: Int = 37,
+        schemaFingerprint: String = String(repeating: "b", count: 16)
+    ) -> SQLiteBuildValidationSchemaSnapshot {
+        SQLiteBuildValidationSchemaSnapshot(
+            identifier: identifier,
+            databaseSHA256: databaseSHA256,
+            databaseByteCount: databaseByteCount,
+            schemaRowCount: schemaRowCount,
+            schemaFingerprint: schemaFingerprint
+        )
+    }
+
+    static func manifest(
+        conformanceInventoryVersion: String = "190.1.0",
+        combinatorialManifestVersion: String = "c191-v2",
+        schemaSnapshot: SQLiteBuildValidationSchemaSnapshot? = nil,
+        queries: [SQLiteBuildValidationQueryEntry]
+    ) -> SQLiteBuildValidationManifest {
+        SQLiteBuildValidationManifest(
+            conformanceInventoryVersion: conformanceInventoryVersion,
+            combinatorialManifestVersion: combinatorialManifestVersion,
+            schemaSnapshot: schemaSnapshot ?? Self.schemaSnapshot(),
+            queries: queries
+        )
+    }
+
+    static func query(
+        id: String = "query.id",
+        conformanceFeatureIDs: [String] = [],
+        conformanceCaseIDs: [String] = [],
+        northwindAnchorCaseIDs: [String] = [],
+        parameters: [SQLiteBuildValidationParameterEntry] = [],
+        results: [SQLiteBuildValidationResultEntry] = [],
+        requiredCapabilities: [String] = []
+    ) -> SQLiteBuildValidationQueryEntry {
+        SQLiteBuildValidationQueryEntry(
+            id: id,
+            definitionIdentity: "tests/\(id)@1",
+            descriptorIdentity: "swiftql-query-v1-deadbeef",
+            conformanceFeatureIDs: conformanceFeatureIDs,
+            conformanceCaseIDs: conformanceCaseIDs,
+            northwindAnchorCaseIDs: northwindAnchorCaseIDs,
+            sql: "SELECT 1",
+            dialectIdentifier: XLSQLiteDialect.identity.rawValue,
+            cardinality: XLQueryCardinality.exactlyOne.rawValue,
+            parameters: parameters,
+            results: results.isEmpty ? [Self.result()] : results,
+            requiredCapabilities: requiredCapabilities
+        )
+    }
+
+    static func parameter(
+        logicalIndex: Int = 0,
+        physicalIndex: Int = 1,
+        identity: String = "parameter/first",
+        keyKind: SQLiteBuildValidationParameterEntry.KeyKind = .named,
+        keyName: String? = "first",
+        keyIndex: Int? = nil,
+        codec: SQLiteBuildValidationCodecReference? = nil
+    ) -> SQLiteBuildValidationParameterEntry {
+        SQLiteBuildValidationParameterEntry(
+            logicalIndex: logicalIndex,
+            physicalIndex: physicalIndex,
+            identity: identity,
+            keyKind: keyKind,
+            keyName: keyName,
+            keyIndex: keyIndex,
+            valueTypeIdentifier: "swift.int",
+            valueTypeName: "Swift.Int",
+            nullability: "required",
+            codec: codec,
+            storageIdentifier: "integer"
+        )
+    }
+
+    static func result(
+        index: Int = 0,
+        identity: String = "result/first",
+        declaredAlias: String? = "first",
+        codec: SQLiteBuildValidationCodecReference? = nil
+    ) -> SQLiteBuildValidationResultEntry {
+        SQLiteBuildValidationResultEntry(
+            index: index,
+            identity: identity,
+            declaredAlias: declaredAlias,
+            valueTypeIdentifier: "swift.int",
+            valueTypeName: "Swift.Int",
+            nullability: "required",
+            codec: codec,
+            storageIdentifier: "integer"
+        )
+    }
+
+    static func codec(
+        keyID: String = "tests.codec",
+        keyVersion: UInt = 1,
+        valueTypeIdentifier: String = "tests.token",
+        dialectIdentifier: String = XLSQLiteDialect.identity.rawValue,
+        storageIdentifier: String = "text"
+    ) -> SQLiteBuildValidationCodecReference {
+        SQLiteBuildValidationCodecReference(
+            keyID: keyID,
+            keyVersion: keyVersion,
+            valueTypeIdentifier: valueTypeIdentifier,
+            dialectIdentifier: dialectIdentifier,
+            storageIdentifier: storageIdentifier
+        )
+    }
+
+    static func descriptorCodec() -> XLValueCodecIdentity {
+        XLValueCodecIdentity(
+            key: XLValueCodecKey(id: "tests.codec.token", version: 7),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "tests.token"),
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: XLValueStorageIdentifier(rawValue: "text")
+        )
+    }
+
+    /// A descriptor mixing an indexed and a named parameter, matching the SQL
+    /// physical placeholder ordering exercised by the #132 research prototype.
+    static func mixedBindingDescriptor(
+        codec: XLValueCodecIdentity,
+        sql: String = "SELECT ?5 AS indexed_value, :token AS token"
+    ) throws -> XLStaticQueryDescriptor {
+        let indexed = XLParameterSlot(
+            index: XLLogicalParameterIndex(0),
+            key: .indexed(4),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: "Swift.Int",
+            nullability: .required,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath(["parameter", "indexed"])
+            )
+        )
+        let named = XLParameterSlot(
+            index: XLLogicalParameterIndex(1),
+            key: .named("token"),
+            valueTypeIdentifier: codec.valueTypeIdentifier,
+            valueTypeName: "Tests.Token",
+            nullability: .nullable,
+            codecIdentity: codec,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath(["parameter", "token"])
+            )
+        )
+        let integerStorage = XLValueStorageIdentifier(rawValue: "integer")
+        let textStorage = XLValueStorageIdentifier(rawValue: "text")
+
+        return try XLStaticQueryDescriptor(
+            definitionIdentity: XLQueryDefinitionIdentity(
+                path: ["tests", "build-validation", "manifest-projection"],
+                version: 1
+            ),
+            statement: XLStaticStatementDefinition(
+                sql: sql,
+                dialectRequirement: XLDialectRequirement(
+                    identity: XLSQLiteDialect.identity,
+                    minimumVersion: XLDialectVersion(3, 38, 0),
+                    capabilities: [.namedBindings, .indexedBindings]
+                ),
+                parameterLayout: try XLParameterLayout(slots: [named, indexed])
+            ),
+            parameters: [
+                XLStaticQueryParameterMetadata(
+                    identity: try XLQuerySlotIdentity(path: ["parameter", "token"]),
+                    slot: named,
+                    storageIdentifier: textStorage
+                ),
+                XLStaticQueryParameterMetadata(
+                    identity: try XLQuerySlotIdentity(path: ["parameter", "indexed"]),
+                    slot: indexed,
+                    storageIdentifier: integerStorage
+                ),
+            ],
+            results: try XLStaticQueryResultMetadata(slots: [
+                XLStaticQueryResultSlot(
+                    index: XLLogicalResultIndex(0),
+                    identity: try XLQuerySlotIdentity(path: ["result", "indexed"]),
+                    valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+                    valueTypeName: "Swift.Int",
+                    nullability: .required,
+                    codecIdentity: nil,
+                    storageIdentifier: integerStorage,
+                    codingContext: XLValueCodingContext(
+                        site: .result,
+                        path: XLValueCodingPath(["result", "indexed"])
+                    )
+                ),
+                XLStaticQueryResultSlot(
+                    index: XLLogicalResultIndex(1),
+                    identity: try XLQuerySlotIdentity(path: ["result", "token"]),
+                    valueTypeIdentifier: codec.valueTypeIdentifier,
+                    valueTypeName: "Tests.Token",
+                    nullability: .required,
+                    codecIdentity: codec,
+                    storageIdentifier: textStorage,
+                    codingContext: XLValueCodingContext(
+                        site: .result,
+                        path: XLValueCodingPath(["result", "token"])
+                    )
+                ),
+            ]),
+            cardinality: .exactlyOne
+        )
+    }
+}

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTestSupport.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTestSupport.swift
@@ -38,6 +38,7 @@ enum SQLiteBuildValidationManifestTestSupport {
 
     static func query(
         id: String = "query.id",
+        sql: String = "SELECT 1",
         conformanceFeatureIDs: [String] = [],
         conformanceCaseIDs: [String] = [],
         northwindAnchorCaseIDs: [String] = [],
@@ -52,7 +53,7 @@ enum SQLiteBuildValidationManifestTestSupport {
             conformanceFeatureIDs: conformanceFeatureIDs,
             conformanceCaseIDs: conformanceCaseIDs,
             northwindAnchorCaseIDs: northwindAnchorCaseIDs,
-            sql: "SELECT 1",
+            sql: sql,
             dialectIdentifier: XLSQLiteDialect.identity.rawValue,
             cardinality: XLQueryCardinality.exactlyOne.rawValue,
             parameters: parameters,

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
@@ -128,6 +128,26 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
         }
     }
 
+    func testDescriptorProjectionRejectsIndexedParameterAbsentFromSQL() throws {
+        let descriptor = try Support.mixedBindingDescriptor(
+            codec: Support.descriptorCodec(),
+            sql: "SELECT 1 AS indexed_value, :token AS token"
+        )
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationQueryEntry(
+                id: "projection.missing-indexed-parameter",
+                descriptor: descriptor
+            )
+        ) { error in
+            guard case .invalidQuery(let queryID, let reason) =
+                    error as? SQLiteBuildValidationManifestError else {
+                return XCTFail("Expected invalid query, received \(error)")
+            }
+            XCTAssertEqual(queryID, "projection.missing-indexed-parameter")
+            XCTAssertTrue(reason.contains("?5"))
+        }
+    }
+
     // MARK: - Determinism (Done-When #2)
 
     func testManifestCanonicalizesOrderingAndIsByteIdenticalAcrossReorderingAndRepeatedRuns() throws {
@@ -231,6 +251,24 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
             XCTAssertEqual(
                 error as? SQLiteBuildValidationManifestError,
                 .duplicateQueryID("duplicate")
+            )
+        }
+    }
+
+    /// Reports the lexicographically smallest duplicated id rather than an
+    /// arbitrary one, so the diagnostic does not vary with Dictionary's
+    /// process-randomized iteration order across multiple duplicate groups.
+    func testManifestReportsDeterministicDuplicateQueryIDAcrossMultipleGroups() {
+        let manifest = Support.manifest(queries: [
+            Support.query(id: "zebra"),
+            Support.query(id: "zebra"),
+            Support.query(id: "apple"),
+            Support.query(id: "apple"),
+        ])
+        XCTAssertThrowsError(try manifest.validating()) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationManifestError,
+                .duplicateQueryID("apple")
             )
         }
     }

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
@@ -311,6 +311,28 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
         )
     }
 
+    func testManifestRejectsUnrecognizedCardinalityRawValue() {
+        let manifest = Support.manifest(queries: [
+            SQLiteBuildValidationQueryEntry(
+                id: "bad-cardinality",
+                definitionIdentity: "tests/bad-cardinality@1",
+                descriptorIdentity: "swiftql-query-v1-deadbeef",
+                sql: "SELECT 1",
+                dialectIdentifier: XLSQLiteDialect.identity.rawValue,
+                cardinality: 99,
+                results: [Support.result()]
+            ),
+        ])
+        XCTAssertThrowsError(try manifest.validating()) { error in
+            guard case .invalidQuery(let queryID, let reason) =
+                error as? SQLiteBuildValidationManifestError else {
+                return XCTFail("Expected invalid query, received \(error)")
+            }
+            XCTAssertEqual(queryID, "bad-cardinality")
+            XCTAssertTrue(reason.contains("cardinality"))
+        }
+    }
+
     func testManifestRejectsIncompleteCodecMetadata() {
         let incompleteCodec = Support.codec(keyID: "")
         assertInvalidQuery(
@@ -384,6 +406,26 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
         ])
 
         XCTAssertNoThrow(try manifest.validating(against: registry))
+    }
+
+    /// `validating(against:)` takes `any SQLiteBuildValidationReferenceRegistry`
+    /// so a caller that stores its registry as a type-erased existential (e.g.
+    /// a property typed `any SQLiteBuildValidationReferenceRegistry`) can pass
+    /// it directly, without requiring the concrete conforming type at the call site.
+    func testManifestValidatingAgainstAcceptsATypeErasedRegistry() {
+        let erased: any SQLiteBuildValidationReferenceRegistry =
+            SQLiteBuildValidationStaticReferenceRegistry(
+                conformanceFeatureIDs: ["syntax.select.core"],
+                conformanceCaseIDs: ["c191.v1.select.j-inner.w-named-binding"],
+                northwindAnchorCaseIDs: ["northwind.cte.order-subtotals"]
+            )
+        let manifest = Support.manifest(queries: [
+            Support.query(
+                id: "erased-registry",
+                conformanceFeatureIDs: ["syntax.select.core"]
+            ),
+        ])
+        XCTAssertNoThrow(try manifest.validating(against: erased))
     }
 
     func testManifestFailsClosedOnUnresolvedFeatureCaseAndAnchorReferences() {

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
@@ -333,6 +333,69 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
         }
     }
 
+    func testManifestRejectsCardinalityResultCountMismatches() {
+        let commandWithResults = Support.manifest(queries: [
+            SQLiteBuildValidationQueryEntry(
+                id: "command-with-results",
+                definitionIdentity: "tests/command-with-results@1",
+                descriptorIdentity: "swiftql-query-v1-deadbeef",
+                sql: "DELETE FROM t",
+                dialectIdentifier: XLSQLiteDialect.identity.rawValue,
+                cardinality: XLQueryCardinality.command.rawValue,
+                results: [Support.result()]
+            ),
+        ])
+        XCTAssertThrowsError(try commandWithResults.validating()) { error in
+            guard case .invalidQuery(_, let reason) =
+                error as? SQLiteBuildValidationManifestError else {
+                return XCTFail("Expected invalid query, received \(error)")
+            }
+            XCTAssertTrue(reason.contains("must not declare result slots"))
+        }
+
+        let rowWithNoResults = Support.manifest(queries: [
+            SQLiteBuildValidationQueryEntry(
+                id: "row-with-no-results",
+                definitionIdentity: "tests/row-with-no-results@1",
+                descriptorIdentity: "swiftql-query-v1-deadbeef",
+                sql: "SELECT 1",
+                dialectIdentifier: XLSQLiteDialect.identity.rawValue,
+                cardinality: XLQueryCardinality.exactlyOne.rawValue,
+                results: []
+            ),
+        ])
+        XCTAssertThrowsError(try rowWithNoResults.validating()) { error in
+            guard case .invalidQuery(_, let reason) =
+                error as? SQLiteBuildValidationManifestError else {
+                return XCTFail("Expected invalid query, received \(error)")
+            }
+            XCTAssertTrue(reason.contains("requires at least one result slot"))
+        }
+    }
+
+    func testManifestRejectsUnrecognizedNullabilityRawValue() {
+        assertInvalidQuery(
+            Support.query(parameters: [
+                Support.parameter()
+            ].map { param in
+                SQLiteBuildValidationParameterEntry(
+                    logicalIndex: param.logicalIndex,
+                    physicalIndex: param.physicalIndex,
+                    identity: param.identity,
+                    keyKind: param.keyKind,
+                    keyName: param.keyName,
+                    keyIndex: param.keyIndex,
+                    valueTypeIdentifier: param.valueTypeIdentifier,
+                    valueTypeName: param.valueTypeName,
+                    nullability: "maybe",
+                    codec: param.codec,
+                    storageIdentifier: param.storageIdentifier
+                )
+            }),
+            contains: "nullability"
+        )
+    }
+
     func testManifestRejectsIncompleteCodecMetadata() {
         let incompleteCodec = Support.codec(keyID: "")
         assertInvalidQuery(

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
@@ -434,7 +434,8 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
     func testPlaceholderScannerTreatsDoubledClosingBracketAsEscapedInsideQuotedIdentifier() {
         // "[x]]y:fake]" is one bracket-quoted identifier ("x]y:fake") where
         // "]]" escapes a literal "]", matching the doubled-delimiter escape
-        // already honored for '/"/`. A scanner that stops at the first "]"
+        // already honored for the single-quote, double-quote, and backtick
+        // delimiters. A scanner that stops at the first "]"
         // would incorrectly split out ":fake" as a placeholder occurrence.
         let analysis = SQLiteBuildValidationManifestPlaceholderScanner.scan(
             "SELECT [x]]y:fake] AS col, :real AS r"

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
@@ -1,0 +1,389 @@
+import Foundation
+import SwiftQLCore
+import SwiftQLSQLiteCombinatorialSupport
+import SwiftQLSQLiteConformanceFixtures
+import XCTest
+@testable import SwiftQLSQLiteBuildValidationManifest
+
+
+final class SQLiteBuildValidationManifestTests: XCTestCase {
+    typealias Support = SQLiteBuildValidationManifestTestSupport
+
+    // MARK: - Descriptor projection (Done-When #1)
+
+    func testDescriptorProjectionPreservesStableIdentityPhysicalSlotsAndCodec() throws {
+        let descriptorCodec = Support.descriptorCodec()
+        let descriptor = try Support.mixedBindingDescriptor(codec: descriptorCodec)
+
+        let projected = try SQLiteBuildValidationQueryEntry(
+            id: "projection.mixed-bindings",
+            descriptor: descriptor,
+            declaredAliases: ["indexed_value", "token"],
+            conformanceFeatureIDs: ["binding.named", "binding.indexed"],
+            conformanceCaseIDs: [
+                "c191.v1.select.j-inner.w-named-binding",
+                "c191.v1.northwind.cte-order-subtotals",
+                "c191.v1.select.j-inner.w-named-binding",
+            ],
+            northwindAnchorCaseIDs: ["northwind.cte.order-subtotals"],
+            requiredCapabilities: ["function:JSON_VALID", "function:ABS"]
+        )
+
+        XCTAssertEqual(
+            projected.definitionIdentity,
+            "tests/build-validation/manifest-projection@1"
+        )
+        XCTAssertEqual(projected.descriptorIdentity, descriptor.identity.description)
+        XCTAssertEqual(projected.sql, "SELECT ?5 AS indexed_value, :token AS token")
+        XCTAssertEqual(projected.parameters.map(\.logicalIndex), [0, 1])
+        XCTAssertEqual(projected.parameters.map(\.physicalIndex), [5, 6])
+        XCTAssertEqual(projected.expectedPhysicalParameterCount, 6)
+        XCTAssertEqual(projected.parameters[0].expectedSQLiteSpelling, "?5")
+        XCTAssertEqual(projected.parameters[1].expectedSQLiteSpelling, ":token")
+        XCTAssertNil(projected.parameters[0].codec)
+        XCTAssertEqual(
+            projected.parameters[1].codec,
+            SQLiteBuildValidationCodecReference(descriptorCodec)
+        )
+        XCTAssertEqual(
+            projected.results.map(\.declaredAlias),
+            ["indexed_value", "token"]
+        )
+        XCTAssertEqual(
+            projected.results[1].codec,
+            SQLiteBuildValidationCodecReference(descriptorCodec)
+        )
+        XCTAssertEqual(
+            projected.requiredCodecIdentifiers,
+            [SQLiteBuildValidationCodecReference(descriptorCodec).stableIdentifier]
+        )
+        // Reordered/duplicated set-like inputs canonicalize identically.
+        XCTAssertEqual(projected.conformanceFeatureIDs, ["binding.indexed", "binding.named"])
+        XCTAssertEqual(projected.conformanceCaseIDs, [
+            "c191.v1.northwind.cte-order-subtotals",
+            "c191.v1.select.j-inner.w-named-binding",
+        ])
+        XCTAssertEqual(
+            projected.requiredCapabilities.map(\.id),
+            ["function:ABS", "function:JSON_VALID"]
+        )
+    }
+
+    func testDescriptorProjectionUsesSQLTokenOrderForPhysicalSlots() throws {
+        let descriptor = try Support.mixedBindingDescriptor(
+            codec: Support.descriptorCodec(),
+            sql: "SELECT :token AS indexed_value, ?5 AS token"
+        )
+        let projected = try SQLiteBuildValidationQueryEntry(
+            id: "projection.sql-token-order",
+            descriptor: descriptor
+        )
+
+        XCTAssertEqual(projected.parameters.map(\.logicalIndex), [0, 1])
+        XCTAssertEqual(projected.parameters.map(\.physicalIndex), [5, 1])
+        XCTAssertEqual(
+            projected.parameters.map(\.expectedSQLiteSpelling),
+            ["?5", ":token"]
+        )
+        XCTAssertEqual(projected.expectedPhysicalParameterCount, 5)
+    }
+
+    func testDescriptorProjectionRejectsAliasCountMismatch() throws {
+        let descriptor = try Support.mixedBindingDescriptor(codec: Support.descriptorCodec())
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationQueryEntry(
+                id: "projection.alias-mismatch",
+                descriptor: descriptor,
+                declaredAliases: ["only-one"]
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationManifestError,
+                .resultAliasCountMismatch(
+                    queryID: "projection.alias-mismatch",
+                    expected: 2,
+                    actual: 1
+                )
+            )
+        }
+    }
+
+    func testDescriptorProjectionRejectsNamedParameterAbsentFromSQL() throws {
+        let descriptor = try Support.mixedBindingDescriptor(
+            codec: Support.descriptorCodec(),
+            sql: "SELECT ?5 AS indexed_value, 1 AS token"
+        )
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationQueryEntry(
+                id: "projection.missing-named-parameter",
+                descriptor: descriptor
+            )
+        ) { error in
+            guard case .invalidQuery(let queryID, let reason) =
+                    error as? SQLiteBuildValidationManifestError else {
+                return XCTFail("Expected invalid query, received \(error)")
+            }
+            XCTAssertEqual(queryID, "projection.missing-named-parameter")
+            XCTAssertTrue(reason.contains(":token"))
+        }
+    }
+
+    // MARK: - Determinism (Done-When #2)
+
+    func testManifestCanonicalizesOrderingAndIsByteIdenticalAcrossReorderingAndRepeatedRuns() throws {
+        let later = Support.query(
+            id: "z-later",
+            conformanceFeatureIDs: ["syntax.select.core", "binding.named", "syntax.select.core"],
+            conformanceCaseIDs: [
+                "c191.v1.select.j-inner.w-named-binding",
+                "c191.v1.northwind.cte-order-subtotals",
+                "c191.v1.select.j-inner.w-named-binding",
+            ],
+            northwindAnchorCaseIDs: ["northwind.cte.order-subtotals", "northwind.cte.order-subtotals"],
+            requiredCapabilities: ["function:FLOOR", "function:ABS", "function:FLOOR"]
+        )
+        let earlier = Support.query(id: "a-earlier")
+        let manifest = Support.manifest(queries: [later, earlier])
+        let reordered = Support.manifest(queries: [earlier, later])
+
+        let validated = try manifest.validating()
+        XCTAssertEqual(validated.queries.map(\.id), ["a-earlier", "z-later"])
+        XCTAssertEqual(
+            validated.queries[1].conformanceCaseIDs,
+            [
+                "c191.v1.northwind.cte-order-subtotals",
+                "c191.v1.select.j-inner.w-named-binding",
+            ]
+        )
+        XCTAssertEqual(
+            validated.queries[1].conformanceFeatureIDs,
+            ["binding.named", "syntax.select.core"]
+        )
+        XCTAssertEqual(
+            validated.queries[1].requiredCapabilities.map(\.id),
+            ["function:ABS", "function:FLOOR"]
+        )
+
+        let data = try manifest.canonicalJSONData()
+        let reorderedData = try reordered.canonicalJSONData()
+        let repeatedData = try manifest.canonicalJSONData()
+
+        XCTAssertEqual(data, reorderedData)
+        XCTAssertEqual(data, repeatedData)
+        XCTAssertEqual(data.last, 0x0A)
+        XCTAssertNotEqual(data.dropLast().last, 0x0A)
+        XCTAssertEqual(try SQLiteBuildValidationManifest.decode(data), validated)
+        XCTAssertEqual(
+            try SQLiteBuildValidationManifest.decode(data).canonicalJSONData(),
+            data
+        )
+
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+        let earlierRange = try XCTUnwrap(json.range(of: "a-earlier"))
+        let laterRange = try XCTUnwrap(json.range(of: "z-later"))
+        XCTAssertLessThan(earlierRange.lowerBound, laterRange.lowerBound)
+        XCTAssertTrue(json.contains("\"format_version\" : 1"))
+
+        // No nondeterministic evidence anywhere in the schema.
+        for excluded in ["timestamp", "hostname", "host_name", "process_id", "elapsed", "duration"] {
+            XCTAssertFalse(json.lowercased().contains(excluded), excluded)
+        }
+    }
+
+    // MARK: - Fail-closed structural validation (Done-When #3a)
+
+    func testManifestRejectsUnsupportedFormatVersion() {
+        let manifest = SQLiteBuildValidationManifest(
+            formatVersion: SQLiteBuildValidationManifestFormatVersion(rawValue: 2),
+            conformanceInventoryVersion: "190.1.0",
+            combinatorialManifestVersion: "c191-v2",
+            schemaSnapshot: Support.schemaSnapshot(),
+            queries: [Support.query()]
+        )
+        XCTAssertThrowsError(try manifest.validating()) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationManifestError,
+                .unsupportedFormatVersion(SQLiteBuildValidationManifestFormatVersion(rawValue: 2))
+            )
+        }
+    }
+
+    func testManifestRejectsInvalidSchemaSnapshotAndDuplicateQueryIDs() throws {
+        XCTAssertThrowsError(
+            try Support.manifest(
+                schemaSnapshot: Support.schemaSnapshot(
+                    databaseSHA256: String(repeating: "g", count: 64)
+                ),
+                queries: [Support.query()]
+            ).validating()
+        ) { error in
+            guard case .invalidManifest(let reason) =
+                error as? SQLiteBuildValidationManifestError else {
+                return XCTFail("Expected invalid manifest, received \(error)")
+            }
+            XCTAssertTrue(reason.contains("SHA-256"))
+        }
+
+        let duplicate = Support.query(id: "duplicate")
+        XCTAssertThrowsError(
+            try Support.manifest(queries: [duplicate, duplicate]).validating()
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationManifestError,
+                .duplicateQueryID("duplicate")
+            )
+        }
+    }
+
+    func testManifestRejectsParameterGapsPhysicalCollisionsAndMalformedKeys() {
+        let logicalGap = Support.parameter(logicalIndex: 1)
+        assertInvalidQuery(
+            Support.query(parameters: [logicalGap]),
+            contains: "contiguous"
+        )
+
+        let first = Support.parameter(
+            logicalIndex: 0, physicalIndex: 1, identity: "parameter/first", keyName: "first"
+        )
+        let collision = Support.parameter(
+            logicalIndex: 1, physicalIndex: 1, identity: "parameter/second", keyName: "second"
+        )
+        assertInvalidQuery(
+            Support.query(parameters: [first, collision]),
+            contains: "must not share"
+        )
+
+        let malformedIndexed = Support.parameter(
+            logicalIndex: 0,
+            physicalIndex: 3,
+            keyKind: .indexed,
+            keyName: nil,
+            keyIndex: 0
+        )
+        assertInvalidQuery(
+            Support.query(parameters: [malformedIndexed]),
+            contains: "matching physical_index"
+        )
+    }
+
+    func testManifestRejectsIncompleteCodecMetadata() {
+        let incompleteCodec = Support.codec(keyID: "")
+        assertInvalidQuery(
+            Support.query(results: [Support.result(codec: incompleteCodec)]),
+            contains: "codec metadata"
+        )
+    }
+
+    private func assertInvalidQuery(
+        _ query: SQLiteBuildValidationQueryEntry,
+        contains expectedReason: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(
+            try Support.manifest(queries: [query]).validating(),
+            file: file,
+            line: line
+        ) { error in
+            guard case .invalidQuery(_, let reason) =
+                error as? SQLiteBuildValidationManifestError else {
+                return XCTFail(
+                    "Expected invalid query, received \(error)", file: file, line: line
+                )
+            }
+            XCTAssertTrue(
+                reason.contains(expectedReason),
+                "Expected '\(reason)' to contain '\(expectedReason)'",
+                file: file, line: line
+            )
+        }
+    }
+
+    // MARK: - Reference resolution against real #190/#191/#254 registries (Done-When #3b)
+
+    func testManifestResolvesRepresentativeReferencesAgainstCanonicalRegistries() throws {
+        let inventory = try SQLiteConformanceInventory.load()
+        let combinatorial = try SQLiteCombinatorialSuite.makeManifest()
+        let registry = SQLiteBuildValidationStaticReferenceRegistry(
+            conformanceFeatureIDs: Set(inventory.features.map(\.id)),
+            conformanceCaseIDs: Set(combinatorial.cases.map(\.id)),
+            northwindAnchorCaseIDs: Set(
+                SQLiteNorthwindConformanceCaseID.allCases.map(\.rawValue)
+            )
+        )
+
+        let realFeatureID = try XCTUnwrap(inventory.features.first?.id)
+        let realCaseID = try XCTUnwrap(combinatorial.cases.first?.id)
+        let realAnchorID = try XCTUnwrap(SQLiteNorthwindConformanceCaseID.allCases.first?.rawValue)
+
+        let manifest = Support.manifest(queries: [
+            Support.query(
+                id: "real-references",
+                conformanceFeatureIDs: [realFeatureID],
+                conformanceCaseIDs: [realCaseID],
+                northwindAnchorCaseIDs: [realAnchorID]
+            ),
+        ])
+
+        XCTAssertNoThrow(try manifest.validating(against: registry))
+    }
+
+    func testManifestFailsClosedOnUnresolvedFeatureCaseAndAnchorReferences() {
+        let registry = SQLiteBuildValidationStaticReferenceRegistry(
+            conformanceFeatureIDs: ["syntax.select.core"],
+            conformanceCaseIDs: ["c191.v1.select.j-inner.w-named-binding"],
+            northwindAnchorCaseIDs: ["northwind.cte.order-subtotals"]
+        )
+
+        let badFeature = Support.manifest(queries: [
+            Support.query(id: "q", conformanceFeatureIDs: ["not.a.real.feature"]),
+        ])
+        XCTAssertThrowsError(try badFeature.validating(against: registry)) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationManifestError,
+                .unresolvedReference(
+                    queryID: "q", kind: .conformanceFeature, id: "not.a.real.feature"
+                )
+            )
+        }
+
+        let badCase = Support.manifest(queries: [
+            Support.query(id: "q", conformanceCaseIDs: ["c999.not-real"]),
+        ])
+        XCTAssertThrowsError(try badCase.validating(against: registry)) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationManifestError,
+                .unresolvedReference(queryID: "q", kind: .conformanceCase, id: "c999.not-real")
+            )
+        }
+
+        let badAnchor = Support.manifest(queries: [
+            Support.query(id: "q", northwindAnchorCaseIDs: ["northwind.not-real"]),
+        ])
+        XCTAssertThrowsError(try badAnchor.validating(against: registry)) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationManifestError,
+                .unresolvedReference(queryID: "q", kind: .northwindAnchor, id: "northwind.not-real")
+            )
+        }
+    }
+
+    // MARK: - Unknown schema (format) versions fail closed on decode
+
+    func testDecodeFailsClosedOnUnknownFormatVersion() throws {
+        let manifest = SQLiteBuildValidationManifest(
+            formatVersion: SQLiteBuildValidationManifestFormatVersion(rawValue: 2),
+            conformanceInventoryVersion: "190.1.0",
+            combinatorialManifestVersion: "c191-v2",
+            schemaSnapshot: Support.schemaSnapshot(),
+            queries: [Support.query()]
+        )
+        let data = try JSONEncoder().encode(manifest)
+        XCTAssertThrowsError(try SQLiteBuildValidationManifest.decode(data)) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationManifestError,
+                .unsupportedFormatVersion(SQLiteBuildValidationManifestFormatVersion(rawValue: 2))
+            )
+        }
+    }
+}

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
@@ -304,6 +304,51 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
         )
     }
 
+    /// `Codable`'s synthesized decoder populates stored properties directly
+    /// and never routes through the canonicalizing memberwise initializer,
+    /// so JSON whose `parameters`/`results` arrays are not already in
+    /// canonical order (but is otherwise a perfectly valid manifest) must
+    /// still decode and validate successfully rather than spuriously
+    /// failing the contiguity checks in `validateStructure`.
+    func testDecodeAcceptsAndNormalizesOutOfOrderJSON() throws {
+        let first = Support.parameter(
+            logicalIndex: 0, physicalIndex: 1, identity: "parameter/first", keyName: "first"
+        )
+        let second = Support.parameter(
+            logicalIndex: 1, physicalIndex: 2, identity: "parameter/second", keyName: "second"
+        )
+        let manifest = Support.manifest(queries: [
+            Support.query(
+                sql: "SELECT :first AS first, :second AS second",
+                parameters: [first, second],
+                results: [
+                    Support.result(index: 0, identity: "result/first", declaredAlias: "first"),
+                    Support.result(index: 1, identity: "result/second", declaredAlias: "second"),
+                ]
+            ),
+        ])
+        let canonicalData = try manifest.canonicalJSONData()
+
+        var json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: canonicalData) as? [String: Any]
+        )
+        var queries = try XCTUnwrap(json["queries"] as? [[String: Any]])
+        var query = queries[0]
+        query["parameters"] = Array(
+            (query["parameters"] as? [Any] ?? []).reversed()
+        )
+        query["results"] = Array(
+            (query["results"] as? [Any] ?? []).reversed()
+        )
+        queries[0] = query
+        json["queries"] = queries
+        let shuffledData = try JSONSerialization.data(withJSONObject: json)
+
+        let decoded = try SQLiteBuildValidationManifest.decode(shuffledData)
+        XCTAssertEqual(decoded, try manifest.validating())
+        XCTAssertEqual(try decoded.canonicalJSONData(), canonicalData)
+    }
+
     func testManifestValidatingSucceedsWhenParametersMatchSQLPlaceholders() throws {
         let parameter = Support.parameter(
             logicalIndex: 0, physicalIndex: 1, identity: "parameter/first", keyName: "first"

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
@@ -304,6 +304,13 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
         )
     }
 
+    func testManifestRejectsEmptySQL() {
+        assertInvalidQuery(
+            Support.query(sql: ""),
+            contains: "SQL must not be empty"
+        )
+    }
+
     func testManifestRejectsIncompleteCodecMetadata() {
         let incompleteCodec = Support.codec(keyID: "")
         assertInvalidQuery(
@@ -335,6 +342,19 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
                 file: file, line: line
             )
         }
+    }
+
+    // MARK: - Placeholder scanner
+
+    func testPlaceholderScannerTreatsDoubledClosingBracketAsEscapedInsideQuotedIdentifier() {
+        // "[x]]y:fake]" is one bracket-quoted identifier ("x]y:fake") where
+        // "]]" escapes a literal "]", matching the doubled-delimiter escape
+        // already honored for '/"/`. A scanner that stops at the first "]"
+        // would incorrectly split out ":fake" as a placeholder occurrence.
+        let analysis = SQLiteBuildValidationManifestPlaceholderScanner.scan(
+            "SELECT [x]]y:fake] AS col, :real AS r"
+        )
+        XCTAssertEqual(analysis.occurrences.map(\.spelling), [":real"])
     }
 
     // MARK: - Reference resolution against real #190/#191/#254 registries (Done-When #3b)

--- a/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationManifestTests/SQLiteBuildValidationManifestTests.swift
@@ -304,6 +304,42 @@ final class SQLiteBuildValidationManifestTests: XCTestCase {
         )
     }
 
+    func testManifestValidatingSucceedsWhenParametersMatchSQLPlaceholders() throws {
+        let parameter = Support.parameter(
+            logicalIndex: 0, physicalIndex: 1, identity: "parameter/first", keyName: "first"
+        )
+        let manifest = Support.manifest(queries: [
+            Support.query(sql: "SELECT :first AS first", parameters: [parameter]),
+        ])
+        XCTAssertNoThrow(try manifest.validating())
+    }
+
+    /// `validateStructure` cross-checks declared parameters against the raw
+    /// SQL, independent of the `init(id:descriptor:...)` projection path —
+    /// this is the fail-closed contract for a manifest decoded straight from
+    /// externally authored/edited JSON.
+    func testManifestRejectsParametersInconsistentWithSQLPlaceholders() {
+        // Declared parameter has no corresponding placeholder in the SQL.
+        assertInvalidQuery(
+            Support.query(sql: "SELECT 1", parameters: [Support.parameter()]),
+            contains: "do not match the placeholders found in SQL"
+        )
+        // SQL contains a placeholder the manifest never declares.
+        assertInvalidQuery(
+            Support.query(sql: "SELECT :first"),
+            contains: "do not match the placeholders found in SQL"
+        )
+        // The declared spelling disagrees with the actual placeholder at
+        // that physical index.
+        let wrongSpelling = Support.parameter(
+            logicalIndex: 0, physicalIndex: 1, identity: "parameter/first", keyName: "wrong"
+        )
+        assertInvalidQuery(
+            Support.query(sql: "SELECT :first", parameters: [wrongSpelling]),
+            contains: "does not match its placeholder occurrence"
+        )
+    }
+
     func testManifestRejectsEmptySQL() {
         assertInvalidQuery(
             Support.query(sql: ""),


### PR DESCRIPTION
Closes #292.

## Summary

Adds `SwiftQLSQLiteBuildValidationManifest`: a versioned, deterministic sidecar for static SwiftQL query descriptors, per the [#132 research decision](https://github.com/lukevanin/swiftql/blob/main/Documentation/Architecture/SQLiteBuildValidation.md) (§16-17). This is step 1 of the recommended v1.5 implementation sequence — the manifest schema and deterministic serialization, with no SQLite database I/O.

- **Projects `XLStaticQueryDescriptor`** into canonical JSON, adding only the reproducible-build fields the frozen `XLQueryIdentity` v1 representation deliberately excludes: physical placeholder positions (recovered by scanning rendered SQL), declared result aliases, pinned schema-snapshot identity, and cross-references into the #190 conformance inventory, #191 combinatorial cases, and #254 Northwind anchors.
- **Two-step validation**: `validating()` is structural/registry-independent (fails closed on unsupported format version, invalid schema snapshot, duplicate query ids, malformed physical parameter slots, incomplete codec metadata). `validating(against:)` does exhaustive #190/#191/#254 reference resolution via an injected `SQLiteBuildValidationReferenceRegistry` protocol — the manifest module itself has zero dependency on those test-only targets, matching this codebase's existing target-boundary convention.
- **Deterministic canonical JSON**: sorted keys, deduplicated/sorted set-like fields, exactly one trailing newline, byte-identical across reordered input and repeated runs. No timestamp/hostname/PID/path field exists anywhere in the schema.
- Format version 1 is frozen (mirrors the `XLQueryIdentity` v1 policy).
- Extends the downstream Swift 5 compatibility fixture (`IntegrationTests/Swift5Client`) to exercise the new module end-to-end in Swift 5 language mode.
- New architecture doc: [`Documentation/Architecture/SQLiteBuildValidationManifest.md`](../blob/issue-292-build-validation-manifest/Documentation/Architecture/SQLiteBuildValidationManifest.md) covering schema, determinism, registry wiring, and the versioning/upgrade policy.

## Non-goals (per issue)

No SQLite database I/O, no SwiftPM build-tool plugin, no macro implementation, no typed DDL/migration/statement persistence. Does not change `XLQueryIdentity` v1 or make `XLStaticQueryDescriptor` wholesale `Codable`.

## Test plan

- [x] `swift build` (whole package) — clean
- [x] `swift test --filter SwiftQLSQLiteBuildValidationManifestTests` — 12/12 passing, covering descriptor projection round-trip, determinism/canonical-JSON byte-identity across reordering, fail-closed structural validation (format version, schema snapshot, duplicate ids, parameter gaps/collisions, malformed codec metadata), and reference resolution against both a real #190/#191/#254-backed registry and fabricated bad IDs
- [x] `swift test --filter SwiftQLCoreTests` — 91/91 passing (no regressions)
- [x] Downstream Swift 5 fixture (`IntegrationTests/Swift5Client`) builds and runs clean in Swift 5 language mode
