### PR TITLE
Measure EXPLAIN QUERY PLAN determinism across two SQLite builds (#390)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 *.orig
+__pycache__/

--- a/Documentation/Architecture/SQLiteEQPVariance.md
+++ b/Documentation/Architecture/SQLiteEQPVariance.md
@@ -63,7 +63,7 @@ statement, binds the same resolved values the #191 harness uses
 same connection. Two capture methods feed the same schema
 (`EQPCaptureRun`/`EQPStatementCapture`/`EQPRow` in `EQPVarianceModels.swift`):
 
-1. **In-process, GRDB** (`swiftql-eqp-variance capture`) — whatever SQLite
+1. **In-process, GRDB** (`swift run SwiftQLSQLiteEQPVarianceCLI capture`) — whatever SQLite
    the Swift toolchain links (this repo's system libsqlite3, unpinned).
 2. **Out-of-process, Python's `sqlite3` module**
    (`Research/SQLiteBuildValidation/Scripts/capture_eqp.py`) — a second,
@@ -179,7 +179,7 @@ actually reaches — Linux's custom-built SQLite 3.53.3
 Xcode versions or a from-source SQLite build was out of scope for this pass.
 Per this issue's hard constraint, that is recorded as **honestly not
 reachable in this delivery**, not interpolated from the two builds that were
-measured. `swiftql-eqp-variance capture` is a small, self-contained CLI
+measured. `swift run SwiftQLSQLiteEQPVarianceCLI capture` is a small, self-contained CLI
 already wired to run inside any of those CI legs unchanged; wiring an actual
 CI step to capture and archive that evidence is left as follow-up (recorded
 for #393 to schedule against a milestone).

--- a/Documentation/Architecture/SQLiteEQPVariance.md
+++ b/Documentation/Architecture/SQLiteEQPVariance.md
@@ -1,0 +1,239 @@
+# SQLite `EXPLAIN QUERY PLAN` variance measurement (issue #390)
+
+Milestone 29, "Spike: SQLite query-plan analysis and index advice." This
+document is the measurement write-up issue #390 asks for: how much does
+`EXPLAIN QUERY PLAN` (EQP) output vary across the SQLite builds SwiftQL
+actually encounters, and which properties of that output are stable enough
+to build advisory diagnostics on. It is evidence and a recommendation, not a
+diagnostic, a report schema, or a public API — see [Non-goals](#non-goals).
+
+## Inputs audited
+
+- [`Conformance/SQLite/COMBINATORIAL_CASES.json`](../../Conformance/SQLite/COMBINATORIAL_CASES.json)
+  — issue #191's 208-case pairwise/targeted SELECT corpus, reused unmodified
+  via `SQLiteCombinatorialSuite.makeManifest()`.
+- [`Tests/SwiftQLNorthwindFixtures/Resources/Northwind/`](../../Tests/SwiftQLNorthwindFixtures/Resources/Northwind)
+  — issue #254's pinned, checksum-verified Northwind snapshot.
+- [`Tests/SQLTests/NorthwindSemanticCorpusTests.swift`](../../Tests/SQLTests/NorthwindSemanticCorpusTests.swift)
+  — the only place in the repo defining Northwind join/CTE/subquery shapes as
+  literal SQL; six of those shapes are cribbed verbatim as this corpus's
+  Northwind anchor statements (`EQPVarianceCorpus.northwindAnchorStatements()`).
+- [`Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationRuntime.swift`](../../Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationRuntime.swift)
+  — issue #132's capability-audit capture (`sqlite_version()`,
+  `sqlite_source_id()`, `PRAGMA compile_options`, `function_list`,
+  `collation_list`, `module_list`, a schema fingerprint), reused as-is for
+  every capture's runtime provenance.
+
+## Question and non-goals
+
+**Question:** how much does EQP output move across SQLite versions, along
+which axes, and which properties can advisory tooling trust?
+
+**Non-goals**, per this issue's hard constraints:
+
+- No diagnostics, candidate generation, report schema, or public API. That is
+  #391/#392/the v1.8 issues, contingent on this write-up's recommendation.
+- No mutation of the pinned Northwind snapshot. Every capture in this
+  pipeline opens a validator-owned copy read-only with `PRAGMA query_only =
+  ON`; the pinned file's SHA-256 (`cb6f0071…3381d8`) is asserted unchanged
+  after every run (`EQPVarianceCaptureTests.testCaptureNeverMutatesThePinnedNorthwindSnapshot`).
+- No conclusion drawn from a single SQLite version or a single host (see
+  [Methodology](#methodology)).
+- Honest `unsupported` results where a version isn't reachable, not
+  interpolation (see [Coverage and limitations](#coverage-and-limitations)).
+
+## Methodology
+
+**Corpus** (`EQPVarianceCorpus.assemble()`, 214 statements, deterministic —
+`EQPVarianceCorpusTests.testCorpusAssemblyIsDeterministic`):
+
+- 208 statements from the #191 combinatorial manifest, verbatim
+  (`rendered_sql` + resolved `bindings`, unmodified).
+- 6 hand-authored Northwind anchor statements the pairwise grid doesn't
+  itself exercise against real data: a five-table inner join, a self
+  left-join with NULLs, `GROUP BY`/`HAVING`, a scalar subquery, a `UNION`
+  compound, and a `WITH` aggregate CTE — each tagged with its
+  `SQLiteNorthwindConformanceCaseID` from #254's registry.
+
+**Capture** (`EQPVarianceCapture.capture(from:corpus:label:)`): for every
+statement, binds the same resolved values the #191 harness uses
+(`arguments(for:)`, mirroring `SQLiteCombinatorialConformanceTests`), runs
+`EXPLAIN QUERY PLAN <rendered_sql>`, and records every row's `id`, `parent`,
+`notused`, and `detail` verbatim — plus the #132 runtime metadata from the
+same connection. Two capture methods feed the same schema
+(`EQPCaptureRun`/`EQPStatementCapture`/`EQPRow` in `EQPVarianceModels.swift`):
+
+1. **In-process, GRDB** (`swiftql-eqp-variance capture`) — whatever SQLite
+   the Swift toolchain links (this repo's system libsqlite3, unpinned).
+2. **Out-of-process, Python's `sqlite3` module**
+   (`Research/SQLiteBuildValidation/Scripts/capture_eqp.py`) — a second,
+   genuinely distinct SQLite build reachable without vendoring a custom
+   SQLite into the shipping package. The script ports the #132 runtime-
+   metadata capture (including the FNV-1a-64 schema fingerprint) into Python
+   field-for-field; both captures against a copy of the pinned snapshot
+   produced the identical fingerprint `e2c8fadbd38c2313`, cross-validating
+   the port and confirming both runs saw byte-identical schemas.
+
+**Classification** (`EQPVarianceClassifier`): compares two capture runs
+statement-by-statement. Row `id`/`parent` values are first renumbered to
+their position in emission order (EQP always emits a parent before its
+children, so this is a valid, order-preserving renumbering) before any other
+comparison — see [why](#finding-1-idparent-numbering-is-not-a-stable-identifier).
+Remaining differences are bucketed into the classes below by pattern-matching
+`detail` text for table/access-method tokens and known materialization
+markers (`SEARCH`/`SCAN`, `USING INDEX`, `TEMP B-TREE`, `MERGE (`, etc.).
+
+## Evidence: two real SQLite builds, one pinned corpus
+
+| | Build A | Build B |
+|---|---|---|
+| Label | `apple-system-3.51.0` | `homebrew-3.53.2` |
+| `sqlite_version()` | 3.51.0 | 3.53.2 |
+| `sqlite_source_id()` | 2025-06-12 13:14:41 f0ca7bb… | 2026-06-03 19:12:13 d6e03d8… |
+| Capture method | in-process, GRDB (Swift toolchain's linked SQLite) | out-of-process, `python3`'s `sqlite3` module (Homebrew's `libsqlite3`) |
+| Schema fingerprint | `e2c8fadbd38c2313` | `e2c8fadbd38c2313` (match) |
+| Statements captured | 214 | 214 |
+
+Checked-in evidence (`Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/`):
+`corpus.json`, `capture_apple-system-3.51.0.json`, `capture_homebrew-3.53.2.json`,
+`comparison_apple-system-3.51.0_vs_homebrew-3.53.2.json`.
+
+### Classification result (214 statements)
+
+| Class | Count | Stable enough for diagnostics? |
+|---|---:|---|
+| `identical` | 203 | Yes — byte-identical, including `id`/`parent` |
+| `id_renumbering_only` | 2 | Structure only — see Finding 1 |
+| `materialization_strategy_change` | 9 | No — see Finding 2 |
+| `access_path_change` | 0 (not observed) | Not evaluated by this pair |
+| `join_order_change` | 0 (not observed) | Not evaluated by this pair |
+| `cosmetic_wording_change` | 0 (not observed) | Not evaluated by this pair |
+| `unclassified` | 0 | — |
+
+### Finding 1: `id`/`parent` numbering is not a stable identifier
+
+Two statements — the five-table Northwind join
+(`c390.northwind.join.customer-order-employee-product`) and the scalar-
+subquery Northwind case (`c390.northwind.subquery.products-above-average`) —
+produced **identical plan structure and `detail` text** on both builds, but
+every `id` and `parent` value was offset by a constant (e.g. `9→12`,
+`12→15`, `18→21`, …). The chosen indexes, join order, and access methods were
+completely unaffected; only SQLite's internal EQP row-numbering counter
+differed. **Any future diagnostic must key on structure (parent shape plus
+`detail` text) and never on raw `id`/`parent` values.**
+
+### Finding 2: compound-query execution strategy changed between builds
+
+All 9 `materialization_strategy_change` cases are #191's CTE ×
+compound-operator cases (`UNION`/`EXCEPT`/`INTERSECT` over ordinary and
+recursive CTEs). 3.51.0 renders the older `COMPOUND QUERY` /
+`LEFT-MOST SUBQUERY` / `<OP> USING TEMP B-TREE` shape; 3.53.2 renders a
+`MERGE (<OP>)` / `LEFT` / `RIGHT` shape with `USE TEMP B-TREE FOR ORDER BY`
+attached differently. Example (`c191.v1.cte.ordinary-nullable.union`):
+
+```
+# apple-system-3.51.0
+COMPOUND QUERY
+├─ LEFT-MOST SUBQUERY
+│  ├─ CO-ROUTINE nullable_seed
+│  │  └─ SCAN CONSTANT ROW
+│  └─ SCAN nullable_rows
+└─ UNION USING TEMP B-TREE
+   └─ SCAN CONSTANT ROW
+
+# homebrew-3.53.2
+MERGE (UNION)
+├─ LEFT
+│  ├─ CO-ROUTINE nullable_seed
+│  │  └─ SCAN CONSTANT ROW
+│  ├─ SCAN nullable_rows
+│  └─ USE TEMP B-TREE FOR ORDER BY
+└─ RIGHT
+   └─ SCAN CONSTANT ROW
+```
+
+Both are legitimate plans for the same query; SQLite changed how it *executes*
+compound queries between these versions. This is real evidence that
+materialization/execution-strategy diagnostics are the least stable of the
+four axes named in this issue, at least for compound queries. **This is
+exactly the class of variance SQLite explicitly does not promise stability
+on**, and would show up as false-positive "regression" noise in any
+per-plan-shape diagnostic keyed on this wording.
+
+For the other 205 statements (203 identical + 2 renumbered), the chosen
+index, join order, and access method were completely stable across this
+version pair — including the five-table join, the self left-join, the
+`GROUP BY`/`HAVING`, and the `UNION`/CTE Northwind anchors that were not
+compound-CTE cases.
+
+## Coverage and limitations
+
+This pass measured two real, distinct SQLite builds reachable from this
+delivery's environment directly (no custom SQLite build, no vendored
+amalgamation): the system libsqlite3 this repo's Swift toolchain links, and
+Homebrew's separately-installed libsqlite3. It did **not** capture the
+additional builds this repo's CI matrix (`.github/workflows/swift.yml`)
+actually reaches — Linux's custom-built SQLite 3.53.3
+(`compatibility` job), or the system SQLite bundled with Xcode 16.2, 16.4,
+26.3, and 26.5 (`apple-clean-resolution` job) — because provisioning those
+Xcode versions or a from-source SQLite build was out of scope for this pass.
+Per this issue's hard constraint, that is recorded as **honestly not
+reachable in this delivery**, not interpolated from the two builds that were
+measured. `swiftql-eqp-variance capture` is a small, self-contained CLI
+already wired to run inside any of those CI legs unchanged; wiring an actual
+CI step to capture and archive that evidence is left as follow-up (recorded
+for #393 to schedule against a milestone).
+
+No conclusion here should be read as "SQLite's query planner is stable
+across arbitrary versions" — only that it was stable, for this specific
+214-statement corpus, across these two specific builds, except for compound
+queries.
+
+## Recommendation
+
+1. **Plan records belong in a sidecar, not the canonical report.** EQP output
+   is not a stability contract (SQLite's own documentation says so), and
+   Finding 2 demonstrates real, version-driven variance for at least one
+   query shape family even between two builds ~a year apart. Folding raw EQP
+   into the canonical validation report (`SQLiteBuildValidationReport`) would
+   make report diffs noisy across environments for reasons unrelated to
+   SwiftQL. A sidecar (opt-in, clearly advisory) keeps that noise out of the
+   pass/fail contract.
+2. **`id`/`parent` must never be used as a diagnostic key.** Any classifier
+   or diagnostic built in #391 must normalize on structure (Finding 1) before
+   comparing captures, exactly as `EQPVarianceClassifier.normalize` does here.
+3. **Materialization-strategy diagnostics need the widest safety margin.**
+   Of the four axes, this pass found real variance only in materialization
+   strategy (compound-query execution), and only for compound-CTE queries.
+   Access-path and join-order diagnostics were not observed to vary in this
+   pair; #391/#392 should not assume this generalizes to a wider version
+   matrix, and should re-check against whatever additional builds a future
+   CI-wired capture reaches.
+4. **Proceed to #391** (normalised plan capture and shape classification)
+   using this corpus, capture pipeline, and the renumbering-first comparison
+   discipline established here.
+
+## Reproducing this evidence
+
+```bash
+# In-process capture (whatever SQLite this Swift toolchain links)
+swift run SwiftQLSQLiteEQPVarianceCLI export-corpus --output corpus.json
+swift run SwiftQLSQLiteEQPVarianceCLI capture \
+  --database path/to/northwind-copy.db --label <label> --output capture.json
+
+# Out-of-process capture against a different installed SQLite build
+python3 Research/SQLiteBuildValidation/Scripts/capture_eqp.py \
+  --corpus corpus.json --database path/to/northwind-copy.db \
+  --label <label> --output capture.json
+
+# Classify the difference between two captures
+swift run SwiftQLSQLiteEQPVarianceCLI compare \
+  --baseline capture_a.json --comparison capture_b.json --output comparison.json
+```
+
+`EQPVarianceCaptureTests.testCheckedInAppleSystemEvidenceMatchesWhenRuntimeIsIdentical`
+re-runs the in-process capture on every `swift test` invocation and asserts
+byte-identity with the checked-in `apple-system` evidence — but only when the
+host's linked SQLite version and source ID match the pinned evidence exactly;
+otherwise it skips with an explicit message naming both versions, rather than
+failing CI legs that (correctly, per this issue) link a different SQLite.

--- a/Package.swift
+++ b/Package.swift
@@ -141,6 +141,28 @@ let package = Package(
             path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototypeCLI"
         ),
 
+        // Package-private research engine for issue #390 (milestone 29 spike).
+        // Measures EXPLAIN QUERY PLAN determinism across reachable SQLite
+        // builds. Deliberately outside the package's public products: this is
+        // measurement/evidence only, not a shipping diagnostic or public API.
+        .target(
+            name: "SwiftQLSQLiteEQPVariancePrototype",
+            dependencies: [
+                "SwiftQLSQLiteBuildValidationPrototype",
+                "SwiftQLNorthwindFixtures",
+                "SwiftQLSQLiteConformanceFixtures",
+                "SwiftQLSQLiteCombinatorialSupport",
+                .product(name: "GRDB", package: "GRDB.swift"),
+            ],
+            path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype"
+        ),
+
+        .executableTarget(
+            name: "SwiftQLSQLiteEQPVarianceCLI",
+            dependencies: ["SwiftQLSQLiteEQPVariancePrototype"],
+            path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVarianceCLI"
+        ),
+
         // A test target used to develop the macro implementation.
         .testTarget(
             name: "SwiftQLCoreTests",
@@ -226,6 +248,19 @@ let package = Package(
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],
             path: "Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteBuildValidationPrototypeTests"
+        ),
+
+        .testTarget(
+            name: "SwiftQLSQLiteEQPVariancePrototypeTests",
+            dependencies: [
+                "SwiftQLSQLiteEQPVariancePrototype",
+                "SwiftQLSQLiteBuildValidationPrototype",
+                "SwiftQLNorthwindFixtures",
+                "SwiftQLSQLiteCombinatorialSupport",
+                .product(name: "GRDB", package: "GRDB.swift"),
+            ],
+            path: "Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests",
+            resources: [.copy("Evidence")]
         ),
     ]
 )

--- a/Research/SQLiteBuildValidation/Scripts/capture_eqp.py
+++ b/Research/SQLiteBuildValidation/Scripts/capture_eqp.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Second-build EQP capture for issue #390 (milestone 29 spike).
+
+The Swift CLI (`swiftql-eqp-variance capture`) only ever links whatever
+SQLite the Swift toolchain resolves at build time (this repo's system
+libsqlite3, unpinned). To get a second, genuinely distinct SQLite build's
+worth of evidence without vendoring a custom SQLite into the shipping
+package, this script drives Python's own `sqlite3` module (linked against
+a different libsqlite3, e.g. Homebrew's) against the *same* corpus JSON
+exported by `swiftql-eqp-variance export-corpus`, and writes an
+EQPCaptureRun-shaped JSON evidence file in the same schema the Swift side
+uses (see EQPVarianceModels.swift), so both are comparable by the same
+classifier without a schema translation step.
+
+Research/measurement only. Never mutates the database it reads from: opens
+the given path read-only via the "file:...?mode=ro" URI form.
+
+Usage:
+    python3 capture_eqp.py --corpus corpus.json --database northwind_copy.db \
+        --label homebrew-3.53.2 --output capture_homebrew.json
+"""
+import argparse
+import json
+import sqlite3
+import sys
+
+
+FNV_OFFSET_BASIS = 14_695_981_039_346_656_037
+FNV_PRIME = 1_099_511_628_211
+FNV_MASK = (1 << 64) - 1
+
+
+def fnv1a64_update(h, data):
+    for byte in data:
+        h ^= byte
+        h = (h * FNV_PRIME) & FNV_MASK
+    return h
+
+
+def fnv1a64_update_length_prefixed(h, field):
+    field_bytes = field.encode("utf-8")
+    h = fnv1a64_update(h, str(len(field_bytes)).encode("ascii"))
+    h = fnv1a64_update(h, b":")
+    h = fnv1a64_update(h, field_bytes)
+    h = fnv1a64_update(h, b"\n")
+    return h
+
+
+def schema_fingerprint(connection):
+    """Mirrors SQLiteBuildValidationRuntime.schemaFingerprint(rows:) exactly
+    (same field order, same length-prefixed FNV-1a-64), so a capture against
+    an unmodified copy of the pinned Northwind snapshot produces the same
+    digest as the Swift-side capture against another copy of the same file.
+    """
+    rows = connection.execute(
+        """
+        SELECT type, name, tbl_name, rootpage, COALESCE(sql, '') AS sql
+        FROM sqlite_schema
+        ORDER BY
+            type COLLATE BINARY,
+            name COLLATE BINARY,
+            tbl_name COLLATE BINARY,
+            rootpage,
+            sql COLLATE BINARY
+        """
+    ).fetchall()
+    h = FNV_OFFSET_BASIS
+    for row in rows:
+        type_, name, tbl_name, rootpage, sql = row
+        for field in (type_, name, tbl_name, str(rootpage), sql):
+            h = fnv1a64_update_length_prefixed(h, field)
+    return format(h, "016x")
+
+
+def capture_runtime_metadata(connection):
+    sqlite_version, sqlite_source_id = connection.execute(
+        "SELECT sqlite_version(), sqlite_source_id()"
+    ).fetchone()
+
+    compile_options = sorted({
+        row[0] for row in connection.execute("PRAGMA compile_options")
+    })
+
+    functions = []
+    for row in connection.execute("PRAGMA function_list"):
+        name, builtin, type_, enc, narg, flags = row
+        functions.append({
+            "name": name,
+            "is_built_in": bool(builtin),
+            "kind": type_,
+            "encoding": enc,
+            "argument_count": narg,
+            "flags": flags,
+        })
+    functions.sort(key=lambda f: (
+        f["name"], f["is_built_in"], f["kind"], f["encoding"],
+        f["argument_count"], f["flags"],
+    ))
+
+    collations = sorted({
+        row[1] for row in connection.execute("PRAGMA collation_list")
+    })
+    module_names = sorted({
+        row[0] for row in connection.execute("PRAGMA module_list")
+    })
+
+    schema_row_count = connection.execute(
+        "SELECT COUNT(*) FROM sqlite_schema"
+    ).fetchone()[0]
+
+    return {
+        "sqlite_version": sqlite_version,
+        "sqlite_source_id": sqlite_source_id,
+        "compile_options": compile_options,
+        "functions": functions,
+        "collations": collations,
+        "module_names": module_names,
+        "extension_names": [],
+        "schema_row_count": schema_row_count,
+        "schema_fnv1a_64": schema_fingerprint(connection),
+    }
+
+
+def resolve_tagged_value(tagged):
+    tag = tagged["tag"]
+    if tag == "null":
+        return None
+    if tag == "integer":
+        return int(tagged["value"])
+    if tag == "real":
+        raw = tagged["value"]
+        return {"nan": float("nan"), "infinity": float("inf"), "-infinity": float("-inf")}.get(
+            raw, float(raw)
+        )
+    if tag == "text":
+        return tagged["value"]
+    if tag == "blob":
+        return bytes.fromhex(tagged["value"])
+    raise ValueError(f"unknown tagged_value tag: {tag}")
+
+
+def statement_arguments(bindings):
+    """Mirrors EQPVarianceCapture.arguments(for:): all-named bindings bind by
+    name, otherwise all-indexed bindings bind positionally by logical_index.
+    """
+    if not bindings:
+        return {}
+    if all(binding["key_kind"] == "named" for binding in bindings):
+        return {
+            binding["key_name"]: resolve_tagged_value(binding["tagged_value"])
+            for binding in bindings
+        }
+    ordered = sorted(bindings, key=lambda binding: binding["logical_index"])
+    return [resolve_tagged_value(binding["tagged_value"]) for binding in ordered]
+
+
+def capture_statement(connection, statement):
+    arguments = statement_arguments(statement["bindings"])
+    sql = f"EXPLAIN QUERY PLAN {statement['rendered_sql']}"
+    if isinstance(arguments, dict):
+        rows = connection.execute(sql, arguments).fetchall()
+    else:
+        rows = connection.execute(sql, arguments).fetchall()
+    return {
+        "statement_id": statement["id"],
+        "rows": [
+            {"id": row[0], "parent": row[1], "notused": row[2], "detail": row[3]}
+            for row in rows
+        ],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", required=True)
+    parser.add_argument("--database", required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--capture-method",
+        default="python3-sqlite3-module",
+        help="recorded verbatim in the evidence file's capture_method field",
+    )
+    args = parser.parse_args()
+
+    with open(args.corpus, "r", encoding="utf-8") as handle:
+        corpus = json.load(handle)
+
+    connection = sqlite3.connect(f"file:{args.database}?mode=ro", uri=True)
+    try:
+        connection.execute("PRAGMA query_only = ON")
+        runtime_metadata = capture_runtime_metadata(connection)
+        statements = sorted(
+            (capture_statement(connection, statement) for statement in corpus),
+            key=lambda entry: entry["statement_id"],
+        )
+    finally:
+        connection.close()
+
+    run = {
+        "label": args.label,
+        "capture_method": args.capture_method,
+        "runtime_metadata": runtime_metadata,
+        "statements": statements,
+    }
+
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(run, handle, indent=2, sort_keys=True, ensure_ascii=False)
+        handle.write("\n")
+
+    print(
+        f"Captured {len(statements)} statements (label: {args.label}) to {args.output}",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/Research/SQLiteBuildValidation/Scripts/capture_eqp.py
+++ b/Research/SQLiteBuildValidation/Scripts/capture_eqp.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 """Second-build EQP capture for issue #390 (milestone 29 spike).
 
-The Swift CLI (`swiftql-eqp-variance capture`) only ever links whatever
-SQLite the Swift toolchain resolves at build time (this repo's system
-libsqlite3, unpinned). To get a second, genuinely distinct SQLite build's
-worth of evidence without vendoring a custom SQLite into the shipping
-package, this script drives Python's own `sqlite3` module (linked against
-a different libsqlite3, e.g. Homebrew's) against the *same* corpus JSON
-exported by `swiftql-eqp-variance export-corpus`, and writes an
-EQPCaptureRun-shaped JSON evidence file in the same schema the Swift side
-uses (see EQPVarianceModels.swift), so both are comparable by the same
-classifier without a schema translation step.
+The Swift CLI (`swift run SwiftQLSQLiteEQPVarianceCLI`) only ever links
+whatever SQLite the Swift toolchain resolves at build time (this repo's
+system libsqlite3, unpinned). To get a second, genuinely distinct SQLite
+build's worth of evidence without vendoring a custom SQLite into the
+shipping package, this script drives Python's own `sqlite3` module (linked
+against a different libsqlite3, e.g. Homebrew's) against the *same* corpus
+JSON exported by `swift run SwiftQLSQLiteEQPVarianceCLI export-corpus`, and
+writes an EQPCaptureRun-shaped JSON evidence file in the same schema the
+Swift side uses (see EQPVarianceModels.swift), so both are comparable by the
+same classifier without a schema translation step.
 
 Research/measurement only. Never mutates the database it reads from: opens
 the given path read-only via the "file:...?mode=ro" URI form.
@@ -139,28 +139,51 @@ def resolve_tagged_value(tagged):
     raise ValueError(f"unknown tagged_value tag: {tag}")
 
 
-def statement_arguments(bindings):
-    """Mirrors EQPVarianceCapture.arguments(for:): all-named bindings bind by
-    name, otherwise all-indexed bindings bind positionally by logical_index.
+class InvalidBindingError(ValueError):
+    pass
+
+
+def statement_arguments(statement_id, bindings):
+    """Mirrors EQPVarianceCapture.arguments(for:statementID:): all-named
+    bindings bind by name, all-indexed bindings bind positionally by
+    logical_index. Raises rather than silently dropping a missing key_name,
+    silently overwriting a duplicate named key, or silently treating a mixed
+    named/indexed binding list as positional.
     """
     if not bindings:
         return {}
-    if all(binding["key_kind"] == "named" for binding in bindings):
-        return {
-            binding["key_name"]: resolve_tagged_value(binding["tagged_value"])
-            for binding in bindings
-        }
+
+    all_named = all(binding["key_kind"] == "named" for binding in bindings)
+    all_indexed = all(binding["key_kind"] == "indexed" for binding in bindings)
+    if not (all_named or all_indexed):
+        raise InvalidBindingError(
+            f"{statement_id}: bindings mix named and indexed keys"
+        )
+
+    if all_named:
+        arguments = {}
+        for binding in bindings:
+            key_name = binding.get("key_name")
+            if not key_name:
+                raise InvalidBindingError(
+                    f"{statement_id}: named binding at logical index "
+                    f"{binding['logical_index']} has no key_name"
+                )
+            if key_name in arguments:
+                raise InvalidBindingError(
+                    f"{statement_id}: duplicate named binding key_name {key_name!r}"
+                )
+            arguments[key_name] = resolve_tagged_value(binding["tagged_value"])
+        return arguments
+
     ordered = sorted(bindings, key=lambda binding: binding["logical_index"])
     return [resolve_tagged_value(binding["tagged_value"]) for binding in ordered]
 
 
 def capture_statement(connection, statement):
-    arguments = statement_arguments(statement["bindings"])
+    arguments = statement_arguments(statement["id"], statement["bindings"])
     sql = f"EXPLAIN QUERY PLAN {statement['rendered_sql']}"
-    if isinstance(arguments, dict):
-        rows = connection.execute(sql, arguments).fetchall()
-    else:
-        rows = connection.execute(sql, arguments).fetchall()
+    rows = connection.execute(sql, arguments).fetchall()
     return {
         "statement_id": statement["id"],
         "rows": [

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVarianceCLI/main.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVarianceCLI/main.swift
@@ -1,0 +1,122 @@
+import Foundation
+import GRDB
+import SwiftQLSQLiteEQPVariancePrototype
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+
+private let usage = """
+    Usage:
+      SwiftQLSQLiteEQPVarianceCLI export-corpus --output <path>
+      SwiftQLSQLiteEQPVarianceCLI capture --database <path> --label <label> --output <path>
+      SwiftQLSQLiteEQPVarianceCLI compare --baseline <path> --comparison <path> --output <path>
+
+    export-corpus writes the #390 statement corpus (combinatorial cases plus
+    Northwind semantic anchors) as canonical JSON.
+
+    capture opens <database> read-only/query-only, runs EXPLAIN QUERY PLAN for
+    every corpus statement, and writes an EQPCaptureRun as canonical JSON
+    tagged with <label> and this process's SQLite runtime provenance.
+
+    compare classifies the per-statement difference between two capture runs
+    (from `capture` or the Python capture script) and writes the classified
+    comparisons as canonical JSON.
+    """
+
+
+private func writeStandardError(_ message: String) {
+    guard let data = "\(message)\n".data(using: .utf8) else {
+        return
+    }
+    FileHandle.standardError.write(data)
+}
+
+
+private func flagValue(_ name: String, in arguments: [String]) -> String? {
+    guard let index = arguments.firstIndex(of: name), index + 1 < arguments.count else {
+        return nil
+    }
+    return arguments[index + 1]
+}
+
+
+do {
+    let arguments = Array(CommandLine.arguments.dropFirst())
+    guard let subcommand = arguments.first else {
+        writeStandardError(usage)
+        exit(2)
+    }
+
+    switch subcommand {
+    case "export-corpus":
+        guard let outputPath = flagValue("--output", in: arguments) else {
+            writeStandardError(usage)
+            exit(2)
+        }
+        let corpus = try EQPVarianceCorpus.assemble()
+        let data = try EQPVarianceCanonicalJSON.encode(corpus)
+        try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+        print("Wrote \(corpus.count) statements to \(outputPath)")
+
+    case "capture":
+        guard let databasePath = flagValue("--database", in: arguments),
+              let label = flagValue("--label", in: arguments),
+              let outputPath = flagValue("--output", in: arguments) else {
+            writeStandardError(usage)
+            exit(2)
+        }
+        var configuration = Configuration()
+        configuration.readonly = true
+        configuration.prepareDatabase { database in
+            try database.execute(sql: "PRAGMA query_only = ON")
+        }
+        let queue = try DatabaseQueue(path: databasePath, configuration: configuration)
+        let corpus = try EQPVarianceCorpus.assemble()
+        let run = try queue.read { database in
+            try EQPVarianceCapture.capture(from: database, corpus: corpus, label: label)
+        }
+        let data = try EQPVarianceCanonicalJSON.encode(run)
+        try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+        print("Captured \(run.statements.count) statements (label: \(label)) to \(outputPath)")
+
+    case "compare":
+        guard let baselinePath = flagValue("--baseline", in: arguments),
+              let comparisonPath = flagValue("--comparison", in: arguments),
+              let outputPath = flagValue("--output", in: arguments) else {
+            writeStandardError(usage)
+            exit(2)
+        }
+        let decoder = JSONDecoder()
+        let baseline = try decoder.decode(
+            EQPCaptureRun.self,
+            from: Data(contentsOf: URL(fileURLWithPath: baselinePath))
+        )
+        let comparison = try decoder.decode(
+            EQPCaptureRun.self,
+            from: Data(contentsOf: URL(fileURLWithPath: comparisonPath))
+        )
+        let comparisons = try EQPVarianceClassifier.compare(baseline: baseline, comparison: comparison)
+        let data = try EQPVarianceCanonicalJSON.encode(comparisons)
+        try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+
+        var counts: [String: Int] = [:]
+        for entry in comparisons {
+            counts[entry.classification.rawValue, default: 0] += 1
+        }
+        for (classification, count) in counts.sorted(by: { $0.key < $1.key }) {
+            print("\(classification): \(count)")
+        }
+
+    default:
+        writeStandardError(usage)
+        exit(2)
+    }
+} catch {
+    writeStandardError(String(describing: error))
+    writeStandardError(usage)
+    exit(2)
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCapture.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCapture.swift
@@ -1,0 +1,94 @@
+import Foundation
+import GRDB
+import SwiftQLSQLiteCombinatorialSupport
+import SwiftQLSQLiteBuildValidationPrototype
+
+
+package enum EQPVarianceCaptureError: Error, Sendable {
+    case emptyCorpus
+}
+
+
+/// Runs the #390 corpus's `EXPLAIN QUERY PLAN` against one live SQLite
+/// connection and records the runtime provenance that produced it.
+///
+/// Mirrors the existing `SQLiteCombinatorialConformanceTests.arguments(for:)`
+/// binding logic (same all-named-or-all-indexed assumption, which every
+/// corpus statement here satisfies) so the same statement, with the same
+/// bound values, is comparable across capture methods.
+package enum EQPVarianceCapture {
+    package static func capture(
+        from database: Database,
+        corpus: [EQPVarianceStatement],
+        label: String,
+        captureMethod: String = "grdb-in-process"
+    ) throws -> EQPCaptureRun {
+        guard !corpus.isEmpty else {
+            throw EQPVarianceCaptureError.emptyCorpus
+        }
+
+        let runtimeMetadata = try SQLiteBuildValidationRuntime.capture(from: database)
+
+        let statements = try corpus.map { statement -> EQPStatementCapture in
+            let rows = try Row.fetchAll(
+                database,
+                sql: "EXPLAIN QUERY PLAN \(statement.renderedSQL)",
+                arguments: arguments(for: statement.bindings)
+            ).map { row -> EQPRow in
+                EQPRow(
+                    id: row["id"],
+                    parent: row["parent"],
+                    notused: row["notused"],
+                    detail: row["detail"]
+                )
+            }
+            return EQPStatementCapture(statementID: statement.id, rows: rows)
+        }
+
+        return EQPCaptureRun(
+            label: label,
+            captureMethod: captureMethod,
+            runtimeMetadata: runtimeMetadata,
+            statements: statements
+        )
+    }
+
+    package static func arguments(
+        for bindings: [SQLiteCombinatorialBinding]
+    ) -> StatementArguments {
+        guard !bindings.isEmpty else {
+            return StatementArguments()
+        }
+        if bindings.allSatisfy({ $0.keyKind == .named }) {
+            let pairs = bindings.compactMap { binding -> (String, DatabaseValue)? in
+                guard let keyName = binding.keyName else {
+                    return nil
+                }
+                return (keyName, databaseValue(binding.taggedValue))
+            }
+            return StatementArguments(Dictionary(uniqueKeysWithValues: pairs))
+        }
+        return StatementArguments(
+            bindings
+                .sorted { $0.logicalIndex < $1.logicalIndex }
+                .map { databaseValue($0.taggedValue) }
+        )
+    }
+
+    private static func databaseValue(
+        _ value: SQLiteCombinatorialTaggedValue
+    ) -> DatabaseValue {
+        switch value {
+        case .null:
+            return .null
+        case .integer(let value):
+            return value.databaseValue
+        case .real(let value):
+            return value.databaseValue
+        case .text(let value):
+            return value.databaseValue
+        case .blob(let value):
+            return value.databaseValue
+        }
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCapture.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCapture.swift
@@ -85,7 +85,12 @@ package enum EQPVarianceCapture {
                         reason: "named binding at logical index \(binding.logicalIndex) has no key_name"
                     )
                 }
-                pairs[keyName] = databaseValue(binding.taggedValue)
+                guard pairs.updateValue(databaseValue(binding.taggedValue), forKey: keyName) == nil else {
+                    throw EQPVarianceCaptureError.invalidBinding(
+                        statementID: statementID,
+                        reason: "duplicate named binding key_name \"\(keyName)\""
+                    )
+                }
             }
             return StatementArguments(pairs)
         }

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCapture.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCapture.swift
@@ -6,6 +6,7 @@ import SwiftQLSQLiteBuildValidationPrototype
 
 package enum EQPVarianceCaptureError: Error, Sendable {
     case emptyCorpus
+    case invalidBinding(statementID: String, reason: String)
 }
 
 
@@ -33,7 +34,7 @@ package enum EQPVarianceCapture {
             let rows = try Row.fetchAll(
                 database,
                 sql: "EXPLAIN QUERY PLAN \(statement.renderedSQL)",
-                arguments: arguments(for: statement.bindings)
+                arguments: try arguments(for: statement.bindings, statementID: statement.id)
             ).map { row -> EQPRow in
                 EQPRow(
                     id: row["id"],
@@ -53,21 +54,42 @@ package enum EQPVarianceCapture {
         )
     }
 
+    /// Throws rather than silently dropping or reinterpreting a malformed
+    /// binding: a missing named key or a mix of named/indexed keys within one
+    /// statement would otherwise produce a capture with quietly missing or
+    /// wrongly-positioned bound values instead of a clear failure.
     package static func arguments(
-        for bindings: [SQLiteCombinatorialBinding]
-    ) -> StatementArguments {
+        for bindings: [SQLiteCombinatorialBinding],
+        statementID: String
+    ) throws -> StatementArguments {
         guard !bindings.isEmpty else {
             return StatementArguments()
         }
-        if bindings.allSatisfy({ $0.keyKind == .named }) {
-            let pairs = bindings.compactMap { binding -> (String, DatabaseValue)? in
-                guard let keyName = binding.keyName else {
-                    return nil
-                }
-                return (keyName, databaseValue(binding.taggedValue))
-            }
-            return StatementArguments(Dictionary(uniqueKeysWithValues: pairs))
+
+        let allNamed = bindings.allSatisfy { $0.keyKind == .named }
+        let allIndexed = bindings.allSatisfy { $0.keyKind == .indexed }
+        guard allNamed || allIndexed else {
+            throw EQPVarianceCaptureError.invalidBinding(
+                statementID: statementID,
+                reason: "bindings mix named and indexed keys"
+            )
         }
+
+        if allNamed {
+            var pairs: [String: DatabaseValue] = [:]
+            pairs.reserveCapacity(bindings.count)
+            for binding in bindings {
+                guard let keyName = binding.keyName else {
+                    throw EQPVarianceCaptureError.invalidBinding(
+                        statementID: statementID,
+                        reason: "named binding at logical index \(binding.logicalIndex) has no key_name"
+                    )
+                }
+                pairs[keyName] = databaseValue(binding.taggedValue)
+            }
+            return StatementArguments(pairs)
+        }
+
         return StatementArguments(
             bindings
                 .sorted { $0.logicalIndex < $1.logicalIndex }

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceClassifier.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceClassifier.swift
@@ -50,6 +50,7 @@ package struct EQPVarianceStatementComparison: Codable, Equatable, Sendable {
 
 package enum EQPVarianceClassifierError: Error, Sendable {
     case statementSetMismatch(onlyInBaseline: [String], onlyInComparison: [String])
+    case duplicateStatementID(String, runLabel: String)
 }
 
 
@@ -62,12 +63,8 @@ package enum EQPVarianceClassifier {
         baseline: EQPCaptureRun,
         comparison: EQPCaptureRun
     ) throws -> [EQPVarianceStatementComparison] {
-        let baselineByID = Dictionary(
-            uniqueKeysWithValues: baseline.statements.map { ($0.statementID, $0.rows) }
-        )
-        let comparisonByID = Dictionary(
-            uniqueKeysWithValues: comparison.statements.map { ($0.statementID, $0.rows) }
-        )
+        let baselineByID = try rowsByStatementID(baseline.statements, runLabel: baseline.label)
+        let comparisonByID = try rowsByStatementID(comparison.statements, runLabel: comparison.label)
         let baselineIDs = Set(baselineByID.keys)
         let comparisonIDs = Set(comparisonByID.keys)
         guard baselineIDs == comparisonIDs else {
@@ -87,6 +84,26 @@ package enum EQPVarianceClassifier {
                 comparisonRows: comparisonRows
             )
         }
+    }
+
+    /// Builds a statement-id-keyed lookup without trapping on a duplicate id
+    /// (e.g. a corrupted evidence file or a capture-pipeline bug): duplicates
+    /// are a structured error here, not a crash.
+    private static func rowsByStatementID(
+        _ statements: [EQPStatementCapture],
+        runLabel: String
+    ) throws -> [String: [EQPRow]] {
+        var result: [String: [EQPRow]] = [:]
+        result.reserveCapacity(statements.count)
+        for statement in statements {
+            guard result.updateValue(statement.rows, forKey: statement.statementID) == nil else {
+                throw EQPVarianceClassifierError.duplicateStatementID(
+                    statement.statementID,
+                    runLabel: runLabel
+                )
+            }
+        }
+        return result
     }
 
     package static func classify(

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceClassifier.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceClassifier.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+
+/// The four variance axes #390 asks for, plus one class this prototype found
+/// necessary in practice: SQLite's own EQP `id`/`parent` numbering is not a
+/// stable identifier across builds even when the plan is otherwise identical
+/// (see `SQLiteEQPVariance.md`). Keeping it distinct from `cosmeticWording`
+/// matters because it means naive byte-diffing over-reports variance: two
+/// evidence captures must be renumbered before they can be compared at all.
+package enum EQPVarianceDifferenceClass: String, Codable, Sendable {
+    case identical
+    case idRenumberingOnly = "id_renumbering_only"
+    case cosmeticWordingChange = "cosmetic_wording_change"
+    case accessPathChange = "access_path_change"
+    case joinOrderChange = "join_order_change"
+    case materializationStrategyChange = "materialization_strategy_change"
+    case unclassified
+}
+
+
+/// One statement's classified before/after comparison. Raw rows from both
+/// captures are always retained so a classification is auditable rather than
+/// asserted (same principle #391 will apply to shape classification).
+package struct EQPVarianceStatementComparison: Codable, Equatable, Sendable {
+    package let statementID: String
+    package let classification: EQPVarianceDifferenceClass
+    package let baselineRows: [EQPRow]
+    package let comparisonRows: [EQPRow]
+
+    package init(
+        statementID: String,
+        classification: EQPVarianceDifferenceClass,
+        baselineRows: [EQPRow],
+        comparisonRows: [EQPRow]
+    ) {
+        self.statementID = statementID
+        self.classification = classification
+        self.baselineRows = baselineRows
+        self.comparisonRows = comparisonRows
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case statementID = "statement_id"
+        case classification
+        case baselineRows = "baseline_rows"
+        case comparisonRows = "comparison_rows"
+    }
+}
+
+
+package enum EQPVarianceClassifierError: Error, Sendable {
+    case statementSetMismatch(onlyInBaseline: [String], onlyInComparison: [String])
+}
+
+
+package enum EQPVarianceClassifier {
+    /// Compares two capture runs statement-by-statement. Both runs must
+    /// contain the same statement ids (i.e. both ran the same corpus) or the
+    /// comparison is meaningless and this throws rather than silently
+    /// skipping statements.
+    package static func compare(
+        baseline: EQPCaptureRun,
+        comparison: EQPCaptureRun
+    ) throws -> [EQPVarianceStatementComparison] {
+        let baselineByID = Dictionary(
+            uniqueKeysWithValues: baseline.statements.map { ($0.statementID, $0.rows) }
+        )
+        let comparisonByID = Dictionary(
+            uniqueKeysWithValues: comparison.statements.map { ($0.statementID, $0.rows) }
+        )
+        let baselineIDs = Set(baselineByID.keys)
+        let comparisonIDs = Set(comparisonByID.keys)
+        guard baselineIDs == comparisonIDs else {
+            throw EQPVarianceClassifierError.statementSetMismatch(
+                onlyInBaseline: Array(baselineIDs.subtracting(comparisonIDs)).sorted(),
+                onlyInComparison: Array(comparisonIDs.subtracting(baselineIDs)).sorted()
+            )
+        }
+
+        return baselineIDs.sorted().map { statementID in
+            let baselineRows = baselineByID[statementID] ?? []
+            let comparisonRows = comparisonByID[statementID] ?? []
+            return EQPVarianceStatementComparison(
+                statementID: statementID,
+                classification: classify(baselineRows: baselineRows, comparisonRows: comparisonRows),
+                baselineRows: baselineRows,
+                comparisonRows: comparisonRows
+            )
+        }
+    }
+
+    package static func classify(
+        baselineRows: [EQPRow],
+        comparisonRows: [EQPRow]
+    ) -> EQPVarianceDifferenceClass {
+        if baselineRows == comparisonRows {
+            return .identical
+        }
+
+        let normalizedBaseline = normalize(baselineRows)
+        let normalizedComparison = normalize(comparisonRows)
+        if normalizedBaseline == normalizedComparison {
+            return .idRenumberingOnly
+        }
+
+        guard normalizedBaseline.count == normalizedComparison.count else {
+            return .materializationStrategyChangeIfPlausible(
+                normalizedBaseline,
+                normalizedComparison
+            )
+        }
+
+        let baselineShapes = normalizedBaseline.map { RowShape(detail: $0.detail) }
+        let comparisonShapes = normalizedComparison.map { RowShape(detail: $0.detail) }
+
+        let baselineTables = baselineShapes.compactMap(\.table)
+        let comparisonTables = comparisonShapes.compactMap(\.table)
+        if Set(baselineTables) == Set(comparisonTables), baselineTables != comparisonTables {
+            return .joinOrderChange
+        }
+
+        let baselineAccess: [TableAccess] = baselineShapes.compactMap { shape in
+            shape.table.map { TableAccess(table: $0, accessMethod: shape.accessMethod) }
+        }
+        let comparisonAccess: [TableAccess] = comparisonShapes.compactMap { shape in
+            shape.table.map { TableAccess(table: $0, accessMethod: shape.accessMethod) }
+        }
+        if baselineAccess.map(\.table) == comparisonAccess.map(\.table),
+           baselineAccess.map(\.accessMethod) != comparisonAccess.map(\.accessMethod) {
+            return .accessPathChange
+        }
+
+        let baselineMarkers = baselineShapes.map(\.materializationMarker)
+        let comparisonMarkers = comparisonShapes.map(\.materializationMarker)
+        if baselineMarkers != comparisonMarkers {
+            return .materializationStrategyChange
+        }
+
+        // Same row count, same parent shape (post-normalization), same
+        // extracted tables/access/materialization markers: whatever differs
+        // is limited to incidental detail-string wording.
+        return .cosmeticWordingChange
+    }
+
+    fileprivate struct NormalizedRow: Equatable {
+        let parent: Int64
+        let detail: String
+    }
+
+    private struct TableAccess {
+        let table: String
+        let accessMethod: String?
+    }
+
+    /// Remaps every row's `id`/`parent` to its 1-based position in emission
+    /// order. EQP always emits a parent before its children, so this is a
+    /// valid, deterministic renumbering without needing full tree recursion.
+    private static func normalize(_ rows: [EQPRow]) -> [NormalizedRow] {
+        var oldToNew: [Int64: Int64] = [0: 0]
+        for (offset, row) in rows.enumerated() {
+            oldToNew[row.id] = Int64(offset + 1)
+        }
+        return rows.map { row in
+            NormalizedRow(parent: oldToNew[row.parent] ?? row.parent, detail: row.detail)
+        }
+    }
+
+    private struct RowShape {
+        let table: String?
+        let accessMethod: String?
+        let materializationMarker: String?
+
+        init(detail: String) {
+            if detail.hasPrefix("SEARCH ") || detail.hasPrefix("SCAN ") {
+                let body = detail.hasPrefix("SEARCH ")
+                    ? String(detail.dropFirst("SEARCH ".count))
+                    : String(detail.dropFirst("SCAN ".count))
+                let tableToken = body.split(separator: " ").first.map(String.init)
+                if tableToken == "CONSTANT" {
+                    table = nil
+                    accessMethod = nil
+                } else {
+                    table = tableToken
+                    if let usingRange = body.range(of: "USING ") {
+                        accessMethod = String(body[usingRange.upperBound...])
+                    } else {
+                        accessMethod = detail.hasPrefix("SEARCH ") ? "search-default" : "full-scan"
+                    }
+                }
+                materializationMarker = nil
+            } else {
+                table = nil
+                accessMethod = nil
+                materializationMarker = Self.materializationMarker(for: detail)
+            }
+        }
+
+        private static func materializationMarker(for detail: String) -> String? {
+            if detail.contains("TEMP B-TREE") {
+                return "temp-b-tree"
+            }
+            if detail.hasPrefix("MERGE (") {
+                return "merge-compound"
+            }
+            if detail == "COMPOUND QUERY" || detail == "LEFT-MOST SUBQUERY" {
+                return "legacy-compound"
+            }
+            if detail == "LEFT" || detail == "RIGHT" {
+                return "merge-compound-branch"
+            }
+            if detail.hasPrefix("CO-ROUTINE") {
+                return "co-routine"
+            }
+            if detail.hasPrefix("SCALAR SUBQUERY") {
+                return "scalar-subquery"
+            }
+            return nil
+        }
+    }
+}
+
+
+private extension EQPVarianceDifferenceClass {
+    /// A row-count change is either a materialization-strategy change (the
+    /// two builds chose structurally different plans, e.g. merge-based vs.
+    /// materialize-then-set-op compound execution) or something this
+    /// prototype's heuristics do not recognise. There is no way to align two
+    /// differently-shaped row lists well enough to check for a join-order or
+    /// access-path change, so this collapses to one of those two buckets.
+    static func materializationStrategyChangeIfPlausible(
+        _ baseline: [EQPVarianceClassifier.NormalizedRow],
+        _ comparison: [EQPVarianceClassifier.NormalizedRow]
+    ) -> EQPVarianceDifferenceClass {
+        let materializationKeywords = [
+            "TEMP B-TREE", "MERGE (", "COMPOUND QUERY", "LEFT-MOST SUBQUERY",
+            "CO-ROUTINE", "RECURSIVE STEP", "SETUP",
+        ]
+        func mentionsMaterialization(_ rows: [EQPVarianceClassifier.NormalizedRow]) -> Bool {
+            rows.contains { row in
+                materializationKeywords.contains { row.detail.contains($0) }
+            }
+        }
+        if mentionsMaterialization(baseline) || mentionsMaterialization(comparison) {
+            return .materializationStrategyChange
+        }
+        return .unclassified
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCorpus.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCorpus.swift
@@ -1,0 +1,146 @@
+import Foundation
+import SwiftQLSQLiteCombinatorialSupport
+import SwiftQLSQLiteConformanceFixtures
+
+
+package enum EQPVarianceCorpus {
+    /// Assembles the #390 statement corpus: every #191 combinatorial case
+    /// (`SQLiteCombinatorialSuite.makeManifest()`, reused unmodified) plus a
+    /// small set of hand-authored Northwind (#254) semantic anchors covering
+    /// join/CTE/subquery shapes the pairwise grid does not itself exercise
+    /// against real data. Deterministic: the same manifest generator plus a
+    /// fixed anchor list always yields the same corpus, sorted by id.
+    package static func assemble() throws -> [EQPVarianceStatement] {
+        let manifest = try SQLiteCombinatorialSuite.makeManifest()
+        let combinatorial = manifest.cases.map { testCase in
+            EQPVarianceStatement(
+                id: testCase.id,
+                source: .combinatorial,
+                renderedSQL: testCase.renderedSQL,
+                northwindAnchorCaseIDs: testCase.northwindAnchorCaseIDs ?? [],
+                bindings: testCase.bindings
+            )
+        }
+        return (combinatorial + northwindAnchorStatements()).sorted { $0.id < $1.id }
+    }
+
+    /// Cribbed verbatim from the raw-SQL oracle strings in
+    /// `Tests/SQLTests/NorthwindSemanticCorpusTests.swift`, which is the only
+    /// place in the repo that defines these shapes as literal SQL today.
+    package static func northwindAnchorStatements() -> [EQPVarianceStatement] {
+        let sentinelOrderID = SQLiteNorthwindConformanceFixtures.sentinelOrderID
+
+        return [
+            EQPVarianceStatement(
+                id: "c390.northwind.join.customer-order-employee-product",
+                source: .northwindAnchor,
+                renderedSQL: """
+                    SELECT o.OrderID AS orderID, c.CustomerID AS customerID,
+                           c.CompanyName AS companyName, e.EmployeeID AS employeeID,
+                           e.LastName AS employeeLastName, p.ProductID AS productID,
+                           p.ProductName AS productName, d.UnitPrice AS unitPrice,
+                           d.Quantity AS quantity, d.Discount AS discount
+                    FROM Orders AS o
+                    JOIN Customers AS c ON c.CustomerID = o.CustomerID
+                    JOIN Employees AS e ON e.EmployeeID = o.EmployeeID
+                    JOIN "Order Details" AS d ON d.OrderID = o.OrderID
+                    JOIN Products AS p ON p.ProductID = d.ProductID
+                    WHERE o.OrderID = ?
+                    ORDER BY p.ProductID
+                    """,
+                northwindAnchorCaseIDs: [SQLiteNorthwindConformanceCaseID.customerOrderEmployeeProductJoin.rawValue],
+                bindings: [indexedIntegerBinding(logicalIndex: 0, value: Int64(sentinelOrderID))]
+            ),
+            EQPVarianceStatement(
+                id: "c390.northwind.join.left-null-manager",
+                source: .northwindAnchor,
+                renderedSQL: """
+                    SELECT e.EmployeeID AS employeeID,
+                           e.LastName AS employeeLastName,
+                           m.EmployeeID AS managerID,
+                           m.LastName AS managerLastName
+                    FROM Employees AS e
+                    LEFT JOIN Employees AS m ON e.ReportsTo = m.EmployeeID
+                    ORDER BY e.EmployeeID
+                    """,
+                northwindAnchorCaseIDs: [SQLiteNorthwindConformanceCaseID.leftNullManager.rawValue],
+                bindings: []
+            ),
+            EQPVarianceStatement(
+                id: "c390.northwind.aggregate.grouped-having",
+                source: .northwindAnchor,
+                renderedSQL: """
+                    SELECT CustomerID AS customerID, COUNT(OrderID) AS orderCount
+                    FROM Orders
+                    GROUP BY CustomerID
+                    HAVING COUNT(OrderID) >= 10
+                    ORDER BY orderCount DESC, customerID ASC
+                    """,
+                northwindAnchorCaseIDs: [SQLiteNorthwindConformanceCaseID.groupedHaving.rawValue],
+                bindings: []
+            ),
+            EQPVarianceStatement(
+                id: "c390.northwind.subquery.products-above-average",
+                source: .northwindAnchor,
+                renderedSQL: """
+                    SELECT ProductID AS productID, ProductName AS productName,
+                           UnitPrice AS unitPrice
+                    FROM Products
+                    WHERE UnitPrice > (SELECT AVG(UnitPrice) FROM Products)
+                    ORDER BY UnitPrice DESC, ProductID ASC
+                    """,
+                northwindAnchorCaseIDs: [SQLiteNorthwindConformanceCaseID.productsAboveAverage.rawValue],
+                bindings: []
+            ),
+            EQPVarianceStatement(
+                id: "c390.northwind.compound.customer-supplier-cities",
+                source: .northwindAnchor,
+                renderedSQL: """
+                    SELECT City AS city, CompanyName AS companyName,
+                           ContactName AS contactName, 'Customers' AS relationship
+                    FROM Customers
+                    UNION
+                    SELECT City AS city, CompanyName AS companyName,
+                           ContactName AS contactName, 'Suppliers' AS relationship
+                    FROM Suppliers
+                    ORDER BY city, companyName, relationship, contactName
+                    """,
+                northwindAnchorCaseIDs: [SQLiteNorthwindConformanceCaseID.customerSupplierCities.rawValue],
+                bindings: []
+            ),
+            EQPVarianceStatement(
+                id: "c390.northwind.cte.order-subtotals",
+                source: .northwindAnchor,
+                renderedSQL: """
+                    WITH order_subtotals AS (
+                        SELECT OrderID AS orderID,
+                               SUM(UnitPrice * Quantity * (1.0 - Discount)) AS subtotal
+                        FROM "Order Details"
+                        GROUP BY OrderID
+                    )
+                    SELECT orderID, subtotal
+                    FROM order_subtotals
+                    WHERE orderID = ?
+                    ORDER BY orderID
+                    """,
+                northwindAnchorCaseIDs: [SQLiteNorthwindConformanceCaseID.cteOrderSubtotals.rawValue],
+                bindings: [indexedIntegerBinding(logicalIndex: 0, value: Int64(sentinelOrderID))]
+            ),
+        ]
+    }
+
+    private static func indexedIntegerBinding(
+        logicalIndex: Int,
+        value: Int64
+    ) -> SQLiteCombinatorialBinding {
+        SQLiteCombinatorialBinding(
+            logicalIndex: logicalIndex,
+            keyKind: .indexed,
+            keyName: nil,
+            keyIndex: logicalIndex + 1,
+            storage: .integer,
+            taggedValue: .integer(value),
+            repeatCount: 1
+        )
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCorpus.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceCorpus.swift
@@ -133,11 +133,13 @@ package enum EQPVarianceCorpus {
         logicalIndex: Int,
         value: Int64
     ) -> SQLiteCombinatorialBinding {
+        // key_index is 0-based, matching the #191 manifest's own convention
+        // (e.g. "c191.v1.expression.indexed-binding" uses key_index: 0).
         SQLiteCombinatorialBinding(
             logicalIndex: logicalIndex,
             keyKind: .indexed,
             keyName: nil,
-            keyIndex: logicalIndex + 1,
+            keyIndex: logicalIndex,
             storage: .integer,
             taggedValue: .integer(value),
             repeatCount: 1

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceModels.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVariancePrototype/EQPVarianceModels.swift
@@ -1,0 +1,126 @@
+import Foundation
+import SwiftQLSQLiteCombinatorialSupport
+import SwiftQLSQLiteBuildValidationPrototype
+
+
+/// One statement in the #390 EQP-variance corpus: a rendered SQL string with
+/// resolved bind values, tagged back to the case identity it came from.
+///
+/// The corpus is a superset of the #191 combinatorial manifest (reused as-is,
+/// including its own `northwind_anchor_case_ids` linkage) plus a small,
+/// hand-authored set of Northwind semantic-corpus (#254) anchor statements
+/// cribbed from `NorthwindSemanticCorpusTests` for join/CTE/subquery shapes
+/// the pairwise grid does not itself exercise against real data.
+package struct EQPVarianceStatement: Codable, Equatable, Sendable {
+    package enum Source: String, Codable, Sendable {
+        case combinatorial
+        case northwindAnchor = "northwind_anchor"
+    }
+
+    package let id: String
+    package let source: Source
+    package let renderedSQL: String
+    package let northwindAnchorCaseIDs: [String]
+    package let bindings: [SQLiteCombinatorialBinding]
+
+    package init(
+        id: String,
+        source: Source,
+        renderedSQL: String,
+        northwindAnchorCaseIDs: [String],
+        bindings: [SQLiteCombinatorialBinding]
+    ) {
+        self.id = id
+        self.source = source
+        self.renderedSQL = renderedSQL
+        self.northwindAnchorCaseIDs = northwindAnchorCaseIDs.sorted()
+        self.bindings = bindings.sorted { $0.logicalIndex < $1.logicalIndex }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case source
+        case renderedSQL = "rendered_sql"
+        case northwindAnchorCaseIDs = "northwind_anchor_case_ids"
+        case bindings
+    }
+}
+
+
+/// A raw `EXPLAIN QUERY PLAN` row, kept in SQLite's own column order.
+package struct EQPRow: Codable, Equatable, Sendable {
+    package let id: Int64
+    package let parent: Int64
+    package let notused: Int64
+    package let detail: String
+
+    package init(id: Int64, parent: Int64, notused: Int64, detail: String) {
+        self.id = id
+        self.parent = parent
+        self.notused = notused
+        self.detail = detail
+    }
+}
+
+
+/// The captured EQP rows for one statement, on one SQLite build.
+package struct EQPStatementCapture: Codable, Equatable, Sendable {
+    package let statementID: String
+    package let rows: [EQPRow]
+
+    package init(statementID: String, rows: [EQPRow]) {
+        self.statementID = statementID
+        self.rows = rows
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case statementID = "statement_id"
+        case rows
+    }
+}
+
+
+/// One full capture run: every statement's EQP rows plus the runtime
+/// provenance (#132 capability-audit evidence) of the SQLite build that
+/// produced them.
+package struct EQPCaptureRun: Codable, Equatable, Sendable {
+    package let label: String
+    package let captureMethod: String
+    package let runtimeMetadata: SQLiteBuildValidationRuntimeMetadata
+    package let statements: [EQPStatementCapture]
+
+    package init(
+        label: String,
+        captureMethod: String,
+        runtimeMetadata: SQLiteBuildValidationRuntimeMetadata,
+        statements: [EQPStatementCapture]
+    ) {
+        self.label = label
+        self.captureMethod = captureMethod
+        self.runtimeMetadata = runtimeMetadata
+        self.statements = statements.sorted { $0.statementID < $1.statementID }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case label
+        case captureMethod = "capture_method"
+        case runtimeMetadata = "runtime_metadata"
+        case statements
+    }
+}
+
+
+/// Deterministic, diff-friendly JSON matching the house style established by
+/// `SQLiteBuildValidationCanonicalJSON` (#132 prototype).
+package enum EQPVarianceCanonicalJSON {
+    package static func encode<Value: Encodable>(_ value: Value) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(value)
+        while data.last == 0x0A {
+            data.removeLast()
+        }
+        data.append(0x0A)
+        return data
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCaptureTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCaptureTests.swift
@@ -57,6 +57,35 @@ final class EQPVarianceCaptureTests: XCTestCase {
         }
     }
 
+    func testArgumentsThrowsRatherThanOverwritingADuplicateNamedKey() {
+        let first = SQLiteCombinatorialBinding(
+            logicalIndex: 0,
+            keyKind: .named,
+            keyName: "a",
+            keyIndex: nil,
+            storage: .integer,
+            taggedValue: .integer(1),
+            repeatCount: 1
+        )
+        let duplicate = SQLiteCombinatorialBinding(
+            logicalIndex: 1,
+            keyKind: .named,
+            keyName: "a",
+            keyIndex: nil,
+            storage: .integer,
+            taggedValue: .integer(2),
+            repeatCount: 1
+        )
+        XCTAssertThrowsError(
+            try EQPVarianceCapture.arguments(for: [first, duplicate], statementID: "s3")
+        ) { error in
+            guard case EQPVarianceCaptureError.invalidBinding(let statementID, _) = error else {
+                return XCTFail("expected invalidBinding, got \(error)")
+            }
+            XCTAssertEqual(statementID, "s3")
+        }
+    }
+
 
     func testCaptureIsByteIdenticalAcrossRepeatedRunsInProcess() throws {
         let corpus = try EQPVarianceCorpus.assemble()

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCaptureTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCaptureTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+import GRDB
+import SwiftQLNorthwindFixtures
+import SwiftQLSQLiteEQPVariancePrototype
+
+
+final class EQPVarianceCaptureTests: XCTestCase {
+    func testCaptureIsByteIdenticalAcrossRepeatedRunsInProcess() throws {
+        let corpus = try EQPVarianceCorpus.assemble()
+        let pool = try NorthwindFixture.validatedReadOnlyPool()
+
+        let first = try pool.read { database in
+            try EQPVarianceCapture.capture(from: database, corpus: corpus, label: "reproducibility-check")
+        }
+        let second = try pool.read { database in
+            try EQPVarianceCapture.capture(from: database, corpus: corpus, label: "reproducibility-check")
+        }
+
+        XCTAssertEqual(
+            try EQPVarianceCanonicalJSON.encode(first),
+            try EQPVarianceCanonicalJSON.encode(second)
+        )
+    }
+
+    func testCaptureCoversEveryCorpusStatementWithAtLeastOneRow() throws {
+        let corpus = try EQPVarianceCorpus.assemble()
+        let pool = try NorthwindFixture.validatedReadOnlyPool()
+
+        let run = try pool.read { database in
+            try EQPVarianceCapture.capture(from: database, corpus: corpus, label: "coverage-check")
+        }
+
+        XCTAssertEqual(run.statements.count, corpus.count)
+        for statement in run.statements {
+            XCTAssertFalse(statement.rows.isEmpty, "\(statement.statementID) produced no EQP rows")
+        }
+    }
+
+    func testCaptureNeverMutatesThePinnedNorthwindSnapshot() throws {
+        let before = try NorthwindFixture.validateCanonical()
+        let corpus = try EQPVarianceCorpus.assemble()
+        let pool = try NorthwindFixture.validatedReadOnlyPool()
+        _ = try pool.read { database in
+            try EQPVarianceCapture.capture(from: database, corpus: corpus, label: "mutation-check")
+        }
+        let after = try NorthwindFixture.validateCanonical()
+        XCTAssertEqual(before.databaseSHA256, after.databaseSHA256)
+    }
+
+    /// Guards the checked-in `apple-system` evidence against silent drift
+    /// from a corpus/schema change, but only when this host's linked SQLite
+    /// is the exact build the evidence was captured on. A mismatch is
+    /// exactly the variance #390 measures, not a test failure — SQLite does
+    /// not guarantee a stable EQP output across versions, and Apple ships a
+    /// different SQLite per OS release, so asserting byte-identity
+    /// unconditionally would make this test fail on most CI legs by design.
+    func testCheckedInAppleSystemEvidenceMatchesWhenRuntimeIsIdentical() throws {
+        let pinnedURL = try pinnedEvidenceURL(named: "capture_apple-system-3.51.0.json")
+        let pinnedRun = try JSONDecoder().decode(
+            EQPCaptureRun.self,
+            from: Data(contentsOf: pinnedURL)
+        )
+
+        let corpus = try EQPVarianceCorpus.assemble()
+        let pool = try NorthwindFixture.validatedReadOnlyPool()
+        let freshRun = try pool.read { database in
+            try EQPVarianceCapture.capture(from: database, corpus: corpus, label: pinnedRun.label)
+        }
+
+        guard freshRun.runtimeMetadata.sqliteVersion == pinnedRun.runtimeMetadata.sqliteVersion,
+              freshRun.runtimeMetadata.sqliteSourceID == pinnedRun.runtimeMetadata.sqliteSourceID
+        else {
+            throw XCTSkip(
+                "Pinned evidence was captured on SQLite \(pinnedRun.runtimeMetadata.sqliteVersion) "
+                    + "(\(pinnedRun.runtimeMetadata.sqliteSourceID)); this host links "
+                    + "\(freshRun.runtimeMetadata.sqliteVersion) (\(freshRun.runtimeMetadata.sqliteSourceID))."
+            )
+        }
+
+        XCTAssertEqual(
+            try EQPVarianceCanonicalJSON.encode(freshRun),
+            try EQPVarianceCanonicalJSON.encode(pinnedRun)
+        )
+    }
+}
+
+
+func pinnedEvidenceURL(named name: String) throws -> URL {
+    guard let url = Bundle.module.url(forResource: name, withExtension: nil, subdirectory: "Evidence") else {
+        throw EvidenceFixtureError.missingResource(name)
+    }
+    return url
+}
+
+
+enum EvidenceFixtureError: Error {
+    case missingResource(String)
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCaptureTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCaptureTests.swift
@@ -1,10 +1,63 @@
 import XCTest
 import GRDB
 import SwiftQLNorthwindFixtures
+import SwiftQLSQLiteCombinatorialSupport
 import SwiftQLSQLiteEQPVariancePrototype
 
 
 final class EQPVarianceCaptureTests: XCTestCase {
+    func testArgumentsThrowsRatherThanDroppingAMissingNamedKey() {
+        // A malformed named binding with no key_name: silently dropping it
+        // would bind fewer values than the rendered SQL expects.
+        let malformed = SQLiteCombinatorialBinding(
+            logicalIndex: 0,
+            keyKind: .named,
+            keyName: nil,
+            keyIndex: nil,
+            storage: .integer,
+            taggedValue: .integer(1),
+            repeatCount: 1
+        )
+        XCTAssertThrowsError(
+            try EQPVarianceCapture.arguments(for: [malformed], statementID: "s1")
+        ) { error in
+            guard case EQPVarianceCaptureError.invalidBinding(let statementID, _) = error else {
+                return XCTFail("expected invalidBinding, got \(error)")
+            }
+            XCTAssertEqual(statementID, "s1")
+        }
+    }
+
+    func testArgumentsThrowsOnMixedNamedAndIndexedBindings() {
+        let named = SQLiteCombinatorialBinding(
+            logicalIndex: 0,
+            keyKind: .named,
+            keyName: "a",
+            keyIndex: nil,
+            storage: .integer,
+            taggedValue: .integer(1),
+            repeatCount: 1
+        )
+        let indexed = SQLiteCombinatorialBinding(
+            logicalIndex: 1,
+            keyKind: .indexed,
+            keyName: nil,
+            keyIndex: 2,
+            storage: .integer,
+            taggedValue: .integer(2),
+            repeatCount: 1
+        )
+        XCTAssertThrowsError(
+            try EQPVarianceCapture.arguments(for: [named, indexed], statementID: "s2")
+        ) { error in
+            guard case EQPVarianceCaptureError.invalidBinding(let statementID, _) = error else {
+                return XCTFail("expected invalidBinding, got \(error)")
+            }
+            XCTAssertEqual(statementID, "s2")
+        }
+    }
+
+
     func testCaptureIsByteIdenticalAcrossRepeatedRunsInProcess() throws {
         let corpus = try EQPVarianceCorpus.assemble()
         let pool = try NorthwindFixture.validatedReadOnlyPool()

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceClassifierTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceClassifierTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+import SwiftQLSQLiteBuildValidationPrototype
+import SwiftQLSQLiteEQPVariancePrototype
+
+
+final class EQPVarianceClassifierTests: XCTestCase {
+    // MARK: - Real evidence
+
+    /// Replays the actual observed variance between two real, distinct
+    /// SQLite builds captured on this host (Apple system libsqlite3 3.51.0
+    /// vs. Homebrew's 3.53.2, both against the same pinned Northwind copy —
+    /// see `capture_eqp.py` and `SQLiteEQPVariance.md`). This is not a
+    /// synthetic fixture: it is the literal evidence checked in alongside
+    /// this test, so a change to the classifier's heuristics that would
+    /// mis-classify real, observed variance is caught here.
+    func testClassifiesRealObservedVarianceBetweenTwoSQLiteBuilds() throws {
+        let baseline = try loadEvidence("capture_apple-system-3.51.0.json")
+        let comparison = try loadEvidence("capture_homebrew-3.53.2.json")
+
+        let comparisons = try EQPVarianceClassifier.compare(baseline: baseline, comparison: comparison)
+        XCTAssertEqual(comparisons.count, 214)
+
+        var counts: [EQPVarianceDifferenceClass: Int] = [:]
+        for entry in comparisons {
+            counts[entry.classification, default: 0] += 1
+        }
+
+        // Exactly what was observed: 203 statements produced byte-identical
+        // plans, 2 produced the same plan renumbered, and 9 (all CTE
+        // compound-query cases: UNION/EXCEPT/INTERSECT) used a materially
+        // different compound-execution strategy between the two builds.
+        XCTAssertEqual(counts[.identical], 203)
+        XCTAssertEqual(counts[.idRenumberingOnly], 2)
+        XCTAssertEqual(counts[.materializationStrategyChange], 9)
+        XCTAssertEqual(counts[.accessPathChange] ?? 0, 0)
+        XCTAssertEqual(counts[.joinOrderChange] ?? 0, 0)
+        XCTAssertEqual(counts[.cosmeticWordingChange] ?? 0, 0)
+        XCTAssertEqual(counts[.unclassified] ?? 0, 0)
+    }
+
+    func testIDRenumberingCaseIsTheFiveTableJoinAndTheScalarSubquery() throws {
+        let baseline = try loadEvidence("capture_apple-system-3.51.0.json")
+        let comparison = try loadEvidence("capture_homebrew-3.53.2.json")
+        let comparisons = try EQPVarianceClassifier.compare(baseline: baseline, comparison: comparison)
+
+        let renumbered = comparisons
+            .filter { $0.classification == .idRenumberingOnly }
+            .map(\.statementID)
+            .sorted()
+
+        XCTAssertEqual(renumbered, [
+            "c390.northwind.join.customer-order-employee-product",
+            "c390.northwind.subquery.products-above-average",
+        ])
+    }
+
+    func testComparingIdenticalRunsProducesOnlyIdenticalClassifications() throws {
+        let run = try loadEvidence("capture_apple-system-3.51.0.json")
+        let comparisons = try EQPVarianceClassifier.compare(baseline: run, comparison: run)
+        XCTAssertTrue(comparisons.allSatisfy { $0.classification == .identical })
+    }
+
+    func testMismatchedStatementSetsThrow() {
+        let baseline = EQPCaptureRun(
+            label: "a",
+            captureMethod: "test",
+            runtimeMetadata: .fixture(),
+            statements: [EQPStatementCapture(statementID: "only-in-baseline", rows: [])]
+        )
+        let comparison = EQPCaptureRun(
+            label: "b",
+            captureMethod: "test",
+            runtimeMetadata: .fixture(),
+            statements: [EQPStatementCapture(statementID: "only-in-comparison", rows: [])]
+        )
+        XCTAssertThrowsError(try EQPVarianceClassifier.compare(baseline: baseline, comparison: comparison))
+    }
+
+    // MARK: - Synthetic fixtures for axes not observed in the real 3.51.0/3.53.2 pair
+
+    /// Illustrative only: this exact shape was not observed between the two
+    /// real SQLite builds captured for #390. It exists so the classifier's
+    /// access-path-change branch has a unit test independent of whatever
+    /// variance a future SQLite pairing happens to produce.
+    func testSyntheticAccessPathChangeIsClassified() {
+        let baseline = [
+            EQPRow(id: 1, parent: 0, notused: 0, detail: "SEARCH t0 USING INDEX ix_a (col=?)"),
+        ]
+        let comparison = [
+            EQPRow(id: 1, parent: 0, notused: 0, detail: "SEARCH t0 USING INDEX ix_b (col=?)"),
+        ]
+        XCTAssertEqual(
+            EQPVarianceClassifier.classify(baselineRows: baseline, comparisonRows: comparison),
+            .accessPathChange
+        )
+    }
+
+    func testSyntheticJoinOrderChangeIsClassified() {
+        let baseline = [
+            EQPRow(id: 1, parent: 0, notused: 0, detail: "SCAN t0"),
+            EQPRow(id: 2, parent: 0, notused: 0, detail: "SEARCH t1 USING INTEGER PRIMARY KEY (rowid=?)"),
+        ]
+        let comparison = [
+            EQPRow(id: 1, parent: 0, notused: 0, detail: "SCAN t1"),
+            EQPRow(id: 2, parent: 0, notused: 0, detail: "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)"),
+        ]
+        XCTAssertEqual(
+            EQPVarianceClassifier.classify(baselineRows: baseline, comparisonRows: comparison),
+            .joinOrderChange
+        )
+    }
+
+    func testSyntheticCosmeticWordingChangeIsClassified() {
+        let baseline = [
+            EQPRow(id: 1, parent: 0, notused: 0, detail: "SCAN t0"),
+        ]
+        let comparison = [
+            EQPRow(id: 7, parent: 0, notused: 0, detail: "SCAN t0 (~1000000 rows)"),
+        ]
+        XCTAssertEqual(
+            EQPVarianceClassifier.classify(baselineRows: baseline, comparisonRows: comparison),
+            .cosmeticWordingChange
+        )
+    }
+
+    func testSyntheticIdenticalRowsAreIdentical() {
+        let rows = [EQPRow(id: 1, parent: 0, notused: 0, detail: "SCAN t0")]
+        XCTAssertEqual(
+            EQPVarianceClassifier.classify(baselineRows: rows, comparisonRows: rows),
+            .identical
+        )
+    }
+}
+
+
+private func loadEvidence(_ name: String) throws -> EQPCaptureRun {
+    let url = try pinnedEvidenceURL(named: name)
+    return try JSONDecoder().decode(EQPCaptureRun.self, from: Data(contentsOf: url))
+}
+
+
+extension SQLiteBuildValidationRuntimeMetadata {
+    static func fixture() -> SQLiteBuildValidationRuntimeMetadata {
+        SQLiteBuildValidationRuntimeMetadata(
+            sqliteVersion: "0.0.0",
+            sqliteSourceID: "test-fixture",
+            compileOptions: [],
+            functions: [],
+            collations: [],
+            moduleNames: [],
+            extensionNames: [],
+            schemaRowCount: 0,
+            schemaFNV1A64: "0000000000000000"
+        )
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceClassifierTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceClassifierTests.swift
@@ -76,6 +76,33 @@ final class EQPVarianceClassifierTests: XCTestCase {
         XCTAssertThrowsError(try EQPVarianceClassifier.compare(baseline: baseline, comparison: comparison))
     }
 
+    /// A duplicate statement id (corrupted evidence file, or a capture
+    /// pipeline bug) must be a structured error, not a `Dictionary` trap.
+    func testDuplicateStatementIDThrowsRatherThanTrapping() {
+        let duplicated = EQPCaptureRun(
+            label: "a",
+            captureMethod: "test",
+            runtimeMetadata: .fixture(),
+            statements: [
+                EQPStatementCapture(statementID: "dup", rows: []),
+                EQPStatementCapture(statementID: "dup", rows: [EQPRow(id: 1, parent: 0, notused: 0, detail: "SCAN t0")]),
+            ]
+        )
+        let other = EQPCaptureRun(
+            label: "b",
+            captureMethod: "test",
+            runtimeMetadata: .fixture(),
+            statements: [EQPStatementCapture(statementID: "dup", rows: [])]
+        )
+        XCTAssertThrowsError(try EQPVarianceClassifier.compare(baseline: duplicated, comparison: other)) { error in
+            guard case EQPVarianceClassifierError.duplicateStatementID(let id, runLabel: let label) = error else {
+                return XCTFail("expected duplicateStatementID, got \(error)")
+            }
+            XCTAssertEqual(id, "dup")
+            XCTAssertEqual(label, "a")
+        }
+    }
+
     // MARK: - Synthetic fixtures for axes not observed in the real 3.51.0/3.53.2 pair
 
     /// Illustrative only: this exact shape was not observed between the two

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCorpusTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCorpusTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import SwiftQLSQLiteEQPVariancePrototype
+
+
+final class EQPVarianceCorpusTests: XCTestCase {
+    func testCorpusAssemblyIsDeterministic() throws {
+        let first = try EQPVarianceCorpus.assemble()
+        let second = try EQPVarianceCorpus.assemble()
+        XCTAssertEqual(first, second)
+    }
+
+    /// Pins the corpus size so an accidental #191 manifest regeneration or a
+    /// dropped Northwind anchor is caught immediately, rather than silently
+    /// shrinking the evidence this issue's "Done When" bullets depend on.
+    func testCorpusCombinesCombinatorialCasesAndNorthwindAnchors() throws {
+        let corpus = try EQPVarianceCorpus.assemble()
+        let combinatorial = corpus.filter { $0.source == .combinatorial }
+        let anchors = corpus.filter { $0.source == .northwindAnchor }
+
+        XCTAssertEqual(combinatorial.count, 208)
+        XCTAssertEqual(anchors.count, 6)
+        XCTAssertEqual(corpus.count, 214)
+        XCTAssertEqual(Set(corpus.map(\.id)).count, corpus.count, "statement ids must be unique")
+    }
+
+    func testCorpusIsSortedByID() throws {
+        let corpus = try EQPVarianceCorpus.assemble()
+        XCTAssertEqual(corpus.map(\.id), corpus.map(\.id).sorted())
+    }
+
+    func testNorthwindAnchorsCoverJoinCTEAndSubqueryShapes() {
+        let anchorIDs = Set(
+            EQPVarianceCorpus.northwindAnchorStatements()
+                .flatMap(\.northwindAnchorCaseIDs)
+        )
+        // These are the exact case identities #254's fixture registry assigns
+        // to the join/CTE/subquery/compound shapes this corpus reuses from
+        // NorthwindSemanticCorpusTests, so the linkage in Required Approach
+        // ("reusing stable feature/case identities") is checked, not assumed.
+        XCTAssertEqual(anchorIDs, [
+            "northwind.join.customer-order-employee-product",
+            "northwind.join.left-null-manager",
+            "northwind.aggregate.grouped-having",
+            "northwind.subquery.products-above-average",
+            "northwind.compound.customer-supplier-cities",
+            "northwind.cte.order-subtotals",
+        ])
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCorpusTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/EQPVarianceCorpusTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftQLSQLiteCombinatorialSupport
 import SwiftQLSQLiteEQPVariancePrototype
 
 
@@ -45,5 +46,20 @@ final class EQPVarianceCorpusTests: XCTestCase {
             "northwind.compound.customer-supplier-cities",
             "northwind.cte.order-subtotals",
         ])
+    }
+
+    /// `key_index` is 0-based in the #191 manifest's own convention (e.g.
+    /// "c191.v1.expression.indexed-binding" uses `key_index: 0`); an anchor
+    /// binding using a 1-based `key_index` would be inconsistent evidence
+    /// even though today's capture path only reads `logical_index`.
+    func testIndexedAnchorBindingsUseZeroBasedKeyIndex() {
+        let indexedBindings = EQPVarianceCorpus.northwindAnchorStatements()
+            .flatMap(\.bindings)
+            .filter { $0.keyKind == .indexed }
+
+        XCTAssertFalse(indexedBindings.isEmpty)
+        for binding in indexedBindings {
+            XCTAssertEqual(binding.keyIndex, binding.logicalIndex)
+        }
     }
 }

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/capture_apple-system-3.51.0.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/capture_apple-system-3.51.0.json
@@ -1,0 +1,5115 @@
+{
+  "capture_method" : "grdb-in-process",
+  "label" : "apple-system-3.51.0",
+  "runtime_metadata" : {
+    "collations" : [
+      "BINARY",
+      "NOCASE",
+      "RTRIM",
+      "swiftCaseInsensitiveCompare",
+      "swiftCompare",
+      "swiftLocalizedCaseInsensitiveCompare",
+      "swiftLocalizedCompare",
+      "swiftLocalizedStandardCompare"
+    ],
+    "compile_options" : [
+      "ATOMIC_INTRINSICS=1",
+      "BUG_COMPATIBLE_20160819",
+      "CCCRYPT256",
+      "CODEC=see-cccrypt",
+      "COMPILER=clang-21.0.0",
+      "DEFAULT_AUTOVACUUM",
+      "DEFAULT_CACHE_SIZE=2000",
+      "DEFAULT_CKPTFULLFSYNC",
+      "DEFAULT_FILE_FORMAT=4",
+      "DEFAULT_JOURNAL_SIZE_LIMIT=32768",
+      "DEFAULT_LOOKASIDE=1200,102",
+      "DEFAULT_MEMSTATUS=0",
+      "DEFAULT_MMAP_SIZE=0",
+      "DEFAULT_PAGE_SIZE=4096",
+      "DEFAULT_PCACHE_INITSZ=20",
+      "DEFAULT_RECURSIVE_TRIGGERS",
+      "DEFAULT_SECTOR_SIZE=4096",
+      "DEFAULT_SYNCHRONOUS=2",
+      "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+      "DEFAULT_WAL_SYNCHRONOUS=1",
+      "DEFAULT_WORKER_THREADS=0",
+      "DIRECT_OVERFLOW_READ",
+      "DQS=3",
+      "ENABLE_API_ARMOR",
+      "ENABLE_BYTECODE_VTAB",
+      "ENABLE_COLUMN_METADATA",
+      "ENABLE_DBSTAT_VTAB",
+      "ENABLE_FTS3",
+      "ENABLE_FTS3_PARENTHESIS",
+      "ENABLE_FTS3_TOKENIZER",
+      "ENABLE_FTS4",
+      "ENABLE_FTS5",
+      "ENABLE_LOCKING_STYLE=1",
+      "ENABLE_MATH_FUNCTIONS",
+      "ENABLE_NORMALIZE",
+      "ENABLE_PREUPDATE_HOOK",
+      "ENABLE_RTREE",
+      "ENABLE_SESSION",
+      "ENABLE_SETLK_TIMEOUT",
+      "ENABLE_SNAPSHOT",
+      "ENABLE_SQLLOG",
+      "ENABLE_STMT_SCANSTATUS",
+      "ENABLE_UNKNOWN_SQL_FUNCTION",
+      "ENABLE_UPDATE_DELETE_LIMIT",
+      "HAS_CODEC_RESTRICTED",
+      "HAVE_ISNAN",
+      "MALLOC_SOFT_LIMIT=1024",
+      "MAX_ATTACHED=10",
+      "MAX_COLUMN=2000",
+      "MAX_COMPOUND_SELECT=500",
+      "MAX_DEFAULT_PAGE_SIZE=8192",
+      "MAX_EXPR_DEPTH=1000",
+      "MAX_FUNCTION_ARG=127",
+      "MAX_LENGTH=2147483645",
+      "MAX_LIKE_PATTERN_LENGTH=50000",
+      "MAX_MMAP_SIZE=1073741824",
+      "MAX_PAGE_COUNT=1073741823",
+      "MAX_PAGE_SIZE=65536",
+      "MAX_SQL_LENGTH=1000000000",
+      "MAX_TRIGGER_DEPTH=1000",
+      "MAX_VARIABLE_NUMBER=500000",
+      "MAX_VDBE_OP=250000000",
+      "MAX_WORKER_THREADS=8",
+      "MUTEX_UNFAIR",
+      "OMIT_AUTORESET",
+      "OMIT_LOAD_EXTENSION",
+      "STMTJRNL_SPILL=131072",
+      "SYSTEM_MALLOC",
+      "TEMP_STORE=1",
+      "THREADSAFE=2",
+      "USE_URI"
+    ],
+    "extension_names" : [
+
+    ],
+    "functions" : [
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "->"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "->>"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "abs"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "acos"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "acosh"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "asin"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "asinh"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "atan"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "atan2"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "atanh"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "avg"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "bm25"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ceil"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ceiling"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "changes"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "char"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "coalesce"
+      },
+      {
+        "argument_count" : -3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "concat"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "concat_ws"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "cos"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "cosh"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "count"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "count"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "cume_dist"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "current_date"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "current_time"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "current_timestamp"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "date"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "datetime"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "degrees"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "dense_rank"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "exp"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "first_value"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "floor"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "format"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 524288,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts3_tokenizer"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 524288,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts3_tokenizer"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_get_locale"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_insttoken"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 3145728,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_locale"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_source_id"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "glob"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "group_concat"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "group_concat"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "hex"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "highlight"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_exponent"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_from_blob"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_inc"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_mantissa"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_to_blob"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "if"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ifnull"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "iif"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "instr"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_array"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_array_length"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_array_length"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_error_position"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_extract"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "json_group_array"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "json_group_object"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_insert"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_object"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_patch"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_pretty"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_pretty"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_quote"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_remove"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_replace"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_set"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_type"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_type"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_valid"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_valid"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_array"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_extract"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "jsonb_group_array"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "jsonb_group_object"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_insert"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_object"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_patch"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_remove"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_replace"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_set"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "julianday"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lag"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lag"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lag"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "last_insert_rowid"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "last_value"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lead"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lead"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lead"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "length"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "like"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "like"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "likelihood"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "likely"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ln"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log10"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log2"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "lower"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ltrim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ltrim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "match"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "matchinfo"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "matchinfo"
+      },
+      {
+        "argument_count" : -3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "max"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "max"
+      },
+      {
+        "argument_count" : -3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "min"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "min"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "mod"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "nth_value"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "ntile"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "nullif"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "octet_length"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "offsets"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "optimize"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "percent_rank"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "pi"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "pow"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "power"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "printf"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "quote"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "radians"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "random"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "randomblob"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "rank"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "replace"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "round"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "round"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "row_number"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "rtreecheck"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "rtreedepth"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "rtreenode"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "rtrim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "rtrim"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sign"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sin"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sinh"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "snippet"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_compileoption_get"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_compileoption_used"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_log"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_source_id"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_version"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqrt"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "strftime"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "string_agg"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substr"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substr"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substring"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "subtype"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "sum"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftcapitalizedstring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlocalizedcapitalizedstring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlocalizedlowercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlocalizeduppercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlowercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftuppercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "tan"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "tanh"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "time"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "timediff"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "total"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "total_changes"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "trim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "trim"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "trunc"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "typeof"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unhex"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unhex"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unicode"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unistr"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unistr_quote"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unixepoch"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unknown"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unlikely"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "upper"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "uuid"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "uuid_blob"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "uuid_str"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "zeroblob"
+      }
+    ],
+    "module_names" : [
+      "bytecode",
+      "dbstat",
+      "fts3",
+      "fts3tokenize",
+      "fts4",
+      "fts4aux",
+      "fts5",
+      "fts5vocab",
+      "json_each",
+      "json_tree",
+      "rtree",
+      "rtree_i32",
+      "tables_used"
+    ],
+    "schema_fnv1a_64" : "e2c8fadbd38c2313",
+    "schema_row_count" : 37,
+    "sqlite_source_id" : "2025-06-12 13:14:41 f0ca7bba1c5e232e5d279fad6338121ab55af0c8c68c84cdfb18ba5114dcaapl",
+    "sqlite_version" : "3.51.0"
+  },
+  "statements" : [
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "EXCEPT USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.except"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "INTERSECT USING TEMP B-TREE",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 18
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.intersect"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.union"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 9,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION ALL",
+          "id" : 15,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 15
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.union-all"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "EXCEPT USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.except"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "INTERSECT USING TEMP B-TREE",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 18
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.intersect"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.union"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 9,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION ALL",
+          "id" : 15,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 15
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.union-all"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 8
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 20,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 21,
+          "notused" : 216,
+          "parent" : 20
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 31,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "EXCEPT USING TEMP B-TREE",
+          "id" : 38,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 39,
+          "notused" : 0,
+          "parent" : 38
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.except"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 8
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 20,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 21,
+          "notused" : 216,
+          "parent" : 20
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 31,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "INTERSECT USING TEMP B-TREE",
+          "id" : 39,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 40,
+          "notused" : 0,
+          "parent" : 39
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.intersect"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 8
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 20,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 21,
+          "notused" : 216,
+          "parent" : 20
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 31,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION USING TEMP B-TREE",
+          "id" : 38,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 39,
+          "notused" : 0,
+          "parent" : 38
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.union"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 7,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 7
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 20,
+          "notused" : 216,
+          "parent" : 19
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 30,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION ALL",
+          "id" : 36,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 37,
+          "notused" : 0,
+          "parent" : 36
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.union-all"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.cast-text-blob"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.cast-text-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.comparable-min"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.date-unixepoch"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.indexed-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.json-array-length"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.json-valid"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.numeric-abs"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.numeric-floor"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.numeric-round"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.operator-arithmetic-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.operator-glob"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.string-printf"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "MERGE (UNION)",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 4
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "RIGHT",
+          "id" : 28,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN t1",
+          "id" : 31,
+          "notused" : 216,
+          "parent" : 28
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 40,
+          "notused" : 0,
+          "parent" : 28
+        }
+      ],
+      "statement_id" : "c191.v1.northwind.compound-customer-supplier-cities"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "CO-ROUTINE cte0",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id" : 9,
+          "notused" : 62,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 52,
+          "notused" : 82,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.northwind.cte-order-subtotals"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 46,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 9,
+          "notused" : 209,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 11,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 9,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 14,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 22,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 7,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 7,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 11,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 9,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 22,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 3,
+          "notused" : 44,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 9,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 5,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 7,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 11,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 45,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id" : 6,
+          "notused" : 45,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.j-left"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 12,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 18,
+          "notused" : 44,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 23,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 66,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.s-subquery-alias.j-inner.w-repeated-binding.g-customer-id.h-count-greater-than-one.o-descending.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.s-table-alias"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 5,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.j-inner"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.s-subquery-alias"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 12,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id" : 16,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 21,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 69,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.j-left"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 10,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 5,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.j-inner"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 11,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 25,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 27,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 12,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 6,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 11,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 13,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 51,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.o-ascending.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 10,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-null-comparison.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-null-comparison.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 14,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.l-five"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-repeated-binding.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 14,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-repeated-binding.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR avg(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-average-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR count(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-count-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR group_concat(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-group-concat-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR max(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-max-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR min(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-min-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR sum(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-sum-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-blob-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-bool-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-integer-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-integer-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-blob-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-bool-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-integer-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-integer-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-real-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-real-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-text-blob"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-text-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-text-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-real-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-real-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-text-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.comparable-max"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.json-array-length-path"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.numeric-round-no-places"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.numeric-round-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.string-printf-array"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.boolean-and-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.boolean-not-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.boolean-or-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.coalesce-storage-classes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.coalescing-operator"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-both-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-left-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-right-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.equality-optional-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.equality-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.inequality-optional-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-both-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-left-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-right-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-division-boundaries"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.optional-predicates"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-both-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-left-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-right-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-division-boundaries"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-concatenation-null"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-concatenation-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-glob-case-sensitivity"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-glob-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-glob-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-like-ascii-case-folding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-like-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-like-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.unary-nesting"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.unary-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 1",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-query-builder-empty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 1",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-query-builder-nonempty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 1",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t1 USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 12,
+          "notused" : 39,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 22,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-query-functional-nonempty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 2",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-table-empty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 2",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-table-nonempty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN Orders",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 47,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.aggregate.grouped-having"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "MERGE (UNION)",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN Customers",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 4
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "RIGHT",
+          "id" : 28,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN Suppliers",
+          "id" : 31,
+          "notused" : 216,
+          "parent" : 28
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 40,
+          "notused" : 0,
+          "parent" : 28
+        }
+      ],
+      "statement_id" : "c390.northwind.compound.customer-supplier-cities"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "CO-ROUTINE order_subtotals",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH Order Details USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id" : 9,
+          "notused" : 62,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN order_subtotals",
+          "id" : 51,
+          "notused" : 82,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.cte.order-subtotals"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH o USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 9,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH c USING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 12,
+          "notused" : 46,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 18,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH d USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id" : 21,
+          "notused" : 62,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH p USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 27,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 44,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.join.customer-order-employee-product"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN e",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id" : 6,
+          "notused" : 45,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.join.left-null-manager"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN Products",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCALAR SUBQUERY 1",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN Products",
+          "id" : 13,
+          "notused" : 216,
+          "parent" : 8
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 29,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.subquery.products-above-average"
+    }
+  ]
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/capture_homebrew-3.53.2.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/capture_homebrew-3.53.2.json
@@ -1,0 +1,5173 @@
+{
+  "capture_method": "python3-sqlite3-module",
+  "label": "homebrew-3.53.2",
+  "runtime_metadata": {
+    "collations": [
+      "BINARY",
+      "NOCASE",
+      "RTRIM"
+    ],
+    "compile_options": [
+      "ATOMIC_INTRINSICS=1",
+      "COMPILER=clang-21.0.0",
+      "DEFAULT_AUTOVACUUM",
+      "DEFAULT_CACHE_SIZE=-2000",
+      "DEFAULT_FILE_FORMAT=4",
+      "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+      "DEFAULT_MMAP_SIZE=0",
+      "DEFAULT_PAGE_SIZE=4096",
+      "DEFAULT_PCACHE_INITSZ=20",
+      "DEFAULT_RECURSIVE_TRIGGERS",
+      "DEFAULT_SECTOR_SIZE=4096",
+      "DEFAULT_SYNCHRONOUS=2",
+      "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+      "DEFAULT_WAL_SYNCHRONOUS=2",
+      "DEFAULT_WORKER_THREADS=0",
+      "DIRECT_OVERFLOW_READ",
+      "ENABLE_API_ARMOR",
+      "ENABLE_COLUMN_METADATA",
+      "ENABLE_DBSTAT_VTAB",
+      "ENABLE_FTS3",
+      "ENABLE_FTS3_PARENTHESIS",
+      "ENABLE_FTS5",
+      "ENABLE_GEOPOLY",
+      "ENABLE_MATH_FUNCTIONS",
+      "ENABLE_MEMORY_MANAGEMENT",
+      "ENABLE_PERCENTILE",
+      "ENABLE_PREUPDATE_HOOK",
+      "ENABLE_RTREE",
+      "ENABLE_SESSION",
+      "ENABLE_STAT4",
+      "ENABLE_UNLOCK_NOTIFY",
+      "MALLOC_SOFT_LIMIT=1024",
+      "MAX_ATTACHED=10",
+      "MAX_COLUMN=2000",
+      "MAX_COMPOUND_SELECT=500",
+      "MAX_DEFAULT_PAGE_SIZE=8192",
+      "MAX_EXPR_DEPTH=1000",
+      "MAX_FUNCTION_ARG=1000",
+      "MAX_LENGTH=1000000000",
+      "MAX_LIKE_PATTERN_LENGTH=50000",
+      "MAX_MMAP_SIZE=0x7fff0000",
+      "MAX_PAGE_COUNT=0xfffffffe",
+      "MAX_PAGE_SIZE=65536",
+      "MAX_SQL_LENGTH=1000000000",
+      "MAX_TRIGGER_DEPTH=1000",
+      "MAX_VARIABLE_NUMBER=250000",
+      "MAX_VDBE_OP=250000000",
+      "MAX_WORKER_THREADS=8",
+      "MUTEX_PTHREADS",
+      "SYSTEM_MALLOC",
+      "TEMP_STORE=1",
+      "THREADSAFE=1",
+      "USE_URI"
+    ],
+    "extension_names": [],
+    "functions": [
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "->"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "->>"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "abs"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "acos"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "acosh"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "asin"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "asinh"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "atan"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "atan2"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "atanh"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "avg"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "bm25"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ceil"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ceiling"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "changes"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "char"
+      },
+      {
+        "argument_count": -4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "coalesce"
+      },
+      {
+        "argument_count": -3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "concat"
+      },
+      {
+        "argument_count": -4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "concat_ws"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "cos"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "cosh"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "count"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "count"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "cume_dist"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "current_date"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "current_time"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "current_timestamp"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "date"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "datetime"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "degrees"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "dense_rank"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "exp"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "first_value"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "floor"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "format"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts3_tokenizer"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts3_tokenizer"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5_get_locale"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5_insttoken"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 3145728,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5_locale"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5_source_id"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_area"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_bbox"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_blob"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_ccw"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_contains_point"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_debug"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "a",
+        "name": "geopoly_group_bbox"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_json"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_overlap"
+      },
+      {
+        "argument_count": 4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_regular"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_svg"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_within"
+      },
+      {
+        "argument_count": 7,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_xform"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "glob"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "group_concat"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "group_concat"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "hex"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "highlight"
+      },
+      {
+        "argument_count": -4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "if"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ifnull"
+      },
+      {
+        "argument_count": -4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "iif"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "instr"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_array"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_array_insert"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_array_length"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_array_length"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_error_position"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_extract"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "json_group_array"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "json_group_object"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_insert"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_object"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_patch"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_pretty"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_pretty"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_quote"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_remove"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_replace"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_set"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_type"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_type"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_valid"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_valid"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_array"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_array_insert"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_extract"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "jsonb_group_array"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "jsonb_group_object"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_insert"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_object"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_patch"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_remove"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_replace"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_set"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "julianday"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lag"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lag"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lag"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "last_insert_rowid"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "last_value"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lead"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lead"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lead"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "length"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "like"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "like"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "likelihood"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "likely"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ln"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "load_extension"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "load_extension"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "log"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "log"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "log10"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "log2"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "lower"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ltrim"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ltrim"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "match"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "matchinfo"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "matchinfo"
+      },
+      {
+        "argument_count": -3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "max"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "max"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "median"
+      },
+      {
+        "argument_count": -3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "min"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "min"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "mod"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "nth_value"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "ntile"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "nullif"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "octet_length"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "offsets"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "optimize"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "percent_rank"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "percentile"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "percentile_cont"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "percentile_disc"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "pi"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "pow"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "power"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "printf"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "quote"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "radians"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "random"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "randomblob"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "rank"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "replace"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "round"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "round"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "row_number"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "rtreecheck"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "rtreedepth"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "rtreenode"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "rtrim"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "rtrim"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sign"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sin"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sinh"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "snippet"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_compileoption_get"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_compileoption_used"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_log"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_source_id"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_version"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqrt"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "strftime"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "string_agg"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "substr"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "substr"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "substring"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "substring"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "subtype"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "sum"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "tan"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "tanh"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "time"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "timediff"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "total"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "total_changes"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "trim"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "trim"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "trunc"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "typeof"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unhex"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unhex"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unicode"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unistr"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unistr_quote"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unixepoch"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unlikely"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "upper"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "zeroblob"
+      }
+    ],
+    "module_names": [
+      "dbstat",
+      "fts3",
+      "fts3tokenize",
+      "fts4",
+      "fts4aux",
+      "fts5",
+      "fts5vocab",
+      "geopoly",
+      "rtree",
+      "rtree_i32"
+    ],
+    "schema_fnv1a_64": "e2c8fadbd38c2313",
+    "schema_row_count": 37,
+    "sqlite_source_id": "2026-06-03 19:12:13 d6e03d8c777cfa2d35e3b60d8ec3e0187f3e9f99d8e2ee9cac695fd6fcdf1a24",
+    "sqlite_version": "3.53.2"
+  },
+  "statements": [
+    {
+      "rows": [
+        {
+          "detail": "MERGE (EXCEPT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE nullable_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN nullable_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-nullable.except"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (INTERSECT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE nullable_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN nullable_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-nullable.intersect"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE nullable_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN nullable_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-nullable.union"
+    },
+    {
+      "rows": [
+        {
+          "detail": "COMPOUND QUERY",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT-MOST SUBQUERY",
+          "id": 2,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "CO-ROUTINE nullable_seed",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 5,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN nullable_rows",
+          "id": 9,
+          "notused": 16,
+          "parent": 2
+        },
+        {
+          "detail": "UNION ALL",
+          "id": 15,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 16,
+          "notused": 0,
+          "parent": 15
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-nullable.union-all"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (EXCEPT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE required_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN required_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-required.except"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (INTERSECT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE required_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN required_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-required.intersect"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE required_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN required_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-required.union"
+    },
+    {
+      "rows": [
+        {
+          "detail": "COMPOUND QUERY",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT-MOST SUBQUERY",
+          "id": 2,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "CO-ROUTINE required_seed",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 5,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN required_rows",
+          "id": 9,
+          "notused": 16,
+          "parent": 2
+        },
+        {
+          "detail": "UNION ALL",
+          "id": 15,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 16,
+          "notused": 0,
+          "parent": 15
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-required.union-all"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (EXCEPT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE integer_sequence",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SETUP",
+          "id": 9,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 10,
+          "notused": 0,
+          "parent": 9
+        },
+        {
+          "detail": "RECURSIVE STEP",
+          "id": 21,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 22,
+          "notused": 216,
+          "parent": 21
+        },
+        {
+          "detail": "SCAN recursive_rows",
+          "id": 33,
+          "notused": 215,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 49,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 51,
+          "notused": 0,
+          "parent": 49
+        }
+      ],
+      "statement_id": "c191.v1.cte.recursive-required.except"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (INTERSECT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE integer_sequence",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SETUP",
+          "id": 9,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 10,
+          "notused": 0,
+          "parent": 9
+        },
+        {
+          "detail": "RECURSIVE STEP",
+          "id": 21,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 22,
+          "notused": 216,
+          "parent": 21
+        },
+        {
+          "detail": "SCAN recursive_rows",
+          "id": 33,
+          "notused": 215,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 49,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 51,
+          "notused": 0,
+          "parent": 49
+        }
+      ],
+      "statement_id": "c191.v1.cte.recursive-required.intersect"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE integer_sequence",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SETUP",
+          "id": 9,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 10,
+          "notused": 0,
+          "parent": 9
+        },
+        {
+          "detail": "RECURSIVE STEP",
+          "id": 21,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 22,
+          "notused": 216,
+          "parent": 21
+        },
+        {
+          "detail": "SCAN recursive_rows",
+          "id": 33,
+          "notused": 215,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 49,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 51,
+          "notused": 0,
+          "parent": 49
+        }
+      ],
+      "statement_id": "c191.v1.cte.recursive-required.union"
+    },
+    {
+      "rows": [
+        {
+          "detail": "COMPOUND QUERY",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT-MOST SUBQUERY",
+          "id": 2,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "CO-ROUTINE integer_sequence",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SETUP",
+          "id": 7,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 8,
+          "notused": 0,
+          "parent": 7
+        },
+        {
+          "detail": "RECURSIVE STEP",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 20,
+          "notused": 216,
+          "parent": 19
+        },
+        {
+          "detail": "SCAN recursive_rows",
+          "id": 30,
+          "notused": 215,
+          "parent": 2
+        },
+        {
+          "detail": "UNION ALL",
+          "id": 36,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 37,
+          "notused": 0,
+          "parent": 36
+        }
+      ],
+      "statement_id": "c191.v1.cte.recursive-required.union-all"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.cast-text-blob"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.cast-text-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.comparable-min"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.date-unixepoch"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.indexed-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.json-array-length"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.json-valid"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.numeric-abs"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.numeric-floor"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.numeric-round"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.operator-arithmetic-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.operator-glob"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.string-printf"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 16,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN t1",
+          "id": 31,
+          "notused": 216,
+          "parent": 28
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.northwind.compound-customer-supplier-cities"
+    },
+    {
+      "rows": [
+        {
+          "detail": "CO-ROUTINE cte0",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id": 9,
+          "notused": 62,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 52,
+          "notused": 82,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.northwind.cte-order-subtotals"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 46,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 9,
+          "notused": 209,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 11,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 9,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 14,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 22,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 7,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 5,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 7,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-null-comparison"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 11,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 9,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-repeated-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 6,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 6,
+          "notused": 44,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 16,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 6,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 22,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 3,
+          "notused": 44,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 9,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 6,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 5,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 7,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-null-comparison"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 11,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 45,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 2,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-repeated-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.j-cross"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id": 6,
+          "notused": 45,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.j-left"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 12,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 18,
+          "notused": 44,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 23,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 66,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.s-subquery-alias.j-inner.w-repeated-binding.g-customer-id.h-count-greater-than-one.o-descending.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.s-table-alias"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-null-comparison"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 5,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.j-cross"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 5,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.j-inner"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.s-subquery-alias"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 12,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id": 16,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 21,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 69,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 2,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-repeated-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 5,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.j-cross"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.j-left"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 10,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 2,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-null-comparison"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 5,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.j-cross"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 5,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.j-inner"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 2,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-repeated-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 11,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 6,
+          "notused": 61,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 25,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 6,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 27,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 6,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 6,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 12,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 6,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 6,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 6,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 8,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-named-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 11,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 13,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 51,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-named-binding.g-customer-id.o-ascending.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 10,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-named-binding.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-named-binding.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-null-comparison.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-null-comparison.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 6,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 14,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.l-five"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 6,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 16,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-repeated-binding.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 14,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-repeated-binding.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR avg(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-average-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR count(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-count-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR group_concat(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-group-concat-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR max(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-max-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR min(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-min-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR sum(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-sum-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-blob-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-bool-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-integer-real"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-integer-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-blob-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-bool-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-integer-real"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-integer-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-real-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-real-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-text-blob"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-text-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-text-real"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-real-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-real-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-text-real"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.comparable-max"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.json-array-length-path"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.numeric-round-no-places"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.numeric-round-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.string-printf-array"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.boolean-and-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.boolean-not-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.boolean-or-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.coalesce-storage-classes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.coalescing-operator"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.comparison-both-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.comparison-left-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.comparison-required"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.comparison-right-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.equality-optional-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.equality-required"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.inequality-optional-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-both-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-left-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-null-propagation"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-required"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-right-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-division-boundaries"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.optional-predicates"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-both-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-left-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-null-propagation"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-required"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-right-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-division-boundaries"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-concatenation-null"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-concatenation-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-glob-case-sensitivity"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-glob-null-propagation"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-glob-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-like-ascii-case-folding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-like-null-propagation"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-like-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.unary-nesting"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.unary-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 1",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 33,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 19,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-query-builder-empty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 1",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 33,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 19,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-query-builder-nonempty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 1",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t1 USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 12,
+          "notused": 39,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 22,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-query-functional-nonempty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 2",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 33,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 19,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-table-empty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 2",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 33,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 19,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-table-nonempty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN Orders",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 47,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.aggregate.grouped-having"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN Customers",
+          "id": 7,
+          "notused": 216,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 16,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN Suppliers",
+          "id": 31,
+          "notused": 216,
+          "parent": 28
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c390.northwind.compound.customer-supplier-cities"
+    },
+    {
+      "rows": [
+        {
+          "detail": "CO-ROUTINE order_subtotals",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH Order Details USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id": 9,
+          "notused": 62,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN order_subtotals",
+          "id": 51,
+          "notused": 82,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.cte.order-subtotals"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH o USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH c USING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 15,
+          "notused": 46,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 21,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH d USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id": 24,
+          "notused": 62,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH p USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 30,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 47,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.join.customer-order-employee-product"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN e",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id": 6,
+          "notused": 45,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.join.left-null-manager"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN Products",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCALAR SUBQUERY 1",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN Products",
+          "id": 14,
+          "notused": 216,
+          "parent": 9
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 30,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.subquery.products-above-average"
+    }
+  ]
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/comparison_apple-system-3.51.0_vs_homebrew-3.53.2.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/comparison_apple-system-3.51.0_vs_homebrew-3.53.2.json
@@ -1,0 +1,6556 @@
+[
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE nullable_seed",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN nullable_rows",
+        "id" : 10,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "EXCEPT USING TEMP B-TREE",
+        "id" : 17,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 18,
+        "notused" : 0,
+        "parent" : 17
+      }
+    ],
+    "classification" : "materialization_strategy_change",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (EXCEPT)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "CO-ROUTINE nullable_seed",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 7,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN nullable_rows",
+        "id" : 12,
+        "notused" : 16,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 30,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.except"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE nullable_seed",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN nullable_rows",
+        "id" : 10,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "INTERSECT USING TEMP B-TREE",
+        "id" : 18,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 18
+      }
+    ],
+    "classification" : "materialization_strategy_change",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (INTERSECT)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "CO-ROUTINE nullable_seed",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 7,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN nullable_rows",
+        "id" : 12,
+        "notused" : 16,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 30,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.intersect"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE nullable_seed",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN nullable_rows",
+        "id" : 10,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "UNION USING TEMP B-TREE",
+        "id" : 17,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 18,
+        "notused" : 0,
+        "parent" : 17
+      }
+    ],
+    "classification" : "materialization_strategy_change",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (UNION)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "CO-ROUTINE nullable_seed",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 7,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN nullable_rows",
+        "id" : 12,
+        "notused" : 16,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 30,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.union"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE nullable_seed",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN nullable_rows",
+        "id" : 9,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "UNION ALL",
+        "id" : 15,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 15
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE nullable_seed",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN nullable_rows",
+        "id" : 9,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "UNION ALL",
+        "id" : 15,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 15
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.union-all"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE required_seed",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN required_rows",
+        "id" : 10,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "EXCEPT USING TEMP B-TREE",
+        "id" : 17,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 18,
+        "notused" : 0,
+        "parent" : 17
+      }
+    ],
+    "classification" : "materialization_strategy_change",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (EXCEPT)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "CO-ROUTINE required_seed",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 7,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN required_rows",
+        "id" : 12,
+        "notused" : 16,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 30,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.except"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE required_seed",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN required_rows",
+        "id" : 10,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "INTERSECT USING TEMP B-TREE",
+        "id" : 18,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 18
+      }
+    ],
+    "classification" : "materialization_strategy_change",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (INTERSECT)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "CO-ROUTINE required_seed",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 7,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN required_rows",
+        "id" : 12,
+        "notused" : 16,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 30,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.intersect"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE required_seed",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN required_rows",
+        "id" : 10,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "UNION USING TEMP B-TREE",
+        "id" : 17,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 18,
+        "notused" : 0,
+        "parent" : 17
+      }
+    ],
+    "classification" : "materialization_strategy_change",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (UNION)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "CO-ROUTINE required_seed",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 7,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN required_rows",
+        "id" : 12,
+        "notused" : 16,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 30,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.union"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE required_seed",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN required_rows",
+        "id" : 9,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "UNION ALL",
+        "id" : 15,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 15
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE required_seed",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN required_rows",
+        "id" : 9,
+        "notused" : 16,
+        "parent" : 2
+      },
+      {
+        "detail" : "UNION ALL",
+        "id" : 15,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 15
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.union-all"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE integer_sequence",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SETUP",
+        "id" : 8,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 8
+      },
+      {
+        "detail" : "RECURSIVE STEP",
+        "id" : 20,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 21,
+        "notused" : 216,
+        "parent" : 20
+      },
+      {
+        "detail" : "SCAN recursive_rows",
+        "id" : 31,
+        "notused" : 215,
+        "parent" : 2
+      },
+      {
+        "detail" : "EXCEPT USING TEMP B-TREE",
+        "id" : 38,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 39,
+        "notused" : 0,
+        "parent" : 38
+      }
+    ],
+    "classification" : "materialization_strategy_change",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (EXCEPT)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "CO-ROUTINE integer_sequence",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SETUP",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 10,
+        "notused" : 0,
+        "parent" : 9
+      },
+      {
+        "detail" : "RECURSIVE STEP",
+        "id" : 21,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 22,
+        "notused" : 216,
+        "parent" : 21
+      },
+      {
+        "detail" : "SCAN recursive_rows",
+        "id" : 33,
+        "notused" : 215,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 40,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 49,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 51,
+        "notused" : 0,
+        "parent" : 49
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.except"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE integer_sequence",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SETUP",
+        "id" : 8,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 8
+      },
+      {
+        "detail" : "RECURSIVE STEP",
+        "id" : 20,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 21,
+        "notused" : 216,
+        "parent" : 20
+      },
+      {
+        "detail" : "SCAN recursive_rows",
+        "id" : 31,
+        "notused" : 215,
+        "parent" : 2
+      },
+      {
+        "detail" : "INTERSECT USING TEMP B-TREE",
+        "id" : 39,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 40,
+        "notused" : 0,
+        "parent" : 39
+      }
+    ],
+    "classification" : "materialization_strategy_change",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (INTERSECT)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "CO-ROUTINE integer_sequence",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SETUP",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 10,
+        "notused" : 0,
+        "parent" : 9
+      },
+      {
+        "detail" : "RECURSIVE STEP",
+        "id" : 21,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 22,
+        "notused" : 216,
+        "parent" : 21
+      },
+      {
+        "detail" : "SCAN recursive_rows",
+        "id" : 33,
+        "notused" : 215,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 40,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 49,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 51,
+        "notused" : 0,
+        "parent" : 49
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.intersect"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE integer_sequence",
+        "id" : 5,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SETUP",
+        "id" : 8,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 8
+      },
+      {
+        "detail" : "RECURSIVE STEP",
+        "id" : 20,
+        "notused" : 0,
+        "parent" : 5
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 21,
+        "notused" : 216,
+        "parent" : 20
+      },
+      {
+        "detail" : "SCAN recursive_rows",
+        "id" : 31,
+        "notused" : 215,
+        "parent" : 2
+      },
+      {
+        "detail" : "UNION USING TEMP B-TREE",
+        "id" : 38,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 39,
+        "notused" : 0,
+        "parent" : 38
+      }
+    ],
+    "classification" : "materialization_strategy_change",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (UNION)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "CO-ROUTINE integer_sequence",
+        "id" : 6,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SETUP",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 10,
+        "notused" : 0,
+        "parent" : 9
+      },
+      {
+        "detail" : "RECURSIVE STEP",
+        "id" : 21,
+        "notused" : 0,
+        "parent" : 6
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 22,
+        "notused" : 216,
+        "parent" : 21
+      },
+      {
+        "detail" : "SCAN recursive_rows",
+        "id" : 33,
+        "notused" : 215,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 40,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 49,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 51,
+        "notused" : 0,
+        "parent" : 49
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.union"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE integer_sequence",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SETUP",
+        "id" : 7,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 8,
+        "notused" : 0,
+        "parent" : 7
+      },
+      {
+        "detail" : "RECURSIVE STEP",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 20,
+        "notused" : 216,
+        "parent" : 19
+      },
+      {
+        "detail" : "SCAN recursive_rows",
+        "id" : 30,
+        "notused" : 215,
+        "parent" : 2
+      },
+      {
+        "detail" : "UNION ALL",
+        "id" : 36,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 37,
+        "notused" : 0,
+        "parent" : 36
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "COMPOUND QUERY",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT-MOST SUBQUERY",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "CO-ROUTINE integer_sequence",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SETUP",
+        "id" : 7,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 8,
+        "notused" : 0,
+        "parent" : 7
+      },
+      {
+        "detail" : "RECURSIVE STEP",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 20,
+        "notused" : 216,
+        "parent" : 19
+      },
+      {
+        "detail" : "SCAN recursive_rows",
+        "id" : 30,
+        "notused" : 215,
+        "parent" : 2
+      },
+      {
+        "detail" : "UNION ALL",
+        "id" : 36,
+        "notused" : 0,
+        "parent" : 1
+      },
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 37,
+        "notused" : 0,
+        "parent" : 36
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.union-all"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.cast-text-blob"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.cast-text-integer"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.comparable-min"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.date-unixepoch"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.indexed-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.json-array-length"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.json-valid"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.numeric-abs"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.numeric-floor"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.numeric-round"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.operator-arithmetic-precedence"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.operator-glob"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.expression.string-printf"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "MERGE (UNION)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN t1",
+        "id" : 31,
+        "notused" : 216,
+        "parent" : 28
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 40,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (UNION)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN t1",
+        "id" : 31,
+        "notused" : 216,
+        "parent" : 28
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 40,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "statement_id" : "c191.v1.northwind.compound-customer-supplier-cities"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "CO-ROUTINE cte0",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+        "id" : 9,
+        "notused" : 62,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 52,
+        "notused" : 82,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "CO-ROUTINE cte0",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+        "id" : 9,
+        "notused" : 62,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 52,
+        "notused" : 82,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.northwind.cte-order-subtotals"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 46,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 46,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 9,
+        "notused" : 209,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 11,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 9,
+        "notused" : 209,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 11,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 9,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 9,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.l-five.x-two"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 14,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 14,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-empty-in"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 22,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 22,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-in-list"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 7,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 7,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-injection-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-literal"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 5,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 5,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-named-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 7,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 7,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-null-comparison"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 11,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 11,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-precedence"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 9,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 9,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-repeated-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 6,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 6,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 6,
+        "notused" : 44,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 6,
+        "notused" : 44,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 6,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 6,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-empty-in"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 22,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 22,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-in-list"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 3,
+        "notused" : 44,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 9,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 3,
+        "notused" : 44,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 9,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-injection-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 6,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 6,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-literal"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 5,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 5,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-named-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 7,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 7,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-null-comparison"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 11,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 11,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-precedence"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-empty-in"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-in-list"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-injection-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 45,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 45,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-literal"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 2,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 2,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-named-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-precedence"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-repeated-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 6,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.j-cross"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "id" : 6,
+        "notused" : 45,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "id" : 6,
+        "notused" : 45,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.j-left"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 12,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 18,
+        "notused" : 44,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 23,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 66,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 12,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 18,
+        "notused" : 44,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 23,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 66,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.s-subquery-alias.j-inner.w-repeated-binding.g-customer-id.h-count-greater-than-one.o-descending.l-five.x-two"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.s-table-alias"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-empty-in"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-in-list"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-injection-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-literal"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-named-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-null-comparison"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-precedence"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 5,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 5,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.j-cross"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 5,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 5,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.j-inner"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.s-subquery-alias"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 12,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "id" : 16,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 21,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 69,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 12,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "id" : 16,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 21,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 69,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-empty-in"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-in-list"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-injection-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-literal"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 2,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 2,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-named-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-precedence"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-repeated-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 5,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 5,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.j-cross"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.j-left"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 10,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 10,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-empty-in"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-in-list"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-injection-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-literal"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 2,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 2,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-named-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-null-comparison"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN source_orders",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-precedence"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 5,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "id" : 5,
+        "notused" : 209,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.j-cross"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 5,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 5,
+        "notused" : 44,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.j-inner"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-empty-in"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-in-list"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-injection-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 2,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-literal"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 2,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 2,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-named-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-precedence"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN orders_case",
+        "id" : 2,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-repeated-binding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.l-five.x-two"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 11,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 11,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 6,
+        "notused" : 61,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 25,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 6,
+        "notused" : 61,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 25,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 6,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 6,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.l-five.x-two"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 27,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 27,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 61,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 6,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 6,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 6,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 6,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.l-five.x-two"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 12,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 12,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 6,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 6,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 6,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 6,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.l-five.x-two"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 3,
+        "notused" : 33,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 6,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 8,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 6,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 8,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 11,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 13,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 51,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 11,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 13,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 51,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.o-ascending.l-five.x-two"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 10,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 10,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "id" : 3,
+        "notused" : 196,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-null-comparison.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-null-comparison.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 6,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 14,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 6,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 14,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.l-five"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 6,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 6,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.l-five.x-two"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.o-descending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-repeated-binding.o-ascending"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 14,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 14,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-repeated-binding.o-collated"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR avg(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR avg(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-average-distinct"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR count(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR count(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-count-distinct"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR group_concat(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR group_concat(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-group-concat-distinct"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR max(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR max(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-max-distinct"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR min(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR min(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-min-distinct"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR sum(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "USE TEMP B-TREE FOR sum(DISTINCT)",
+        "id" : 3,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN t0",
+        "id" : 5,
+        "notused" : 216,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-sum-distinct"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-blob-text"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-bool-integer"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-integer-real"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-integer-text"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-blob-text"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-bool-integer"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-integer-real"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-integer-text"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-real-integer"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-real-text"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-text-blob"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-text-integer"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-text-real"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-real-integer"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-real-text"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-text-real"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.comparable-max"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.json-array-length-path"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.numeric-round-no-places"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.numeric-round-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c286.v1.expression.string-printf-array"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.boolean-and-shapes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.boolean-not-shapes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.boolean-or-shapes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.coalesce-storage-classes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.coalescing-operator"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-both-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-left-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-required"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-right-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.equality-optional-shapes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.equality-required"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.inequality-optional-shapes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-both-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-left-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-null-propagation"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-required"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-right-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-division-boundaries"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.optional-predicates"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-both-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-left-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-null-propagation"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-required"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-right-optional"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-division-boundaries"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-concatenation-null"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-concatenation-shapes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-glob-case-sensitivity"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-glob-null-propagation"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-glob-shapes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-like-ascii-case-folding"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-like-null-propagation"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-like-shapes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.unary-nesting"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN CONSTANT ROW",
+        "id" : 1,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c287.v1.expression.unary-shapes"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 1",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 12,
+        "notused" : 33,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 1",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 12,
+        "notused" : 33,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-query-builder-empty"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 1",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 12,
+        "notused" : 33,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 1",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 12,
+        "notused" : 33,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-query-builder-nonempty"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 1",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t1 USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 12,
+        "notused" : 39,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 22,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 1",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t1 USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 12,
+        "notused" : 39,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 22,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-query-functional-nonempty"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 2",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 12,
+        "notused" : 33,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 2",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 12,
+        "notused" : 33,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-table-empty"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 2",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 12,
+        "notused" : 33,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN t0",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "LIST SUBQUERY 2",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 12,
+        "notused" : 33,
+        "parent" : 9
+      },
+      {
+        "detail" : "CREATE BLOOM FILTER",
+        "id" : 19,
+        "notused" : 0,
+        "parent" : 9
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-table-nonempty"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN Orders",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 47,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN Orders",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 47,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c390.northwind.aggregate.grouped-having"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "MERGE (UNION)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN Customers",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN Suppliers",
+        "id" : 31,
+        "notused" : 216,
+        "parent" : 28
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 40,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "MERGE (UNION)",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "LEFT",
+        "id" : 4,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN Customers",
+        "id" : 7,
+        "notused" : 216,
+        "parent" : 4
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 16,
+        "notused" : 0,
+        "parent" : 4
+      },
+      {
+        "detail" : "RIGHT",
+        "id" : 28,
+        "notused" : 0,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN Suppliers",
+        "id" : 31,
+        "notused" : 216,
+        "parent" : 28
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 40,
+        "notused" : 0,
+        "parent" : 28
+      }
+    ],
+    "statement_id" : "c390.northwind.compound.customer-supplier-cities"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "CO-ROUTINE order_subtotals",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH Order Details USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+        "id" : 9,
+        "notused" : 62,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN order_subtotals",
+        "id" : 51,
+        "notused" : 82,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "CO-ROUTINE order_subtotals",
+        "id" : 2,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH Order Details USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+        "id" : 9,
+        "notused" : 62,
+        "parent" : 2
+      },
+      {
+        "detail" : "SCAN order_subtotals",
+        "id" : 51,
+        "notused" : 82,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c390.northwind.cte.order-subtotals"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SEARCH o USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 9,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH c USING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 12,
+        "notused" : 46,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 18,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH d USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+        "id" : 21,
+        "notused" : 62,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH p USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 27,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 44,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "id_renumbering_only",
+    "comparison_rows" : [
+      {
+        "detail" : "SEARCH o USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 12,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH c USING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "id" : 15,
+        "notused" : 46,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 21,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH d USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+        "id" : 24,
+        "notused" : 62,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH p USING INTEGER PRIMARY KEY (rowid=?)",
+        "id" : 30,
+        "notused" : 45,
+        "parent" : 0
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 47,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c390.northwind.join.customer-order-employee-product"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN e",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "id" : 6,
+        "notused" : 45,
+        "parent" : 0
+      }
+    ],
+    "classification" : "identical",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN e",
+        "id" : 4,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "id" : 6,
+        "notused" : 45,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c390.northwind.join.left-null-manager"
+  },
+  {
+    "baseline_rows" : [
+      {
+        "detail" : "SCAN Products",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCALAR SUBQUERY 1",
+        "id" : 8,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN Products",
+        "id" : 13,
+        "notused" : 216,
+        "parent" : 8
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 29,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "classification" : "id_renumbering_only",
+    "comparison_rows" : [
+      {
+        "detail" : "SCAN Products",
+        "id" : 3,
+        "notused" : 216,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCALAR SUBQUERY 1",
+        "id" : 9,
+        "notused" : 0,
+        "parent" : 0
+      },
+      {
+        "detail" : "SCAN Products",
+        "id" : 14,
+        "notused" : 216,
+        "parent" : 9
+      },
+      {
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "id" : 30,
+        "notused" : 0,
+        "parent" : 0
+      }
+    ],
+    "statement_id" : "c390.northwind.subquery.products-above-average"
+  }
+]

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/corpus.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/corpus.json
@@ -1,0 +1,4091 @@
+[
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.ordinary-nullable.except",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"nullable_seed\" AS (SELECT 1 AS \"value\") SELECT \"nullable_rows\".\"value\" AS \"value\" FROM \"nullable_seed\" AS \"nullable_rows\" EXCEPT SELECT NULL AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.ordinary-nullable.intersect",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"nullable_seed\" AS (SELECT 1 AS \"value\") SELECT \"nullable_rows\".\"value\" AS \"value\" FROM \"nullable_seed\" AS \"nullable_rows\" INTERSECT SELECT 1 AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.ordinary-nullable.union",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"nullable_seed\" AS (SELECT 1 AS \"value\") SELECT \"nullable_rows\".\"value\" AS \"value\" FROM \"nullable_seed\" AS \"nullable_rows\" UNION SELECT NULL AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.ordinary-nullable.union-all",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"nullable_seed\" AS (SELECT 1 AS \"value\") SELECT \"nullable_rows\".\"value\" AS \"value\" FROM \"nullable_seed\" AS \"nullable_rows\" UNION ALL SELECT NULL AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.ordinary-required.except",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"required_seed\" AS (SELECT 1 AS \"value\") SELECT \"required_rows\".\"value\" AS \"value\" FROM \"required_seed\" AS \"required_rows\" EXCEPT SELECT 2 AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.ordinary-required.intersect",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"required_seed\" AS (SELECT 1 AS \"value\") SELECT \"required_rows\".\"value\" AS \"value\" FROM \"required_seed\" AS \"required_rows\" INTERSECT SELECT 1 AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.ordinary-required.union",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"required_seed\" AS (SELECT 1 AS \"value\") SELECT \"required_rows\".\"value\" AS \"value\" FROM \"required_seed\" AS \"required_rows\" UNION SELECT 2 AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.ordinary-required.union-all",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"required_seed\" AS (SELECT 1 AS \"value\") SELECT \"required_rows\".\"value\" AS \"value\" FROM \"required_seed\" AS \"required_rows\" UNION ALL SELECT 2 AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.recursive-required.except",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"integer_sequence\" AS (SELECT 1 AS \"value\" UNION ALL SELECT (\"t0\".\"value\" + 1) AS \"value\" FROM \"integer_sequence\" AS \"t0\" WHERE (\"t0\".\"value\" < 3)) SELECT \"recursive_rows\".\"value\" AS \"value\" FROM \"integer_sequence\" AS \"recursive_rows\" EXCEPT SELECT 2 AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.recursive-required.intersect",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"integer_sequence\" AS (SELECT 1 AS \"value\" UNION ALL SELECT (\"t0\".\"value\" + 1) AS \"value\" FROM \"integer_sequence\" AS \"t0\" WHERE (\"t0\".\"value\" < 3)) SELECT \"recursive_rows\".\"value\" AS \"value\" FROM \"integer_sequence\" AS \"recursive_rows\" INTERSECT SELECT 2 AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.recursive-required.union",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"integer_sequence\" AS (SELECT 1 AS \"value\" UNION ALL SELECT (\"t0\".\"value\" + 1) AS \"value\" FROM \"integer_sequence\" AS \"t0\" WHERE (\"t0\".\"value\" < 3)) SELECT \"recursive_rows\".\"value\" AS \"value\" FROM \"integer_sequence\" AS \"recursive_rows\" UNION SELECT 2 AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.cte.recursive-required.union-all",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"integer_sequence\" AS (SELECT 1 AS \"value\" UNION ALL SELECT (\"t0\".\"value\" + 1) AS \"value\" FROM \"integer_sequence\" AS \"t0\" WHERE (\"t0\".\"value\" < 3)) SELECT \"recursive_rows\".\"value\" AS \"value\" FROM \"integer_sequence\" AS \"recursive_rows\" UNION ALL SELECT 2 AS \"value\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "blob"
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.cast-text-blob",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:text_value AS BLOB)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "42"
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.cast-text-integer",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:text_value AS INTEGER)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "integer_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 254
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.comparable-min",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT MIN(:integer_value, 191)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "2026-07-19T12:00:00Z"
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.date-unixepoch",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT unixepoch(:text_value)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_index" : 0,
+        "key_kind" : "indexed",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 191
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.indexed-binding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT ?1",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "[1,2,3]"
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.json-array-length",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT json_array_length(:text_value)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "{\"ok\":true}"
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.json-valid",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT json_valid(:text_value)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "integer_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : -7
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.numeric-abs",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT ABS(:integer_value)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "3.9"
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.numeric-floor",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT FLOOR(:real_value)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "3.14159"
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.numeric-round",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT ROUND(:real_value, 2)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "integer_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.operator-arithmetic-precedence",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT ((:integer_value + 7) * 2)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "ALFKI"
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.operator-glob",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:text_value GLOB 'A*')",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "case"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "integer_value",
+        "logical_index" : 1,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 191
+        }
+      }
+    ],
+    "id" : "c191.v1.expression.string-printf",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT printf('%s-%d', :text_value, :integer_value)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.northwind.compound-customer-supplier-cities",
+    "northwind_anchor_case_ids" : [
+      "northwind.compound.customer-supplier-cities"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"city\" AS \"city\", \"t0\".\"companyName\" AS \"companyName\", \"t0\".\"contactName\" AS \"contactName\", 'Customers' AS \"relationship\" FROM \"Customers\" AS \"t0\" UNION SELECT \"t1\".\"city\" AS \"city\", \"t1\".\"companyName\" AS \"companyName\", \"t1\".\"contactName\" AS \"contactName\", 'Suppliers' AS \"relationship\" FROM \"Suppliers\" AS \"t1\" ORDER BY \"city\" ASC, \"companyName\" ASC, \"relationship\" ASC, \"contactName\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.northwind.cte-order-subtotals",
+    "northwind_anchor_case_ids" : [
+      "northwind.cte.order-subtotals"
+    ],
+    "rendered_sql" : "WITH \"cte0\" AS (SELECT \"t0\".\"orderID\" AS \"orderID\", COALESCE(SUM(((\"t0\".\"unitPrice\" * CAST(\"t0\".\"quantity\" AS REAL)) * (1.0 - \"t0\".\"discount\"))), 0.0) AS \"subtotal\" FROM \"Order Details\" AS \"t0\" GROUP BY \"t0\".\"orderID\") SELECT \"t0\".\"orderID\" AS \"orderID\", \"t0\".\"subtotal\" AS \"subtotal\" FROM \"cte0\" AS \"t0\" WHERE (\"t0\".\"orderID\" == 10248) ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" GROUP BY \"t0\".\"customerID\" HAVING (COUNT(\"t0\".\"orderID\") > 1) ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.g-customer-id.h-count-greater-than-one",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" GROUP BY \"t0\".\"customerID\" HAVING (COUNT(\"t0\".\"orderID\") > 1)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.l-five.x-two",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.deterministic-pagination"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" LIMIT 5 OFFSET 2",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.o-ascending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.o-collated",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.o-descending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.w-empty-in",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" WHERE (\"t0\".\"orderID\" IN ())",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.w-in-list",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.j-cross.w-injection-binding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" WHERE (\"t0\".\"customerID\" == :customer_input)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.w-literal",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" WHERE (\"t0\".\"orderID\" == 10248)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.j-cross.w-named-binding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" WHERE (\"t0\".\"orderID\" >= :minimum_order_id)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.w-null-comparison",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" WHERE (\"t0\".\"shipRegion\" ISNULL)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-cross.w-precedence",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET'))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "repeated_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      }
+    ],
+    "id" : "c191.v1.select.j-cross.w-repeated-binding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\" WHERE ((\"t0\".\"employeeID\" >= :repeated_employee_id) AND (\"t0\".\"employeeID\" <= :repeated_employee_id))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-inner.o-ascending",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\") ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-inner.o-collated",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\") ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-inner.w-empty-in",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\") WHERE (\"t0\".\"orderID\" IN ())",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-inner.w-in-list",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\") WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.j-inner.w-injection-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\") WHERE (\"t0\".\"customerID\" == :customer_input)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-inner.w-literal",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\") WHERE (\"t0\".\"orderID\" == 10248)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.j-inner.w-named-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\") WHERE (\"t0\".\"orderID\" >= :minimum_order_id)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-inner.w-null-comparison",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product",
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\") WHERE (\"t0\".\"shipRegion\" ISNULL)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-inner.w-precedence",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\") WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET'))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-left.o-ascending",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\") ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-left.o-descending",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\") ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-left.w-empty-in",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\") WHERE (\"t0\".\"orderID\" IN ())",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-left.w-in-list",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\") WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.j-left.w-injection-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\") WHERE (\"t0\".\"customerID\" == :customer_input)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-left.w-literal",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\") WHERE (\"t0\".\"orderID\" == 10248)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.j-left.w-named-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\") WHERE (\"t0\".\"orderID\" >= :minimum_order_id)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.j-left.w-precedence",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\") WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET'))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "repeated_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      }
+    ],
+    "id" : "c191.v1.select.j-left.w-repeated-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\") WHERE ((\"t0\".\"employeeID\" >= :repeated_employee_id) AND (\"t0\".\"employeeID\" <= :repeated_employee_id))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.j-cross",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.j-left",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having",
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"t0\".\"employeeID\" IS \"employees_join\".\"employeeID\")",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.o-ascending",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.o-collated",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "repeated_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      }
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.s-subquery-alias.j-inner.w-repeated-binding.g-customer-id.h-count-greater-than-one.o-descending.l-five.x-two",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having",
+      "northwind.join.customer-order-employee-product",
+      "northwind.select.deterministic-pagination"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"orders_case\".\"orderID\") FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"orders_case\".\"customerID\" == \"customers_join\".\"customerID\") WHERE ((\"orders_case\".\"employeeID\" >= :repeated_employee_id) AND (\"orders_case\".\"employeeID\" <= :repeated_employee_id)) GROUP BY \"orders_case\".\"customerID\" HAVING (COUNT(\"orders_case\".\"orderID\") > 1) ORDER BY \"orders_case\".\"orderID\" DESC LIMIT 5 OFFSET 2",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.s-table-alias",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"orders_case\".\"orderID\") FROM \"Orders\" AS \"orders_case\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.w-empty-in",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN ())",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.w-in-list",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.w-injection-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"customerID\" == :customer_input)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.w-literal",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" == 10248)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.w-named-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" >= :minimum_order_id)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.w-null-comparison",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having",
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"shipRegion\" ISNULL)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-aggregate-count.w-precedence",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT COUNT(\"t0\".\"orderID\") FROM \"Orders\" AS \"t0\" WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET'))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.j-cross",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" CROSS JOIN \"Customers\" AS \"customers_cross\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.j-inner",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product",
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"t0\".\"customerID\" == \"customers_join\".\"customerID\")",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.o-ascending",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.o-descending",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.s-subquery-alias",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"shipRegion\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having",
+      "northwind.join.left-null-manager",
+      "northwind.select.deterministic-pagination",
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"shipRegion\" FROM \"Orders\" AS \"orders_case\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"orders_case\".\"employeeID\" IS \"employees_join\".\"employeeID\") WHERE (\"orders_case\".\"shipRegion\" ISNULL) GROUP BY \"orders_case\".\"customerID\" HAVING (COUNT(\"orders_case\".\"orderID\") > 1) ORDER BY (\"orders_case\".\"customerID\" COLLATE NOCASE) ASC LIMIT 5 OFFSET 2",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.w-empty-in",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN ())",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.w-in-list",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.p-nullable-region.w-injection-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"customerID\" == :customer_input)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.w-literal",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" == 10248)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.p-nullable-region.w-named-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" >= :minimum_order_id)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.p-nullable-region.w-precedence",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET'))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "repeated_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      }
+    ],
+    "id" : "c191.v1.select.p-nullable-region.w-repeated-binding",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"shipRegion\" FROM \"Orders\" AS \"t0\" WHERE ((\"t0\".\"employeeID\" >= :repeated_employee_id) AND (\"t0\".\"employeeID\" <= :repeated_employee_id))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.j-cross",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" CROSS JOIN \"Customers\" AS \"customers_cross\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.j-left",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" LEFT JOIN \"Employees\" AS \"employees_join\" ON (\"orders_case\".\"employeeID\" IS \"employees_join\".\"employeeID\")",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.o-ascending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" ORDER BY \"orders_case\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.o-collated",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" ORDER BY (\"orders_case\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.w-empty-in",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" WHERE (\"orders_case\".\"orderID\" IN ())",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.w-in-list",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" WHERE (\"orders_case\".\"orderID\" IN (10248, 10249, 10250))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.w-injection-binding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" WHERE (\"orders_case\".\"customerID\" == :customer_input)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.w-literal",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" WHERE (\"orders_case\".\"orderID\" == 10248)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.w-named-binding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" WHERE (\"orders_case\".\"orderID\" >= :minimum_order_id)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.w-null-comparison",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" WHERE (\"orders_case\".\"shipRegion\" ISNULL)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-subquery-alias.w-precedence",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM (SELECT \"source_orders\".\"orderID\" AS \"orderID\", \"source_orders\".\"customerID\" AS \"customerID\", \"source_orders\".\"employeeID\" AS \"employeeID\", \"source_orders\".\"shippedDate\" AS \"shippedDate\", \"source_orders\".\"shipRegion\" AS \"shipRegion\" FROM \"Orders\" AS \"source_orders\") AS \"orders_case\" WHERE (((\"orders_case\".\"orderID\" > 10248) AND (\"orders_case\".\"employeeID\" == 1)) OR (\"orders_case\".\"customerID\" == 'VINET'))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-table-alias.j-cross",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" CROSS JOIN \"Customers\" AS \"customers_cross\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-table-alias.j-inner",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" INNER JOIN \"Customers\" AS \"customers_join\" ON (\"orders_case\".\"customerID\" == \"customers_join\".\"customerID\")",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-table-alias.o-ascending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" ORDER BY \"orders_case\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-table-alias.o-descending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" ORDER BY \"orders_case\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-table-alias.w-empty-in",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" WHERE (\"orders_case\".\"orderID\" IN ())",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-table-alias.w-in-list",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" WHERE (\"orders_case\".\"orderID\" IN (10248, 10249, 10250))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.s-table-alias.w-injection-binding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" WHERE (\"orders_case\".\"customerID\" == :customer_input)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-table-alias.w-literal",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" WHERE (\"orders_case\".\"orderID\" == 10248)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.s-table-alias.w-named-binding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" WHERE (\"orders_case\".\"orderID\" >= :minimum_order_id)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.s-table-alias.w-precedence",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" WHERE (((\"orders_case\".\"orderID\" > 10248) AND (\"orders_case\".\"employeeID\" == 1)) OR (\"orders_case\".\"customerID\" == 'VINET'))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "repeated_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      }
+    ],
+    "id" : "c191.v1.select.s-table-alias.w-repeated-binding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"orders_case\".\"orderID\" FROM \"Orders\" AS \"orders_case\" WHERE ((\"orders_case\".\"employeeID\" >= :repeated_employee_id) AND (\"orders_case\".\"employeeID\" <= :repeated_employee_id))",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-empty-in.g-customer-id.h-count-greater-than-one",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN ()) GROUP BY \"t0\".\"customerID\" HAVING (COUNT(\"t0\".\"orderID\") > 1)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-empty-in.l-five.x-two",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.deterministic-pagination"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN ()) LIMIT 5 OFFSET 2",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-empty-in.o-ascending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN ()) ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-empty-in.o-collated",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN ()) ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-empty-in.o-descending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN ()) ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-in-list.g-customer-id.h-count-greater-than-one",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250)) GROUP BY \"t0\".\"customerID\" HAVING (COUNT(\"t0\".\"orderID\") > 1)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-in-list.l-five.x-two",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.deterministic-pagination"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250)) LIMIT 5 OFFSET 2",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-in-list.o-ascending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250)) ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-in-list.o-collated",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250)) ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-in-list.o-descending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" IN (10248, 10249, 10250)) ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"customerID\" == :customer_input) GROUP BY \"t0\".\"customerID\" HAVING (COUNT(\"t0\".\"orderID\") > 1)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-injection-binding.l-five.x-two",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.deterministic-pagination"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"customerID\" == :customer_input) LIMIT 5 OFFSET 2",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-injection-binding.o-ascending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"customerID\" == :customer_input) ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-injection-binding.o-collated",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"customerID\" == :customer_input) ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "customer_input",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET' OR 1=1 --"
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-injection-binding.o-descending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"customerID\" == :customer_input) ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-literal.g-customer-id.h-count-greater-than-one",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" == 10248) GROUP BY \"t0\".\"customerID\" HAVING (COUNT(\"t0\".\"orderID\") > 1)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-literal.l-five.x-two",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.deterministic-pagination"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" == 10248) LIMIT 5 OFFSET 2",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-literal.o-ascending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" == 10248) ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-literal.o-collated",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" == 10248) ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-literal.o-descending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" == 10248) ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-named-binding.g-customer-id.h-count-greater-than-one",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" >= :minimum_order_id) GROUP BY \"t0\".\"customerID\" HAVING (COUNT(\"t0\".\"orderID\") > 1)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-named-binding.g-customer-id.o-ascending.l-five.x-two",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having",
+      "northwind.select.deterministic-pagination"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" >= :minimum_order_id) GROUP BY \"t0\".\"customerID\" ORDER BY \"t0\".\"orderID\" ASC LIMIT 5 OFFSET 2",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-named-binding.o-collated",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" >= :minimum_order_id) ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "minimum_order_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-named-binding.o-descending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"orderID\" >= :minimum_order_id) ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-null-comparison.o-ascending",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"shipRegion\" ISNULL) ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-null-comparison.o-descending",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.nullable-shipping"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"shipRegion\" ISNULL) ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-precedence.g-customer-id.h-count-greater-than-one",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET')) GROUP BY \"t0\".\"customerID\" HAVING (COUNT(\"t0\".\"orderID\") > 1)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-precedence.l-five",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET')) LIMIT 5",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-precedence.l-five.x-two",
+    "northwind_anchor_case_ids" : [
+      "northwind.select.deterministic-pagination"
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET')) LIMIT 5 OFFSET 2",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-precedence.o-ascending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET')) ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-precedence.o-collated",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET')) ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c191.v1.select.w-precedence.o-descending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (((\"t0\".\"orderID\" > 10248) AND (\"t0\".\"employeeID\" == 1)) OR (\"t0\".\"customerID\" == 'VINET')) ORDER BY \"t0\".\"orderID\" DESC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "repeated_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-repeated-binding.o-ascending",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE ((\"t0\".\"employeeID\" >= :repeated_employee_id) AND (\"t0\".\"employeeID\" <= :repeated_employee_id)) ORDER BY \"t0\".\"orderID\" ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "repeated_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      }
+    ],
+    "id" : "c191.v1.select.w-repeated-binding.o-collated",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE ((\"t0\".\"employeeID\" >= :repeated_employee_id) AND (\"t0\".\"employeeID\" <= :repeated_employee_id)) ORDER BY (\"t0\".\"customerID\" COLLATE NOCASE) ASC",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c286.v1.expression.aggregate-average-distinct",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT AVG(DISTINCT CAST(\"t0\".\"employeeID\" AS REAL)) FROM \"Orders\" AS \"t0\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c286.v1.expression.aggregate-count-distinct",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT COUNT(DISTINCT \"t0\".\"employeeID\") FROM \"Orders\" AS \"t0\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c286.v1.expression.aggregate-group-concat-distinct",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT GROUP_CONCAT(DISTINCT \"t0\".\"customerID\") FROM \"Orders\" AS \"t0\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c286.v1.expression.aggregate-max-distinct",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT MAX(DISTINCT \"t0\".\"employeeID\") FROM \"Orders\" AS \"t0\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c286.v1.expression.aggregate-min-distinct",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT MIN(DISTINCT \"t0\".\"employeeID\") FROM \"Orders\" AS \"t0\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c286.v1.expression.aggregate-sum-distinct",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT SUM(DISTINCT \"t0\".\"employeeID\") FROM \"Orders\" AS \"t0\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "blob_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "blob",
+        "tagged_value" : {
+          "tag" : "blob",
+          "value" : "626c6f62"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-blob-text",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:blob_value AS TEXT)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "boolean_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 1
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-bool-integer",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT :boolean_value",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "integer_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 42
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-integer-real",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:integer_value AS REAL)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "integer_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 42
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-integer-text",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:integer_value AS TEXT)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_blob_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-optional-blob-text",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:optional_blob_value AS TEXT)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_boolean_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-optional-bool-integer",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT :optional_boolean_value",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_integer_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-optional-integer-real",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:optional_integer_value AS REAL)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_integer_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-optional-integer-text",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:optional_integer_value AS TEXT)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_real_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-optional-real-integer",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:optional_real_value AS INTEGER)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_real_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-optional-real-text",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:optional_real_value AS TEXT)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-optional-text-blob",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:optional_text_value AS BLOB)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-optional-text-integer",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:optional_text_value AS INTEGER)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-optional-text-real",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:optional_text_value AS REAL)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "42.75"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-real-integer",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:real_value AS INTEGER)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "42.5"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-real-text",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:real_value AS TEXT)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "42.5"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.cast-text-real",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT CAST(:text_value AS REAL)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "integer_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 254
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.comparable-max",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT MAX(:integer_value, 191)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "{\"items\":[1,2,3]}"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.json-array-length-path",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT json_array_length(:text_value, '$.items')",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "3.6"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.numeric-round-no-places",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT ROUND(:real_value)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "optional_real_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.numeric-round-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT ROUND(:optional_real_value)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_value",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "case"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "integer_value",
+        "logical_index" : 1,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 286
+        }
+      }
+    ],
+    "id" : "c286.v1.expression.string-printf-array",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT printf('%s-%d', :text_value, :integer_value)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "bool_true",
+        "logical_index" : 0,
+        "repeat_count" : 3,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 1
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "bool_false",
+        "logical_index" : 1,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 0
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "bool_null",
+        "logical_index" : 2,
+        "repeat_count" : 5,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.boolean-and-shapes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:bool_true AND :bool_false) AS \"required\", (:bool_true AND :bool_null) AS \"rightOptional\", (:bool_null AND :bool_true) AS \"leftOptional\", (:bool_null AND :bool_null) AS \"bothOptional\", (:bool_null AND :bool_false) AS \"shortCircuit\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "bool_true",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 1
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "bool_null",
+        "logical_index" : 1,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.boolean-not-shapes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (NOT :bool_true) AS \"required\", (NOT :bool_null) AS \"optional\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "bool_true",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 1
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "bool_false",
+        "logical_index" : 1,
+        "repeat_count" : 3,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 0
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "bool_null",
+        "logical_index" : 2,
+        "repeat_count" : 5,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.boolean-or-shapes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:bool_true OR :bool_false) AS \"required\", (:bool_true OR :bool_null) AS \"rightOptional\", (:bool_null OR :bool_false) AS \"leftOptional\", (:bool_null OR :bool_null) AS \"bothOptional\", (:bool_false OR :bool_null) AS \"shortCircuit\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_null",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_seven",
+        "logical_index" : 1,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "real_null",
+        "logical_index" : 2,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_null",
+        "logical_index" : 3,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.coalesce-storage-classes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT COALESCE(:int_null, 0) AS \"integerFallback\", COALESCE(:int_optional_seven, 0) AS \"integerPresent\", COALESCE(:real_null, 1.5) AS \"realFallback\", COALESCE(:text_null, 'fallback') AS \"textFallback\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_null",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.coalescing-operator",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT COALESCE(:int_null, 42)",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional",
+        "logical_index" : 0,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_b",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_null",
+        "logical_index" : 2,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.comparison-both-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_optional < :int_optional_b) AS \"less\", (:int_optional <= :int_optional_b) AS \"lessOrEqual\", (:int_optional > :int_optional_b) AS \"greater\", (:int_optional >= :int_optional_b) AS \"greaterOrEqual\", (:int_optional > :int_null) AS \"nullOperand\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional",
+        "logical_index" : 0,
+        "repeat_count" : 4,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_right",
+        "logical_index" : 1,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_null",
+        "logical_index" : 2,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.comparison-left-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_optional < :int_right) AS \"less\", (:int_optional <= :int_right) AS \"lessOrEqual\", (:int_optional > :int_right) AS \"greater\", (:int_optional >= :int_right) AS \"greaterOrEqual\", (:int_null > :int_right) AS \"nullOperand\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_left",
+        "logical_index" : 0,
+        "repeat_count" : 4,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_right",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.comparison-required",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_left < :int_right) AS \"less\", (:int_left <= :int_right) AS \"lessOrEqual\", (:int_left > :int_right) AS \"greater\", (:int_left >= :int_right) AS \"greaterOrEqual\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_left",
+        "logical_index" : 0,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_null",
+        "logical_index" : 2,
+        "repeat_count" : 1,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.comparison-right-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_left < :int_optional) AS \"less\", (:int_left <= :int_optional) AS \"lessOrEqual\", (:int_left > :int_optional) AS \"greater\", (:int_left >= :int_optional) AS \"greaterOrEqual\", (:int_left > :int_null) AS \"nullOperand\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_left",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional",
+        "logical_index" : 1,
+        "repeat_count" : 3,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_right",
+        "logical_index" : 2,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_b",
+        "logical_index" : 3,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_null",
+        "logical_index" : 4,
+        "repeat_count" : 3,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.equality-optional-shapes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_left IS :int_optional) AS \"rightOptional\", (:int_optional IS :int_right) AS \"leftOptional\", (:int_optional IS :int_optional_b) AS \"bothOptional\", (:int_left IS :int_null) AS \"nullOperand\", (:int_null IS :int_null) AS \"bothNull\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_left",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_right",
+        "logical_index" : 1,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_left",
+        "logical_index" : 2,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.equality-required",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_left == :int_right) AS \"integerEqual\", (:int_left != :int_right) AS \"integerNotEqual\", (:text_left == :text_left) AS \"textEqual\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_left",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional",
+        "logical_index" : 1,
+        "repeat_count" : 3,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_right",
+        "logical_index" : 2,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_b",
+        "logical_index" : 3,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_null",
+        "logical_index" : 4,
+        "repeat_count" : 3,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.inequality-optional-shapes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_left IS NOT :int_optional) AS \"rightOptional\", (:int_optional IS NOT :int_right) AS \"leftOptional\", (:int_optional IS NOT :int_optional_b) AS \"bothOptional\", (:int_left IS NOT :int_null) AS \"nullOperand\", (:int_null IS NOT :int_null) AS \"bothNull\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_seven",
+        "logical_index" : 0,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_two",
+        "logical_index" : 1,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 2
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.integer-arithmetic-both-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_optional_seven + :int_optional_two) AS \"add\", (:int_optional_seven - :int_optional_two) AS \"subtract\", (:int_optional_seven * :int_optional_two) AS \"multiply\", (:int_optional_seven / :int_optional_two) AS \"divide\", (:int_optional_seven % :int_optional_two) AS \"modulo\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_seven",
+        "logical_index" : 0,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_two",
+        "logical_index" : 1,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 2
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.integer-arithmetic-left-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_optional_seven + :int_two) AS \"add\", (:int_optional_seven - :int_two) AS \"subtract\", (:int_optional_seven * :int_two) AS \"multiply\", (:int_optional_seven / :int_two) AS \"divide\", (:int_optional_seven % :int_two) AS \"modulo\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_seven",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_null",
+        "logical_index" : 1,
+        "repeat_count" : 5,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_two",
+        "logical_index" : 2,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 2
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_seven",
+        "logical_index" : 3,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.integer-arithmetic-null-propagation",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_seven + :int_null) AS \"add\", (:int_null - :int_two) AS \"subtract\", (:int_optional_seven * :int_null) AS \"multiply\", (:int_seven / :int_null) AS \"divide\", (:int_null % :int_two) AS \"modulo\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_seven",
+        "logical_index" : 0,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_two",
+        "logical_index" : 1,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 2
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.integer-arithmetic-required",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_seven + :int_two) AS \"add\", (:int_seven - :int_two) AS \"subtract\", (:int_seven * :int_two) AS \"multiply\", (:int_seven / :int_two) AS \"divide\", (:int_seven % :int_two) AS \"modulo\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_seven",
+        "logical_index" : 0,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_two",
+        "logical_index" : 1,
+        "repeat_count" : 5,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 2
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.integer-arithmetic-right-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_seven + :int_optional_two) AS \"add\", (:int_seven - :int_optional_two) AS \"subtract\", (:int_seven * :int_optional_two) AS \"multiply\", (:int_seven / :int_optional_two) AS \"divide\", (:int_seven % :int_optional_two) AS \"modulo\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_seven",
+        "logical_index" : 0,
+        "repeat_count" : 4,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_two",
+        "logical_index" : 1,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 2
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_negative_seven",
+        "logical_index" : 2,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : -7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_three",
+        "logical_index" : 3,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 3
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_negative_three",
+        "logical_index" : 4,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : -3
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.integer-division-boundaries",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_seven / :int_two) AS \"truncation\", (:int_negative_seven / :int_two) AS \"negativeTruncation\", (:int_seven / 0) AS \"divideByZero\", (:int_seven % 0) AS \"moduloByZero\", (:int_negative_seven % :int_three) AS \"negativeDividendModulo\", (:int_seven % :int_negative_three) AS \"negativeDivisorModulo\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_null",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_seven",
+        "logical_index" : 1,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_seven",
+        "logical_index" : 2,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.optional-predicates",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:int_null ISNULL) AS \"isNullOnNull\", (:int_optional_seven ISNULL) AS \"isNullOnValue\", (:int_null NOTNULL) AS \"notNullOnNull\", (:int_optional_seven NOTNULL) AS \"notNullOnValue\", :int_seven AS \"widened\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_optional_seven",
+        "logical_index" : 0,
+        "repeat_count" : 4,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "7.0"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "real_optional_two",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "2.0"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.real-arithmetic-both-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:real_optional_seven + :real_optional_two) AS \"add\", (:real_optional_seven - :real_optional_two) AS \"subtract\", (:real_optional_seven * :real_optional_two) AS \"multiply\", (:real_optional_seven / :real_optional_two) AS \"divide\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_optional_seven",
+        "logical_index" : 0,
+        "repeat_count" : 4,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "7.0"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "real_two",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "2.0"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.real-arithmetic-left-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:real_optional_seven + :real_two) AS \"add\", (:real_optional_seven - :real_two) AS \"subtract\", (:real_optional_seven * :real_two) AS \"multiply\", (:real_optional_seven / :real_two) AS \"divide\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_seven",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "7.0"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "real_null",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "real_two",
+        "logical_index" : 2,
+        "repeat_count" : 1,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "2.0"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "real_optional_seven",
+        "logical_index" : 3,
+        "repeat_count" : 1,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "7.0"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.real-arithmetic-null-propagation",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:real_seven + :real_null) AS \"add\", (:real_null - :real_two) AS \"subtract\", (:real_optional_seven * :real_null) AS \"multiply\", (:real_seven / :real_null) AS \"divide\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_seven",
+        "logical_index" : 0,
+        "repeat_count" : 4,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "7.0"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "real_two",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "2.0"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.real-arithmetic-required",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:real_seven + :real_two) AS \"add\", (:real_seven - :real_two) AS \"subtract\", (:real_seven * :real_two) AS \"multiply\", (:real_seven / :real_two) AS \"divide\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_seven",
+        "logical_index" : 0,
+        "repeat_count" : 4,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "7.0"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "real_optional_two",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "2.0"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.real-arithmetic-right-optional",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:real_seven + :real_optional_two) AS \"add\", (:real_seven - :real_optional_two) AS \"subtract\", (:real_seven * :real_optional_two) AS \"multiply\", (:real_seven / :real_optional_two) AS \"divide\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "real_seven",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "7.0"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "real_two",
+        "logical_index" : 1,
+        "repeat_count" : 1,
+        "storage" : "real",
+        "tagged_value" : {
+          "tag" : "real",
+          "value" : "2.0"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.real-division-boundaries",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:real_seven / :real_two) AS \"exactHalf\", (:real_seven / 0.0) AS \"divideByZero\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_alfa",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_beta",
+        "logical_index" : 1,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "beta"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_null",
+        "logical_index" : 2,
+        "repeat_count" : 4,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.text-concatenation-null",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:text_alfa || :text_beta) AS \"required\", (:text_alfa || :text_null) AS \"rightOptional\", (:text_null || :text_beta) AS \"leftOptional\", (:text_null || :text_null) AS \"bothOptional\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_alfa",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_beta",
+        "logical_index" : 1,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "beta"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_optional_beta",
+        "logical_index" : 2,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "beta"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_optional_alfa",
+        "logical_index" : 3,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.text-concatenation-shapes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:text_alfa || :text_beta) AS \"required\", (:text_alfa || :text_optional_beta) AS \"rightOptional\", (:text_optional_alfa || :text_beta) AS \"leftOptional\", (:text_optional_alfa || :text_optional_beta) AS \"bothOptional\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_alfa",
+        "logical_index" : 0,
+        "repeat_count" : 3,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.text-glob-case-sensitivity",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:text_alfa GLOB 'a*') AS \"lowercasePattern\", (:text_alfa GLOB 'A*') AS \"uppercasePattern\", (:text_alfa GLOB '?lfa') AS \"singleCharacterWildcard\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_alfa",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_null",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.text-glob-null-propagation",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:text_alfa GLOB 'a*') AS \"required\", (:text_alfa GLOB :text_null) AS \"rightOptional\", (:text_null GLOB 'a*') AS \"leftOptional\", (:text_null GLOB :text_null) AS \"bothOptional\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_alfa",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_optional_beta",
+        "logical_index" : 1,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "beta"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_optional_alfa",
+        "logical_index" : 2,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.text-glob-shapes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:text_alfa GLOB 'a*') AS \"required\", (:text_alfa GLOB :text_optional_beta) AS \"rightOptional\", (:text_optional_alfa GLOB 'a*') AS \"leftOptional\", (:text_optional_alfa GLOB :text_optional_beta) AS \"bothOptional\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_alfa",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_upper",
+        "logical_index" : 1,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "ALFA"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_accented",
+        "logical_index" : 2,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "Ä"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.text-like-ascii-case-folding",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:text_alfa LIKE 'A%') AS \"asciiLower\", (:text_upper LIKE 'a%') AS \"asciiUpper\", (:text_accented LIKE 'ä') AS \"nonASCII\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_alfa",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_null",
+        "logical_index" : 1,
+        "repeat_count" : 4,
+        "storage" : "null",
+        "tagged_value" : {
+          "tag" : "null"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.text-like-null-propagation",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:text_alfa LIKE 'a%') AS \"required\", (:text_alfa LIKE :text_null) AS \"rightOptional\", (:text_null LIKE 'a%') AS \"leftOptional\", (:text_null LIKE :text_null) AS \"bothOptional\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "text_alfa",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_optional_beta",
+        "logical_index" : 1,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "beta"
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "text_optional_alfa",
+        "logical_index" : 2,
+        "repeat_count" : 2,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "alfa"
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.text-like-shapes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT (:text_alfa LIKE 'a%') AS \"required\", (:text_alfa LIKE :text_optional_beta) AS \"rightOptional\", (:text_optional_alfa LIKE 'a%') AS \"leftOptional\", (:text_optional_alfa LIKE :text_optional_beta) AS \"bothOptional\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_seven",
+        "logical_index" : 0,
+        "repeat_count" : 2,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_two",
+        "logical_index" : 1,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 2
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.unary-nesting",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT -(-(:int_seven)) AS \"doubleNegation\", -((:int_seven + :int_two)) AS \"negatedSum\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "int_seven",
+        "logical_index" : 0,
+        "repeat_count" : 3,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      },
+      {
+        "key_kind" : "named",
+        "key_name" : "int_optional_seven",
+        "logical_index" : 1,
+        "repeat_count" : 3,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 7
+        }
+      }
+    ],
+    "id" : "c287.v1.expression.unary-shapes",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT ~(:int_seven) AS \"bitwiseNot\", ~(:int_optional_seven) AS \"optionalBitwiseNot\", +(:int_seven) AS \"unaryPlus\", +(:int_optional_seven) AS \"optionalUnaryPlus\", -(:int_seven) AS \"unaryMinus\", -(:int_optional_seven) AS \"optionalUnaryMinus\"",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "in_subquery_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : -1
+        }
+      }
+    ],
+    "id" : "c288.v1.subquery.in-query-builder-empty",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"employeeID\" IN (SELECT \"t0\".\"employeeID\" FROM \"Employees\" AS \"t0\" WHERE (\"t0\".\"employeeID\" == :in_subquery_employee_id))) ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "in_subquery_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 5
+        }
+      }
+    ],
+    "id" : "c288.v1.subquery.in-query-builder-nonempty",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"employeeID\" IN (SELECT \"t0\".\"employeeID\" FROM \"Employees\" AS \"t0\" WHERE (\"t0\".\"employeeID\" == :in_subquery_employee_id))) ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "in_subquery_customer_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "text",
+        "tagged_value" : {
+          "tag" : "text",
+          "value" : "VINET"
+        }
+      }
+    ],
+    "id" : "c288.v1.subquery.in-query-functional-nonempty",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"customerID\" IN (SELECT \"t1\".\"customerID\" FROM \"Customers\" AS \"t1\" WHERE (\"t1\".\"customerID\" == :in_subquery_customer_id))) ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "in_table_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : -1
+        }
+      }
+    ],
+    "id" : "c288.v1.subquery.in-table-empty",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"cte0\" AS (SELECT \"t0\".\"employeeID\" AS \"employeeID\" FROM \"Employees\" AS \"t0\" WHERE (\"t0\".\"employeeID\" == :in_table_employee_id)) SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"employeeID\" IN \"cte0\") ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+      {
+        "key_kind" : "named",
+        "key_name" : "in_table_employee_id",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 4
+        }
+      }
+    ],
+    "id" : "c288.v1.subquery.in-table-nonempty",
+    "northwind_anchor_case_ids" : [
+
+    ],
+    "rendered_sql" : "WITH \"cte0\" AS (SELECT \"t0\".\"employeeID\" AS \"employeeID\" FROM \"Employees\" AS \"t0\" WHERE (\"t0\".\"employeeID\" == :in_table_employee_id)) SELECT \"t0\".\"orderID\" FROM \"Orders\" AS \"t0\" WHERE (\"t0\".\"employeeID\" IN \"cte0\") ORDER BY \"t0\".\"orderID\" ASC LIMIT 5",
+    "source" : "combinatorial"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c390.northwind.aggregate.grouped-having",
+    "northwind_anchor_case_ids" : [
+      "northwind.aggregate.grouped-having"
+    ],
+    "rendered_sql" : "SELECT CustomerID AS customerID, COUNT(OrderID) AS orderCount\nFROM Orders\nGROUP BY CustomerID\nHAVING COUNT(OrderID) >= 10\nORDER BY orderCount DESC, customerID ASC",
+    "source" : "northwind_anchor"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c390.northwind.compound.customer-supplier-cities",
+    "northwind_anchor_case_ids" : [
+      "northwind.compound.customer-supplier-cities"
+    ],
+    "rendered_sql" : "SELECT City AS city, CompanyName AS companyName,\n       ContactName AS contactName, 'Customers' AS relationship\nFROM Customers\nUNION\nSELECT City AS city, CompanyName AS companyName,\n       ContactName AS contactName, 'Suppliers' AS relationship\nFROM Suppliers\nORDER BY city, companyName, relationship, contactName",
+    "source" : "northwind_anchor"
+  },
+  {
+    "bindings" : [
+      {
+        "key_index" : 1,
+        "key_kind" : "indexed",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c390.northwind.cte.order-subtotals",
+    "northwind_anchor_case_ids" : [
+      "northwind.cte.order-subtotals"
+    ],
+    "rendered_sql" : "WITH order_subtotals AS (\n    SELECT OrderID AS orderID,\n           SUM(UnitPrice * Quantity * (1.0 - Discount)) AS subtotal\n    FROM \"Order Details\"\n    GROUP BY OrderID\n)\nSELECT orderID, subtotal\nFROM order_subtotals\nWHERE orderID = ?\nORDER BY orderID",
+    "source" : "northwind_anchor"
+  },
+  {
+    "bindings" : [
+      {
+        "key_index" : 1,
+        "key_kind" : "indexed",
+        "logical_index" : 0,
+        "repeat_count" : 1,
+        "storage" : "integer",
+        "tagged_value" : {
+          "tag" : "integer",
+          "value" : 10248
+        }
+      }
+    ],
+    "id" : "c390.northwind.join.customer-order-employee-product",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.customer-order-employee-product"
+    ],
+    "rendered_sql" : "SELECT o.OrderID AS orderID, c.CustomerID AS customerID,\n       c.CompanyName AS companyName, e.EmployeeID AS employeeID,\n       e.LastName AS employeeLastName, p.ProductID AS productID,\n       p.ProductName AS productName, d.UnitPrice AS unitPrice,\n       d.Quantity AS quantity, d.Discount AS discount\nFROM Orders AS o\nJOIN Customers AS c ON c.CustomerID = o.CustomerID\nJOIN Employees AS e ON e.EmployeeID = o.EmployeeID\nJOIN \"Order Details\" AS d ON d.OrderID = o.OrderID\nJOIN Products AS p ON p.ProductID = d.ProductID\nWHERE o.OrderID = ?\nORDER BY p.ProductID",
+    "source" : "northwind_anchor"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c390.northwind.join.left-null-manager",
+    "northwind_anchor_case_ids" : [
+      "northwind.join.left-null-manager"
+    ],
+    "rendered_sql" : "SELECT e.EmployeeID AS employeeID,\n       e.LastName AS employeeLastName,\n       m.EmployeeID AS managerID,\n       m.LastName AS managerLastName\nFROM Employees AS e\nLEFT JOIN Employees AS m ON e.ReportsTo = m.EmployeeID\nORDER BY e.EmployeeID",
+    "source" : "northwind_anchor"
+  },
+  {
+    "bindings" : [
+
+    ],
+    "id" : "c390.northwind.subquery.products-above-average",
+    "northwind_anchor_case_ids" : [
+      "northwind.subquery.products-above-average"
+    ],
+    "rendered_sql" : "SELECT ProductID AS productID, ProductName AS productName,\n       UnitPrice AS unitPrice\nFROM Products\nWHERE UnitPrice > (SELECT AVG(UnitPrice) FROM Products)\nORDER BY UnitPrice DESC, ProductID ASC",
+    "source" : "northwind_anchor"
+  }
+]

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/corpus.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/corpus.json
@@ -4027,7 +4027,7 @@
   {
     "bindings" : [
       {
-        "key_index" : 1,
+        "key_index" : 0,
         "key_kind" : "indexed",
         "logical_index" : 0,
         "repeat_count" : 1,
@@ -4048,7 +4048,7 @@
   {
     "bindings" : [
       {
-        "key_index" : 1,
+        "key_index" : 0,
         "key_kind" : "indexed",
         "logical_index" : 0,
         "repeat_count" : 1,


### PR DESCRIPTION
Closes #390.

## Summary

- Adds a package-private research target, `SwiftQLSQLiteEQPVariancePrototype` (research-only, no public API / report schema / build-plugin changes, per this issue's hard constraints).
- Assembles a 214-statement corpus: all 208 cases from the #191 combinatorial manifest (reused unmodified) plus 6 hand-authored Northwind join/left-join/GROUP BY-HAVING/subquery/UNION/CTE anchor statements cribbed from `NorthwindSemanticCorpusTests`, each tagged with its `SQLiteNorthwindConformanceCaseID`.
- Captures raw `EXPLAIN QUERY PLAN` rows (`id`, `parent`, `notused`, `detail`) plus #132's runtime-provenance capture (`SQLiteBuildValidationRuntime`) for every statement, via two independent capture methods:
  - In-process, Swift/GRDB (`swift run SwiftQLSQLiteEQPVarianceCLI capture ...`) — whatever SQLite this repo's toolchain links.
  - Out-of-process, a Python script (`Research/SQLiteBuildValidation/Scripts/capture_eqp.py`) — a second, genuinely distinct installed SQLite build, without vendoring a custom SQLite into the package.
- Classifies the difference between two capture runs (`EQPVarianceClassifier`) into named axes, always renumbering `id`/`parent` to emission order first (see Finding 1 below).

## Evidence

Captured and classified two real SQLite builds against the pinned Northwind snapshot: this host's system libsqlite3 (3.51.0) and a separate Homebrew install (3.53.2). Of 214 statements:
- **203 identical**, including `id`/`parent`.
- **2 identical in structure**, but with EQP row ids offset by a constant → **`id`/`parent` is not a stable identifier across SQLite versions**, even for an otherwise-unchanged plan.
- **9 (all CTE × UNION/EXCEPT/INTERSECT cases) show a real materialization-strategy change** — 3.51.0's `COMPOUND QUERY`/`LEFT-MOST SUBQUERY` execution vs. 3.53.2's `MERGE (...)`/`LEFT`/`RIGHT` execution for the same query.
- Chosen index, join order, and access method were stable across this pair for every non-compound statement.

Full write-up, evidence tables, and recommendation: [`Documentation/Architecture/SQLiteEQPVariance.md`](../blob/claude/issue-390-eqp-determinism/Documentation/Architecture/SQLiteEQPVariance.md).

Honestly out of scope for this pass (not interpolated): the CI matrix's Linux custom-built SQLite 3.53.3 and the Xcode 16.2/16.4/26.3/26.5-bundled SQLite versions. The capture CLI is self-contained and already runnable unchanged inside any of those CI legs; wiring an actual CI capture step is left as follow-up for #393 to schedule.

## Test plan

- [x] `swift build` — full package builds clean.
- [x] `swift test` — full suite (822 tests) passes, including 16 new tests for the corpus, capture, and classifier.
- [x] Verified the pinned Northwind snapshot's SHA-256 is unchanged after every capture run (also asserted by `testCaptureNeverMutatesThePinnedNorthwindSnapshot`).
- [x] Cross-validated the Python runtime-metadata port against the Swift capture: both produce the identical schema fingerprint (`e2c8fadbd38c2313`) against copies of the same pinned file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
