### PR TITLE
Ship a standalone SQLite static-query build validator (#293)

### DIFF
--- a/Documentation/Architecture/SQLiteBuildValidation.md
+++ b/Documentation/Architecture/SQLiteBuildValidation.md
@@ -415,7 +415,9 @@ Three atomic v1.5 follow-ups are recommended:
    manifest and snapshot, own a read-only connection, call
    `sqlite3_prepare_v3`, produce stable fail-closed diagnostics, and validate a
    real downstream fixture. No plugin, macro, DDL, migrations, or statement
-   persistence.
+   persistence. Delivered as `SwiftQLSQLiteBuildValidationValidator` and the
+   `swiftql-build-validate` CLI; see
+   [SQLiteBuildValidationValidator.md](SQLiteBuildValidationValidator.md).
 3. [**#294: Add a SwiftPM build-tool plugin wrapper for SQLite query
    validation.**](https://github.com/lukevanin/swiftql/issues/294) Use declared
    inputs/outputs and invoke the standalone tool. No validation logic, schema

--- a/Documentation/Architecture/SQLiteBuildValidationValidator.md
+++ b/Documentation/Architecture/SQLiteBuildValidationValidator.md
@@ -1,0 +1,110 @@
+# Standalone SQLite Build Validator (#293)
+
+This is the standalone SQLite static-query build validator recommended by
+the [#132 research](SQLiteBuildValidation.md) and produced by
+[#293](https://github.com/lukevanin/swiftql/issues/293), consuming the
+[#292 manifest](SQLiteBuildValidationManifest.md) and an explicit checked-in
+SQLite snapshot. It is a promotion of the already-validated `#132` research
+prototype (`Research/SQLiteBuildValidation/`) into a real product, adapted to
+consume `SwiftQLSQLiteBuildValidationManifest` types instead of the
+prototype's own local model.
+
+## Package surface
+
+`SwiftQLSQLiteBuildValidationValidator` (`Sources/SwiftQLSQLiteBuildValidationValidator`)
+is a library target depending on `SwiftQLCore`, `SwiftQLSQLiteBuildValidationManifest`,
+GRDB, and CSQLite. `SwiftQLSQLiteBuildValidationValidatorCLI` wraps it as the
+`swiftql-build-validate` executable product.
+
+```
+swiftql-build-validate \
+  --database  Northwind.sqlite \
+  --manifest  build-validation-manifest.json \
+  --output    report.json \
+  [--codec <identity>]     # repeatable
+  [--extension <name>]     # repeatable
+  [--capability <id>]      # repeatable
+```
+
+Exit code `0` only for an overall `passed` report; `1` for a report
+containing `failed`/`unsupported`; `2` for anything that prevented producing
+a report at all (bad arguments, unreadable manifest, I/O failure) — errors go
+to stderr alongside the usage string.
+
+## What it proves, and what it doesn't
+
+Owns one dedicated read-only, query-only `DatabaseQueue` for the entire run
+(`PRAGMA query_only = ON`), verifies the snapshot is byte-identical before and
+after validation, and refuses a snapshot with an adjacent `-journal`/`-shm`/
+`-wal` sidecar. On that connection it prepares exactly one statement per
+manifest entry with `sqlite3_prepare_v3` (via `SQLitePrepareV3Probe`), which
+returns only copied Swift values — no `sqlite3_stmt` pointer, claim, or
+serialized format ever escapes the probe, and every statement is finalized
+exactly once on every path (success, inspection failure, or finalize
+failure).
+
+This proves: the SQL is one non-empty statement the real SQLite parser
+accepts; referenced tables/columns/functions/collations resolve on that
+connection; the C parameter index/name layout and result-column count/alias
+agree with the manifest; declared capabilities are present in captured
+runtime evidence; and the snapshot/SQLite build match recorded provenance.
+
+It does **not** prove result values, row counts, application behavior,
+runtime storage classes for dynamically typed expressions, general result
+nullability, codec encode/decode behavior, or catalog/alias/nullability
+semantics — those remain #214's responsibility (`delegatedChecks` on every
+report names them explicitly so a reader knows what "passed" does not cover).
+
+## Verdicts are fail-closed
+
+`SQLiteBuildValidationVerdict` is `passed` / `failed` / `unsupported`. Only
+`passed` is success — `unsupported` (a required capability or evidence
+source was unavailable, so the declaration could not be proven) fails the
+gate exactly like `failed`. An `unsupported` capability can never be
+"spoofed" into passing: only genuinely opaque, non-observable capability IDs
+(anything without a `function:`/`collation:`/`compile-option:`/`module:`/
+`extension:` prefix, and not `sqlite-json-functions`) may be satisfied by
+`SQLiteBuildValidationEnvironment.capabilityIDs`; an observable capability
+(e.g. `function:FLOOR`) must actually be present in the connection's captured
+`PRAGMA function_list` evidence.
+
+A query whose preparation prerequisites are unavailable (missing dialect
+capability, SQLite version, function, collation, module, or JSON-function
+support) never reaches `sqlite3_prepare_v3` at all — it fails closed as
+`unsupported` before preparation, rather than surfacing a confusing prepare
+failure.
+
+## Determinism
+
+Same canonical-JSON contract as the manifest: `[.prettyPrinted, .sortedKeys,
+.withoutEscapingSlashes]`, diagnostics sorted by `[queryID, code, stage,
+resultCode, extendedResultCode, message]`, outcomes sorted by `queryID`, and
+every evidence list (compile options, functions, collations, modules,
+extension names, environment identifiers) sorted and deduplicated. No
+timestamp, hostname, process ID, or local path exists anywhere in the report
+schema — two runs against the same manifest, snapshot, SQLite build, and
+capability registration produce byte-identical canonical JSON.
+
+## Relationship to the #292 manifest
+
+The manifest's own `validating()` already cross-checks declared parameters
+against the raw SQL text (lexically) before the validator ever runs, so a
+manifest that reaches this validator is already internally self-consistent.
+What the validator adds is comparison against the **real SQLite parser**:
+schema resolution, C-level bind/result metadata, and engine capability
+evidence that no amount of manifest-level static checking can substitute
+for. `query.minimumDialectVersion`, `query.conformanceFeatureIDs`, and the
+other #292 fields carry straight through into report diagnostics/outcomes so
+a failure links back to the originating #190/#191/#254 references.
+
+## What this does not do
+
+Per the #132 research decision, this module owns only the standalone
+validation engine. It does not:
+
+- provide a build-tool plugin or declare SwiftPM build-command inputs/outputs
+  (owned by [#294](https://github.com/lukevanin/swiftql/issues/294));
+- implement or lower the `@SQLQuery` macro (owned by #26);
+- own catalog membership, table-reference binding, alias scopes, nullability
+  propagation, or DML roles (owned by #214); or
+- persist, reuse, or expose a serialized `sqlite3_stmt` at runtime.

--- a/IntegrationTests/Swift5Client/Package.swift
+++ b/IntegrationTests/Swift5Client/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
                 .product(name: "SwiftQLCore", package: "SwiftQL"),
                 .product(name: "SwiftQL", package: "SwiftQL"),
                 .product(name: "SwiftQLSQLiteBuildValidationManifest", package: "SwiftQL"),
+                .product(name: "SwiftQLSQLiteBuildValidationValidator", package: "SwiftQL"),
             ]
         ),
     ],

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -1,7 +1,9 @@
 import Foundation
+import GRDB
 import SwiftQL
 import SwiftQLCore
 import SwiftQLSQLiteBuildValidationManifest
+import SwiftQLSQLiteBuildValidationValidator
 
 #if compiler(<6.0)
 #error("The downstream compatibility fixture must use the supported Swift 6 compiler.")
@@ -437,11 +439,82 @@ private func validateBuildValidationManifestFixture() throws {
     }
 }
 
+private func validateBuildValidationValidatorFixture() throws {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("swiftql-build-validator-fixture-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+        at: directory,
+        withIntermediateDirectories: false
+    )
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let databaseURL = directory.appendingPathComponent("fixture.sqlite")
+
+    let writeQueue = try DatabaseQueue(path: databaseURL.path)
+    try writeQueue.write { database in
+        try database.execute(sql: "CREATE TABLE t (id INTEGER)")
+    }
+    try writeQueue.close()
+
+    let databaseData = try Data(contentsOf: databaseURL, options: .mappedIfSafe)
+    let databaseSHA256 = SQLiteBuildValidationSHA256.hexDigest(of: databaseData)
+
+    var readConfiguration = Configuration()
+    readConfiguration.readonly = true
+    let readQueue = try DatabaseQueue(path: databaseURL.path, configuration: readConfiguration)
+    let runtimeMetadata = try readQueue.read { database in
+        try SQLiteBuildValidationRuntime.capture(from: database)
+    }
+    try readQueue.close()
+
+    let manifest = SQLiteBuildValidationManifest(
+        conformanceInventoryVersion: "downstream-fixture",
+        combinatorialManifestVersion: "downstream-fixture",
+        schemaSnapshot: SQLiteBuildValidationSchemaSnapshot(
+            identifier: "downstream-fixture",
+            databaseSHA256: databaseSHA256,
+            databaseByteCount: databaseData.count,
+            schemaRowCount: runtimeMetadata.schemaRowCount,
+            schemaFingerprint: runtimeMetadata.schemaFNV1A64
+        ),
+        queries: [
+            SQLiteBuildValidationQueryEntry(
+                id: "downstream.validator-fixture",
+                definitionIdentity: "downstream/validator-fixture@1",
+                descriptorIdentity: "swiftql-query-v1-downstream-validator-fixture",
+                sql: "SELECT 1 AS value",
+                dialectIdentifier: XLSQLiteDialect.identity.rawValue,
+                cardinality: XLQueryCardinality.exactlyOne.rawValue,
+                results: [
+                    SQLiteBuildValidationResultEntry(
+                        index: 0,
+                        identity: "result/value",
+                        declaredAlias: "value",
+                        valueTypeIdentifier: "swift.int",
+                        valueTypeName: "Swift.Int",
+                        nullability: "required",
+                        codec: nil,
+                        storageIdentifier: "integer"
+                    ),
+                ]
+            ),
+        ]
+    )
+
+    let report = try SQLiteBuildValidator.validate(
+        manifest: manifest,
+        againstDatabaseAt: databaseURL
+    )
+    guard report.overallVerdict == .passed, report.diagnostics.isEmpty else {
+        throw FixtureError.invalidCoreContract
+    }
+}
+
 private func runFixture() throws {
     try validateLiteralReaderCompatibility()
     try validateRowReaderCompatibility()
     try validateSeparatorCompatibility()
     try validateBuildValidationManifestFixture()
+    try validateBuildValidationValidatorFixture()
     let codingConfiguration = try validateCoreContractProduct()
 
     let directory = FileManager.default.temporaryDirectory

--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,17 @@ let package = Package(
             name: "SwiftQLSQLiteBuildValidationManifest",
             targets: ["SwiftQLSQLiteBuildValidationManifest"]
         ),
+        .library(
+            name: "SwiftQLSQLiteBuildValidationValidator",
+            targets: ["SwiftQLSQLiteBuildValidationValidator"]
+        ),
         .executable(
             name: "swiftql-benchmark",
             targets: ["SwiftQLBenchmarkCLI"]
+        ),
+        .executable(
+            name: "swiftql-build-validate",
+            targets: ["SwiftQLSQLiteBuildValidationValidatorCLI"]
         ),
     ],
     dependencies: [
@@ -122,6 +130,27 @@ let package = Package(
         .target(
             name: "SwiftQLSQLiteBuildValidationManifest",
             dependencies: ["SwiftQLCore"]
+        ),
+
+        // Standalone SQLite static-query build validator (#293). Consumes
+        // the #292 manifest and an explicit checked-in SQLite snapshot, owns
+        // one dedicated read-only/query-only connection per run, and
+        // prepares each manifest entry with sqlite3_prepare_v3. No prepared
+        // statement escapes this target: SQLitePrepareV3Probe returns copied
+        // Swift values only.
+        .target(
+            name: "SwiftQLSQLiteBuildValidationValidator",
+            dependencies: [
+                "SwiftQLCore",
+                "SwiftQLSQLiteBuildValidationManifest",
+                .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "CSQLite", package: "GRDB.swift"),
+            ]
+        ),
+
+        .executableTarget(
+            name: "SwiftQLSQLiteBuildValidationValidatorCLI",
+            dependencies: ["SwiftQLSQLiteBuildValidationValidator"]
         ),
 
         // Package-private research engine for issue #132. This deliberately
@@ -225,6 +254,20 @@ let package = Package(
                 "SwiftQLSQLiteConformanceFixtures",
                 "SwiftQLSQLiteCombinatorialSupport",
                 "SwiftQLNorthwindFixtures",
+                .product(name: "GRDB", package: "GRDB.swift"),
+            ]
+        ),
+
+        .testTarget(
+            name: "SwiftQLSQLiteBuildValidationValidatorTests",
+            dependencies: [
+                "SwiftQLCore",
+                "SwiftQL",
+                "SwiftQLSQLiteBuildValidationManifest",
+                "SwiftQLSQLiteBuildValidationValidator",
+                "SwiftQLNorthwindFixtures",
+                "SwiftQLSQLiteConformanceFixtures",
+                "SwiftQLSQLiteCombinatorialSupport",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ]
         ),

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationReport.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationReport.swift
@@ -1,0 +1,319 @@
+import Foundation
+import SwiftQLSQLiteBuildValidationManifest
+
+
+/// A single query's or run's overall pass/fail/unsupported classification.
+///
+/// Only `passed` is success. `failed` and `unsupported` both fail the
+/// validation gate — an absent or unavailable capability must never report
+/// as `passed`.
+public enum SQLiteBuildValidationVerdict: String, Codable, CaseIterable, Sendable {
+    case passed
+    case failed
+    case unsupported
+}
+
+
+/// Explicit caller-supplied evidence used during one validation run.
+///
+/// The encoded form is deliberately limited to stable identifiers: it does
+/// not retain paths, timestamps, process identity, or host identity. Every
+/// list is sorted and deduplicated so semantically equivalent invocations
+/// produce byte-identical canonical reports.
+public struct SQLiteBuildValidationEnvironment:
+    Codable,
+    Equatable,
+    Sendable
+{
+    public let codecIdentifiers: [String]
+    public let extensionNames: [String]
+    public let capabilityIDs: [String]
+
+    public init(
+        codecIdentifiers: [String] = [],
+        extensionNames: [String] = [],
+        capabilityIDs: [String] = []
+    ) {
+        self.codecIdentifiers = Self.sortedUnique(codecIdentifiers)
+        self.extensionNames = Self.sortedUnique(extensionNames)
+        self.capabilityIDs = Self.sortedUnique(capabilityIDs)
+    }
+
+    public init(
+        codecIdentities: [SQLiteBuildValidationCodecReference],
+        extensionNames: [String] = [],
+        capabilityIDs: [String] = []
+    ) {
+        self.init(
+            codecIdentifiers: codecIdentities.map(\.stableIdentifier),
+            extensionNames: extensionNames,
+            capabilityIDs: capabilityIDs
+        )
+    }
+
+    private static func sortedUnique(_ values: [String]) -> [String] {
+        Array(Set(values)).sorted()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case codecIdentifiers = "codec_identifiers"
+        case extensionNames = "extension_names"
+        case capabilityIDs = "capability_ids"
+    }
+}
+
+
+public struct SQLiteBuildValidationDiagnostic: Codable, Equatable, Sendable {
+    public enum Stage: String, Codable, CaseIterable, Sendable {
+        case schema
+        case runtime
+        case codec
+        case capability
+        case prepare
+        case parameter
+        case result
+    }
+
+    public let verdict: SQLiteBuildValidationVerdict
+    public let stage: Stage
+    public let code: String
+    public let message: String
+    public let queryID: String?
+    public let definitionIdentity: String?
+    public let descriptorIdentity: String?
+    public let conformanceFeatureIDs: [String]
+    public let conformanceCaseIDs: [String]
+    public let northwindAnchorCaseIDs: [String]
+    public let sqliteResultCode: Int32?
+    public let sqliteExtendedResultCode: Int32?
+
+    public init(
+        verdict: SQLiteBuildValidationVerdict,
+        stage: Stage,
+        code: String,
+        message: String,
+        query: SQLiteBuildValidationQueryEntry? = nil,
+        sqliteResultCode: Int32? = nil,
+        sqliteExtendedResultCode: Int32? = nil
+    ) {
+        precondition(verdict != .passed, "A diagnostic cannot carry a passed verdict.")
+        self.verdict = verdict
+        self.stage = stage
+        self.code = code
+        self.message = message
+        self.queryID = query?.id
+        self.definitionIdentity = query?.definitionIdentity
+        self.descriptorIdentity = query?.descriptorIdentity
+        self.conformanceFeatureIDs = query?.conformanceFeatureIDs ?? []
+        self.conformanceCaseIDs = query?.conformanceCaseIDs ?? []
+        self.northwindAnchorCaseIDs = query?.northwindAnchorCaseIDs ?? []
+        self.sqliteResultCode = sqliteResultCode
+        self.sqliteExtendedResultCode = sqliteExtendedResultCode
+    }
+
+    static func canonicalOrder(
+        _ lhs: Self,
+        _ rhs: Self
+    ) -> Bool {
+        let lhsKey = [
+            lhs.queryID ?? "",
+            lhs.code,
+            lhs.stage.rawValue,
+            String(lhs.sqliteResultCode ?? 0),
+            String(lhs.sqliteExtendedResultCode ?? 0),
+            lhs.message,
+        ]
+        let rhsKey = [
+            rhs.queryID ?? "",
+            rhs.code,
+            rhs.stage.rawValue,
+            String(rhs.sqliteResultCode ?? 0),
+            String(rhs.sqliteExtendedResultCode ?? 0),
+            rhs.message,
+        ]
+        return lhsKey.lexicographicallyPrecedes(rhsKey)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case verdict
+        case stage
+        case code
+        case message
+        case queryID = "query_id"
+        case definitionIdentity = "definition_identity"
+        case descriptorIdentity = "descriptor_identity"
+        case conformanceFeatureIDs = "conformance_feature_ids"
+        case conformanceCaseIDs = "conformance_case_ids"
+        case northwindAnchorCaseIDs = "northwind_anchor_case_ids"
+        case sqliteResultCode = "sqlite_result_code"
+        case sqliteExtendedResultCode = "sqlite_extended_result_code"
+    }
+}
+
+
+public struct SQLiteBuildValidationQueryOutcome:
+    Codable,
+    Equatable,
+    Sendable
+{
+    public let queryID: String
+    public let definitionIdentity: String
+    public let descriptorIdentity: String
+    public let conformanceFeatureIDs: [String]
+    public let conformanceCaseIDs: [String]
+    public let northwindAnchorCaseIDs: [String]
+    public let verdict: SQLiteBuildValidationVerdict
+    public let placeholderAnalysis: SQLiteBuildValidationValidatorPlaceholderAnalysis
+    public let preparedShape: SQLitePreparedStatementShape?
+    public let diagnostics: [SQLiteBuildValidationDiagnostic]
+
+    public init(
+        query: SQLiteBuildValidationQueryEntry,
+        placeholderAnalysis: SQLiteBuildValidationValidatorPlaceholderAnalysis,
+        preparedShape: SQLitePreparedStatementShape?,
+        diagnostics: [SQLiteBuildValidationDiagnostic]
+    ) {
+        let diagnostics = diagnostics.sorted(
+            by: SQLiteBuildValidationDiagnostic.canonicalOrder
+        )
+        self.queryID = query.id
+        self.definitionIdentity = query.definitionIdentity
+        self.descriptorIdentity = query.descriptorIdentity
+        self.conformanceFeatureIDs = query.conformanceFeatureIDs
+        self.conformanceCaseIDs = query.conformanceCaseIDs
+        self.northwindAnchorCaseIDs = query.northwindAnchorCaseIDs
+        self.verdict = Self.verdict(for: diagnostics)
+        self.placeholderAnalysis = placeholderAnalysis
+        self.preparedShape = preparedShape
+        self.diagnostics = diagnostics
+    }
+
+    private static func verdict(
+        for diagnostics: [SQLiteBuildValidationDiagnostic]
+    ) -> SQLiteBuildValidationVerdict {
+        if diagnostics.contains(where: { $0.verdict == .failed }) {
+            return .failed
+        }
+        if diagnostics.contains(where: { $0.verdict == .unsupported }) {
+            return .unsupported
+        }
+        return .passed
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case queryID = "query_id"
+        case definitionIdentity = "definition_identity"
+        case descriptorIdentity = "descriptor_identity"
+        case conformanceFeatureIDs = "conformance_feature_ids"
+        case conformanceCaseIDs = "conformance_case_ids"
+        case northwindAnchorCaseIDs = "northwind_anchor_case_ids"
+        case verdict
+        case placeholderAnalysis = "placeholder_analysis"
+        case preparedShape = "prepared_shape"
+        case diagnostics
+    }
+}
+
+
+public struct SQLiteBuildValidationReport: Codable, Equatable, Sendable {
+    public let formatVersion: Int
+    public let manifestFormatVersion: Int
+    public let conformanceInventoryVersion: String
+    public let combinatorialManifestVersion: String
+    public let schemaSnapshot: SQLiteBuildValidationSchemaSnapshot
+    public let observedDatabaseByteCount: Int?
+    public let observedDatabaseSHA256: String?
+    public let runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?
+    public let environmentEvidence: SQLiteBuildValidationEnvironment
+    public let delegatedChecks: [String]
+    public let overallVerdict: SQLiteBuildValidationVerdict
+    public let diagnostics: [SQLiteBuildValidationDiagnostic]
+    public let outcomes: [SQLiteBuildValidationQueryOutcome]
+
+    public init(
+        manifest: SQLiteBuildValidationManifest,
+        observedDatabaseByteCount: Int?,
+        observedDatabaseSHA256: String?,
+        runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?,
+        environmentEvidence: SQLiteBuildValidationEnvironment,
+        diagnostics: [SQLiteBuildValidationDiagnostic],
+        outcomes: [SQLiteBuildValidationQueryOutcome]
+    ) {
+        let diagnostics = diagnostics.sorted(
+            by: SQLiteBuildValidationDiagnostic.canonicalOrder
+        )
+        let outcomes = outcomes.sorted { $0.queryID < $1.queryID }
+        self.formatVersion = 1
+        self.manifestFormatVersion = manifest.formatVersion.rawValue
+        self.conformanceInventoryVersion = manifest.conformanceInventoryVersion
+        self.combinatorialManifestVersion = manifest.combinatorialManifestVersion
+        self.schemaSnapshot = manifest.schemaSnapshot
+        self.observedDatabaseByteCount = observedDatabaseByteCount
+        self.observedDatabaseSHA256 = observedDatabaseSHA256?.lowercased()
+        self.runtimeMetadata = runtimeMetadata
+        self.environmentEvidence = environmentEvidence
+        self.delegatedChecks = [
+            "#214 catalog membership and table-reference binding",
+            "#214 correlated and nested reference scopes",
+            "#214 DML target roles",
+            "#214 nullability views",
+            "#214 same-scope alias uniqueness",
+            "SQLite declared types do not prove dynamic expression storage or codec compatibility",
+        ].sorted()
+        self.overallVerdict = Self.overallVerdict(
+            diagnostics: diagnostics,
+            outcomes: outcomes
+        )
+        self.diagnostics = diagnostics
+        self.outcomes = outcomes
+    }
+
+    public func canonicalJSONData() throws -> Data {
+        try SQLiteBuildValidationValidatorCanonicalJSON.encode(self)
+    }
+
+    private static func overallVerdict(
+        diagnostics: [SQLiteBuildValidationDiagnostic],
+        outcomes: [SQLiteBuildValidationQueryOutcome]
+    ) -> SQLiteBuildValidationVerdict {
+        if diagnostics.contains(where: { $0.verdict == .failed })
+            || outcomes.contains(where: { $0.verdict == .failed }) {
+            return .failed
+        }
+        if diagnostics.contains(where: { $0.verdict == .unsupported })
+            || outcomes.contains(where: { $0.verdict == .unsupported }) {
+            return .unsupported
+        }
+        return .passed
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case formatVersion = "format_version"
+        case manifestFormatVersion = "manifest_format_version"
+        case conformanceInventoryVersion = "conformance_inventory_version"
+        case combinatorialManifestVersion = "combinatorial_manifest_version"
+        case schemaSnapshot = "schema_snapshot"
+        case observedDatabaseByteCount = "observed_database_byte_count"
+        case observedDatabaseSHA256 = "observed_database_sha256"
+        case runtimeMetadata = "runtime_metadata"
+        case environmentEvidence = "environment_evidence"
+        case delegatedChecks = "delegated_checks"
+        case overallVerdict = "overall_verdict"
+        case diagnostics
+        case outcomes
+    }
+}
+
+
+enum SQLiteBuildValidationValidatorCanonicalJSON {
+    static func encode<Value: Encodable>(_ value: Value) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(value)
+        while data.last == 0x0A {
+            data.removeLast()
+        }
+        data.append(0x0A)
+        return data
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationReport.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationReport.swift
@@ -35,7 +35,11 @@ public struct SQLiteBuildValidationEnvironment:
         capabilityIDs: [String] = []
     ) {
         self.codecIdentifiers = Self.sortedUnique(codecIdentifiers)
-        self.extensionNames = Self.sortedUnique(extensionNames)
+        // Fold before deduping: extension-name matching is ASCII
+        // case-insensitive (SQLiteBuildValidationRuntimeMetadata.hasExtension),
+        // so "MyExt" and "myext" are the same semantic requirement and must
+        // not survive as two distinct entries in the canonical report.
+        self.extensionNames = Self.sortedUnique(extensionNames.map(sqliteASCIIFolded))
         self.capabilityIDs = Self.sortedUnique(capabilityIDs)
     }
 

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationRuntime.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationRuntime.swift
@@ -1,0 +1,408 @@
+import Foundation
+import GRDB
+
+
+/// Stable process, connection-capability, and schema identity for one build
+/// validation run.
+///
+/// Every encoded list is sorted and deduplicated. No timestamp, hostname,
+/// process identifier, or database path is retained.
+public struct SQLiteBuildValidationRuntimeMetadata:
+    Codable,
+    Equatable,
+    Sendable
+{
+    public let sqliteVersion: String
+    public let sqliteSourceID: String
+    public let compileOptions: [String]
+    public let functions: [SQLiteBuildValidationRuntimeFunction]
+    public let collations: [String]
+    public let moduleNames: [String]
+    public let extensionNames: [String]
+    public let schemaRowCount: Int
+    public let schemaFNV1A64: String
+
+    public init(
+        sqliteVersion: String,
+        sqliteSourceID: String,
+        compileOptions: [String],
+        functions: [SQLiteBuildValidationRuntimeFunction],
+        collations: [String],
+        moduleNames: [String],
+        extensionNames: [String],
+        schemaRowCount: Int,
+        schemaFNV1A64: String
+    ) {
+        self.sqliteVersion = sqliteVersion
+        self.sqliteSourceID = sqliteSourceID
+        self.compileOptions = sortedUniqueRuntimeStrings(compileOptions)
+        self.functions = Array(Set(functions)).sorted(
+            by: SQLiteBuildValidationRuntimeFunction.canonicalOrder
+        )
+        self.collations = sortedUniqueRuntimeStrings(collations)
+        self.moduleNames = sortedUniqueRuntimeStrings(moduleNames)
+        self.extensionNames = sortedUniqueRuntimeStrings(extensionNames)
+        self.schemaRowCount = schemaRowCount
+        self.schemaFNV1A64 = schemaFNV1A64.lowercased()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sqliteVersion = "sqlite_version"
+        case sqliteSourceID = "sqlite_source_id"
+        case compileOptions = "compile_options"
+        case functions
+        case collations
+        case moduleNames = "module_names"
+        case extensionNames = "extension_names"
+        case schemaRowCount = "schema_row_count"
+        case schemaFNV1A64 = "schema_fnv1a_64"
+    }
+
+    /// Computed sets are for capability lookup only and are not serialized.
+    public var compileOptionCapabilities: Set<String> {
+        Set(compileOptions)
+    }
+
+    public var functionCapabilities: Set<SQLiteBuildValidationRuntimeFunction> {
+        Set(functions)
+    }
+
+    public var collationCapabilities: Set<String> {
+        Set(collations)
+    }
+
+    public var moduleCapabilities: Set<String> {
+        Set(moduleNames)
+    }
+
+    public var extensionCapabilities: Set<String> {
+        Set(extensionNames)
+    }
+
+    public func hasFunction(
+        named name: String,
+        argumentCount: Int? = nil
+    ) -> Bool {
+        let requiredName = sqliteASCIIFolded(name)
+        return functions.contains { function in
+            guard sqliteASCIIFolded(function.name) == requiredName else {
+                return false
+            }
+            guard let argumentCount else {
+                return true
+            }
+            return function.argumentCount == argumentCount
+                || function.argumentCount == -1
+        }
+    }
+
+    public func hasCollation(named name: String) -> Bool {
+        let requiredName = sqliteASCIIFolded(name)
+        return collations.contains {
+            sqliteASCIIFolded($0) == requiredName
+        }
+    }
+
+    public func hasModule(named name: String) -> Bool {
+        moduleCapabilities.contains(name)
+    }
+
+    public func hasCompileOption(_ option: String) -> Bool {
+        compileOptionCapabilities.contains(option)
+    }
+
+    public func hasExtension(named name: String) -> Bool {
+        extensionCapabilities.contains(name)
+    }
+}
+
+
+public struct SQLiteBuildValidationRuntimeFunction:
+    Codable,
+    Equatable,
+    Hashable,
+    Sendable
+{
+    public let name: String
+    public let isBuiltIn: Bool
+    public let kind: String
+    public let encoding: String
+    public let argumentCount: Int
+    public let flags: Int64
+
+    public init(
+        name: String,
+        isBuiltIn: Bool,
+        kind: String,
+        encoding: String,
+        argumentCount: Int,
+        flags: Int64
+    ) {
+        self.name = name
+        self.isBuiltIn = isBuiltIn
+        self.kind = kind
+        self.encoding = encoding
+        self.argumentCount = argumentCount
+        self.flags = flags
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case isBuiltIn = "is_built_in"
+        case kind
+        case encoding
+        case argumentCount = "argument_count"
+        case flags
+    }
+
+    fileprivate static func canonicalOrder(
+        _ lhs: SQLiteBuildValidationRuntimeFunction,
+        _ rhs: SQLiteBuildValidationRuntimeFunction
+    ) -> Bool {
+        if lhs.name != rhs.name {
+            return lhs.name < rhs.name
+        }
+        if lhs.isBuiltIn != rhs.isBuiltIn {
+            return !lhs.isBuiltIn && rhs.isBuiltIn
+        }
+        if lhs.kind != rhs.kind {
+            return lhs.kind < rhs.kind
+        }
+        if lhs.encoding != rhs.encoding {
+            return lhs.encoding < rhs.encoding
+        }
+        if lhs.argumentCount != rhs.argumentCount {
+            return lhs.argumentCount < rhs.argumentCount
+        }
+        return lhs.flags < rhs.flags
+    }
+}
+
+
+public enum SQLiteBuildValidationRuntimeError: Error, Equatable, Sendable {
+    case missingSQLiteIdentity
+}
+
+
+public enum SQLiteBuildValidationRuntime {
+    /// Captures capabilities from the same validator-owned connection used by
+    /// raw preparation. SQLite can enumerate registered functions, collations,
+    /// and virtual-table modules, but not arbitrary loaded-extension library
+    /// names. Callers must therefore supply stable extension names explicitly.
+    public static func capture(
+        from database: Database,
+        extensionNames: [String] = []
+    ) throws -> SQLiteBuildValidationRuntimeMetadata {
+        guard let identity = try Row.fetchOne(
+            database,
+            sql: """
+                SELECT
+                    sqlite_version() AS sqlite_version,
+                    sqlite_source_id() AS sqlite_source_id
+                """
+        ) else {
+            throw SQLiteBuildValidationRuntimeError.missingSQLiteIdentity
+        }
+
+        let sqliteVersion: String = identity["sqlite_version"]
+        let sqliteSourceID: String = identity["sqlite_source_id"]
+        guard !sqliteVersion.isEmpty, !sqliteSourceID.isEmpty else {
+            throw SQLiteBuildValidationRuntimeError.missingSQLiteIdentity
+        }
+
+        let compileOptions = try firstColumnStrings(
+            database,
+            pragma: "compile_options"
+        )
+        let functions = try Row.fetchAll(
+            database,
+            sql: "PRAGMA function_list"
+        ).map { row in
+            let name: String = row["name"]
+            let builtIn: Int = row["builtin"]
+            let kind: String = row["type"]
+            let encoding: String = row["enc"]
+            let argumentCount: Int = row["narg"]
+            let flags: Int64 = row["flags"]
+            return SQLiteBuildValidationRuntimeFunction(
+                name: name,
+                isBuiltIn: builtIn != 0,
+                kind: kind,
+                encoding: encoding,
+                argumentCount: argumentCount,
+                flags: flags
+            )
+        }
+        let collations = try namedPragmaEntries(
+            database,
+            pragma: "collation_list"
+        )
+        let moduleNames = try namedPragmaEntries(
+            database,
+            pragma: "module_list"
+        )
+        let schemaRows = try SQLiteBuildValidationSchemaRow.fetchAll(
+            from: database
+        )
+
+        return SQLiteBuildValidationRuntimeMetadata(
+            sqliteVersion: sqliteVersion,
+            sqliteSourceID: sqliteSourceID,
+            compileOptions: compileOptions,
+            functions: functions,
+            collations: collations,
+            moduleNames: moduleNames,
+            extensionNames: extensionNames,
+            schemaRowCount: schemaRows.count,
+            schemaFNV1A64: schemaFingerprint(rows: schemaRows)
+        )
+    }
+
+    private static func firstColumnStrings(
+        _ database: Database,
+        pragma: String
+    ) throws -> [String] {
+        try Row.fetchAll(
+            database,
+            sql: "PRAGMA \(pragma)"
+        ).map { row in
+            let value: String = row[0]
+            return value
+        }
+    }
+
+    private static func namedPragmaEntries(
+        _ database: Database,
+        pragma: String
+    ) throws -> [String] {
+        try Row.fetchAll(
+            database,
+            sql: "PRAGMA \(pragma)"
+        ).map { row in
+            let value: String = row["name"]
+            return value
+        }
+    }
+
+    private static func schemaFingerprint(
+        rows: [SQLiteBuildValidationSchemaRow]
+    ) -> String {
+        let rows = rows.sorted(
+            by: SQLiteBuildValidationSchemaRow.canonicalOrder
+        )
+        var hash = SQLiteBuildValidationFNV1A64.offsetBasis
+        for row in rows {
+            for field in row.canonicalFields {
+                SQLiteBuildValidationFNV1A64.update(
+                    &hash,
+                    withLengthPrefixed: field
+                )
+            }
+        }
+        let unpadded = String(hash, radix: 16, uppercase: false)
+        return String(repeating: "0", count: 16 - unpadded.count) + unpadded
+    }
+}
+
+
+private struct SQLiteBuildValidationSchemaRow: Equatable {
+    let type: String
+    let name: String
+    let tableName: String
+    let rootPage: Int64
+    let sql: String
+
+    var canonicalFields: [String] {
+        [type, name, tableName, String(rootPage), sql]
+    }
+
+    static func fetchAll(from database: Database) throws -> [Self] {
+        try Row.fetchAll(
+            database,
+            sql: """
+                SELECT
+                    type,
+                    name,
+                    tbl_name,
+                    rootpage,
+                    COALESCE(sql, '') AS sql
+                FROM sqlite_schema
+                ORDER BY
+                    type COLLATE BINARY,
+                    name COLLATE BINARY,
+                    tbl_name COLLATE BINARY,
+                    rootpage,
+                    sql COLLATE BINARY
+                """
+        ).map { row in
+            let type: String = row["type"]
+            let name: String = row["name"]
+            let tableName: String = row["tbl_name"]
+            let rootPage: Int64 = row["rootpage"]
+            let sql: String = row["sql"]
+            return Self(
+                type: type,
+                name: name,
+                tableName: tableName,
+                rootPage: rootPage,
+                sql: sql
+            )
+        }
+    }
+
+    static func canonicalOrder(_ lhs: Self, _ rhs: Self) -> Bool {
+        if lhs.type != rhs.type {
+            return lhs.type < rhs.type
+        }
+        if lhs.name != rhs.name {
+            return lhs.name < rhs.name
+        }
+        if lhs.tableName != rhs.tableName {
+            return lhs.tableName < rhs.tableName
+        }
+        if lhs.rootPage != rhs.rootPage {
+            return lhs.rootPage < rhs.rootPage
+        }
+        return lhs.sql < rhs.sql
+    }
+}
+
+
+private enum SQLiteBuildValidationFNV1A64 {
+    static let offsetBasis: UInt64 = 14_695_981_039_346_656_037
+    static let prime: UInt64 = 1_099_511_628_211
+
+    static func update(
+        _ hash: inout UInt64,
+        withLengthPrefixed field: String
+    ) {
+        let bytes = Array(field.utf8)
+        update(&hash, bytes: Array(String(bytes.count).utf8))
+        update(&hash, bytes: [0x3A])
+        update(&hash, bytes: bytes)
+        update(&hash, bytes: [0x0A])
+    }
+
+    private static func update(_ hash: inout UInt64, bytes: [UInt8]) {
+        for byte in bytes {
+            hash ^= UInt64(byte)
+            hash &*= prime
+        }
+    }
+}
+
+
+private func sortedUniqueRuntimeStrings(_ values: [String]) -> [String] {
+    Array(Set(values)).sorted()
+}
+
+
+/// SQLite compares function and collation names with ASCII case folding.
+private func sqliteASCIIFolded(_ value: String) -> String {
+    String(decoding: value.utf8.map { byte in
+        if byte >= 0x41, byte <= 0x5A {
+            return byte + 0x20
+        }
+        return byte
+    }, as: UTF8.self)
+}

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationRuntime.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationRuntime.swift
@@ -406,8 +406,12 @@ private func sortedUniqueRuntimeStrings(_ values: [String]) -> [String] {
 }
 
 
-/// SQLite compares function and collation names with ASCII case folding.
-private func sqliteASCIIFolded(_ value: String) -> String {
+/// SQLite compares function, collation, module, and extension names with
+/// ASCII case folding. Shared (not `private`) so environment normalization
+/// in `SQLiteBuildValidationReport.swift` can fold extension names the same
+/// way, keeping capability matching and canonical-report determinism
+/// consistent.
+func sqliteASCIIFolded(_ value: String) -> String {
     String(decoding: value.utf8.map { byte in
         if byte >= 0x41, byte <= 0x5A {
             return byte + 0x20

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationRuntime.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationRuntime.swift
@@ -104,15 +104,24 @@ public struct SQLiteBuildValidationRuntimeMetadata:
     }
 
     public func hasModule(named name: String) -> Bool {
-        moduleCapabilities.contains(name)
+        let requiredName = sqliteASCIIFolded(name)
+        return moduleNames.contains {
+            sqliteASCIIFolded($0) == requiredName
+        }
     }
 
     public func hasCompileOption(_ option: String) -> Bool {
-        compileOptionCapabilities.contains(option)
+        let requiredOption = sqliteASCIIFolded(option)
+        return compileOptions.contains {
+            sqliteASCIIFolded($0) == requiredOption
+        }
     }
 
     public func hasExtension(named name: String) -> Bool {
-        extensionCapabilities.contains(name)
+        let requiredName = sqliteASCIIFolded(name)
+        return extensionNames.contains {
+            sqliteASCIIFolded($0) == requiredName
+        }
     }
 }
 

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationSHA256.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationSHA256.swift
@@ -40,71 +40,47 @@ public enum SQLiteBuildValidationSHA256 {
         return String(decoding: encoded, as: UTF8.self)
     }
 
-    // `message` is the sole owner of this buffer from construction, so the
-    // padding appends below mutate in place instead of triggering a
-    // copy-on-write duplicate of the (potentially large) snapshot bytes.
+    // Processes the input directly from its own backing storage instead of
+    // copying it into a padded buffer first: for a large checked-in
+    // snapshot, that copy would otherwise hold the full file in memory a
+    // second time alongside whatever `Data` the caller already mapped. Only
+    // the final, fixed-size (at most 128-byte) padded tail is materialized.
     private static func digest(_ input: Data) -> [UInt8] {
-        var message = Array(input)
-        let bitCount = UInt64(message.count) &* 8
-        message.append(0x80)
-        while message.count % 64 != 56 {
-            message.append(0)
-        }
-        for shift in stride(from: 56, through: 0, by: -8) {
-            message.append(UInt8(truncatingIfNeeded: bitCount >> UInt64(shift)))
-        }
-
         var state = initialState
-        var words = [UInt32](repeating: 0, count: 64)
-        for blockStart in stride(from: 0, to: message.count, by: 64) {
-            for index in 0..<16 {
-                let offset = blockStart + index * 4
-                words[index] =
-                    UInt32(message[offset]) << 24 |
-                    UInt32(message[offset + 1]) << 16 |
-                    UInt32(message[offset + 2]) << 8 |
-                    UInt32(message[offset + 3])
-            }
-            for index in 16..<64 {
-                words[index] = smallSigma1(words[index - 2])
-                    &+ words[index - 7]
-                    &+ smallSigma0(words[index - 15])
-                    &+ words[index - 16]
+        let totalCount = input.count
+        let bitCount = UInt64(totalCount) &* 8
+
+        input.withUnsafeBytes { (rawBuffer: UnsafeRawBufferPointer) in
+            var offset = 0
+            while offset + 64 <= totalCount {
+                processBlock(
+                    UnsafeRawBufferPointer(rebasing: rawBuffer[offset..<(offset + 64)]),
+                    state: &state
+                )
+                offset += 64
             }
 
-            var a = state[0]
-            var b = state[1]
-            var c = state[2]
-            var d = state[3]
-            var e = state[4]
-            var f = state[5]
-            var g = state[6]
-            var h = state[7]
-            for index in 0..<64 {
-                let temporary1 = h
-                    &+ bigSigma1(e)
-                    &+ choose(e, f, g)
-                    &+ roundConstants[index]
-                    &+ words[index]
-                let temporary2 = bigSigma0(a) &+ majority(a, b, c)
-                h = g
-                g = f
-                f = e
-                e = d &+ temporary1
-                d = c
-                c = b
-                b = a
-                a = temporary1 &+ temporary2
+            var tail = Array(rawBuffer[offset..<totalCount])
+            tail.append(0x80)
+            while tail.count % 64 != 56 {
+                tail.append(0)
+            }
+            for shift in stride(from: 56, through: 0, by: -8) {
+                tail.append(UInt8(truncatingIfNeeded: bitCount >> UInt64(shift)))
             }
 
-            state[0] &+= a
-            state[1] &+= b
-            state[2] &+= c
-            state[3] &+= d
-            state[4] &+= e
-            state[5] &+= f
-            state[6] &+= g
-            state[7] &+= h
+            tail.withUnsafeBytes { (tailBuffer: UnsafeRawBufferPointer) in
+                var tailOffset = 0
+                while tailOffset < tailBuffer.count {
+                    processBlock(
+                        UnsafeRawBufferPointer(
+                            rebasing: tailBuffer[tailOffset..<(tailOffset + 64)]
+                        ),
+                        state: &state
+                    )
+                    tailOffset += 64
+                }
+            }
         }
 
         var output: [UInt8] = []
@@ -116,6 +92,62 @@ public enum SQLiteBuildValidationSHA256 {
             output.append(UInt8(truncatingIfNeeded: word))
         }
         return output
+    }
+
+    /// Processes exactly one 64-byte block, updating `state` in place.
+    private static func processBlock(
+        _ block: UnsafeRawBufferPointer,
+        state: inout [UInt32]
+    ) {
+        var words = [UInt32](repeating: 0, count: 64)
+        for index in 0..<16 {
+            let offset = index * 4
+            words[index] =
+                UInt32(block[offset]) << 24 |
+                UInt32(block[offset + 1]) << 16 |
+                UInt32(block[offset + 2]) << 8 |
+                UInt32(block[offset + 3])
+        }
+        for index in 16..<64 {
+            words[index] = smallSigma1(words[index - 2])
+                &+ words[index - 7]
+                &+ smallSigma0(words[index - 15])
+                &+ words[index - 16]
+        }
+
+        var a = state[0]
+        var b = state[1]
+        var c = state[2]
+        var d = state[3]
+        var e = state[4]
+        var f = state[5]
+        var g = state[6]
+        var h = state[7]
+        for index in 0..<64 {
+            let temporary1 = h
+                &+ bigSigma1(e)
+                &+ choose(e, f, g)
+                &+ roundConstants[index]
+                &+ words[index]
+            let temporary2 = bigSigma0(a) &+ majority(a, b, c)
+            h = g
+            g = f
+            f = e
+            e = d &+ temporary1
+            d = c
+            c = b
+            b = a
+            a = temporary1 &+ temporary2
+        }
+
+        state[0] &+= a
+        state[1] &+= b
+        state[2] &+= c
+        state[3] &+= d
+        state[4] &+= e
+        state[5] &+= f
+        state[6] &+= g
+        state[7] &+= h
     }
 
     private static func rotateRight(_ value: UInt32, by count: UInt32) -> UInt32 {

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationSHA256.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationSHA256.swift
@@ -29,7 +29,7 @@ public enum SQLiteBuildValidationSHA256 {
     ]
 
     public static func hexDigest(of data: Data) -> String {
-        let bytes = digest(Array(data))
+        let bytes = digest(data)
         let digits = Array("0123456789abcdef".utf8)
         var encoded: [UInt8] = []
         encoded.reserveCapacity(bytes.count * 2)
@@ -40,8 +40,11 @@ public enum SQLiteBuildValidationSHA256 {
         return String(decoding: encoded, as: UTF8.self)
     }
 
-    private static func digest(_ input: [UInt8]) -> [UInt8] {
-        var message = input
+    // `message` is the sole owner of this buffer from construction, so the
+    // padding appends below mutate in place instead of triggering a
+    // copy-on-write duplicate of the (potentially large) snapshot bytes.
+    private static func digest(_ input: Data) -> [UInt8] {
+        var message = Array(input)
         let bitCount = UInt64(message.count) &* 8
         message.append(0x80)
         while message.count % 64 != 56 {

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationSHA256.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationSHA256.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+
+/// Small cross-platform SHA-256 used to authenticate the checked-in schema
+/// snapshot without adding CryptoKit or another package dependency.
+public enum SQLiteBuildValidationSHA256 {
+    private static let initialState: [UInt32] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+        0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+    ]
+
+    private static let roundConstants: [UInt32] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+        0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+        0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ]
+
+    public static func hexDigest(of data: Data) -> String {
+        let bytes = digest(Array(data))
+        let digits = Array("0123456789abcdef".utf8)
+        var encoded: [UInt8] = []
+        encoded.reserveCapacity(bytes.count * 2)
+        for byte in bytes {
+            encoded.append(digits[Int(byte >> 4)])
+            encoded.append(digits[Int(byte & 0x0f)])
+        }
+        return String(decoding: encoded, as: UTF8.self)
+    }
+
+    private static func digest(_ input: [UInt8]) -> [UInt8] {
+        var message = input
+        let bitCount = UInt64(message.count) &* 8
+        message.append(0x80)
+        while message.count % 64 != 56 {
+            message.append(0)
+        }
+        for shift in stride(from: 56, through: 0, by: -8) {
+            message.append(UInt8(truncatingIfNeeded: bitCount >> UInt64(shift)))
+        }
+
+        var state = initialState
+        var words = [UInt32](repeating: 0, count: 64)
+        for blockStart in stride(from: 0, to: message.count, by: 64) {
+            for index in 0..<16 {
+                let offset = blockStart + index * 4
+                words[index] =
+                    UInt32(message[offset]) << 24 |
+                    UInt32(message[offset + 1]) << 16 |
+                    UInt32(message[offset + 2]) << 8 |
+                    UInt32(message[offset + 3])
+            }
+            for index in 16..<64 {
+                words[index] = smallSigma1(words[index - 2])
+                    &+ words[index - 7]
+                    &+ smallSigma0(words[index - 15])
+                    &+ words[index - 16]
+            }
+
+            var a = state[0]
+            var b = state[1]
+            var c = state[2]
+            var d = state[3]
+            var e = state[4]
+            var f = state[5]
+            var g = state[6]
+            var h = state[7]
+            for index in 0..<64 {
+                let temporary1 = h
+                    &+ bigSigma1(e)
+                    &+ choose(e, f, g)
+                    &+ roundConstants[index]
+                    &+ words[index]
+                let temporary2 = bigSigma0(a) &+ majority(a, b, c)
+                h = g
+                g = f
+                f = e
+                e = d &+ temporary1
+                d = c
+                c = b
+                b = a
+                a = temporary1 &+ temporary2
+            }
+
+            state[0] &+= a
+            state[1] &+= b
+            state[2] &+= c
+            state[3] &+= d
+            state[4] &+= e
+            state[5] &+= f
+            state[6] &+= g
+            state[7] &+= h
+        }
+
+        var output: [UInt8] = []
+        output.reserveCapacity(32)
+        for word in state {
+            output.append(UInt8(truncatingIfNeeded: word >> 24))
+            output.append(UInt8(truncatingIfNeeded: word >> 16))
+            output.append(UInt8(truncatingIfNeeded: word >> 8))
+            output.append(UInt8(truncatingIfNeeded: word))
+        }
+        return output
+    }
+
+    private static func rotateRight(_ value: UInt32, by count: UInt32) -> UInt32 {
+        (value >> count) | (value << (32 - count))
+    }
+
+    private static func choose(_ x: UInt32, _ y: UInt32, _ z: UInt32) -> UInt32 {
+        (x & y) ^ (~x & z)
+    }
+
+    private static func majority(_ x: UInt32, _ y: UInt32, _ z: UInt32) -> UInt32 {
+        (x & y) ^ (x & z) ^ (y & z)
+    }
+
+    private static func bigSigma0(_ value: UInt32) -> UInt32 {
+        rotateRight(value, by: 2)
+            ^ rotateRight(value, by: 13)
+            ^ rotateRight(value, by: 22)
+    }
+
+    private static func bigSigma1(_ value: UInt32) -> UInt32 {
+        rotateRight(value, by: 6)
+            ^ rotateRight(value, by: 11)
+            ^ rotateRight(value, by: 25)
+    }
+
+    private static func smallSigma0(_ value: UInt32) -> UInt32 {
+        rotateRight(value, by: 7)
+            ^ rotateRight(value, by: 18)
+            ^ (value >> 3)
+    }
+
+    private static func smallSigma1(_ value: UInt32) -> UInt32 {
+        rotateRight(value, by: 17)
+            ^ rotateRight(value, by: 19)
+            ^ (value >> 10)
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationValidatorCLIOptions.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationValidatorCLIOptions.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+
+// Swift 5.9's Linux Foundation predates URL's Sendable annotation. Options are
+// immutable values, and newer Foundation versions declare URL Sendable.
+public struct SQLiteBuildValidationValidatorCLIOptions: Equatable, @unchecked Sendable {
+    public let databaseURL: URL?
+    public let manifestURL: URL?
+    public let outputURL: URL?
+    public let codecIdentifiers: [String]
+    public let extensionNames: [String]
+    public let capabilityIDs: [String]
+    public let showsHelp: Bool
+
+    public static func parse(
+        arguments: [String],
+        currentDirectory: URL = URL(
+            fileURLWithPath: FileManager.default.currentDirectoryPath,
+            isDirectory: true
+        )
+    ) throws -> Self {
+        var databasePath: String?
+        var manifestPath: String?
+        var outputPath: String?
+        var codecIdentifiers: [String] = []
+        var extensionNames: [String] = []
+        var capabilityIDs: [String] = []
+        var showsHelp = false
+        var index = 0
+
+        func value(after option: String) throws -> String {
+            let valueIndex = index + 1
+            guard arguments.indices.contains(valueIndex) else {
+                throw SQLiteBuildValidationValidatorCLIError.missingValue(option)
+            }
+            index = valueIndex
+            let value = arguments[valueIndex]
+            guard !value.isEmpty else {
+                throw SQLiteBuildValidationValidatorCLIError.missingValue(option)
+            }
+            return value
+        }
+
+        func assignOnce(
+            _ current: inout String?,
+            option: String
+        ) throws {
+            guard current == nil else {
+                throw SQLiteBuildValidationValidatorCLIError.duplicateOption(option)
+            }
+            current = try value(after: option)
+        }
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--database":
+                try assignOnce(&databasePath, option: argument)
+            case "--manifest":
+                try assignOnce(&manifestPath, option: argument)
+            case "--output":
+                try assignOnce(&outputPath, option: argument)
+            case "--codec":
+                codecIdentifiers.append(try value(after: argument))
+            case "--extension":
+                extensionNames.append(try value(after: argument))
+            case "--capability":
+                capabilityIDs.append(try value(after: argument))
+            case "--help", "-h":
+                showsHelp = true
+            default:
+                throw SQLiteBuildValidationValidatorCLIError.unknownOption(argument)
+            }
+            index += 1
+        }
+
+        if !showsHelp {
+            for (option, value) in [
+                ("--database", databasePath),
+                ("--manifest", manifestPath),
+                ("--output", outputPath),
+            ] where value == nil {
+                throw SQLiteBuildValidationValidatorCLIError.requiredOption(option)
+            }
+        }
+
+        return Self(
+            databaseURL: databasePath.map {
+                resolvedURL(path: $0, currentDirectory: currentDirectory)
+            },
+            manifestURL: manifestPath.map {
+                resolvedURL(path: $0, currentDirectory: currentDirectory)
+            },
+            outputURL: outputPath.map {
+                resolvedURL(path: $0, currentDirectory: currentDirectory)
+            },
+            codecIdentifiers: sortedUnique(codecIdentifiers),
+            extensionNames: sortedUnique(extensionNames),
+            capabilityIDs: sortedUnique(capabilityIDs),
+            showsHelp: showsHelp
+        )
+    }
+
+    public static let usage = """
+        Usage: swiftql-build-validate [options]
+
+          --database <path>      Checked-in SQLite snapshot to open read-only
+          --manifest <path>      Codable build-validation manifest (#292)
+          --output <path>        Deterministic JSON report destination
+          --codec <identity>     Available codec identity (repeatable)
+          --extension <name>     Registered extension name (repeatable)
+          --capability <id>      Explicit caller-owned capability (repeatable)
+          --help                 Show this help
+        """
+
+    public static func preflightOutputSafety(
+        databaseURL: URL,
+        manifestURL: URL,
+        outputURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        let outputIdentityURL = identityURL(
+            for: outputURL,
+            fileManager: fileManager
+        )
+        let outputFileIdentity = existingFileIdentity(
+            at: outputIdentityURL,
+            fileManager: fileManager
+        )
+        let databasePaths = [
+            databaseURL.path,
+            identityURL(for: databaseURL, fileManager: fileManager).path,
+        ]
+        let protectedDatabaseSidecarPaths = Set(databasePaths.flatMap { path in
+            ["-journal", "-shm", "-wal"].map { suffix in
+                ((path + suffix) as NSString).standardizingPath
+            }
+        })
+        let outputPaths = Set([
+            (outputURL.path as NSString).standardizingPath,
+            outputIdentityURL.path,
+        ])
+        if !protectedDatabaseSidecarPaths.isDisjoint(with: outputPaths) {
+            throw SQLiteBuildValidationValidatorCLIError.outputConflictsWithDatabaseSidecar
+        }
+
+        for (option, inputURL) in [
+            ("--database", databaseURL),
+            ("--manifest", manifestURL),
+        ] {
+            let inputIdentityURL = identityURL(
+                for: inputURL,
+                fileManager: fileManager
+            )
+            if outputIdentityURL.path == inputIdentityURL.path {
+                throw SQLiteBuildValidationValidatorCLIError.outputConflictsWithInput(option)
+            }
+
+            if let outputFileIdentity,
+               let inputFileIdentity = existingFileIdentity(
+                   at: inputIdentityURL,
+                   fileManager: fileManager
+               ),
+               outputFileIdentity == inputFileIdentity {
+                throw SQLiteBuildValidationValidatorCLIError.outputConflictsWithInput(option)
+            }
+        }
+    }
+
+    private static func resolvedURL(path: String, currentDirectory: URL) -> URL {
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path).standardizedFileURL
+        }
+        return currentDirectory.appendingPathComponent(path).standardizedFileURL
+    }
+
+    private static func sortedUnique(_ values: [String]) -> [String] {
+        Array(Set(values)).sorted()
+    }
+
+    private static func identityURL(
+        for url: URL,
+        fileManager: FileManager
+    ) -> URL {
+        var existingAncestor = url.standardizedFileURL
+        var missingComponents: [String] = []
+        while existingAncestor.path != "/",
+              !fileManager.fileExists(atPath: existingAncestor.path) {
+            missingComponents.insert(
+                existingAncestor.lastPathComponent,
+                at: 0
+            )
+            existingAncestor.deleteLastPathComponent()
+        }
+        let resolvedAncestor = existingAncestor.resolvingSymlinksInPath()
+        return missingComponents.reduce(resolvedAncestor) { partialURL, component in
+            partialURL.appendingPathComponent(component)
+        }.standardizedFileURL
+    }
+
+    private static func existingFileIdentity(
+        at url: URL,
+        fileManager: FileManager
+    ) -> ExistingFileIdentity? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let device = unsignedInteger(attributes[.systemNumber]),
+              let inode = unsignedInteger(attributes[.systemFileNumber]) else {
+            return nil
+        }
+        return ExistingFileIdentity(device: device, inode: inode)
+    }
+
+    private static func unsignedInteger(_ value: Any?) -> UInt64? {
+        (value as? NSNumber)?.uint64Value
+    }
+
+    private struct ExistingFileIdentity: Equatable {
+        let device: UInt64
+        let inode: UInt64
+    }
+}
+
+
+public enum SQLiteBuildValidationValidatorCLIError:
+    Error,
+    Equatable,
+    Sendable,
+    CustomStringConvertible
+{
+    case missingValue(String)
+    case duplicateOption(String)
+    case requiredOption(String)
+    case unknownOption(String)
+    case outputConflictsWithInput(String)
+    case outputConflictsWithDatabaseSidecar
+
+    public var description: String {
+        switch self {
+        case .missingValue(let option):
+            return "\(option) requires a nonempty value."
+        case .duplicateOption(let option):
+            return "\(option) may only be supplied once."
+        case .requiredOption(let option):
+            return "\(option) is required."
+        case .unknownOption(let option):
+            return "Unknown option \(option)."
+        case .outputConflictsWithInput(let option):
+            return "--output must not identify the same file as \(option)."
+        case .outputConflictsWithDatabaseSidecar:
+            return "--output must not use a SQLite sidecar path adjacent to --database."
+        }
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationValidatorCLIOptions.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationValidatorCLIOptions.swift
@@ -110,7 +110,7 @@ public struct SQLiteBuildValidationValidatorCLIOptions: Equatable, @unchecked Se
           --codec <identity>     Available codec identity (repeatable)
           --extension <name>     Registered extension name (repeatable)
           --capability <id>      Explicit caller-owned capability (repeatable)
-          --help                 Show this help
+          --help, -h              Show this help
         """
 
     public static func preflightOutputSafety(

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationValidatorCLIRunner.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationValidatorCLIRunner.swift
@@ -1,0 +1,56 @@
+import Foundation
+import SwiftQLSQLiteBuildValidationManifest
+
+
+public struct SQLiteBuildValidationValidatorCLIRunResult: Equatable, Sendable {
+    public let report: SQLiteBuildValidationReport
+
+    public var exitCode: Int32 {
+        report.overallVerdict == .passed ? 0 : 1
+    }
+}
+
+
+/// Executes the operational CLI path without terminating the process.
+///
+/// Keeping orchestration here lets tests exercise input protection, manifest
+/// decoding, real SQLite validation, report writing, and the zero/nonzero
+/// verdict contract. The executable entry point remains responsible only for
+/// argument/help handling and mapping thrown usage errors to exit code 2.
+public enum SQLiteBuildValidationValidatorCLIRunner {
+    public static func run(
+        options: SQLiteBuildValidationValidatorCLIOptions
+    ) throws -> SQLiteBuildValidationValidatorCLIRunResult {
+        guard let databaseURL = options.databaseURL,
+              let manifestURL = options.manifestURL,
+              let outputURL = options.outputURL else {
+            throw SQLiteBuildValidationValidatorCLIError.requiredOption(
+                "--database, --manifest, and --output"
+            )
+        }
+
+        try SQLiteBuildValidationValidatorCLIOptions.preflightOutputSafety(
+            databaseURL: databaseURL,
+            manifestURL: manifestURL,
+            outputURL: outputURL
+        )
+
+        let manifest = try SQLiteBuildValidationManifest.decode(contentsOf: manifestURL)
+        let report = try SQLiteBuildValidator.validate(
+            manifest: manifest,
+            againstDatabaseAt: databaseURL,
+            environment: SQLiteBuildValidationEnvironment(
+                codecIdentifiers: options.codecIdentifiers,
+                extensionNames: options.extensionNames,
+                capabilityIDs: options.capabilityIDs
+            )
+        )
+
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try report.canonicalJSONData().write(to: outputURL, options: .atomic)
+        return SQLiteBuildValidationValidatorCLIRunResult(report: report)
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationValidatorPlaceholderScanner.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationValidatorPlaceholderScanner.swift
@@ -1,0 +1,344 @@
+import Foundation
+
+
+public struct SQLiteBuildValidationValidatorPlaceholderOccurrence:
+    Codable,
+    Equatable,
+    Sendable
+{
+    public let spelling: String
+    public let byteOffset: Int
+    public let physicalIndex: Int
+
+    public init(spelling: String, byteOffset: Int, physicalIndex: Int) {
+        self.spelling = spelling
+        self.byteOffset = byteOffset
+        self.physicalIndex = physicalIndex
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case spelling
+        case byteOffset = "byte_offset"
+        case physicalIndex = "physical_index"
+    }
+}
+
+
+public struct SQLiteBuildValidationUnsupportedPlaceholder:
+    Codable,
+    Equatable,
+    Sendable
+{
+    public let spelling: String
+    public let byteOffset: Int
+    public let reason: String
+
+    public init(spelling: String, byteOffset: Int, reason: String) {
+        self.spelling = spelling
+        self.byteOffset = byteOffset
+        self.reason = reason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case spelling
+        case byteOffset = "byte_offset"
+        case reason
+    }
+}
+
+
+/// Quote/comment-aware evidence for SwiftQL's supported placeholder spellings.
+///
+/// This is deliberately smaller than SQLite's tokenizer. It recognizes only
+/// the two forms emitted by `XLSQLiteDialect`: `:name` and one-based `?N`.
+/// Anonymous `?`, `@name`, and `$name` remain explicit unsupported evidence.
+public struct SQLiteBuildValidationValidatorPlaceholderAnalysis:
+    Codable,
+    Equatable,
+    Sendable
+{
+    public let physicalParameterCount: Int
+    public let parameters: [SQLitePreparedParameter]
+    public let occurrences: [SQLiteBuildValidationValidatorPlaceholderOccurrence]
+    public let unsupported: [SQLiteBuildValidationUnsupportedPlaceholder]
+    public let collisions: [String]
+
+    public init(
+        physicalParameterCount: Int,
+        parameters: [SQLitePreparedParameter],
+        occurrences: [SQLiteBuildValidationValidatorPlaceholderOccurrence],
+        unsupported: [SQLiteBuildValidationUnsupportedPlaceholder],
+        collisions: [String]
+    ) {
+        self.physicalParameterCount = physicalParameterCount
+        self.parameters = parameters
+        self.occurrences = occurrences
+        self.unsupported = unsupported
+        self.collisions = collisions.sorted()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case physicalParameterCount = "physical_parameter_count"
+        case parameters
+        case occurrences
+        case unsupported
+        case collisions
+    }
+}
+
+
+public enum SQLiteBuildValidationValidatorPlaceholderScanner {
+    public static func scan(
+        _ sql: String
+    ) -> SQLiteBuildValidationValidatorPlaceholderAnalysis {
+        let bytes = Array(sql.utf8)
+        var physicalNameByIndex: [Int: String] = [:]
+        var physicalIndexByNamedToken: [String: Int] = [:]
+        var largestPhysicalIndex = 0
+        var occurrences: [SQLiteBuildValidationValidatorPlaceholderOccurrence] = []
+        var unsupported: [SQLiteBuildValidationUnsupportedPlaceholder] = []
+        var collisions: [String] = []
+        var index = 0
+
+        while index < bytes.count {
+            let currentByte = bytes[index]
+            if currentByte == 0x2D, byte(at: index + 1, in: bytes) == 0x2D {
+                index = skipLineComment(startingAt: index + 2, bytes: bytes)
+                continue
+            }
+            if currentByte == 0x2F, byte(at: index + 1, in: bytes) == 0x2A {
+                index = skipBlockComment(startingAt: index + 2, bytes: bytes)
+                continue
+            }
+            if currentByte == 0x27 || currentByte == 0x22 || currentByte == 0x60 {
+                index = skipQuoted(
+                    startingAt: index + 1,
+                    delimiter: currentByte,
+                    bytes: bytes
+                )
+                continue
+            }
+            if currentByte == 0x5B {
+                index = skipBracketQuoted(startingAt: index + 1, bytes: bytes)
+                continue
+            }
+
+            if currentByte == 0x3F { // ? or ?NNN
+                let tokenEnd = consumeDigits(startingAt: index + 1, bytes: bytes)
+                guard tokenEnd > index + 1 else {
+                    unsupported.append(SQLiteBuildValidationUnsupportedPlaceholder(
+                        spelling: "?",
+                        byteOffset: index,
+                        reason: "Anonymous ? placeholders are not emitted by SwiftQL static descriptors."
+                    ))
+                    index += 1
+                    continue
+                }
+                let spelling = String(
+                    decoding: bytes[index..<tokenEnd],
+                    as: UTF8.self
+                )
+                guard let physicalIndex = Int(spelling.dropFirst()),
+                      physicalIndex > 0 else {
+                    unsupported.append(SQLiteBuildValidationUnsupportedPlaceholder(
+                        spelling: spelling,
+                        byteOffset: index,
+                        reason: "Indexed placeholders require a positive one-based SQLite index."
+                    ))
+                    index = tokenEnd
+                    continue
+                }
+                largestPhysicalIndex = max(largestPhysicalIndex, physicalIndex)
+                register(
+                    spelling: spelling,
+                    physicalIndex: physicalIndex,
+                    byteOffset: index,
+                    physicalNameByIndex: &physicalNameByIndex,
+                    occurrences: &occurrences,
+                    collisions: &collisions
+                )
+                index = tokenEnd
+                continue
+            }
+
+            if currentByte == 0x3A { // :name
+                let tokenEnd = consumeName(startingAt: index + 1, bytes: bytes)
+                guard tokenEnd > index + 1 else {
+                    index += 1
+                    continue
+                }
+                let spelling = String(
+                    decoding: bytes[index..<tokenEnd],
+                    as: UTF8.self
+                )
+                let physicalIndex: Int
+                if let existing = physicalIndexByNamedToken[spelling] {
+                    physicalIndex = existing
+                } else {
+                    physicalIndex = largestPhysicalIndex + 1
+                    largestPhysicalIndex = physicalIndex
+                    physicalIndexByNamedToken[spelling] = physicalIndex
+                }
+                register(
+                    spelling: spelling,
+                    physicalIndex: physicalIndex,
+                    byteOffset: index,
+                    physicalNameByIndex: &physicalNameByIndex,
+                    occurrences: &occurrences,
+                    collisions: &collisions
+                )
+                index = tokenEnd
+                continue
+            }
+
+            if currentByte == 0x40 || currentByte == 0x24 { // @name or $name
+                let tokenEnd = consumeName(startingAt: index + 1, bytes: bytes)
+                let end = max(index + 1, tokenEnd)
+                let spelling = String(
+                    decoding: bytes[index..<end],
+                    as: UTF8.self
+                )
+                unsupported.append(SQLiteBuildValidationUnsupportedPlaceholder(
+                    spelling: spelling,
+                    byteOffset: index,
+                    reason: "Only SwiftQL-emitted :name and ?N placeholders are supported."
+                ))
+                index = end
+                continue
+            }
+
+            index += 1
+        }
+
+        let parameters: [SQLitePreparedParameter]
+        if largestPhysicalIndex == 0 {
+            parameters = []
+        } else {
+            parameters = (1...largestPhysicalIndex).map {
+                SQLitePreparedParameter(
+                    physicalIndex: $0,
+                    name: physicalNameByIndex[$0]
+                )
+            }
+        }
+        return SQLiteBuildValidationValidatorPlaceholderAnalysis(
+            physicalParameterCount: largestPhysicalIndex,
+            parameters: parameters,
+            occurrences: occurrences,
+            unsupported: unsupported,
+            collisions: collisions
+        )
+    }
+}
+
+
+private extension SQLiteBuildValidationValidatorPlaceholderScanner {
+    static func register(
+        spelling: String,
+        physicalIndex: Int,
+        byteOffset: Int,
+        physicalNameByIndex: inout [Int: String],
+        occurrences: inout [SQLiteBuildValidationValidatorPlaceholderOccurrence],
+        collisions: inout [String]
+    ) {
+        if let existing = physicalNameByIndex[physicalIndex],
+           existing != spelling {
+            collisions.append(
+                "Physical parameter \(physicalIndex) is named by both '\(existing)' and '\(spelling)'."
+            )
+        } else {
+            physicalNameByIndex[physicalIndex] = spelling
+        }
+        occurrences.append(SQLiteBuildValidationValidatorPlaceholderOccurrence(
+            spelling: spelling,
+            byteOffset: byteOffset,
+            physicalIndex: physicalIndex
+        ))
+    }
+
+    static func byte(at index: Int, in bytes: [UInt8]) -> UInt8? {
+        bytes.indices.contains(index) ? bytes[index] : nil
+    }
+
+    static func skipLineComment(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count, bytes[index] != 0x0A, bytes[index] != 0x0D {
+            index += 1
+        }
+        return index
+    }
+
+    static func skipBlockComment(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count {
+            if bytes[index] == 0x2A, byte(at: index + 1, in: bytes) == 0x2F {
+                return index + 2
+            }
+            index += 1
+        }
+        return index
+    }
+
+    static func skipQuoted(
+        startingAt index: Int,
+        delimiter: UInt8,
+        bytes: [UInt8]
+    ) -> Int {
+        var index = index
+        while index < bytes.count {
+            guard bytes[index] == delimiter else {
+                index += 1
+                continue
+            }
+            if byte(at: index + 1, in: bytes) == delimiter {
+                index += 2
+                continue
+            }
+            return index + 1
+        }
+        return index
+    }
+
+    // Treats a doubled "]]" as an escaped literal "]" inside a bracket-quoted
+    // identifier, matching the doubled-delimiter escape honored above for
+    // the single-quote, double-quote, and backtick delimiters.
+    static func skipBracketQuoted(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count {
+            guard bytes[index] == 0x5D else {
+                index += 1
+                continue
+            }
+            if byte(at: index + 1, in: bytes) == 0x5D {
+                index += 2
+                continue
+            }
+            return index + 1
+        }
+        return index
+    }
+
+    static func consumeDigits(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count, (0x30...0x39).contains(bytes[index]) {
+            index += 1
+        }
+        return index
+    }
+
+    static func consumeName(startingAt index: Int, bytes: [UInt8]) -> Int {
+        var index = index
+        while index < bytes.count, isNameByte(bytes[index]) {
+            index += 1
+        }
+        return index
+    }
+
+    static func isNameByte(_ byte: UInt8) -> Bool {
+        (0x30...0x39).contains(byte)
+            || (0x41...0x5A).contains(byte)
+            || byte == 0x5F
+            || (0x61...0x7A).contains(byte)
+            || byte >= 0x80
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -441,6 +441,7 @@ private extension SQLiteBuildValidator {
     ) -> Bool {
         let preparationBlockingCodes = Set([
             "capability.collation",
+            "capability.compile-option",
             "capability.dialect",
             "capability.dialect-flags",
             "capability.extension",

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -690,11 +690,26 @@ private extension SQLiteBuildValidator {
                 sqliteResultCode: resultCode,
                 sqliteExtendedResultCode: extendedResultCode
             )
+        case .sqliteFinalize(let resultCode, let extendedResultCode, let message):
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .prepare,
+                code: "sqlite.finalize.failed",
+                message: message,
+                query: query,
+                sqliteResultCode: resultCode,
+                sqliteExtendedResultCode: extendedResultCode
+            )
         }
     }
 
     static func suffix(of value: String, after prefix: String) -> String? {
-        guard value.hasPrefix(prefix) else {
+        // Case-insensitive to match isOpaqueCapability/capabilityDiagnosticCode,
+        // which both fold to lowercase before prefix-matching. A capability
+        // like "Function:JSON_VALID" must still resolve here, or it silently
+        // falls through to "unavailable" even though it is a recognized,
+        // observable capability.
+        guard value.lowercased().hasPrefix(prefix.lowercased()) else {
             return nil
         }
         let suffix = String(value.dropFirst(prefix.count))

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -1,0 +1,754 @@
+import Foundation
+import GRDB
+import SwiftQLCore
+import SwiftQLSQLiteBuildValidationManifest
+
+
+/// A standalone SQLite static-query build validator.
+///
+/// Consumes a deterministic ``SQLiteBuildValidationManifest`` (#292) and an
+/// explicit checked-in SQLite snapshot, owns one dedicated read-only/
+/// query-only connection for the run, prepares exactly one statement per
+/// manifest entry with `sqlite3_prepare_v3`, and emits a deterministic
+/// fail-closed report. Only `passed` is success; `failed` and `unsupported`
+/// both fail the validation gate. No prepared statement escapes, persists,
+/// or is reused at runtime — `SQLitePrepareV3Probe` returns copied Swift
+/// values only, never a `sqlite3_stmt` pointer.
+public enum SQLiteBuildValidator {
+    /// Validates a manifest against a checked-in SQLite database file.
+    ///
+    /// This is the authoritative entry point: it owns a fresh read-only,
+    /// query-only `DatabaseQueue` for the entire run, verifies the snapshot
+    /// is byte-identical before and after validation, and refuses a
+    /// snapshot with an adjacent `-journal`/`-shm`/`-wal` sidecar (evidence
+    /// the file is not an immutable checked-in artifact).
+    public static func validate(
+        manifest: SQLiteBuildValidationManifest,
+        againstDatabaseAt databaseURL: URL,
+        environment: SQLiteBuildValidationEnvironment = .init()
+    ) throws -> SQLiteBuildValidationReport {
+        let databaseURL = databaseURL.standardizedFileURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let manifest = try manifest.validating()
+        let resourceValues = try databaseURL.resourceValues(
+            forKeys: [.isRegularFileKey]
+        )
+        guard resourceValues.isRegularFile == true else {
+            throw SQLiteBuildValidationValidatorError.databaseIsNotARegularFile(
+                databaseURL.path
+            )
+        }
+        try requireSidecarFreeSnapshot(at: databaseURL)
+        let databaseData = try Data(
+            contentsOf: databaseURL,
+            options: .mappedIfSafe
+        )
+        let observedDatabaseSHA256 = SQLiteBuildValidationSHA256.hexDigest(
+            of: databaseData
+        )
+
+        var configuration = Configuration()
+        configuration.label = "SwiftQLSQLiteBuildValidationValidator"
+        configuration.readonly = true
+        configuration.prepareDatabase { database in
+            try database.execute(sql: "PRAGMA query_only = ON")
+        }
+        let queue = try DatabaseQueue(
+            path: databaseURL.path,
+            configuration: configuration
+        )
+        defer { try? queue.close() }
+
+        let report = try queue.read { database in
+            try validate(
+                manifest: manifest,
+                in: database,
+                observedDatabaseByteCount: databaseData.count,
+                observedDatabaseSHA256: observedDatabaseSHA256,
+                environment: environment
+            )
+        }
+
+        let finalDatabaseData = try Data(
+            contentsOf: databaseURL,
+            options: .mappedIfSafe
+        )
+        let finalDatabaseSHA256 = SQLiteBuildValidationSHA256.hexDigest(
+            of: finalDatabaseData
+        )
+        try requireSidecarFreeSnapshot(at: databaseURL)
+        guard finalDatabaseData.count == databaseData.count,
+              finalDatabaseSHA256 == observedDatabaseSHA256 else {
+            throw SQLiteBuildValidationValidatorError
+                .databaseChangedDuringValidation(
+                    initialByteCount: databaseData.count,
+                    initialSHA256: observedDatabaseSHA256,
+                    finalByteCount: finalDatabaseData.count,
+                    finalSHA256: finalDatabaseSHA256
+                )
+        }
+        return report
+    }
+
+    /// Validates on a caller-supplied connection. The URL overload is the
+    /// authoritative path because it owns a read-only/query-only queue; this
+    /// seam exists for callers that already own a validator-safe connection
+    /// and must supply the database's byte count/SHA-256 evidence
+    /// themselves — omitting either produces an `unsupported` schema
+    /// diagnostic rather than a silent pass.
+    public static func validate(
+        manifest: SQLiteBuildValidationManifest,
+        in database: Database,
+        observedDatabaseByteCount: Int? = nil,
+        observedDatabaseSHA256: String? = nil,
+        environment: SQLiteBuildValidationEnvironment = .init()
+    ) throws -> SQLiteBuildValidationReport {
+        let validatedManifest = try manifest.validating()
+
+        var reportDiagnostics: [SQLiteBuildValidationDiagnostic] = []
+        if let observedDatabaseByteCount {
+            if observedDatabaseByteCount != validatedManifest.schemaSnapshot.databaseByteCount {
+                reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .schema,
+                    code: "schema.byte-count",
+                    message: "Schema snapshot byte count is \(observedDatabaseByteCount); expected \(validatedManifest.schemaSnapshot.databaseByteCount)."
+                ))
+            }
+        } else {
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .schema,
+                code: "schema.byte-count",
+                message: "Schema snapshot byte count evidence was not supplied to the caller-owned validation seam."
+            ))
+        }
+        if let observedDatabaseSHA256 {
+            if observedDatabaseSHA256.lowercased() != validatedManifest.schemaSnapshot.databaseSHA256 {
+                reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .schema,
+                    code: "schema.snapshot-sha",
+                    message: "Schema snapshot SHA-256 is \(observedDatabaseSHA256.lowercased()); expected \(validatedManifest.schemaSnapshot.databaseSHA256)."
+                ))
+            }
+        } else {
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .schema,
+                code: "schema.snapshot-sha",
+                message: "Schema snapshot SHA-256 evidence was not supplied to the caller-owned validation seam."
+            ))
+        }
+
+        let runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?
+        do {
+            runtimeMetadata = try SQLiteBuildValidationRuntime.capture(
+                from: database,
+                extensionNames: environment.extensionNames
+            )
+        } catch {
+            runtimeMetadata = nil
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .runtime,
+                code: "runtime.capture",
+                message: "SQLite runtime metadata capture failed: \(String(describing: error))."
+            ))
+        }
+
+        if let runtimeMetadata {
+            if runtimeMetadata.schemaRowCount != validatedManifest.schemaSnapshot.schemaRowCount {
+                reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .schema,
+                    code: "schema.row-count",
+                    message: "Schema contains \(runtimeMetadata.schemaRowCount) sqlite_schema rows; expected \(validatedManifest.schemaSnapshot.schemaRowCount)."
+                ))
+            }
+            if runtimeMetadata.schemaFNV1A64 != validatedManifest.schemaSnapshot.schemaFingerprint {
+                reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .schema,
+                    code: "schema.fingerprint",
+                    message: "Schema FNV-1a-64 is \(runtimeMetadata.schemaFNV1A64); expected \(validatedManifest.schemaSnapshot.schemaFingerprint)."
+                ))
+            }
+        }
+
+        let outcomes = validatedManifest.queries.map { query in
+            validate(
+                query: query,
+                in: database,
+                runtimeMetadata: runtimeMetadata,
+                environment: environment
+            )
+        }
+        return SQLiteBuildValidationReport(
+            manifest: validatedManifest,
+            observedDatabaseByteCount: observedDatabaseByteCount,
+            observedDatabaseSHA256: observedDatabaseSHA256,
+            runtimeMetadata: runtimeMetadata,
+            environmentEvidence: environment,
+            diagnostics: reportDiagnostics,
+            outcomes: outcomes
+        )
+    }
+}
+
+
+private extension SQLiteBuildValidator {
+    static func validate(
+        query: SQLiteBuildValidationQueryEntry,
+        in database: Database,
+        runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?,
+        environment: SQLiteBuildValidationEnvironment
+    ) -> SQLiteBuildValidationQueryOutcome {
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        let placeholderAnalysis = SQLiteBuildValidationValidatorPlaceholderScanner.scan(
+            query.sql
+        )
+        diagnostics.append(contentsOf: placeholderDiagnostics(
+            query: query,
+            analysis: placeholderAnalysis
+        ))
+        diagnostics.append(contentsOf: dialectDiagnostics(
+            query: query,
+            runtimeMetadata: runtimeMetadata
+        ))
+        diagnostics.append(contentsOf: codecDiagnostics(
+            query: query,
+            environment: environment
+        ))
+        diagnostics.append(contentsOf: capabilityDiagnostics(
+            query: query,
+            runtimeMetadata: runtimeMetadata,
+            environment: environment
+        ))
+
+        let preparedShape: SQLitePreparedStatementShape?
+        if hasUnavailablePreparationPrerequisite(diagnostics) {
+            preparedShape = nil
+        } else {
+            do {
+                let shape = try SQLitePrepareV3Probe.prepare(
+                    sql: query.sql,
+                    in: database
+                )
+                preparedShape = shape
+                if placeholderAnalysis.unsupported.isEmpty {
+                    diagnostics.append(contentsOf: parameterDiagnostics(
+                        query: query,
+                        shape: shape,
+                        analysis: placeholderAnalysis
+                    ))
+                }
+                diagnostics.append(contentsOf: resultDiagnostics(
+                    query: query,
+                    shape: shape
+                ))
+            } catch let error as SQLitePrepareV3ProbeError {
+                preparedShape = nil
+                diagnostics.append(prepareDiagnostic(error, query: query))
+            } catch {
+                preparedShape = nil
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .prepare,
+                    code: "sqlite.prepare.failed",
+                    message: "SQLite preparation failed: \(String(describing: error)).",
+                    query: query
+                ))
+            }
+        }
+
+        return SQLiteBuildValidationQueryOutcome(
+            query: query,
+            placeholderAnalysis: placeholderAnalysis,
+            preparedShape: preparedShape,
+            diagnostics: diagnostics
+        )
+    }
+
+    static func dialectDiagnostics(
+        query: SQLiteBuildValidationQueryEntry,
+        runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        if query.dialectIdentifier != XLSQLiteDialect.identity.rawValue {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .capability,
+                code: "capability.dialect",
+                message: "Descriptor requires dialect '\(query.dialectIdentifier)'; this validator validates SQLite only.",
+                query: query
+            ))
+        }
+
+        if let requiredVersion = query.minimumDialectVersion {
+            guard let actualVersion = runtimeMetadata?.sqliteVersion else {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .unsupported,
+                    stage: .capability,
+                    code: "capability.sqlite-version",
+                    message: "SQLite \(requiredVersion) or newer is required, but runtime identity is unavailable.",
+                    query: query
+                ))
+                return diagnostics
+            }
+            if !version(actualVersion, isAtLeast: requiredVersion) {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .unsupported,
+                    stage: .capability,
+                    code: "capability.sqlite-version",
+                    message: "SQLite \(actualVersion) does not satisfy required version \(requiredVersion).",
+                    query: query
+                ))
+            }
+        }
+
+        let availableDialectCapabilities = XLSQLiteDialect
+            .standardCapabilities.rawValue
+        let unavailable = query.dialectCapabilitiesRawValue
+            & ~availableDialectCapabilities
+        if unavailable != 0 {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .capability,
+                code: "capability.dialect-flags",
+                message: "Descriptor requires unsupported dialect capability bits \(unavailable).",
+                query: query
+            ))
+        }
+        return diagnostics
+    }
+
+    static func codecDiagnostics(
+        query: SQLiteBuildValidationQueryEntry,
+        environment: SQLiteBuildValidationEnvironment
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        struct Slot {
+            let identity: String
+            let valueTypeIdentifier: String
+            let storageIdentifier: String
+            let codec: SQLiteBuildValidationCodecReference
+        }
+
+        let slots = query.parameters.compactMap { parameter -> Slot? in
+            parameter.codec.map {
+                Slot(
+                    identity: parameter.identity,
+                    valueTypeIdentifier: parameter.valueTypeIdentifier,
+                    storageIdentifier: parameter.storageIdentifier,
+                    codec: $0
+                )
+            }
+        } + query.results.compactMap { result -> Slot? in
+            result.codec.map {
+                Slot(
+                    identity: result.identity,
+                    valueTypeIdentifier: result.valueTypeIdentifier,
+                    storageIdentifier: result.storageIdentifier,
+                    codec: $0
+                )
+            }
+        }
+
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        for slot in slots {
+            if slot.codec.valueTypeIdentifier != slot.valueTypeIdentifier {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .codec,
+                    code: "codec.value-type",
+                    message: "Slot '\(slot.identity)' value type '\(slot.valueTypeIdentifier)' does not match codec value type '\(slot.codec.valueTypeIdentifier)'.",
+                    query: query
+                ))
+            }
+            if slot.codec.dialectIdentifier != query.dialectIdentifier {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .codec,
+                    code: "codec.dialect",
+                    message: "Slot '\(slot.identity)' codec dialect '\(slot.codec.dialectIdentifier)' does not match query dialect '\(query.dialectIdentifier)'.",
+                    query: query
+                ))
+            }
+            if slot.codec.storageIdentifier != slot.storageIdentifier {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .codec,
+                    code: "codec.storage",
+                    message: "Slot '\(slot.identity)' storage '\(slot.storageIdentifier)' does not match codec storage '\(slot.codec.storageIdentifier)'.",
+                    query: query
+                ))
+            }
+        }
+
+        let available = Set(environment.codecIdentifiers)
+        for identifier in query.requiredCodecIdentifiers where !available.contains(identifier) {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .codec,
+                code: "codec.missing",
+                message: "Required codec '\(identifier)' was not supplied to the validator environment.",
+                query: query
+            ))
+        }
+        return diagnostics
+    }
+
+    static func capabilityDiagnostics(
+        query: SQLiteBuildValidationQueryEntry,
+        runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?,
+        environment: SQLiteBuildValidationEnvironment
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        let explicitCapabilities = Set(environment.capabilityIDs)
+        return query.requiredCapabilities.compactMap { requirement in
+            if capability(
+                    requirement.id,
+                    isAvailableIn: runtimeMetadata
+                ) || (isOpaqueCapability(requirement.id)
+                    && explicitCapabilities.contains(requirement.id)) {
+                return nil
+            }
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .capability,
+                code: capabilityDiagnosticCode(requirement.id),
+                message: "Required capability '\(requirement.id)' is unavailable on the validator connection.",
+                query: query
+            )
+        }
+    }
+
+    static func isOpaqueCapability(_ id: String) -> Bool {
+        let foldedID = id.lowercased()
+        let observablePrefixes = [
+            "function:",
+            "collation:",
+            "compile-option:",
+            "module:",
+            "extension:",
+        ]
+        return foldedID != "sqlite-json-functions"
+            && !observablePrefixes.contains(where: foldedID.hasPrefix)
+    }
+
+    static func hasUnavailablePreparationPrerequisite(
+        _ diagnostics: [SQLiteBuildValidationDiagnostic]
+    ) -> Bool {
+        let preparationBlockingCodes = Set([
+            "capability.collation",
+            "capability.dialect",
+            "capability.dialect-flags",
+            "capability.extension",
+            "capability.function",
+            "capability.module",
+            "capability.sqlite-json-functions",
+            "capability.sqlite-version",
+        ])
+        return diagnostics.contains { diagnostic in
+            diagnostic.verdict == .unsupported
+                && preparationBlockingCodes.contains(diagnostic.code)
+        }
+    }
+
+    static func requireSidecarFreeSnapshot(at databaseURL: URL) throws {
+        for suffix in ["-journal", "-shm", "-wal"] {
+            let sidecarPath = databaseURL.path + suffix
+            guard !FileManager.default.fileExists(atPath: sidecarPath) else {
+                throw SQLiteBuildValidationValidatorError.databaseHasSidecar(
+                    sidecarPath
+                )
+            }
+        }
+    }
+
+    static func capability(
+        _ id: String,
+        isAvailableIn runtimeMetadata: SQLiteBuildValidationRuntimeMetadata?
+    ) -> Bool {
+        guard let runtimeMetadata else {
+            return false
+        }
+        if let name = suffix(of: id, after: "function:") {
+            return runtimeMetadata.hasFunction(named: name)
+        }
+        if let name = suffix(of: id, after: "collation:") {
+            return runtimeMetadata.hasCollation(named: name)
+        }
+        if let option = suffix(of: id, after: "compile-option:") {
+            return runtimeMetadata.hasCompileOption(option)
+        }
+        if let name = suffix(of: id, after: "module:") {
+            return runtimeMetadata.hasModule(named: name)
+        }
+        if let name = suffix(of: id, after: "extension:") {
+            return runtimeMetadata.hasExtension(named: name)
+        }
+        switch id {
+        case "named-bindings", "indexed-bindings", "sqlite-core-parser",
+             "sqlite-storage-classes", "compound-select", "recursive-cte",
+             "transactions":
+            return true
+        case "sqlite-json-functions":
+            return runtimeMetadata.hasFunction(named: "JSON_VALID")
+        default:
+            return false
+        }
+    }
+
+    static func capabilityDiagnosticCode(_ id: String) -> String {
+        let foldedID = id.lowercased()
+        if foldedID.hasPrefix("function:") {
+            return "capability.function"
+        }
+        if foldedID.hasPrefix("collation:") {
+            return "capability.collation"
+        }
+        if foldedID.hasPrefix("compile-option:") {
+            return "capability.compile-option"
+        }
+        if foldedID.hasPrefix("module:") {
+            return "capability.module"
+        }
+        if foldedID.hasPrefix("extension:") {
+            return "capability.extension"
+        }
+        if foldedID == "sqlite-json-functions" {
+            return "capability.sqlite-json-functions"
+        }
+        return "capability.missing"
+    }
+
+    static func parameterDiagnostics(
+        query: SQLiteBuildValidationQueryEntry,
+        shape: SQLitePreparedStatementShape,
+        analysis: SQLiteBuildValidationValidatorPlaceholderAnalysis
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        if shape.physicalParameterCount != query.expectedPhysicalParameterCount {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .parameter,
+                code: "parameter.count",
+                message: "SQLite exposes \(shape.physicalParameterCount) physical parameter slots; descriptor expects \(query.expectedPhysicalParameterCount).",
+                query: query
+            ))
+        }
+
+        let actualByIndex = Dictionary(
+            uniqueKeysWithValues: shape.parameters.map {
+                ($0.physicalIndex, $0.name)
+            }
+        )
+        let expectedByIndex = Dictionary(
+            uniqueKeysWithValues: query.parameters.map {
+                ($0.physicalIndex, $0.expectedSQLiteSpelling)
+            }
+        )
+        let allIndices = Set(actualByIndex.keys).union(expectedByIndex.keys).sorted()
+        for physicalIndex in allIndices {
+            let expected = expectedByIndex[physicalIndex]
+            let actual = actualByIndex[physicalIndex] ?? nil
+            if let expected {
+                guard actual == expected else {
+                    diagnostics.append(SQLiteBuildValidationDiagnostic(
+                        verdict: .failed,
+                        stage: .parameter,
+                        code: "parameter.key",
+                        message: "Physical parameter \(physicalIndex) is '\(actual ?? "anonymous/implicit")'; descriptor expects '\(expected)'.",
+                        query: query
+                    ))
+                    continue
+                }
+            } else if let actual {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .parameter,
+                    code: "parameter.key",
+                    message: "Physical parameter \(physicalIndex) unexpectedly exposes key '\(actual)'.",
+                    query: query
+                ))
+            }
+        }
+
+        if analysis.unsupported.isEmpty {
+            if analysis.physicalParameterCount != shape.physicalParameterCount
+                || analysis.parameters != shape.parameters {
+                diagnostics.append(SQLiteBuildValidationDiagnostic(
+                    verdict: .failed,
+                    stage: .parameter,
+                    code: "parameter.metadata",
+                    message: "Lexical placeholder evidence does not match SQLite's physical parameter table.",
+                    query: query
+                ))
+            }
+        }
+        return diagnostics
+    }
+
+    static func placeholderDiagnostics(
+        query: SQLiteBuildValidationQueryEntry,
+        analysis: SQLiteBuildValidationValidatorPlaceholderAnalysis
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        let unsupported = analysis.unsupported.map { placeholder in
+            SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .parameter,
+                code: "parameter.syntax",
+                message: "Unsupported placeholder '\(placeholder.spelling)' at UTF-8 byte offset \(placeholder.byteOffset): \(placeholder.reason)",
+                query: query
+            )
+        }
+        let collisions = analysis.collisions.map { collision in
+            SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .parameter,
+                code: "parameter.key",
+                message: collision,
+                query: query
+            )
+        }
+        return unsupported + collisions
+    }
+
+    static func resultDiagnostics(
+        query: SQLiteBuildValidationQueryEntry,
+        shape: SQLitePreparedStatementShape
+    ) -> [SQLiteBuildValidationDiagnostic] {
+        var diagnostics: [SQLiteBuildValidationDiagnostic] = []
+        if shape.columns.count != query.results.count {
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .result,
+                code: "result.count",
+                message: "SQLite exposes \(shape.columns.count) result columns; descriptor expects \(query.results.count).",
+                query: query
+            ))
+        }
+
+        let actualByIndex = Dictionary(
+            uniqueKeysWithValues: shape.columns.map { ($0.index, $0) }
+        )
+        for result in query.results {
+            guard let expectedAlias = result.declaredAlias,
+                  let column = actualByIndex[result.index],
+                  column.name != expectedAlias else {
+                continue
+            }
+            diagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .result,
+                code: "result.name",
+                message: "Result column \(result.index) is named '\(column.name)'; descriptor expects explicit alias '\(expectedAlias)'.",
+                query: query
+            ))
+        }
+        return diagnostics
+    }
+
+    static func prepareDiagnostic(
+        _ error: SQLitePrepareV3ProbeError,
+        query: SQLiteBuildValidationQueryEntry
+    ) -> SQLiteBuildValidationDiagnostic {
+        switch error {
+        case .emptyStatement:
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .prepare,
+                code: "statement.empty",
+                message: "SQL contains no preparable SQLite statement.",
+                query: query
+            )
+        case .embeddedNUL:
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .prepare,
+                code: "statement.embedded-nul",
+                message: "SQL contains an embedded NUL byte.",
+                query: query
+            )
+        case .multipleStatements:
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .prepare,
+                code: "statement.multiple",
+                message: "SQL contains more than one preparable SQLite statement.",
+                query: query
+            )
+        case .sqlitePrepare(let resultCode, let extendedResultCode, let message):
+            return SQLiteBuildValidationDiagnostic(
+                verdict: .failed,
+                stage: .prepare,
+                code: "sqlite.prepare.failed",
+                message: message,
+                query: query,
+                sqliteResultCode: resultCode,
+                sqliteExtendedResultCode: extendedResultCode
+            )
+        }
+    }
+
+    static func suffix(of value: String, after prefix: String) -> String? {
+        guard value.hasPrefix(prefix) else {
+            return nil
+        }
+        let suffix = String(value.dropFirst(prefix.count))
+        return suffix.isEmpty ? nil : suffix
+    }
+
+    static func version(_ actual: String, isAtLeast required: String) -> Bool {
+        guard let actual = versionComponents(actual),
+              let required = versionComponents(required) else {
+            return false
+        }
+        return actual.lexicographicallyPrecedes(required) == false
+    }
+
+    static func versionComponents(_ value: String) -> [Int]? {
+        let components = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard !components.isEmpty,
+              components.count <= 3,
+              components.allSatisfy({ Int($0) != nil }) else {
+            return nil
+        }
+        return components.map { Int($0)! }
+            + Array(repeating: 0, count: 3 - components.count)
+    }
+}
+
+
+public enum SQLiteBuildValidationValidatorError:
+    Error,
+    Equatable,
+    Sendable,
+    CustomStringConvertible
+{
+    case databaseIsNotARegularFile(String)
+    case databaseHasSidecar(String)
+    case databaseChangedDuringValidation(
+        initialByteCount: Int,
+        initialSHA256: String,
+        finalByteCount: Int,
+        finalSHA256: String
+    )
+
+    public var description: String {
+        switch self {
+        case .databaseIsNotARegularFile(let path):
+            return "Build-validation database is not a regular file: \(path)"
+        case .databaseHasSidecar(let path):
+            return "Build-validation snapshot has an adjacent SQLite sidecar and is not immutable: \(path)"
+        case .databaseChangedDuringValidation(
+            let initialByteCount,
+            let initialSHA256,
+            let finalByteCount,
+            let finalSHA256
+        ):
+            return "Build-validation snapshot changed during validation: initial byte count \(initialByteCount), SHA-256 \(initialSHA256); final byte count \(finalByteCount), SHA-256 \(finalSHA256)."
+        }
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -489,7 +489,10 @@ private extension SQLiteBuildValidator {
         if let name = suffix(of: id, after: "extension:") {
             return runtimeMetadata.hasExtension(named: name)
         }
-        switch id {
+        // Fold case here too, matching isOpaqueCapability/capabilityDiagnosticCode
+        // — otherwise an id like "SQLite-JSON-Functions" is classified as the
+        // JSON-functions capability but never resolves as available.
+        switch id.lowercased() {
         case "named-bindings", "indexed-bindings", "sqlite-core-parser",
              "sqlite-storage-classes", "compound-select", "recursive-cte",
              "transactions":

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -154,7 +154,7 @@ public enum SQLiteBuildValidator {
                 verdict: .failed,
                 stage: .runtime,
                 code: "runtime.capture",
-                message: "SQLite runtime metadata capture failed: \(String(describing: error))."
+                message: "SQLite runtime metadata capture failed with an unexpected \(String(reflecting: type(of: error)))."
             ))
         }
 
@@ -257,7 +257,7 @@ private extension SQLiteBuildValidator {
                     verdict: .failed,
                     stage: .prepare,
                     code: "sqlite.prepare.failed",
-                    message: "SQLite preparation failed: \(String(describing: error)).",
+                    message: "SQLite preparation failed with an unexpected \(String(reflecting: type(of: error))).",
                     query: query
                 ))
             }

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -114,7 +114,7 @@ public enum SQLiteBuildValidator {
                     verdict: .failed,
                     stage: .schema,
                     code: "schema.byte-count",
-                    message: "Schema snapshot byte count is \(observedDatabaseByteCount); expected \(validatedManifest.schemaSnapshot.databaseByteCount)."
+                    message: "Observed database byte count is \(observedDatabaseByteCount); the manifest's schema snapshot declares \(validatedManifest.schemaSnapshot.databaseByteCount)."
                 ))
             }
         } else {
@@ -131,7 +131,7 @@ public enum SQLiteBuildValidator {
                     verdict: .failed,
                     stage: .schema,
                     code: "schema.snapshot-sha",
-                    message: "Schema snapshot SHA-256 is \(observedDatabaseSHA256.lowercased()); expected \(validatedManifest.schemaSnapshot.databaseSHA256)."
+                    message: "Observed database SHA-256 is \(observedDatabaseSHA256.lowercased()); the manifest's schema snapshot declares \(validatedManifest.schemaSnapshot.databaseSHA256)."
                 ))
             }
         } else {
@@ -165,7 +165,7 @@ public enum SQLiteBuildValidator {
                     verdict: .failed,
                     stage: .schema,
                     code: "schema.row-count",
-                    message: "Schema contains \(runtimeMetadata.schemaRowCount) sqlite_schema rows; expected \(validatedManifest.schemaSnapshot.schemaRowCount)."
+                    message: "Observed sqlite_schema row count is \(runtimeMetadata.schemaRowCount); the manifest's schema snapshot declares \(validatedManifest.schemaSnapshot.schemaRowCount)."
                 ))
             }
             if runtimeMetadata.schemaFNV1A64 != validatedManifest.schemaSnapshot.schemaFingerprint {
@@ -173,7 +173,7 @@ public enum SQLiteBuildValidator {
                     verdict: .failed,
                     stage: .schema,
                     code: "schema.fingerprint",
-                    message: "Schema FNV-1a-64 is \(runtimeMetadata.schemaFNV1A64); expected \(validatedManifest.schemaSnapshot.schemaFingerprint)."
+                    message: "Observed schema FNV-1a-64 is \(runtimeMetadata.schemaFNV1A64); the manifest's schema snapshot declares \(validatedManifest.schemaSnapshot.schemaFingerprint)."
                 ))
             }
         }

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -30,7 +30,8 @@ public enum SQLiteBuildValidator {
         let databaseURL = databaseURL.standardizedFileURL
             .resolvingSymlinksInPath()
             .standardizedFileURL
-        let manifest = try manifest.validating()
+        // Validation happens exactly once, inside the `in:` overload below —
+        // this overload deliberately does not pre-validate `manifest` itself.
         let resourceValues = try databaseURL.resourceValues(
             forKeys: [.isRegularFileKey]
         )

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift
@@ -1,0 +1,312 @@
+import CSQLite
+import Foundation
+import GRDB
+
+
+/// One entry in SQLite's one-based physical parameter table.
+///
+/// `name` preserves SQLite's leading sigil (`:`, `@`, `$`, or `?`). A `nil`
+/// name is intentionally ambiguous at this layer: SQLite does not distinguish
+/// an unused `?NNN` gap from an anonymous `?` through its statement metadata
+/// API. The validator reconciles this table with SwiftQL's logical layout.
+public struct SQLitePreparedParameter: Codable, Equatable, Sendable {
+    public let physicalIndex: Int
+    public let name: String?
+
+    public init(physicalIndex: Int, name: String?) {
+        self.physicalIndex = physicalIndex
+        self.name = name
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case physicalIndex = "physical_index"
+        case name
+    }
+}
+
+
+/// Metadata SQLite exposes for one zero-based result column at prepare time.
+///
+/// A missing `declaredType` is expected for expressions, aggregates, literals,
+/// and other results that do not map directly to a declared schema column. It
+/// is evidence only and must not be treated as a storage, codec, or nullability
+/// proof.
+public struct SQLitePreparedColumn: Codable, Equatable, Sendable {
+    public let index: Int
+    public let name: String
+    public let declaredType: String?
+
+    public init(index: Int, name: String, declaredType: String?) {
+        self.index = index
+        self.name = name
+        self.declaredType = declaredType
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case index
+        case name
+        case declaredType = "declared_type"
+    }
+}
+
+
+/// The connection-bound shape SQLite reports for one prepared statement.
+public struct SQLitePreparedStatementShape: Codable, Equatable, Sendable {
+    /// SQLite's largest physical parameter index, including any `?NNN` gaps.
+    public let physicalParameterCount: Int
+
+    /// One entry for every index in `1...physicalParameterCount`.
+    public let parameters: [SQLitePreparedParameter]
+
+    public let columns: [SQLitePreparedColumn]
+
+    /// Raw `sqlite3_stmt_readonly` evidence. This does not classify SwiftQL's
+    /// semantic command/query role.
+    public let isReadOnly: Bool
+
+    public init(
+        physicalParameterCount: Int,
+        parameters: [SQLitePreparedParameter],
+        columns: [SQLitePreparedColumn],
+        isReadOnly: Bool
+    ) {
+        self.physicalParameterCount = physicalParameterCount
+        self.parameters = parameters
+        self.columns = columns
+        self.isReadOnly = isReadOnly
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case physicalParameterCount = "physical_parameter_count"
+        case parameters
+        case columns
+        case isReadOnly = "is_read_only"
+    }
+}
+
+
+/// Stable preparation failures that the higher-level validator maps into its
+/// deterministic report model.
+public enum SQLitePrepareV3ProbeError: Error, Equatable, Sendable {
+    case emptyStatement
+    case embeddedNUL
+    case multipleStatements
+    case sqlitePrepare(
+        resultCode: Int32,
+        extendedResultCode: Int32,
+        message: String
+    )
+}
+
+
+/// Extracts SQLite statement metadata without executing the statement.
+///
+/// Must be called inside the `read` closure of a validator-owned
+/// `DatabaseQueue`, never against an application's long-lived pool. Raw C
+/// preparation bypasses GRDB's internal statement-authorizer reset and must
+/// not escape the serialized connection closure. Returned values contain
+/// copied Swift strings only; no SQLite pointer survives this call — this is
+/// the validator's entire "no public claim or format for serialized
+/// sqlite3_stmt" contract.
+public enum SQLitePrepareV3Probe {
+    public static func prepare(
+        sql: String,
+        in database: Database
+    ) throws -> SQLitePreparedStatementShape {
+        guard !sql.utf8.contains(0) else {
+            throw SQLitePrepareV3ProbeError.embeddedNUL
+        }
+        guard let connection = database.sqliteConnection else {
+            throw syntheticPrepareFailure(
+                resultCode: SQLITE_MISUSE,
+                message: "The validator-owned SQLite connection is unavailable."
+            )
+        }
+
+        return try sql.utf8CString.withUnsafeBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                throw SQLitePrepareV3ProbeError.emptyStatement
+            }
+
+            // `utf8CString` includes one trailing NUL byte. Supplying an exact
+            // byte count keeps tail offsets deterministic and avoids allowing
+            // embedded NUL to silently truncate the validated statement.
+            let sqlByteCount = buffer.count - 1
+            guard sqlByteCount <= Int(CInt.max) else {
+                throw syntheticPrepareFailure(
+                    resultCode: SQLITE_TOOBIG,
+                    message: "SQL UTF-8 byte count \(sqlByteCount) exceeds Int32.max."
+                )
+            }
+
+            let endAddress = baseAddress.advanced(by: sqlByteCount)
+            var cursor = baseAddress
+            var preparedShape: SQLitePreparedStatementShape?
+
+            while cursor < endAddress {
+                var statement: OpaquePointer?
+                var tail: UnsafePointer<CChar>?
+                let remainingByteCount = cursor.distance(to: endAddress)
+                let resultCode = sqlite3_prepare_v3(
+                    connection,
+                    cursor,
+                    CInt(remainingByteCount),
+                    0,
+                    &statement,
+                    &tail
+                )
+
+                guard resultCode == SQLITE_OK else {
+                    // SQLite owns these pointers. Copy the diagnostic before
+                    // finalization or any subsequent SQLite call can replace it.
+                    let extendedResultCode = sqlite3_extended_errcode(connection)
+                    let message = copiedString(sqlite3_errmsg(connection))
+                        ?? "sqlite3_prepare_v3 failed without an error message."
+                    if let statement {
+                        _ = sqlite3_finalize(statement)
+                    }
+                    throw SQLitePrepareV3ProbeError.sqlitePrepare(
+                        resultCode: resultCode,
+                        extendedResultCode: extendedResultCode,
+                        message: message
+                    )
+                }
+
+                guard let tail,
+                      tail > cursor,
+                      tail <= endAddress else {
+                    if let statement {
+                        _ = sqlite3_finalize(statement)
+                    }
+                    throw syntheticPrepareFailure(
+                        resultCode: SQLITE_MISUSE,
+                        message: "sqlite3_prepare_v3 returned an invalid or non-advancing tail pointer."
+                    )
+                }
+
+                if let statement {
+                    let shape = try inspectAndFinalize(
+                        statement,
+                        connection: connection
+                    )
+                    guard preparedShape == nil else {
+                        throw SQLitePrepareV3ProbeError.multipleStatements
+                    }
+                    preparedShape = shape
+                }
+
+                cursor = tail
+            }
+
+            guard let preparedShape else {
+                throw SQLitePrepareV3ProbeError.emptyStatement
+            }
+            return preparedShape
+        }
+    }
+
+    /// Copies every SQLite-owned string and finalizes `statement` exactly once,
+    /// whether inspection succeeds or fails.
+    private static func inspectAndFinalize(
+        _ statement: OpaquePointer,
+        connection: OpaquePointer
+    ) throws -> SQLitePreparedStatementShape {
+        let inspection: Result<SQLitePreparedStatementShape, SQLitePrepareV3ProbeError>
+        do {
+            inspection = .success(try inspect(statement, connection: connection))
+        } catch let error as SQLitePrepareV3ProbeError {
+            inspection = .failure(error)
+        } catch {
+            inspection = .failure(syntheticPrepareFailure(
+                resultCode: SQLITE_ERROR,
+                message: "Unexpected statement metadata inspection failure."
+            ))
+        }
+
+        let finalizeResultCode = sqlite3_finalize(statement)
+        switch inspection {
+        case .failure(let error):
+            throw error
+        case .success(let shape):
+            guard finalizeResultCode == SQLITE_OK else {
+                let extendedResultCode = sqlite3_extended_errcode(connection)
+                let message = copiedString(sqlite3_errmsg(connection))
+                    ?? "sqlite3_finalize failed without an error message."
+                throw SQLitePrepareV3ProbeError.sqlitePrepare(
+                    resultCode: finalizeResultCode,
+                    extendedResultCode: extendedResultCode,
+                    message: message
+                )
+            }
+            return shape
+        }
+    }
+
+    private static func inspect(
+        _ statement: OpaquePointer,
+        connection: OpaquePointer
+    ) throws -> SQLitePreparedStatementShape {
+        let physicalParameterCount = Int(
+            sqlite3_bind_parameter_count(statement)
+        )
+        var parameters: [SQLitePreparedParameter] = []
+        parameters.reserveCapacity(physicalParameterCount)
+        if physicalParameterCount > 0 {
+            for physicalIndex in 1...physicalParameterCount {
+                parameters.append(SQLitePreparedParameter(
+                    physicalIndex: physicalIndex,
+                    name: copiedString(sqlite3_bind_parameter_name(
+                        statement,
+                        CInt(physicalIndex)
+                    ))
+                ))
+            }
+        }
+
+        let columnCount = Int(sqlite3_column_count(statement))
+        var columns: [SQLitePreparedColumn] = []
+        columns.reserveCapacity(columnCount)
+        for index in 0..<columnCount {
+            let sqliteIndex = CInt(index)
+            guard let name = copiedString(
+                sqlite3_column_name(statement, sqliteIndex)
+            ) else {
+                throw syntheticPrepareFailure(
+                    resultCode: SQLITE_NOMEM,
+                    message: "SQLite returned no name for result column \(index)."
+                )
+            }
+            columns.append(SQLitePreparedColumn(
+                index: index,
+                name: name,
+                declaredType: copiedString(
+                    sqlite3_column_decltype(statement, sqliteIndex)
+                )
+            ))
+        }
+
+        return SQLitePreparedStatementShape(
+            physicalParameterCount: physicalParameterCount,
+            parameters: parameters,
+            columns: columns,
+            isReadOnly: sqlite3_stmt_readonly(statement) != 0
+        )
+    }
+
+    private static func copiedString(
+        _ value: UnsafePointer<CChar>?
+    ) -> String? {
+        value.map(String.init(cString:))
+    }
+
+    private static func syntheticPrepareFailure(
+        resultCode: Int32,
+        message: String
+    ) -> SQLitePrepareV3ProbeError {
+        .sqlitePrepare(
+            resultCode: resultCode,
+            extendedResultCode: resultCode,
+            message: message
+        )
+    }
+}

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift
@@ -171,7 +171,7 @@ public enum SQLitePrepareV3Probe {
                     let message = copiedString(sqlite3_errmsg(connection))
                         ?? "sqlite3_prepare_v3 failed without an error message."
                     if let statement {
-                        _ = sqlite3_finalize(statement)
+                        try finalizeOrThrowFinalizeFailure(statement, connection: connection)
                     }
                     throw SQLitePrepareV3ProbeError.sqlitePrepare(
                         resultCode: resultCode,
@@ -184,7 +184,7 @@ public enum SQLitePrepareV3Probe {
                       tail > cursor,
                       tail <= endAddress else {
                     if let statement {
-                        _ = sqlite3_finalize(statement)
+                        try finalizeOrThrowFinalizeFailure(statement, connection: connection)
                     }
                     throw syntheticPrepareFailure(
                         resultCode: SQLITE_MISUSE,
@@ -231,11 +231,27 @@ public enum SQLitePrepareV3Probe {
             ))
         }
 
-        let finalizeResultCode = sqlite3_finalize(statement)
         // Check the finalize result before considering inspection's outcome:
         // a failing finalize is a statement-lifecycle problem in its own
         // right and must not be silently discarded just because inspection
         // also failed (or, worse, masked by an unrelated inspection error).
+        try finalizeOrThrowFinalizeFailure(statement, connection: connection)
+        switch inspection {
+        case .failure(let error):
+            throw error
+        case .success(let shape):
+            return shape
+        }
+    }
+
+    /// Finalizes `statement` and throws `.sqliteFinalize` if finalization
+    /// itself fails, so a statement-lifecycle problem is never silently
+    /// discarded on any path that must otherwise finalize-and-continue.
+    private static func finalizeOrThrowFinalizeFailure(
+        _ statement: OpaquePointer,
+        connection: OpaquePointer
+    ) throws {
+        let finalizeResultCode = sqlite3_finalize(statement)
         guard finalizeResultCode == SQLITE_OK else {
             let extendedResultCode = sqlite3_extended_errcode(connection)
             let message = copiedString(sqlite3_errmsg(connection))
@@ -245,12 +261,6 @@ public enum SQLitePrepareV3Probe {
                 extendedResultCode: extendedResultCode,
                 message: message
             )
-        }
-        switch inspection {
-        case .failure(let error):
-            throw error
-        case .success(let shape):
-            return shape
         }
     }
 

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift
@@ -96,6 +96,14 @@ public enum SQLitePrepareV3ProbeError: Error, Equatable, Sendable {
         extendedResultCode: Int32,
         message: String
     )
+    /// A distinct case from `sqlitePrepare` so the validator's report
+    /// taxonomy does not misclassify a `sqlite3_finalize` failure — a
+    /// statement-lifecycle problem — as a preparation failure.
+    case sqliteFinalize(
+        resultCode: Int32,
+        extendedResultCode: Int32,
+        message: String
+    )
 }
 
 
@@ -232,7 +240,7 @@ public enum SQLitePrepareV3Probe {
                 let extendedResultCode = sqlite3_extended_errcode(connection)
                 let message = copiedString(sqlite3_errmsg(connection))
                     ?? "sqlite3_finalize failed without an error message."
-                throw SQLitePrepareV3ProbeError.sqlitePrepare(
+                throw SQLitePrepareV3ProbeError.sqliteFinalize(
                     resultCode: finalizeResultCode,
                     extendedResultCode: extendedResultCode,
                     message: message

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift
@@ -232,20 +232,24 @@ public enum SQLitePrepareV3Probe {
         }
 
         let finalizeResultCode = sqlite3_finalize(statement)
+        // Check the finalize result before considering inspection's outcome:
+        // a failing finalize is a statement-lifecycle problem in its own
+        // right and must not be silently discarded just because inspection
+        // also failed (or, worse, masked by an unrelated inspection error).
+        guard finalizeResultCode == SQLITE_OK else {
+            let extendedResultCode = sqlite3_extended_errcode(connection)
+            let message = copiedString(sqlite3_errmsg(connection))
+                ?? "sqlite3_finalize failed without an error message."
+            throw SQLitePrepareV3ProbeError.sqliteFinalize(
+                resultCode: finalizeResultCode,
+                extendedResultCode: extendedResultCode,
+                message: message
+            )
+        }
         switch inspection {
         case .failure(let error):
             throw error
         case .success(let shape):
-            guard finalizeResultCode == SQLITE_OK else {
-                let extendedResultCode = sqlite3_extended_errcode(connection)
-                let message = copiedString(sqlite3_errmsg(connection))
-                    ?? "sqlite3_finalize failed without an error message."
-                throw SQLitePrepareV3ProbeError.sqliteFinalize(
-                    resultCode: finalizeResultCode,
-                    extendedResultCode: extendedResultCode,
-                    message: message
-                )
-            }
             return shape
         }
     }

--- a/Sources/SwiftQLSQLiteBuildValidationValidatorCLI/main.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidatorCLI/main.swift
@@ -1,6 +1,12 @@
 import Foundation
 import SwiftQLSQLiteBuildValidationValidator
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
 
 func writeStandardError(_ message: String) {
     FileHandle.standardError.write(Data((message + "\n").utf8))

--- a/Sources/SwiftQLSQLiteBuildValidationValidatorCLI/main.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidatorCLI/main.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftQLSQLiteBuildValidationValidator
+
+
+func writeStandardError(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
+do {
+    let options = try SQLiteBuildValidationValidatorCLIOptions.parse(
+        arguments: Array(CommandLine.arguments.dropFirst())
+    )
+    if options.showsHelp {
+        print(SQLiteBuildValidationValidatorCLIOptions.usage)
+        exit(EXIT_SUCCESS)
+    }
+    let result = try SQLiteBuildValidationValidatorCLIRunner.run(options: options)
+    exit(result.exitCode)
+} catch {
+    writeStandardError(String(describing: error))
+    writeStandardError(SQLiteBuildValidationValidatorCLIOptions.usage)
+    exit(2)
+}

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidationSHA256Tests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidationSHA256Tests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+@testable import SwiftQLSQLiteBuildValidationValidator
+
+
+final class SQLiteBuildValidationSHA256Tests: XCTestCase {
+    func testStandardTestVectors() {
+        // NIST/FIPS 180-4 examples, plus the empty-string and a multi-block
+        // input to exercise the streaming block-boundary and tail-padding
+        // logic (a single 64-byte block cannot cover both).
+        let cases: [(input: String, expected: String)] = [
+            ("", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+            ("abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"),
+            (
+                "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+                "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+            ),
+        ]
+        for testCase in cases {
+            XCTAssertEqual(
+                SQLiteBuildValidationSHA256.hexDigest(
+                    of: Data(testCase.input.utf8)
+                ),
+                testCase.expected,
+                "input: \(testCase.input)"
+            )
+        }
+    }
+
+    func testExactBlockBoundaryAndMultiBlockInputsHashDeterministically() {
+        // Exactly 64 bytes: the streaming loop consumes it as one full block
+        // and the padding tail becomes a second, wholly synthetic block.
+        let exactlyOneBlock = Data(repeating: 0x41, count: 64)
+        // Large enough to span many full blocks plus a partial tail.
+        let multiBlock = Data(repeating: 0x5A, count: 10_000)
+
+        for data in [exactlyOneBlock, multiBlock] {
+            let first = SQLiteBuildValidationSHA256.hexDigest(of: data)
+            let second = SQLiteBuildValidationSHA256.hexDigest(of: data)
+            XCTAssertEqual(first, second)
+            XCTAssertEqual(first.count, 64)
+            XCTAssertTrue(first.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+        }
+    }
+}

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidationValidatorCLIRunnerTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidationValidatorCLIRunnerTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import SwiftQLSQLiteBuildValidationManifest
+import XCTest
+@testable import SwiftQLSQLiteBuildValidationValidator
+
+
+final class SQLiteBuildValidationValidatorCLIRunnerTests: XCTestCase {
+    typealias Support = SQLiteBuildValidationValidatorTestSupport
+
+    func testRunnerExitsZeroOnPassAndOneOnFailAndWritesCanonicalReport() throws {
+        try Support.withValidatorOwnedNorthwindURL { databaseURL in
+            let workingDirectory = databaseURL.deletingLastPathComponent()
+
+            let passingManifestURL = workingDirectory.appendingPathComponent("passing.json")
+            try Support.manifest(queries: [
+                Support.query(id: "trivial", sql: "SELECT 1 AS value"),
+            ]).canonicalJSONData().write(to: passingManifestURL)
+            let passingOutputURL = workingDirectory.appendingPathComponent("passing-report.json")
+
+            let passingResult = try SQLiteBuildValidationValidatorCLIRunner.run(
+                options: try SQLiteBuildValidationValidatorCLIOptions.parse(arguments: [
+                    "--database", databaseURL.path,
+                    "--manifest", passingManifestURL.path,
+                    "--output", passingOutputURL.path,
+                ])
+            )
+            XCTAssertEqual(passingResult.exitCode, 0)
+            XCTAssertEqual(
+                try Data(contentsOf: passingOutputURL),
+                try passingResult.report.canonicalJSONData()
+            )
+
+            let failingManifestURL = workingDirectory.appendingPathComponent("failing.json")
+            try Support.manifest(queries: [
+                Support.query(sql: "SELECT * FROM tests_totally_missing_table"),
+            ]).canonicalJSONData().write(to: failingManifestURL)
+            let failingOutputURL = workingDirectory.appendingPathComponent("failing-report.json")
+
+            let failingResult = try SQLiteBuildValidationValidatorCLIRunner.run(
+                options: try SQLiteBuildValidationValidatorCLIOptions.parse(arguments: [
+                    "--database", databaseURL.path,
+                    "--manifest", failingManifestURL.path,
+                    "--output", failingOutputURL.path,
+                ])
+            )
+            XCTAssertEqual(failingResult.exitCode, 1)
+            XCTAssertEqual(failingResult.report.overallVerdict, .failed)
+        }
+    }
+
+    func testOptionsParsingRequiresDatabaseManifestAndOutput() {
+        XCTAssertThrowsError(
+            try SQLiteBuildValidationValidatorCLIOptions.parse(arguments: [
+                "--database", "/tmp/a.sqlite",
+            ])
+        ) { error in
+            XCTAssertEqual(
+                error as? SQLiteBuildValidationValidatorCLIError,
+                .requiredOption("--manifest")
+            )
+        }
+    }
+
+    func testHelpBypassesRequiredOptionChecks() throws {
+        let options = try SQLiteBuildValidationValidatorCLIOptions.parse(
+            arguments: ["--help"]
+        )
+        XCTAssertTrue(options.showsHelp)
+    }
+
+    func testPreflightRejectsOutputAliasingInputs() throws {
+        try Support.withValidatorOwnedNorthwindURL { databaseURL in
+            let manifestURL = databaseURL.deletingLastPathComponent()
+                .appendingPathComponent("manifest.json")
+            try Data().write(to: manifestURL)
+
+            XCTAssertThrowsError(
+                try SQLiteBuildValidationValidatorCLIOptions.preflightOutputSafety(
+                    databaseURL: databaseURL,
+                    manifestURL: manifestURL,
+                    outputURL: databaseURL
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? SQLiteBuildValidationValidatorCLIError,
+                    .outputConflictsWithInput("--database")
+                )
+            }
+        }
+    }
+}

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidationValidatorTestSupport.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidationValidatorTestSupport.swift
@@ -1,0 +1,159 @@
+import Foundation
+import GRDB
+import SwiftQLCore
+import SwiftQLNorthwindFixtures
+import SwiftQLSQLiteBuildValidationManifest
+@testable import SwiftQLSQLiteBuildValidationValidator
+
+
+enum SQLiteBuildValidationValidatorTestSupport {
+    static let northwindSchemaSHA256 =
+        "cb6f0071a264e150d3796f75c4b0643e32b2132e4e02370518b50a1eac3381d8"
+    static let northwindSchemaByteCount = 602_112
+    static let northwindSchemaRowCount = 37
+    static let northwindSchemaFingerprint = "e2c8fadbd38c2313"
+
+    static func schemaSnapshot(
+        databaseSHA256: String = northwindSchemaSHA256,
+        databaseByteCount: Int = northwindSchemaByteCount,
+        schemaRowCount: Int = northwindSchemaRowCount,
+        schemaFingerprint: String = northwindSchemaFingerprint
+    ) -> SQLiteBuildValidationSchemaSnapshot {
+        SQLiteBuildValidationSchemaSnapshot(
+            identifier: "northwind.issue-254",
+            databaseSHA256: databaseSHA256,
+            databaseByteCount: databaseByteCount,
+            schemaRowCount: schemaRowCount,
+            schemaFingerprint: schemaFingerprint
+        )
+    }
+
+    static func query(
+        id: String = "tests.query",
+        sql: String = "SELECT 1 AS value",
+        cardinality: UInt8 = XLQueryCardinality.exactlyOne.rawValue,
+        parameters: [SQLiteBuildValidationParameterEntry] = [],
+        results: [SQLiteBuildValidationResultEntry] = [result()],
+        requiredCapabilities: [String] = []
+    ) -> SQLiteBuildValidationQueryEntry {
+        SQLiteBuildValidationQueryEntry(
+            id: id,
+            definitionIdentity: "tests/\(id)@1",
+            descriptorIdentity: "swiftql-query-v1-\(id)",
+            sql: sql,
+            dialectIdentifier: XLSQLiteDialect.identity.rawValue,
+            cardinality: cardinality,
+            parameters: parameters,
+            results: results,
+            requiredCapabilities: requiredCapabilities
+        )
+    }
+
+    static func parameter(
+        logicalIndex: Int = 0,
+        physicalIndex: Int = 1,
+        identity: String = "parameter/value",
+        keyKind: SQLiteBuildValidationParameterEntry.KeyKind = .named,
+        keyName: String? = "value",
+        keyIndex: Int? = nil,
+        valueTypeIdentifier: String = "swift.int",
+        valueTypeName: String = "Swift.Int",
+        nullability: String = "required",
+        codec: SQLiteBuildValidationCodecReference? = nil,
+        storageIdentifier: String = "integer"
+    ) -> SQLiteBuildValidationParameterEntry {
+        SQLiteBuildValidationParameterEntry(
+            logicalIndex: logicalIndex,
+            physicalIndex: physicalIndex,
+            identity: identity,
+            keyKind: keyKind,
+            keyName: keyName,
+            keyIndex: keyIndex,
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codec: codec,
+            storageIdentifier: storageIdentifier
+        )
+    }
+
+    static func result(
+        index: Int = 0,
+        identity: String = "result/value",
+        declaredAlias: String? = "value",
+        valueTypeIdentifier: String = "swift.int",
+        valueTypeName: String = "Swift.Int",
+        nullability: String = "required",
+        codec: SQLiteBuildValidationCodecReference? = nil,
+        storageIdentifier: String = "integer"
+    ) -> SQLiteBuildValidationResultEntry {
+        SQLiteBuildValidationResultEntry(
+            index: index,
+            identity: identity,
+            declaredAlias: declaredAlias,
+            valueTypeIdentifier: valueTypeIdentifier,
+            valueTypeName: valueTypeName,
+            nullability: nullability,
+            codec: codec,
+            storageIdentifier: storageIdentifier
+        )
+    }
+
+    static func manifest(
+        schemaSnapshot: SQLiteBuildValidationSchemaSnapshot = schemaSnapshot(),
+        queries: [SQLiteBuildValidationQueryEntry] = [query()]
+    ) -> SQLiteBuildValidationManifest {
+        SQLiteBuildValidationManifest(
+            conformanceInventoryVersion: "190.1.0",
+            combinatorialManifestVersion: "c191-v2",
+            schemaSnapshot: schemaSnapshot,
+            queries: queries
+        )
+    }
+
+    static func withNorthwindURL<Result>(
+        _ body: (URL) throws -> Result
+    ) throws -> Result {
+        try NorthwindFixture.withTemporaryCopy { copy in
+            try body(copy.url)
+        }
+    }
+
+    /// Places an untouched canonical snapshot at a second unique path inside
+    /// the fixture's temporary directory. The fixture pool never opens this
+    /// path, so the validator owns its complete connection lifecycle and no
+    /// WAL/SHM sidecars exist before validation begins.
+    static func withValidatorOwnedNorthwindURL<Result>(
+        _ body: (URL) throws -> Result
+    ) throws -> Result {
+        try NorthwindFixture.withTemporaryCopy { copy in
+            let canonicalPool = try NorthwindFixture.validatedReadOnlyPool()
+            defer { try? canonicalPool.close() }
+
+            let sourceURL = URL(fileURLWithPath: canonicalPool.path)
+            let validatorURL = copy.url.deletingLastPathComponent()
+                .appendingPathComponent("validator-owned-northwind.db")
+            try FileManager.default.copyItem(at: sourceURL, to: validatorURL)
+            return try body(validatorURL)
+        }
+    }
+
+    static func withReadOnlyNorthwindDatabase<Result>(
+        _ body: (Database) throws -> Result
+    ) throws -> Result {
+        try withNorthwindURL { url in
+            var configuration = Configuration()
+            configuration.label = "SwiftQLSQLiteBuildValidationValidatorTests.raw-probe"
+            configuration.readonly = true
+            configuration.prepareDatabase { database in
+                try database.execute(sql: "PRAGMA query_only = ON")
+            }
+            let queue = try DatabaseQueue(
+                path: url.path,
+                configuration: configuration
+            )
+            defer { try? queue.close() }
+            return try queue.read(body)
+        }
+    }
+}

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
@@ -165,6 +165,30 @@ final class SQLiteBuildValidatorIntegrationTests: XCTestCase {
         }
     }
 
+    /// `capability.compile-option` must gate preparation exactly like every
+    /// other capability code — a query missing a required compile option
+    /// must never reach `sqlite3_prepare_v3` at all.
+    func testMissingCompileOptionCapabilitySkipsPreparation() throws {
+        let manifest = Support.manifest(queries: [
+            Support.query(
+                sql: "SELECT 1 AS value",
+                requiredCapabilities: ["compile-option:DEFINITELY_MISSING_OPTION"]
+            ),
+        ])
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let report = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(report.overallVerdict, .unsupported)
+            let outcome = try XCTUnwrap(report.outcomes.first)
+            XCTAssertTrue(outcome.diagnostics.contains {
+                $0.code == "capability.compile-option" && $0.verdict == .unsupported
+            })
+            XCTAssertNil(outcome.preparedShape)
+        }
+    }
+
     func testMissingCodecIsUnsupportedUntilSuppliedInEnvironment() throws {
         let codec = SQLiteBuildValidationCodecReference(
             keyID: "tests.codec.value",

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
@@ -231,6 +231,30 @@ final class SQLiteBuildValidatorIntegrationTests: XCTestCase {
         }
     }
 
+    /// `hasExtension`/`hasModule`/`hasCompileOption` must ASCII-fold like
+    /// `hasFunction`/`hasCollation` already do — a caller-supplied extension
+    /// name in different case than the required capability id must still
+    /// resolve.
+    func testExtensionCapabilityMatchingIsCaseInsensitive() throws {
+        let manifest = Support.manifest(queries: [
+            Support.query(
+                sql: "SELECT 1 AS value",
+                requiredCapabilities: ["Extension:MyExt"]
+            ),
+        ])
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let report = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url,
+                environment: SQLiteBuildValidationEnvironment(
+                    extensionNames: ["myext"]
+                )
+            )
+            XCTAssertEqual(report.overallVerdict, .passed)
+            XCTAssertTrue(try XCTUnwrap(report.outcomes.first).diagnostics.isEmpty)
+        }
+    }
+
     func testMissingCodecIsUnsupportedUntilSuppliedInEnvironment() throws {
         let codec = SQLiteBuildValidationCodecReference(
             keyID: "tests.codec.value",

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
@@ -255,6 +255,17 @@ final class SQLiteBuildValidatorIntegrationTests: XCTestCase {
         }
     }
 
+    /// `SQLiteBuildValidationEnvironment` claims semantically equivalent
+    /// invocations produce byte-identical canonical reports. Since extension
+    /// matching is ASCII case-insensitive, "MyExt" and "myext" are the same
+    /// requirement and must fold to one canonical entry, not two.
+    func testEnvironmentNormalizesExtensionNameCaseForDeterminism() {
+        let mixedCase = SQLiteBuildValidationEnvironment(extensionNames: ["MyExt", "myext"])
+        let lowercaseOnly = SQLiteBuildValidationEnvironment(extensionNames: ["myext"])
+        XCTAssertEqual(mixedCase.extensionNames, ["myext"])
+        XCTAssertEqual(mixedCase, lowercaseOnly)
+    }
+
     func testMissingCodecIsUnsupportedUntilSuppliedInEnvironment() throws {
         let codec = SQLiteBuildValidationCodecReference(
             keyID: "tests.codec.value",

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
@@ -189,6 +189,28 @@ final class SQLiteBuildValidatorIntegrationTests: XCTestCase {
         }
     }
 
+    /// Capability-ID prefix classification folds case before comparing
+    /// (`isOpaqueCapability`/`capabilityDiagnosticCode`), so resolution
+    /// against captured runtime evidence must too — a mixed-case id like
+    /// "Function:ABS" must still resolve against the real `ABS` builtin
+    /// instead of silently falling through to "unavailable".
+    func testCapabilityMatchingIsCaseInsensitive() throws {
+        let manifest = Support.manifest(queries: [
+            Support.query(
+                sql: "SELECT 1 AS value",
+                requiredCapabilities: ["Function:ABS"]
+            ),
+        ])
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let report = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(report.overallVerdict, .passed)
+            XCTAssertTrue(try XCTUnwrap(report.outcomes.first).diagnostics.isEmpty)
+        }
+    }
+
     func testMissingCodecIsUnsupportedUntilSuppliedInEnvironment() throws {
         let codec = SQLiteBuildValidationCodecReference(
             keyID: "tests.codec.value",

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
@@ -211,6 +211,26 @@ final class SQLiteBuildValidatorIntegrationTests: XCTestCase {
         }
     }
 
+    /// The fixed-literal capability switch (named-bindings, transactions,
+    /// sqlite-json-functions, ...) must fold case exactly like the prefixed
+    /// (function:/collation:/...) capabilities do.
+    func testFixedLiteralCapabilityMatchingIsCaseInsensitive() throws {
+        let manifest = Support.manifest(queries: [
+            Support.query(
+                sql: "SELECT 1 AS value",
+                requiredCapabilities: ["Transactions", "SQLite-JSON-Functions"]
+            ),
+        ])
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let report = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(report.overallVerdict, .passed)
+            XCTAssertTrue(try XCTUnwrap(report.outcomes.first).diagnostics.isEmpty)
+        }
+    }
+
     func testMissingCodecIsUnsupportedUntilSuppliedInEnvironment() throws {
         let codec = SQLiteBuildValidationCodecReference(
             keyID: "tests.codec.value",

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
@@ -1,0 +1,307 @@
+import Foundation
+import GRDB
+import SwiftQLCore
+import SwiftQLNorthwindFixtures
+import SwiftQLSQLiteBuildValidationManifest
+import XCTest
+@testable import SwiftQLSQLiteBuildValidationValidator
+
+
+final class SQLiteBuildValidatorIntegrationTests: XCTestCase {
+    typealias Support = SQLiteBuildValidationValidatorTestSupport
+
+    // MARK: - Passing path against the real pinned Northwind snapshot
+
+    func testValidQueriesPassAgainstPinnedNorthwindSnapshot() throws {
+        let trivial = Support.query(id: "trivial", sql: "SELECT 1 AS value")
+        let namedBinding = Support.query(
+            id: "customer-company-name",
+            sql: "SELECT CompanyName AS company_name FROM Customers WHERE CustomerID = :customer_id",
+            parameters: [
+                Support.parameter(
+                    logicalIndex: 0,
+                    physicalIndex: 1,
+                    identity: "parameter/customer_id",
+                    keyName: "customer_id",
+                    valueTypeIdentifier: "swift.string",
+                    valueTypeName: "Swift.String",
+                    storageIdentifier: "text"
+                ),
+            ],
+            results: [
+                Support.result(
+                    identity: "result/company_name",
+                    declaredAlias: "company_name",
+                    valueTypeIdentifier: "swift.string",
+                    valueTypeName: "Swift.String",
+                    storageIdentifier: "text"
+                ),
+            ]
+        )
+        let manifest = Support.manifest(queries: [trivial, namedBinding])
+
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let report = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(report.overallVerdict, .passed)
+            XCTAssertTrue(report.diagnostics.isEmpty)
+            XCTAssertEqual(report.outcomes.count, 2)
+            for outcome in report.outcomes {
+                XCTAssertEqual(outcome.verdict, .passed, outcome.queryID)
+                XCTAssertTrue(outcome.diagnostics.isEmpty, outcome.queryID)
+                XCTAssertNotNil(outcome.preparedShape, outcome.queryID)
+            }
+        }
+    }
+
+    // MARK: - Fail-closed: statement/schema-resolution failures
+
+    func testMissingTableFailsClosed() throws {
+        let manifest = Support.manifest(queries: [
+            Support.query(sql: "SELECT * FROM tests_totally_missing_table"),
+        ])
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let report = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(report.overallVerdict, .failed)
+            let outcome = try XCTUnwrap(report.outcomes.first)
+            let diagnostic = try XCTUnwrap(
+                outcome.diagnostics.first { $0.code == "sqlite.prepare.failed" }
+            )
+            XCTAssertEqual(diagnostic.verdict, .failed)
+            XCTAssertNotEqual(diagnostic.sqliteResultCode, 0)
+            XCTAssertFalse(diagnostic.message.isEmpty)
+        }
+    }
+
+    func testEmptyStatementFailsClosed() throws {
+        // Nonempty but non-preparable: passes #292's structural "sql must not
+        // be empty" check, but SQLite prepares no statement from it.
+        let manifest = Support.manifest(queries: [
+            Support.query(sql: "-- just a comment, nothing to prepare"),
+        ])
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let report = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(report.overallVerdict, .failed)
+            let outcome = try XCTUnwrap(report.outcomes.first)
+            XCTAssertTrue(outcome.diagnostics.contains { $0.code == "statement.empty" })
+        }
+    }
+
+    func testResultCountAndAliasMismatchesFailClosed() throws {
+        let extraResult = Support.manifest(queries: [
+            Support.query(
+                sql: "SELECT 1 AS value",
+                results: [Support.result(), Support.result(index: 1, identity: "result/extra")]
+            ),
+        ])
+        let wrongAlias = Support.manifest(queries: [
+            Support.query(sql: "SELECT 1 AS value", results: [
+                Support.result(declaredAlias: "not_value"),
+            ]),
+        ])
+
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let extraReport = try SQLiteBuildValidator.validate(
+                manifest: extraResult,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(extraReport.overallVerdict, .failed)
+            XCTAssertTrue(
+                try XCTUnwrap(extraReport.outcomes.first).diagnostics
+                    .contains { $0.code == "result.count" }
+            )
+        }
+
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let aliasReport = try SQLiteBuildValidator.validate(
+                manifest: wrongAlias,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(aliasReport.overallVerdict, .failed)
+            XCTAssertTrue(
+                try XCTUnwrap(aliasReport.outcomes.first).diagnostics
+                    .contains { $0.code == "result.name" }
+            )
+        }
+    }
+
+    // MARK: - Fail-closed: capabilities and codecs never silently pass
+
+    func testMissingFunctionCapabilityIsUnsupportedAndCannotBeSpoofed() throws {
+        let manifest = Support.manifest(queries: [
+            Support.query(
+                sql: "SELECT 1 AS value",
+                requiredCapabilities: ["function:definitely_missing_function"]
+            ),
+        ])
+        try Support.withValidatorOwnedNorthwindURL { url in
+            // Even explicitly claiming the capability via environment does not
+            // satisfy an *observable* capability the connection doesn't have —
+            // only genuinely opaque (non-observable) capability IDs can be
+            // supplied that way.
+            let report = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url,
+                environment: SQLiteBuildValidationEnvironment(
+                    capabilityIDs: ["function:definitely_missing_function"]
+                )
+            )
+            XCTAssertEqual(report.overallVerdict, .unsupported)
+            let outcome = try XCTUnwrap(report.outcomes.first)
+            XCTAssertTrue(outcome.diagnostics.contains {
+                $0.code == "capability.function" && $0.verdict == .unsupported
+            })
+            // Preparation is skipped entirely when a capability prerequisite
+            // is unavailable — never a confusing prepare failure instead.
+            XCTAssertNil(outcome.preparedShape)
+        }
+    }
+
+    func testMissingCodecIsUnsupportedUntilSuppliedInEnvironment() throws {
+        let codec = SQLiteBuildValidationCodecReference(
+            keyID: "tests.codec.value",
+            keyVersion: 1,
+            valueTypeIdentifier: "swift.int",
+            dialectIdentifier: XLSQLiteDialect.identity.rawValue,
+            storageIdentifier: "integer"
+        )
+        let manifest = Support.manifest(queries: [
+            Support.query(
+                sql: "SELECT 1 AS value",
+                results: [Support.result(codec: codec)]
+            ),
+        ])
+
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let unsupportedReport = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(unsupportedReport.overallVerdict, .unsupported)
+            XCTAssertTrue(
+                try XCTUnwrap(unsupportedReport.outcomes.first).diagnostics
+                    .contains { $0.code == "codec.missing" }
+            )
+        }
+
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let passedReport = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url,
+                environment: SQLiteBuildValidationEnvironment(
+                    codecIdentities: [codec]
+                )
+            )
+            XCTAssertEqual(passedReport.overallVerdict, .passed)
+        }
+    }
+
+    // MARK: - Fail-closed: schema snapshot identity
+
+    func testSnapshotMismatchesFailClosed() throws {
+        let wrongSHA = Support.manifest(
+            schemaSnapshot: Support.schemaSnapshot(
+                databaseSHA256: String(repeating: "0", count: 64)
+            )
+        )
+        let wrongByteCount = Support.manifest(
+            schemaSnapshot: Support.schemaSnapshot(databaseByteCount: 1)
+        )
+        let wrongRowCount = Support.manifest(
+            schemaSnapshot: Support.schemaSnapshot(schemaRowCount: 999)
+        )
+        let wrongFingerprint = Support.manifest(
+            schemaSnapshot: Support.schemaSnapshot(
+                schemaFingerprint: String(repeating: "a", count: 16)
+            )
+        )
+
+        for (manifest, expectedCode) in [
+            (wrongSHA, "schema.snapshot-sha"),
+            (wrongByteCount, "schema.byte-count"),
+            (wrongRowCount, "schema.row-count"),
+            (wrongFingerprint, "schema.fingerprint"),
+        ] {
+            try Support.withValidatorOwnedNorthwindURL { url in
+                let report = try SQLiteBuildValidator.validate(
+                    manifest: manifest,
+                    againstDatabaseAt: url
+                )
+                XCTAssertEqual(report.overallVerdict, .failed, expectedCode)
+                XCTAssertTrue(
+                    report.diagnostics.contains { $0.code == expectedCode },
+                    expectedCode
+                )
+            }
+        }
+    }
+
+    func testValidatorRejectsDatabaseWithAdjacentSidecar() throws {
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let journalPath = url.path + "-journal"
+            FileManager.default.createFile(atPath: journalPath, contents: Data())
+            defer { try? FileManager.default.removeItem(atPath: journalPath) }
+
+            XCTAssertThrowsError(
+                try SQLiteBuildValidator.validate(
+                    manifest: Support.manifest(),
+                    againstDatabaseAt: url
+                )
+            ) { error in
+                guard case .databaseHasSidecar = error as? SQLiteBuildValidationValidatorError else {
+                    return XCTFail("Expected databaseHasSidecar, received \(error)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Determinism
+
+    func testRepeatedValidationsProduceByteIdenticalCanonicalReports() throws {
+        let manifest = Support.manifest(queries: [
+            Support.query(id: "trivial", sql: "SELECT 1 AS value"),
+        ])
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let first = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            let second = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            let firstData = try first.canonicalJSONData()
+            let secondData = try second.canonicalJSONData()
+            XCTAssertEqual(first, second)
+            XCTAssertEqual(firstData, secondData)
+            XCTAssertEqual(firstData.last, 0x0A)
+            XCTAssertNotEqual(firstData.dropLast().last, 0x0A)
+        }
+    }
+
+    // MARK: - Caller-owned-connection seam: missing evidence is unsupported, not passed
+
+    func testCallerOwnedSeamTreatsMissingSnapshotEvidenceAsUnsupported() throws {
+        try Support.withReadOnlyNorthwindDatabase { database in
+            let report = try SQLiteBuildValidator.validate(
+                manifest: Support.manifest(),
+                in: database
+            )
+            XCTAssertEqual(report.overallVerdict, .unsupported)
+            XCTAssertTrue(report.diagnostics.contains {
+                $0.code == "schema.snapshot-sha" && $0.verdict == .unsupported
+            })
+            XCTAssertTrue(report.diagnostics.contains {
+                $0.code == "schema.byte-count" && $0.verdict == .unsupported
+            })
+        }
+    }
+}


### PR DESCRIPTION
Closes #293.

## Summary

Adds `SwiftQLSQLiteBuildValidationValidator` and the `swiftql-build-validate` CLI, per the [#132 research decision](https://github.com/lukevanin/swiftql/blob/main/Documentation/Architecture/SQLiteBuildValidation.md) (§16-17) — step 2 of the recommended v1.5 implementation sequence.

This is a promotion of the already-validated `#132` research prototype (`Research/SQLiteBuildValidation/`, ~2200 lines, ~1850 lines of tests) into a real product, adapted to consume the [#292 manifest](https://github.com/lukevanin/swiftql/pull/400) (`SwiftQLSQLiteBuildValidationManifest`) instead of the prototype's own local model. The `sqlite3_prepare_v3` probe, runtime provenance capture, SHA-256, diagnostic taxonomy, and CLI plumbing are near-verbatim ports of already-proven logic — only field names and the top-level orchestration were adapted to the new manifest's vocabulary.

- **Owns one dedicated read-only/query-only connection** per run (`PRAGMA query_only = ON`), verifies the checked-in snapshot is byte-identical before and after validation, and refuses a snapshot with an adjacent `-journal`/`-shm`/`-wal` sidecar.
- **Prepares exactly one statement per manifest entry** with `sqlite3_prepare_v3` via `SQLitePrepareV3Probe` — returns only copied Swift values, never a `sqlite3_stmt` pointer or claim about its serialized form, and finalizes every statement exactly once on every path (success, inspection failure, or finalize failure).
- **Fail-closed verdicts**: `passed` / `failed` / `unsupported` — `unsupported` fails the gate exactly like `failed`. A query whose preparation prerequisites are unavailable never reaches `sqlite3_prepare_v3` at all. Observable capabilities (`function:`/`collation:`/`compile-option:`/`module:`/`extension:` prefixed, or `sqlite-json-functions`) can never be spoofed via the caller-supplied environment — only genuinely opaque capability IDs can.
- **Deterministic canonical JSON** reports: sorted diagnostics/outcomes, sorted+deduplicated evidence lists, byte-identical across repeated runs against the same manifest/snapshot/SQLite build.
- **CLI**: `swiftql-build-validate --database <path> --manifest <path> --output <path> [--codec ...] [--extension ...] [--capability ...]`. Exit `0` only for an overall `passed` report; `1` for `failed`/`unsupported`; `2` for anything that prevented producing a report (bad args, unreadable manifest, I/O failure).
- Extends the downstream Swift 5 compatibility fixture to create a real SQLite file via GRDB and validate it end-to-end through this module.
- New architecture doc: [`Documentation/Architecture/SQLiteBuildValidationValidator.md`](../blob/issue-293-standalone-validator/Documentation/Architecture/SQLiteBuildValidationValidator.md).

## Non-goals (per issue)

No public claim/format for a serialized `sqlite3_stmt`; no prepared statement escapes, persists, or is reused at runtime. No SwiftPM build-tool plugin (#294), macro implementation, typed DDL, migration runner, or second manifest/report format. Does not borrow an application's long-lived GRDB pool. Missing schema/codecs/functions/collations/extensions/capabilities are always `failed` or explicit `unsupported`, never silently `passed`.

## Test plan

- [x] `swift build` (whole package) — clean
- [x] `swift test --filter SwiftQLSQLiteBuildValidationValidatorTests` — 14/14 passing: real Northwind snapshot passes with named bindings; missing table/empty-statement fail closed with `sqlite.prepare.failed`/`statement.empty`; result count/alias mismatches fail closed; missing function capability is `unsupported` and cannot be spoofed via environment; missing codec is `unsupported` until supplied; SHA/byte-count/row-count/fingerprint snapshot mismatches each fail closed with the correct code; adjacent sidecar is rejected; repeated validations produce byte-identical canonical JSON; caller-owned-connection seam treats missing evidence as `unsupported`, never a silent pass; CLI runner exit-code 0/1 contract and output-safety preflight
- [x] Existing `SwiftQLSQLiteBuildValidationPrototypeTests` (10 tests, unmodified prototype) still pass — no regression to the research code this was promoted from
- [x] `swift test --filter SwiftQLCoreTests` — 91/91 passing
- [x] `swift run swiftql-build-validate --help` — CLI smoke test
- [x] Downstream Swift 5 fixture (`IntegrationTests/Swift5Client`) builds, runs, and validates a real SQLite file it creates via GRDB, clean in Swift 5 language mode
