### PR TITLE
Unify scalar function style on methods (#3)

### DIFF
--- a/Sources/SwiftQL/Functions/AggregateFunctions.swift
+++ b/Sources/SwiftQL/Functions/AggregateFunctions.swift
@@ -35,11 +35,20 @@ public func all() -> XLAllColumns {
 }
 
 
-/// Counts every input row by rendering `COUNT(*)`.
+@available(*, deprecated, message: "Use all().count() instead. count(_:) will be removed in SwiftQL 2.")
 public func count(
     _ expression: any XLExpression<XLAllColumns>
 ) -> some XLExpression<Int> {
     XLFunction<Int>(name: "COUNT", parameters: [expression])
+}
+
+
+extension XLExpression where T == XLAllColumns {
+
+    /// Counts every input row by rendering `COUNT(*)`.
+    public func count() -> some XLExpression<Int> {
+        XLFunction<Int>(name: "COUNT", parameters: [self])
+    }
 }
 
 

--- a/Sources/SwiftQL/Functions/ComparableFunctions.swift
+++ b/Sources/SwiftQL/Functions/ComparableFunctions.swift
@@ -11,6 +11,7 @@ import Foundation
 ///
 /// Returns the miniumum value from a list of expressions.
 ///
+@available(*, deprecated, message: "Use a.min(b, ...) instead. min(_:) will be removed in SwiftQL 2.")
 public func min<T>(_ values: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
     XLFunction(name: "MIN", parameters: values)
 }
@@ -19,6 +20,29 @@ public func min<T>(_ values: any XLExpression<T>...) -> some XLExpression<T> whe
 ///
 /// Returns the maximum value from a list of expressions.
 ///
+@available(*, deprecated, message: "Use a.max(b, ...) instead. max(_:) will be removed in SwiftQL 2.")
 public func max<T>(_ values: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
     XLFunction(name: "MAX", parameters: values)
+}
+
+
+extension XLExpression where T: XLComparable & XLLiteral {
+
+    /// Returns the minimum value among `self` and `others`.
+    ///
+    /// Takes at least one further expression, both to match SQLite's scalar
+    /// `MIN` (meaningless with a single argument) and to stay unambiguous
+    /// against the deprecated zero-argument aggregate `min(distinct:)`.
+    public func min(_ first: any XLExpression<T>, _ rest: any XLExpression<T>...) -> some XLExpression<T> {
+        XLFunction(name: "MIN", parameters: [self, first] + rest)
+    }
+
+    /// Returns the maximum value among `self` and `others`.
+    ///
+    /// Takes at least one further expression, both to match SQLite's scalar
+    /// `MAX` (meaningless with a single argument) and to stay unambiguous
+    /// against the deprecated zero-argument aggregate `max(distinct:)`.
+    public func max(_ first: any XLExpression<T>, _ rest: any XLExpression<T>...) -> some XLExpression<T> {
+        XLFunction(name: "MAX", parameters: [self, first] + rest)
+    }
 }

--- a/Sources/SwiftQL/Functions/ComparableFunctions.swift
+++ b/Sources/SwiftQL/Functions/ComparableFunctions.swift
@@ -11,26 +11,25 @@ import Foundation
 ///
 /// Returns the minimum value from a list of expressions.
 ///
+/// Takes at least two expressions: SQLite's scalar `MIN` is meaningless with
+/// fewer, and a single argument would otherwise parse as the aggregate
+/// `MIN(expr)` instead — enforced in the signature rather than at runtime, so
+/// misuse fails to compile instead of trapping.
 @available(*, deprecated, message: "Use a.min(b, ...) instead. min(_:) will be removed in SwiftQL 2.")
-public func min<T>(_ values: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
-    precondition(
-        values.count >= 2,
-        "min(_:) requires at least two expressions. SQLite's scalar MIN is meaningless with fewer — a single argument parses as the aggregate MIN(expr) instead."
-    )
-    return XLFunction(name: "MIN", parameters: values)
+public func min<T>(_ first: any XLExpression<T>, _ second: any XLExpression<T>, _ rest: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
+    XLFunction(name: "MIN", parameters: [first, second] + rest)
 }
 
 
-///
 /// Returns the maximum value from a list of expressions.
 ///
+/// Takes at least two expressions: SQLite's scalar `MAX` is meaningless with
+/// fewer, and a single argument would otherwise parse as the aggregate
+/// `MAX(expr)` instead — enforced in the signature rather than at runtime, so
+/// misuse fails to compile instead of trapping.
 @available(*, deprecated, message: "Use a.max(b, ...) instead. max(_:) will be removed in SwiftQL 2.")
-public func max<T>(_ values: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
-    precondition(
-        values.count >= 2,
-        "max(_:) requires at least two expressions. SQLite's scalar MAX is meaningless with fewer — a single argument parses as the aggregate MAX(expr) instead."
-    )
-    return XLFunction(name: "MAX", parameters: values)
+public func max<T>(_ first: any XLExpression<T>, _ second: any XLExpression<T>, _ rest: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
+    XLFunction(name: "MAX", parameters: [first, second] + rest)
 }
 
 

--- a/Sources/SwiftQL/Functions/ComparableFunctions.swift
+++ b/Sources/SwiftQL/Functions/ComparableFunctions.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 ///
-/// Returns the miniumum value from a list of expressions.
+/// Returns the minimum value from a list of expressions.
 ///
 @available(*, deprecated, message: "Use a.min(b, ...) instead. min(_:) will be removed in SwiftQL 2.")
 public func min<T>(_ values: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {

--- a/Sources/SwiftQL/Functions/ComparableFunctions.swift
+++ b/Sources/SwiftQL/Functions/ComparableFunctions.swift
@@ -11,10 +11,16 @@ import Foundation
 ///
 /// Returns the minimum value from a list of expressions.
 ///
-/// Takes at least two expressions: SQLite's scalar `MIN` is meaningless with
-/// fewer, and a single argument would otherwise parse as the aggregate
-/// `MIN(expr)` instead — enforced in the signature rather than at runtime, so
-/// misuse fails to compile instead of trapping.
+/// A single-argument call preserves this function's pre-existing behavior
+/// (SQLite parses `MIN(expr)` as its aggregate function, not a scalar
+/// comparison) rather than fixing it, since fixing it would itself be a
+/// source-breaking change; use `a.min(b, ...)` for the scalar comparison.
+@available(*, deprecated, message: "Use a.min(b, ...) instead. min(_:) will be removed in SwiftQL 2.")
+public func min<T>(_ first: any XLExpression<T>) -> some XLExpression<T> where T: XLComparable & XLLiteral {
+    XLFunction(name: "MIN", parameters: [first])
+}
+
+/// Returns the minimum value from a list of expressions.
 @available(*, deprecated, message: "Use a.min(b, ...) instead. min(_:) will be removed in SwiftQL 2.")
 public func min<T>(_ first: any XLExpression<T>, _ second: any XLExpression<T>, _ rest: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
     XLFunction(name: "MIN", parameters: [first, second] + rest)
@@ -23,10 +29,16 @@ public func min<T>(_ first: any XLExpression<T>, _ second: any XLExpression<T>, 
 
 /// Returns the maximum value from a list of expressions.
 ///
-/// Takes at least two expressions: SQLite's scalar `MAX` is meaningless with
-/// fewer, and a single argument would otherwise parse as the aggregate
-/// `MAX(expr)` instead — enforced in the signature rather than at runtime, so
-/// misuse fails to compile instead of trapping.
+/// A single-argument call preserves this function's pre-existing behavior
+/// (SQLite parses `MAX(expr)` as its aggregate function, not a scalar
+/// comparison) rather than fixing it, since fixing it would itself be a
+/// source-breaking change; use `a.max(b, ...)` for the scalar comparison.
+@available(*, deprecated, message: "Use a.max(b, ...) instead. max(_:) will be removed in SwiftQL 2.")
+public func max<T>(_ first: any XLExpression<T>) -> some XLExpression<T> where T: XLComparable & XLLiteral {
+    XLFunction(name: "MAX", parameters: [first])
+}
+
+/// Returns the maximum value from a list of expressions.
 @available(*, deprecated, message: "Use a.max(b, ...) instead. max(_:) will be removed in SwiftQL 2.")
 public func max<T>(_ first: any XLExpression<T>, _ second: any XLExpression<T>, _ rest: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
     XLFunction(name: "MAX", parameters: [first, second] + rest)

--- a/Sources/SwiftQL/Functions/ComparableFunctions.swift
+++ b/Sources/SwiftQL/Functions/ComparableFunctions.swift
@@ -13,7 +13,11 @@ import Foundation
 ///
 @available(*, deprecated, message: "Use a.min(b, ...) instead. min(_:) will be removed in SwiftQL 2.")
 public func min<T>(_ values: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
-    XLFunction(name: "MIN", parameters: values)
+    precondition(
+        values.count >= 2,
+        "min(_:) requires at least two expressions. SQLite's scalar MIN is meaningless with fewer — a single argument parses as the aggregate MIN(expr) instead."
+    )
+    return XLFunction(name: "MIN", parameters: values)
 }
 
 
@@ -22,7 +26,11 @@ public func min<T>(_ values: any XLExpression<T>...) -> some XLExpression<T> whe
 ///
 @available(*, deprecated, message: "Use a.max(b, ...) instead. max(_:) will be removed in SwiftQL 2.")
 public func max<T>(_ values: any XLExpression<T>...) -> some XLExpression<T> where T: XLComparable & XLLiteral {
-    XLFunction(name: "MAX", parameters: values)
+    precondition(
+        values.count >= 2,
+        "max(_:) requires at least two expressions. SQLite's scalar MAX is meaningless with fewer — a single argument parses as the aggregate MAX(expr) instead."
+    )
+    return XLFunction(name: "MAX", parameters: values)
 }
 
 

--- a/Sources/SwiftQL/Functions/ConditionalFunctions.swift
+++ b/Sources/SwiftQL/Functions/ConditionalFunctions.swift
@@ -11,21 +11,49 @@ import Foundation
 // MARK: - IIF
 
 
+@available(*, deprecated, message: "Use condition.iif(then:else:) instead. iif(_:then:else:) will be removed in SwiftQL 2.")
 public func iif<T, U>(_ condition: any XLExpression<U>, then: any XLExpression<T>, else: any XLExpression<T>) -> some XLExpression<T> where U: XLBoolean {
     XLIfExpression(condition: condition, trueResult: then, falseResult: `else`)
 }
 
 
+@available(*, deprecated, message: "Use condition.iif(then:else:) instead. iif(_:then:else:) will be removed in SwiftQL 2.")
 public func iif<T, U>(_ condition: any XLExpression<U>, then: any XLExpression<Optional<T>>, else: any XLExpression<T>) -> some XLExpression<Optional<T>> where U: XLBoolean {
     XLIfExpression(condition: condition, trueResult: then, falseResult: `else`)
 }
 
 
+@available(*, deprecated, message: "Use condition.iif(then:else:) instead. iif(_:then:else:) will be removed in SwiftQL 2.")
 public func iif<T, U>(_ condition: any XLExpression<U>, then: any XLExpression<T>, else: any XLExpression<Optional<T>>) -> some XLExpression<Optional<T>> where U: XLBoolean {
     XLIfExpression(condition: condition, trueResult: then, falseResult: `else`)
 }
 
 
+@available(*, deprecated, message: "Use condition.iif(then:else:) instead. iif(_:then:else:) will be removed in SwiftQL 2.")
 public func iif<T, U>(_ condition: any XLExpression<U>, then: any XLExpression<Optional<T>>, else: any XLExpression<Optional<T>>) -> some XLExpression<Optional<T>> where U: XLBoolean {
     XLIfExpression(condition: condition, trueResult: then, falseResult: `else`)
+}
+
+
+extension XLExpression where T: XLBoolean {
+
+    /// Returns `then` when `self` is true, `else` otherwise.
+    public func iif<V>(then: any XLExpression<V>, else: any XLExpression<V>) -> some XLExpression<V> {
+        XLIfExpression(condition: self, trueResult: then, falseResult: `else`)
+    }
+
+    /// Returns `then` when `self` is true, `else` otherwise.
+    public func iif<V>(then: any XLExpression<Optional<V>>, else: any XLExpression<V>) -> some XLExpression<Optional<V>> {
+        XLIfExpression(condition: self, trueResult: then, falseResult: `else`)
+    }
+
+    /// Returns `then` when `self` is true, `else` otherwise.
+    public func iif<V>(then: any XLExpression<V>, else: any XLExpression<Optional<V>>) -> some XLExpression<Optional<V>> {
+        XLIfExpression(condition: self, trueResult: then, falseResult: `else`)
+    }
+
+    /// Returns `then` when `self` is true, `else` otherwise.
+    public func iif<V>(then: any XLExpression<Optional<V>>, else: any XLExpression<Optional<V>>) -> some XLExpression<Optional<V>> {
+        XLIfExpression(condition: self, trueResult: then, falseResult: `else`)
+    }
 }

--- a/Sources/SwiftQL/Functions/StringFunctions.swift
+++ b/Sources/SwiftQL/Functions/StringFunctions.swift
@@ -122,11 +122,27 @@ extension XLExpression {
 }
 
 
+@available(*, deprecated, message: "Use format.printf(...) instead. printf(format:_:) will be removed in SwiftQL 2.")
 public func printf(format: String, _ parameters: any XLExpression ...) -> some XLExpression<String> {
     XLFunction(name: "printf", parameters: [format] + parameters)
 }
 
 
+@available(*, deprecated, message: "Use format.printf(_:) instead. printf(format:_:) will be removed in SwiftQL 2.")
 public func printf(format: String, _ parameters: [any XLExpression]) -> some XLExpression<String> {
     XLFunction(name: "printf", parameters: [format] + parameters)
+}
+
+
+extension XLExpression where T == String {
+
+    /// Renders SQLite's `printf(format, ...)`, substituting `parameters` into `self`.
+    public func printf(_ parameters: any XLExpression...) -> some XLExpression<String> {
+        XLFunction(name: "printf", parameters: [self] + parameters)
+    }
+
+    /// Renders SQLite's `printf(format, ...)`, substituting `parameters` into `self`.
+    public func printf(_ parameters: [any XLExpression]) -> some XLExpression<String> {
+        XLFunction(name: "printf", parameters: [self] + parameters)
+    }
 }

--- a/Sources/SwiftQL/SQLOperators.swift
+++ b/Sources/SwiftQL/SQLOperators.swift
@@ -404,7 +404,7 @@ public struct XLNullCoalesceExpression<T>: XLExpression {
 ///
 /// *Swift:*
 /// ```swift
-/// iif(foo.bar.isNull(), then: "baz", else: "buzz")
+/// foo.bar.isNull().iif(then: "baz", else: "buzz")
 /// ```
 ///
 /// *SQL:*

--- a/Sources/SwiftQL/SwiftQL.docc/BuiltinFunctions.md
+++ b/Sources/SwiftQL/SwiftQL.docc/BuiltinFunctions.md
@@ -29,9 +29,8 @@ let statement = sql { schema in
     let occupation = schema.nullableTable(Occupation.self)
     let result = EmploymentStatus.columns(
         person: person.name,
-        occupation: iif(
-            occupation.name.isNull(), 
-            then: "Unemployed", 
+        occupation: occupation.name.isNull().iif(
+            then: "Unemployed",
             else: "Employed"
         )
     )
@@ -151,6 +150,20 @@ Returns a `Double` expression rounded to the provided number of decimal places.
 Returns a `Double` expression rounded to the largest integral value less than or
 equal to it.
 
+### min(), max()
+
+Returns the smallest or largest value among two or more expressions, rendered
+as SQLite's scalar `MIN`/`MAX`. This is distinct from the `minOrNull()`/
+`maxOrNull()` aggregate functions, which operate over rows in a group rather
+than a fixed list of expressions.
+
+<!-- test: XLDocumentationTests.testDocumentationConditionalAndScalarFunctions -->
+```swift
+let x = XLNamedBindingReference<Int>(name: "x")
+let smallest = x.min(0, 10)
+let largest = x.max(0, 10)
+```
+
 ## String functions
 
 ### collate()
@@ -210,8 +223,15 @@ sequence`, rather than silently comparing as `BINARY`.
 
 ### printf()
 
-Returns a formatted string. In SwiftQL `printf()` is similar to the same 
-function provided by the standard C library. 
+Returns a formatted string, called on the format expression. In SwiftQL
+`printf()` is similar to the same function provided by the standard C library.
+
+<!-- test: XLDocumentationTests.testDocumentationConditionalAndScalarFunctions -->
+```swift
+let name = XLNamedBindingReference<String>(name: "name")
+let age = XLNamedBindingReference<Int>(name: "age")
+let formatted = "%s is %d years old".printf(name, age)
+```
 
 Refer to the [SQLite printf](https://sqlite.org/printf.html) documentation for
 more information.

--- a/Sources/SwiftQL/SwiftQL.docc/Queries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/Queries.md
@@ -259,7 +259,7 @@ SwiftQL currently supports the following aggregate functions:
 API                               | Input             | Result    | Behavior
 ----------------------------------|-------------------|-----------|-------------------------------------------
 `count()`                         | Any               | `Int`     | Number of non-NULL values; zero for empty input.
-`count(all())`                    | All rows          | `Int`     | Number of input rows, rendered as `COUNT(*)`.
+`all().count()`                   | All rows          | `Int`     | Number of input rows, rendered as `COUNT(*)`.
 `minOrNull()`                     | Any comparable    | `T?`      | Minimum non-NULL value.
 `maxOrNull()`                     | Any comparable    | `T?`      | Maximum non-NULL value.
 `averageOrNull()`                 | `Int`, `Double`, or either nullable form | `Double?` | Average (arithmetic mean) of non-NULL values.
@@ -281,7 +281,7 @@ It always returns a `Double`, ignores individual NULL values, and returns `0.0`
 for empty or all-NULL input. Existing `sum()` and `sumOrNull()` behavior is
 unchanged.
 
-Use `count(all())` when NULL values must still contribute to the row count.
+Use `all().count()` when NULL values must still contribute to the row count.
 
 <!-- test: XLDocumentationTests.testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs -->
 ```swift

--- a/Tests/SQLTests/SQLAggregateTests.swift
+++ b/Tests/SQLTests/SQLAggregateTests.swift
@@ -102,7 +102,7 @@ final class XLAggregateTests: XCTestCase {
         assertExpressionType(text.groupConcatOrNull(separator: "|"), Optional<String>.self)
         assertExpressionType(integer.count(), Int.self)
         assertExpressionType(all(), XLAllColumns.self)
-        assertExpressionType(count(all()), Int.self)
+        assertExpressionType(all().count(), Int.self)
         assertExpressionType(integer.sumOrNull().coalesce(-99), Int.self)
 
         XCTAssertEqual(encoder.makeSQL(integer.minOrNull()).sql, "MIN(:integer)")
@@ -134,7 +134,7 @@ final class XLAggregateTests: XCTestCase {
         )
         XCTAssertEqual(encoder.makeSQL(integer.count()).sql, "COUNT(:integer)")
         XCTAssertEqual(encoder.makeSQL(all()).sql, "*")
-        XCTAssertEqual(encoder.makeSQL(count(all())).sql, "COUNT(*)")
+        XCTAssertEqual(encoder.makeSQL(all().count()).sql, "COUNT(*)")
         XCTAssertEqual(
             encoder.makeSQL(integer.sumOrNull().coalesce(-99)).sql,
             "COALESCE(SUM(:integer), -99)"
@@ -284,7 +284,7 @@ final class XLAggregateTests: XCTestCase {
                     nullableRealTotal: input.nullableRealValue.total(),
                     concatenated: input.textValue.groupConcatOrNull(),
                     pipeConcatenated: input.textValue.groupConcatOrNull(separator: "|"),
-                    rowCount: count(all()),
+                    rowCount: all().count(),
                     integerCount: input.integerValue.count(),
                     coalescedSum: input.integerValue.sumOrNull().coalesce(-99)
                 )

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -854,7 +854,7 @@ final class XLDocumentationTests: XCTestCase {
             let occupation = schema.nullableTable(Occupation.self)
             let result = PersonOccupation.columns(
                 person: person.name,
-                occupation: iif(occupation.name.isNull(), then: "Unemployed", else: "Employed")
+                occupation: occupation.name.isNull().iif(then: "Unemployed", else: "Employed")
             )
             return select(result).from(person).leftJoin(occupation, on: occupation.id == person.occupationId)
         }
@@ -2131,6 +2131,20 @@ extension XLDocumentationTests {
             XLCustomCollationTests.testCustomCollationOrdersByRegisteredSequence
         let _: (XLCustomCollationTests) -> () throws -> Void =
             XLCustomCollationTests.testUnregisteredCollationFailsAtPreparation
+
+        let x = XLNamedBindingReference<Int>(name: "x")
+        let smallest = x.min(0, 10)
+        let largest = x.max(0, 10)
+        XCTAssertEqual(encoder.makeSQL(smallest).sql, "MIN(:x, 0, 10)")
+        XCTAssertEqual(encoder.makeSQL(largest).sql, "MAX(:x, 0, 10)")
+
+        let name = XLNamedBindingReference<String>(name: "name")
+        let age = XLNamedBindingReference<Int>(name: "age")
+        let formatted = "%s is %d years old".printf(name, age)
+        XCTAssertEqual(
+            encoder.makeSQL(formatted).sql,
+            "printf('%s is %d years old', :name, :age)"
+        )
     }
 
     func testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs() throws {

--- a/Tests/SQLTests/SQLScalarFunctionTests.swift
+++ b/Tests/SQLTests/SQLScalarFunctionTests.swift
@@ -28,8 +28,8 @@ final class XLScalarFunctionTests: XCTestCase {
         assertSQL(optionalReal.rounded(), "ROUND(:optionalReal)")
         assertSQL(real.rounded(to: 2), "ROUND(:real, 2)")
         assertSQL(real.floor(), "FLOOR(:real)")
-        assertSQL(min(integer, 0, 10), "MIN(:integer, 0, 10)")
-        assertSQL(max(integer, 0, 10), "MAX(:integer, 0, 10)")
+        assertSQL(integer.min(0, 10), "MIN(:integer, 0, 10)")
+        assertSQL(integer.max(0, 10), "MAX(:integer, 0, 10)")
 
         assertExpressionType(integer.abs(), Int.self)
         assertExpressionType(real.rounded(), Double.self)
@@ -42,10 +42,10 @@ final class XLScalarFunctionTests: XCTestCase {
         let optionalThen = XLNamedBindingReference<String?>(name: "optionalThen")
         let optionalElse = XLNamedBindingReference<String?>(name: "optionalElse")
 
-        let required = iif(condition, then: "yes", else: "no")
-        let optionalTrue = iif(condition, then: optionalThen, else: "no")
-        let optionalFalse = iif(condition, then: "yes", else: optionalElse)
-        let optionalBoth = iif(condition, then: optionalThen, else: optionalElse)
+        let required = condition.iif(then: "yes", else: "no")
+        let optionalTrue = condition.iif(then: optionalThen, else: "no")
+        let optionalFalse = condition.iif(then: "yes", else: optionalElse)
+        let optionalBoth = condition.iif(then: optionalThen, else: optionalElse)
 
         assertSQL(required, "IIF(:condition, 'yes', 'no')")
         assertSQL(optionalTrue, "IIF(:condition, :optionalThen, 'no')")
@@ -173,9 +173,9 @@ final class XLScalarFunctionTests: XCTestCase {
             canonicalEncoder.makeSQL(optionalText.collate(.rtrim)).sql,
             "(:optionalText COLLATE RTRIM)"
         )
-        assertSQL(printf(format: "%s:%d", text, 7), "printf('%s:%d', :text, 7)")
+        assertSQL("%s:%d".printf(text, 7), "printf('%s:%d', :text, 7)")
         assertSQL(
-            printf(format: "%s:%d", [text, 7]),
+            "%s:%d".printf([text, 7]),
             "printf('%s:%d', :text, 7)"
         )
 

--- a/Tests/SQLTests/SQLSyntaxTests.swift
+++ b/Tests/SQLTests/SQLSyntaxTests.swift
@@ -979,19 +979,19 @@ final class XLSyntaxTests: XCTestCase {
     
     func testMinFunction() {
         let x = XLNamedBindingReference<Int>(name: "x")
-        let expression = min(x, 12)
+        let expression = x.min(12)
         XCTAssertEqual(encoder.makeSQL(expression).sql, "MIN(:x, 12)")
     }
-    
+
     func testMaxFunction() {
         let x = XLNamedBindingReference<Int>(name: "x")
-        let expression = max(x, 12)
+        let expression = x.max(12)
         XCTAssertEqual(encoder.makeSQL(expression).sql, "MAX(:x, 12)")
     }
-    
+
     func testMinMaxFunction() {
         let x = XLNamedBindingReference<Int>(name: "x")
-        let expression = min(max(x, 0), 1)
+        let expression = x.max(0).min(1)
         XCTAssertEqual(encoder.makeSQL(expression).sql, "MIN(MAX(:x, 0), 1)")
     }
     

--- a/Tests/SwiftQLSQLiteCombinatorialSupport/SQLiteTypedCombinatorialCases.swift
+++ b/Tests/SwiftQLSQLiteCombinatorialSupport/SQLiteTypedCombinatorialCases.swift
@@ -1566,13 +1566,13 @@ public enum SQLiteTypedCombinatorialCases {
             expressionCase(
                 id: "comparable-min",
                 featureID: "syntax.expression.numeric-comparable-functions",
-                statement: select(min(namedInteger, 191)),
+                statement: select(namedInteger.min(191)),
                 bindings: [.init(key: .named("integer_value"), value: .integer(254))]
             ),
             expressionCase(
                 id: "string-printf",
                 featureID: "syntax.expression.string-functions",
-                statement: select(printf(format: "%s-%d", namedText, namedInteger)),
+                statement: select("%s-%d".printf(namedText, namedInteger)),
                 bindings: [
                     .init(key: .named("text_value"), value: .text("case")),
                     .init(key: .named("integer_value"), value: .integer(191)),
@@ -1676,17 +1676,14 @@ public enum SQLiteTypedCombinatorialCases {
             issue286ExpressionCase(
                 id: "comparable-max",
                 featureID: "syntax.expression.numeric-comparable-functions",
-                statement: select(max(namedInteger, 191)),
+                statement: select(namedInteger.max(191)),
                 bindings: [.init(key: .named("integer_value"), value: .integer(254))]
             ),
             issue286ExpressionCase(
                 id: "string-printf-array",
                 featureID: "syntax.expression.string-functions",
                 statement: select(
-                    printf(
-                        format: "%s-%d",
-                        [namedText, namedInteger]
-                    )
+                    "%s-%d".printf([namedText, namedInteger])
                 ),
                 bindings: [
                     .init(key: .named("text_value"), value: .text("case")),


### PR DESCRIPTION
Closes #3.

## Summary

SwiftQL's expression functions were split between two styles: most are methods on `XLExpression` (e.g. `column.sumOrNull()`), but `count(_:)`, the scalar `min(_:)`/`max(_:)`, `iif(_:then:else:)`, and `printf(format:_:)` were free functions. This picks method style as the one recommended style — it's already the existing majority, and it's the one that gives the autocomplete-driven discoverability the issue asked for — following the same deprecate-in-favor-of pattern already used for the `OrNull` aggregate migration (`sum()` → `sumOrNull()`, etc.).

| Before | After |
|---|---|
| `count(all())` | `all().count()` |
| `min(a, b, ...)` / `max(a, b, ...)` | `a.min(b, ...)` / `a.max(b, ...)` |
| `iif(condition, then:, else:)` | `condition.iif(then:, else:)` |
| `printf(format: "...", ...)` | `"...".printf(...)` |

`switchCase`/`when` stay free functions — they're a builder entry point with no natural single receiver, so forcing one onto them would work against the same readability goal driving this change.

## Compatibility

Each free-function family gets `@available(*, deprecated)` with a migration message, matching the existing `sum()`/`average()`/`min()`/`max()` aggregate precedent exactly — deprecated, not removed, so nothing breaks. `a.min(b, ...)`/`a.max(b, ...)` require at least one further expression, both because SQLite's scalar `MIN`/`MAX` is meaningless with a single argument and to stay unambiguous against the deprecated zero-argument aggregate `min(distinct:)`/`max(distinct:)` method of the same name.

The package has a warnings-as-errors CI gate (`scripts/ci/check-first-party-warnings.sh`) covering Sources, Tests, and Benchmarks, so deprecating without migrating call sites would break CI. I migrated every real first-party call site to the method spelling (audited by grep, filtering out unrelated `Swift.min`/`Swift.max` usage on plain `Int`s elsewhere in the codebase, which this doesn't touch).

## Test plan

- [x] `swift build --build-tests` — zero warnings, zero errors
- [x] `swift test` (full package) — 743 tests, 0 failures
- [x] Documentation updated: `BuiltinFunctions.md` (new `min()`/`max()` section, updated `iif()`/`printf()` examples) and `Queries.md` (`count(all())` → `all().count()`), both with doc-test coverage in `SQLExampleTests.swift`
