### PR TITLE
Infer Setting's Row from the table reference (#96)

### DIFF
--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -265,7 +265,20 @@ public struct Setting<Row>: XLEncodable {
         values(&meta)
         self.values = meta
     }
-    
+
+    /// Infers `Row` from the table reference passed to the enclosing
+    /// `Update(_:)`, instead of restating it as an explicit generic
+    /// argument (`Setting<Row>`). Swift cannot infer `Row` from the closure
+    /// alone here — `Row.MetaUpdate` is a dependent associated type, and a
+    /// `Setting { ... }` statement is type-checked before `Update(_:)`'s own
+    /// `Row` can flow across a result-builder statement boundary — so the
+    /// table reference stands in as the concrete witness.
+    public init<T>(_ table: T, _ values: (inout Row.MetaUpdate) -> Void) where T: XLMetaWritableTable, T.Row == Row, Row: XLTable {
+        var meta = Row.MetaUpdate()
+        values(&meta)
+        self.values = meta
+    }
+
     public init<S>(_ values: S) where S: XLMetaUpdate, S.Row == Row {
         self.values = values
     }

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -276,6 +276,7 @@ public struct Setting<Row>: XLEncodable {
     /// `table` is the same reference passed to the enclosing `Update(_:)`,
     /// though callers typically pass the same one.
     public init<T>(_ table: T, _ values: (inout Row.MetaUpdate) -> Void) where T: XLMetaWritableTable, T.Row == Row, Row: XLTable {
+        _ = table // Only a type witness for inferring Row; never read.
         var meta = Row.MetaUpdate()
         values(&meta)
         self.values = meta

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -277,9 +277,7 @@ public struct Setting<Row>: XLEncodable {
     /// though callers typically pass the same one.
     public init<T>(_ table: T, _ values: (inout Row.MetaUpdate) -> Void) where T: XLMetaWritableTable, T.Row == Row, Row: XLTable {
         _ = table // Only a type witness for inferring Row; never read.
-        var meta = Row.MetaUpdate()
-        values(&meta)
-        self.values = meta
+        self.init(values)
     }
 
     public init<S>(_ values: S) where S: XLMetaUpdate, S.Row == Row {

--- a/Sources/SwiftQL/SQLStatements.swift
+++ b/Sources/SwiftQL/SQLStatements.swift
@@ -266,13 +266,15 @@ public struct Setting<Row>: XLEncodable {
         self.values = meta
     }
 
-    /// Infers `Row` from the table reference passed to the enclosing
-    /// `Update(_:)`, instead of restating it as an explicit generic
-    /// argument (`Setting<Row>`). Swift cannot infer `Row` from the closure
-    /// alone here — `Row.MetaUpdate` is a dependent associated type, and a
-    /// `Setting { ... }` statement is type-checked before `Update(_:)`'s own
-    /// `Row` can flow across a result-builder statement boundary — so the
-    /// table reference stands in as the concrete witness.
+    /// Infers `Row` from `table`, instead of restating it as an explicit
+    /// generic argument (`Setting<Row>`). Swift cannot infer `Row` from the
+    /// closure alone here — `Row.MetaUpdate` is a dependent associated type,
+    /// and a `Setting { ... }` statement is type-checked before an earlier
+    /// `Update(_:)` statement's own `Row` can flow across a result-builder
+    /// statement boundary — so `table` stands in as the concrete witness.
+    /// This initializer only infers from `table`; it does not verify that
+    /// `table` is the same reference passed to the enclosing `Update(_:)`,
+    /// though callers typically pass the same one.
     public init<T>(_ table: T, _ values: (inout Row.MetaUpdate) -> Void) where T: XLMetaWritableTable, T.Row == Row, Row: XLTable {
         var meta = Row.MetaUpdate()
         values(&meta)

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -396,7 +396,7 @@ to `42`:
 let updateFredStatement = sql { schema in
     let person = schema.into(Person.self)
     Update(person)
-    Setting<Person> { row in
+    Setting(person) { row in
         row.age = 42
     }
     Where(person.id == "fred")
@@ -406,7 +406,9 @@ try database.makeRequest(with: updateFredStatement).execute()
 ```
 
 Use `schema.into()` for the table modified by a result-builder update or delete
-statement.
+statement. Passing the same table reference to `Setting(_:_:)` lets Swift infer
+which row type the closure updates, so the type does not need to be repeated
+as an explicit `Setting<Row>` generic argument.
 
 > Warning: An update without a `Where` clause modifies every row in the table.
 
@@ -420,7 +422,7 @@ let ageParameter = XLNamedBindingReference<Int>(name: "age")
 let updateAgeStatement = sql { schema in
     let person = schema.into(Person.self)
     Update(person)
-    Setting<Person> { row in
+    Setting(person) { row in
         row.age = ageParameter
     }
     Where(person.id == personIDParameter)

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1214,7 +1214,7 @@ extension XLDocumentationTests {
         let updateFredStatement = sql { schema in
             let person = schema.into(Person.self)
             Update(person)
-            Setting<Person> { row in
+            Setting(person) { row in
                 row.age = 42
             }
             Where(person.id == "fred")
@@ -1226,7 +1226,7 @@ extension XLDocumentationTests {
         let updateAgeStatement = sql { schema in
             let person = schema.into(Person.self)
             Update(person)
-            Setting<Person> { row in
+            Setting(person) { row in
                 row.age = ageParameter
             }
             Where(person.id == personIDParameter)

--- a/Tests/SQLTests/Tests/Expression Builder/SQLUpdateExpressionBuilderTests.swift
+++ b/Tests/SQLTests/Tests/Expression Builder/SQLUpdateExpressionBuilderTests.swift
@@ -51,6 +51,20 @@ final class XLUpdateExpressionBuilderTests: XCTestCase {
         XCTAssertEqual(encoder.makeSQL(expression).sql, "UPDATE Test AS t0 SET value = (t0.value + 10)")
     }
     
+    /// Issue #96: `Row` is inferred from the table reference already passed
+    /// to `Update(_:)`, so the closure needs no explicit `Setting<Row>`
+    /// generic argument.
+    func testUpdateSettingInfersRowFromTableReference() {
+        let expression = sql { ns in
+            let t = ns.into(TestTable.self)
+            Update(t)
+            Setting(t) { row in
+                row.value = t.value + 10
+            }
+        }
+        XCTAssertEqual(encoder.makeSQL(expression).sql, "UPDATE Test AS t0 SET value = (t0.value + 10)")
+    }
+
     func testUpdateSettingDescreteValuesWithWhere() {
         let expression = sql { ns in
             let t = ns.into(TestTable.self)


### PR DESCRIPTION
Closes #96.

## Summary

`Setting<Row>`'s closure initializer requires `Row: XLTable`, but `Row.MetaUpdate` is a dependent associated type, so Swift cannot infer `Row` purely from the closure body (`row.age = 42` doesn't structurally pin down which table `row` belongs to).

I confirmed empirically that the fully argument-free form the issue describes (`Setting { row in ... }`, relying purely on the preceding `Update(person)` statement) isn't achievable without a larger redesign: a `Setting { ... }` statement in the `Update` result-builder is type-checked independently of the statement before it, so `Row` can't flow across that boundary even when `buildPartialBlock` is restructured to accept the raw closure directly (I tried this — same "generic parameter 'Row' could not be inferred" error). The only way to give the closure a concrete type at the point it's checked is to make `Row` avoid dependent-associated-type-only inference, which fundamentally requires *some* concrete witness at the call site.

Given that, this adds an init overload that uses the table reference already in scope as that witness — the exact same value already passed to `Update(_:)`:

```swift
Update(person)
Setting(person) { row in
    row.age = 42
}
```

instead of

```swift
Update(person)
Setting<Person> { row in
    row.age = 42
}
```

This is source-compatible (the existing `Setting<Row> { ... }` and `Setting(metaInstance)` initializers are untouched) and arguably safer than the old spelling too — you're reusing the same reference `Update` already uses instead of restating its type name, so the two can't silently drift apart.

Updated `GettingStarted.md`'s two update-statement examples (and their backing doc-example test in `SQLExampleTests.swift`) to the new spelling, and added `testUpdateSettingInfersRowFromTableReference` alongside the existing `Setting<Row>` coverage in `SQLUpdateExpressionBuilderTests.swift`.

## Test plan

- [x] `swift build` — clean
- [x] `swift test --filter SQLTests` — 505 tests, 0 failures
- [x] New test and updated doc-example test pass
