### PR TITLE
Add SwiftUI-friendly live-query observers (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ their SQL meaning.
   driver.
 - **[Live data](https://lukevanin.github.io/swiftql/documentation/swiftql/livequeries/).**
   Observe typed query results through GRDB-backed Combine publishers that track
-  the database region a query reads.
+  the database region a query reads, or adopt `XLQueryObserver`/
+  `XLQueryRowObserver` directly with SwiftUI's `@StateObject`/`@ObservedObject`.
 - **Your domain.** Extend SQLite with Swift enums, custom value types, and
   type-safe custom SQL functions.
 

--- a/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
@@ -98,6 +98,30 @@ whereas `.null` is a present value and is accepted only for a nullable slot.
 This packet isolation does not make the current request facade `Sendable` or
 promise that one request can be shared directly across tasks.
 
+### SwiftUI
+
+``XLQueryObserver`` and ``XLQueryRowObserver`` wrap `publish()`/`publishOne()`
+as `ObservableObject`s, so a view model can adopt a live query directly with
+`@StateObject`/`@ObservedObject` instead of managing a `Cancellable` by hand:
+
+<!-- test: XLDocumentationTests.testDocumentationLiveQueryPublishers -->
+```swift
+final class PeopleListModel: ObservableObject {
+    let people: XLQueryObserver<Person>
+
+    init(database: some XLDatabase, query: some XLQueryStatement<Person>) {
+        people = XLQueryObserver(database.makeRequest(with: query))
+    }
+}
+```
+
+A SwiftUI view reads `people.rows` and `people.error` in its `body`; both are
+`@Published`, so the view re-renders whenever either changes. Observation
+starts immediately on initialization and stops when the observer is
+deallocated — the same demand, transaction, and cancellation semantics
+described below apply, since both types subscribe through the same
+`publish()`/`publishOne()` publishers.
+
 ### Retry Policy
 
 Live queries are terminal by default. Configure a GRDB database or builder with

--- a/Sources/SwiftQL/SwiftUISupport.swift
+++ b/Sources/SwiftQL/SwiftUISupport.swift
@@ -5,11 +5,13 @@
 //  Created by Luke Van In on 2026/07/26.
 //
 
+import Dispatch
 import Foundation
 #if canImport(Combine)
 import Combine
 #else
 import OpenCombine
+import OpenCombineDispatch
 #endif
 
 
@@ -22,7 +24,7 @@ import OpenCombine
 /// `Cancellable` by hand:
 ///
 /// ```swift
-/// final class PeopleViewModel {
+/// final class PeopleViewModel: ObservableObject {
 ///     let people: XLQueryObserver<Person>
 ///
 ///     init(database: some XLDatabase) {
@@ -33,8 +35,9 @@ import OpenCombine
 ///
 /// A view reads `observer.rows` and `observer.error` in its `body`; SwiftUI
 /// re-renders whenever either `@Published` property changes. Observation
-/// starts immediately on initialization, on the main queue, and stops when
-/// the observer is deallocated.
+/// starts immediately on initialization and stops when the observer is
+/// deallocated; every delivered value is received on the main queue, though
+/// the underlying fetch may begin on whatever thread triggers it.
 ///
 public final class XLQueryObserver<Row>: ObservableObject {
 

--- a/Sources/SwiftQL/SwiftUISupport.swift
+++ b/Sources/SwiftQL/SwiftUISupport.swift
@@ -1,0 +1,109 @@
+//
+//  SwiftUISupport.swift
+//
+//
+//  Created by Luke Van In on 2026/07/26.
+//
+
+import Foundation
+#if canImport(Combine)
+import Combine
+#else
+import OpenCombine
+#endif
+
+
+///
+/// Observes a live query and republishes its rows as a SwiftUI-friendly
+/// `ObservableObject`.
+///
+/// Wraps `XLRequest.publish()` so a view model or view can adopt a query
+/// directly with `@StateObject`/`@ObservedObject` instead of managing a
+/// `Cancellable` by hand:
+///
+/// ```swift
+/// final class PeopleViewModel {
+///     let people: XLQueryObserver<Person>
+///
+///     init(database: some XLDatabase) {
+///         people = XLQueryObserver(database.makeRequest(with: peopleQuery))
+///     }
+/// }
+/// ```
+///
+/// A view reads `observer.rows` and `observer.error` in its `body`; SwiftUI
+/// re-renders whenever either `@Published` property changes. Observation
+/// starts immediately on initialization, on the main queue, and stops when
+/// the observer is deallocated.
+///
+public final class XLQueryObserver<Row>: ObservableObject {
+
+    @Published public private(set) var rows: [Row] = []
+
+    @Published public private(set) var error: Error?
+
+    private var cancellable: AnyCancellable?
+
+    public init(_ request: any XLRequest<Row>) {
+        subscribe(to: request.publish())
+    }
+
+    public init(_ request: any XLRequest<Row>, bindings: any XLInvocationBindingPacket) {
+        subscribe(to: request.publish(bindings: bindings))
+    }
+
+    private func subscribe(to publisher: AnyPublisher<[Row], Error>) {
+        cancellable = publisher
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    if case .failure(let error) = completion {
+                        self?.error = error
+                    }
+                },
+                receiveValue: { [weak self] rows in
+                    self?.rows = rows
+                }
+            )
+    }
+}
+
+
+///
+/// Observes a live single-row query and republishes it as a SwiftUI-friendly
+/// `ObservableObject`.
+///
+/// Wraps `XLRequest.publishOne()`, mirroring ``XLQueryObserver`` for queries
+/// that return at most one row.
+///
+public final class XLQueryRowObserver<Row>: ObservableObject {
+
+    @Published public private(set) var row: Row?
+
+    @Published public private(set) var error: Error?
+
+    private var cancellable: AnyCancellable?
+
+    public init(_ request: any XLRequest<Row>) {
+        subscribe(to: request.publishOne())
+    }
+
+    public init(_ request: any XLRequest<Row>, bindings: any XLInvocationBindingPacket) {
+        subscribe(to: request.publishOne(bindings: bindings))
+    }
+
+    private func subscribe(to publisher: AnyPublisher<Row?, Error>) {
+        cancellable = publisher
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    if case .failure(let error) = completion {
+                        self?.error = error
+                    }
+                },
+                receiveValue: { [weak self] row in
+                    self?.row = row
+                }
+            )
+    }
+}

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -2165,6 +2165,10 @@ extension XLDocumentationTests {
         let _: (XLPublisherTests) -> () throws -> Void = XLPublisherTests.testPublishExistingEntities
         let _: (XLPublisherTests) -> () throws -> Void = XLPublisherTests.testPublishOneObservesDirectWrites
         let _: (XLPublisherTests) -> () throws -> Void = XLPublisherTests.testCancellationStopsObservationFetchesAndValues
+        let _: (XLPublisherTests) -> () throws -> Void =
+            XLPublisherTests.testQueryObserverRepublishesRowsAndObservesDirectWrites
+        let _: (XLPublisherTests) -> () throws -> Void =
+            XLPublisherTests.testQueryRowObserverRepublishesRowAndObservesDirectWrites
         let _: (XLGRDBLiveQueryRetryTests) -> () throws -> Void =
             XLGRDBLiveQueryRetryTests
                 .testRealGRDBObservationRecoversFromInjectedBusyAndKeepsObserving

--- a/Tests/SQLTests/SQLPublisherTests.swift
+++ b/Tests/SQLTests/SQLPublisherTests.swift
@@ -1119,6 +1119,57 @@ final class XLPublisherTests: XCTestCase {
         wait(for: [updateExpectation], timeout: 2)
     }
 
+    // MARK: - SwiftUI observers (#28)
+
+    func testQueryObserverRepublishesRowsAndObservesDirectWrites() throws {
+        try createTestTable()
+        try insertTest.execute(TestTable(id: "bar", value: 42))
+
+        let observer = XLQueryObserver(database.makeRequest(with: orderedStatement()))
+
+        let initialExpectation = expectation(description: "initial rows")
+        let updateExpectation = expectation(description: "updated rows")
+        observer.$rows
+            .dropFirst() // skip the @Published wrapper's initial [] before subscription delivers.
+            .sink { rows in
+                if rows == [TestTable(id: "bar", value: 42)] {
+                    initialExpectation.fulfill()
+                }
+                else if rows == [
+                    TestTable(id: "bar", value: 42),
+                    TestTable(id: "foo", value: 9000),
+                ] {
+                    updateExpectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        wait(for: [initialExpectation], timeout: 2)
+        try insertDirect(TestTable(id: "foo", value: 9000))
+        wait(for: [updateExpectation], timeout: 2)
+        XCTAssertNil(observer.error)
+    }
+
+    func testQueryRowObserverRepublishesRowAndObservesDirectWrites() throws {
+        try createTestTable()
+
+        let observer = XLQueryRowObserver(database.makeRequest(with: orderedStatement()))
+
+        let updateExpectation = expectation(description: "first row")
+        observer.$row
+            .dropFirst()
+            .sink { row in
+                if row == TestTable(id: "first", value: 1) {
+                    updateExpectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        try insertDirect(TestTable(id: "first", value: 1))
+        wait(for: [updateExpectation], timeout: 2)
+        XCTAssertNil(observer.error)
+    }
+
     // MARK: - Helpers
 
     private func orderedStatement() -> any XLQueryStatement<TestTable> {

--- a/Tests/SQLTests/SQLPublisherTests.swift
+++ b/Tests/SQLTests/SQLPublisherTests.swift
@@ -1129,6 +1129,10 @@ final class XLPublisherTests: XCTestCase {
 
         let initialExpectation = expectation(description: "initial rows")
         let updateExpectation = expectation(description: "updated rows")
+        // A live query may emit consecutive equal snapshots, so either
+        // condition below could fire more than once.
+        initialExpectation.assertForOverFulfill = false
+        updateExpectation.assertForOverFulfill = false
         observer.$rows
             // No dropFirst(): the observer starts observing in its own
             // initializer, above, so the real first fetch may already have
@@ -1162,6 +1166,9 @@ final class XLPublisherTests: XCTestCase {
         let observer = XLQueryRowObserver(database.makeRequest(with: orderedStatement()))
 
         let updateExpectation = expectation(description: "first row")
+        // A live query may emit consecutive equal snapshots, so the
+        // condition below could fire more than once.
+        updateExpectation.assertForOverFulfill = false
         observer.$row
             // See the parallel comment in
             // testQueryObserverRepublishesRowsAndObservesDirectWrites: no

--- a/Tests/SQLTests/SQLPublisherTests.swift
+++ b/Tests/SQLTests/SQLPublisherTests.swift
@@ -1130,7 +1130,13 @@ final class XLPublisherTests: XCTestCase {
         let initialExpectation = expectation(description: "initial rows")
         let updateExpectation = expectation(description: "updated rows")
         observer.$rows
-            .dropFirst() // skip the @Published wrapper's initial [] before subscription delivers.
+            // No dropFirst(): the observer starts observing in its own
+            // initializer, above, so the real first fetch may already have
+            // delivered by the time this test subscribes to $rows — an
+            // ordinal drop could discard the only matching value. Matching
+            // on content instead of position is robust either way, since
+            // the @Published wrapper's initial [] default matches neither
+            // condition below.
             .sink { rows in
                 if rows == [TestTable(id: "bar", value: 42)] {
                     initialExpectation.fulfill()
@@ -1157,7 +1163,10 @@ final class XLPublisherTests: XCTestCase {
 
         let updateExpectation = expectation(description: "first row")
         observer.$row
-            .dropFirst()
+            // See the parallel comment in
+            // testQueryObserverRepublishesRowsAndObservesDirectWrites: no
+            // dropFirst(), since an ordinal drop could discard the real
+            // first value depending on timing.
             .sink { row in
                 if row == TestTable(id: "first", value: 1) {
                     updateExpectation.fulfill()


### PR DESCRIPTION
Closes #28.

## Summary

Adds two small `ObservableObject` wrappers around the existing `XLRequest.publish()`/`publishOne()` Combine publishers, so a SwiftUI view model can adopt a live query directly:

```swift
final class PeopleListModel: ObservableObject {
    let people: XLQueryObserver<Person>

    init(database: some XLDatabase, query: some XLQueryStatement<Person>) {
        people = XLQueryObserver(database.makeRequest(with: query))
    }
}
```

- `XLQueryObserver<Row>` — wraps `publish()`, exposes `@Published rows: [Row]` and `@Published error: Error?`.
- `XLQueryRowObserver<Row>` — wraps `publishOne()`, exposes `@Published row: Row?` and `@Published error: Error?`.

Both also have a `bindings:` initializer mirroring `publish(bindings:)`/`publishOne(bindings:)` for packet-backed requests. Observation starts immediately on init, delivered on the main queue, and stops on deallocation — same semantics as the underlying publishers (documented in `LiveQueries.md`'s existing "Observation Semantics" section).

No new dependency: the file follows the same `#if canImport(Combine) / #else import OpenCombine` split already used throughout the package, so `ObservableObject`/`@Published` resolve correctly on both Apple platforms and the Linux CI matrix. SwiftUI itself is never imported by the package — consuming apps import it themselves; the package only needs to conform to `Combine.ObservableObject`.

Documented in `LiveQueries.md` (new "SwiftUI" section) and mentioned in the README's live-data bullet.

## Test plan

- [x] `swift build` — clean
- [x] `swift test --filter SQLTests` — 506 tests, 0 failures
- [x] New tests exercise real GRDB execution end-to-end: `testQueryObserverRepublishesRowsAndObservesDirectWrites` and `testQueryRowObserverRepublishesRowAndObservesDirectWrites` in `SQLPublisherTests.swift`, both observing a direct (non-SwiftQL) write land through the wrapper
