### PR TITLE
Ship #row's ad hoc row projections in a Swift 5.9-safe form (#408)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -152,6 +152,25 @@ to the selected compiler so SwiftPM loads that toolchain's index-store runtime.
 The exact-version runtime probe, capability report, and full tests remain
 authoritative for the pinned SQLite surface.
 
+### Swift 5.9 API surface gaps
+
+The `#row(...)` freestanding macro's two-to-six column shapes (`SQLRow2`
+through `SQLRow6`) require `#if compiler(>=6.0)` and are unavailable on the
+Swift 5.9 support point. Decoding a result type with 2 or more generic
+parameters through `fetchAll()` or `publish()` crashes `swift-frontend` during
+IR generation (`NativeConventionSchema::mapIntoNative`) on the pinned Swift
+5.9.2 toolchain — reproduced with a minimal case in Docker
+(`swift:5.9.2-jammy` plus the pinned SQLite 3.53.3 amalgamation and the
+`GRDBCUSTOMSQLITE`/`SQLITE_ENABLE_SNAPSHOT` compiler override above),
+independent of restructuring the decode boundary to avoid returning the
+multi-generic-parameter type directly from `pool.read`, `ValueObservation`, or
+a Combine operator closure — every one of those crossings independently
+triggers the same crash for such a type. `#row`'s one-column shape
+(`SQLScalarResult`, a single generic parameter) is unaffected and remains
+available on every pinned cell. This is the package's first source-level API
+divergence across compiler cells; see `Sources/SwiftQL/SQLRowMacro.swift` and
+`Sources/SwiftQL/SQLRowResult.swift` for the gated declarations.
+
 ## Swift 6 series coverage
 
 | Swift series | GitHub runner | Xcode | Swift | macOS SDK |

--- a/Sources/SQLMacros/SQLMacro.swift
+++ b/Sources/SQLMacros/SQLMacro.swift
@@ -155,5 +155,6 @@ extension SQLResultMacro: ExtensionMacro {
     let providingMacros: [Macro.Type] = [
         SQLTableMacro.self,
         SQLResultMacro.self,
+        SQLRowMacro.self,
     ]
 }

--- a/Sources/SQLMacros/SQLRowMacro.swift
+++ b/Sources/SQLMacros/SQLRowMacro.swift
@@ -1,0 +1,76 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+
+///
+/// Implements the `#row(...)` freestanding expression macro.
+///
+/// The public overloads declared in `Sources/SwiftQL/SQLRowMacro.swift` fix the arity (one to
+/// six unlabeled column expressions) and the resulting ad hoc row type (`SQLScalarResult` for one
+/// column, `SQLRow2`...`SQLRow6` for two to six), so the only work left here is rewriting
+/// `#row(a, b, ...)` into the equivalent `Type.columns(...)` call the caller would otherwise have
+/// to spell out by hand:
+///
+///     #row(person.id, person.name)
+///     // -> SQLRow2.columns(_0: person.id, _1: person.name)
+///
+/// Because the public overloads already fix the arity and reject labeled arguments before this
+/// macro ever runs, the diagnostics below are unreachable through the declared `#row` overloads
+/// and only matter for direct `assertMacroExpansion` coverage or a future overload that relaxes
+/// those constraints.
+///
+public struct SQLRowMacro: ExpressionMacro {
+
+    static let fieldNames = ["_0", "_1", "_2", "_3", "_4", "_5"]
+
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        let arguments = Array(node.argumentList)
+
+        guard !arguments.isEmpty else {
+            context.diagnose(
+                Diagnostic(
+                    node: node,
+                    id: "row.emptyArgumentList",
+                    message: "'#row' requires at least one column expression, such as '#row(person.id)'."
+                )
+            )
+            return "()"
+        }
+
+        guard arguments.count <= fieldNames.count else {
+            context.diagnose(
+                Diagnostic(
+                    node: node,
+                    id: "row.tooManyArguments",
+                    message: "'#row' supports at most \(fieldNames.count) columns; declare a named result with '@SQLResult' for wider projections."
+                )
+            )
+            return "()"
+        }
+
+        for argument in arguments where argument.label != nil {
+            context.diagnose(
+                Diagnostic(
+                    node: argument,
+                    id: "row.labeledArgument",
+                    message: "'#row' does not accept labeled arguments; pass column expressions positionally, such as '#row(person.id, person.name)'."
+                )
+            )
+        }
+
+        if arguments.count == 1 {
+            let column = arguments[0].expression
+            return "SQLScalarResult.columns(scalarValue: \(column))"
+        }
+
+        let typeName = "SQLRow\(arguments.count)"
+        let columnArguments = arguments.enumerated().map { index, argument in
+            "\(fieldNames[index]): \(argument.expression)"
+        }.joined(separator: ", ")
+        return "\(raw: typeName).columns(\(raw: columnArguments))"
+    }
+}

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -269,11 +269,15 @@ struct GRDBRequest<Row>: XLRequest {
         // Accumulate into an outer array and return Void from the closure,
         // instead of returning [Row] directly from withReadConnection<Result>.
         // On the pinned Swift 5.9.2 compatibility cell, instantiating that
-        // generic reabstraction boundary with a 2+ generic-parameter Row type
-        // (e.g. #row's SQLRow2...6) crashes swift-frontend in IRGen
+        // specific generic reabstraction boundary with a 2+ generic-parameter
+        // Row type (e.g. #row's SQLRow2...6) crashes swift-frontend in IRGen
         // (NativeConventionSchema::mapIntoNative). This shape has no cost on
-        // any other Row type and protects every multi-generic result type
-        // from the same bug, not just #row's.
+        // any other Row type, and it protects this one fetchAll() boundary
+        // from that crash — it is not a blanket fix for the bug class: the
+        // publish()/publishOne() paths below independently hit the same
+        // crash through their own generic publisher/witness-method return
+        // types, which is why #row's 2+-column shapes stay gated to Swift
+        // 6.0+ (SQLRowMacro.swift) rather than being unlocked by this change.
         var items: [Row] = []
         try driver.withReadConnection { connection in
             items = try decodeRows(packet: packet, in: &connection)

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -266,9 +266,19 @@ struct GRDBRequest<Row>: XLRequest {
         packet: XLInvocationBindings<XLSQLiteValue>
     ) throws -> [Row] {
         var driver = executor.driver
-        return try driver.withReadConnection { connection in
-            try decodeRows(packet: packet, in: &connection)
+        // Accumulate into an outer array and return Void from the closure,
+        // instead of returning [Row] directly from withReadConnection<Result>.
+        // On the pinned Swift 5.9.2 compatibility cell, instantiating that
+        // generic reabstraction boundary with a 2+ generic-parameter Row type
+        // (e.g. #row's SQLRow2...6) crashes swift-frontend in IRGen
+        // (NativeConventionSchema::mapIntoNative). This shape has no cost on
+        // any other Row type and protects every multi-generic result type
+        // from the same bug, not just #row's.
+        var items: [Row] = []
+        try driver.withReadConnection { connection in
+            items = try decodeRows(packet: packet, in: &connection)
         }
+        return items
     }
 
     private func decodeRows(

--- a/Sources/SwiftQL/SQLRowMacro.swift
+++ b/Sources/SwiftQL/SQLRowMacro.swift
@@ -1,0 +1,72 @@
+///
+/// Defines the `#row` macro.
+///
+/// `#row(...)` builds an ad hoc, unnamed row projection from a short list of column
+/// expressions, the same way `Type.columns(...)` builds a named one for a declared
+/// `@SQLResult`/`@SQLTable` type. Use `#row` for a quick, one-off projection that does not
+/// deserve (or does not yet have) a declared result type; use `.columns(...)` on a declared
+/// `@SQLResult`/`@SQLTable` type when the columns have meaningful names that should appear in
+/// the decoded model.
+///
+/// `#row` accepts between one and six column expressions:
+///
+/// ```swift
+/// let row = #row(person.id, person.name)
+/// Select(row)
+/// From(person)
+/// ```
+///
+/// A single column expands to ``SQLScalarResult``; two to six columns expand to the matching
+/// ``SQLRow2``...``SQLRow6`` type, whose fields are named positionally (`_0`, `_1`, ...).
+///
+/// Available on Swift 6.0 and later only. Decoding a 2+ generic-parameter result type
+/// (`SQLRow2`...`SQLRow6`) through `fetchAll()`/`publish()` crashes swift-frontend in IRGen
+/// on the pinned Swift 5.9.2 compatibility cell (`NativeConventionSchema::mapIntoNative`).
+/// See #408 and COMPATIBILITY.md.
+///
+#if compiler(>=6.0)
+@freestanding(expression)
+public macro row<C0>(
+    _ c0: any XLExpression<C0>
+) -> SQLScalarResult<C0>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>
+) -> SQLRow2<C0, C1>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1, C2>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>,
+    _ c2: any XLExpression<C2>
+) -> SQLRow3<C0, C1, C2>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1, C2, C3>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>,
+    _ c2: any XLExpression<C2>,
+    _ c3: any XLExpression<C3>
+) -> SQLRow4<C0, C1, C2, C3>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1, C2, C3, C4>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>,
+    _ c2: any XLExpression<C2>,
+    _ c3: any XLExpression<C3>,
+    _ c4: any XLExpression<C4>
+) -> SQLRow5<C0, C1, C2, C3, C4>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression, C4: XLLiteral & XLExpression
+
+@freestanding(expression)
+public macro row<C0, C1, C2, C3, C4, C5>(
+    _ c0: any XLExpression<C0>,
+    _ c1: any XLExpression<C1>,
+    _ c2: any XLExpression<C2>,
+    _ c3: any XLExpression<C3>,
+    _ c4: any XLExpression<C4>,
+    _ c5: any XLExpression<C5>
+) -> SQLRow6<C0, C1, C2, C3, C4, C5>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression, C4: XLLiteral & XLExpression, C5: XLLiteral & XLExpression
+#endif

--- a/Sources/SwiftQL/SQLRowMacro.swift
+++ b/Sources/SwiftQL/SQLRowMacro.swift
@@ -19,17 +19,19 @@
 /// A single column expands to ``SQLScalarResult``; two to six columns expand to the matching
 /// ``SQLRow2``...``SQLRow6`` type, whose fields are named positionally (`_0`, `_1`, ...).
 ///
-/// Available on Swift 6.0 and later only. Decoding a 2+ generic-parameter result type
-/// (`SQLRow2`...`SQLRow6`) through `fetchAll()`/`publish()` crashes swift-frontend in IRGen
-/// on the pinned Swift 5.9.2 compatibility cell (`NativeConventionSchema::mapIntoNative`).
-/// See #408 and COMPATIBILITY.md.
+/// The two-to-six column shapes are available on Swift 6.0 and later only. Decoding a
+/// 2+ generic-parameter result type (`SQLRow2`...`SQLRow6`) through `fetchAll()`/`publish()`
+/// crashes swift-frontend in IRGen on the pinned Swift 5.9.2 compatibility cell
+/// (`NativeConventionSchema::mapIntoNative`). The one-column shape (`SQLScalarResult`, a single
+/// generic parameter) is unaffected and available on every compatibility cell. See #408 and
+/// COMPATIBILITY.md.
 ///
-#if compiler(>=6.0)
 @freestanding(expression)
 public macro row<C0>(
     _ c0: any XLExpression<C0>
 ) -> SQLScalarResult<C0>.MetaResult = #externalMacro(module: "SQLMacros", type: "SQLRowMacro") where C0: XLLiteral & XLExpression
 
+#if compiler(>=6.0)
 @freestanding(expression)
 public macro row<C0, C1>(
     _ c0: any XLExpression<C0>,

--- a/Sources/SwiftQL/SQLRowResult.swift
+++ b/Sources/SwiftQL/SQLRowResult.swift
@@ -1,0 +1,124 @@
+//
+//  SQLRowResult.swift
+//
+//
+//  Ad hoc row projections used by the `#row` macro (see SQLRowMacro.swift).
+//
+//  Gated to Swift 6.0+: on the pinned Swift 5.9.2 compatibility cell,
+//  decoding a 2+ generic-parameter result type (SQLRow2...6) through
+//  fetchAll()/publish() crashes swift-frontend in IRGen
+//  (NativeConventionSchema::mapIntoNative). See #408 and COMPATIBILITY.md.
+//
+
+#if compiler(>=6.0)
+import Foundation
+
+///
+/// A two-column ad hoc row projection.
+///
+/// `SQLRow2` and its siblings (`SQLRow3`...`SQLRow6`) exist so `#row(...)` can build a result
+/// column set without requiring the caller to declare a named `@SQLResult` type first. Fields are
+/// exposed positionally as `_0`, `_1`, ... because the columns have no caller-chosen name; declare
+/// an `@SQLResult` type instead when the projection is reused or the columns deserve real names.
+///
+@SQLResult
+public struct SQLRow2<C0, C1> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+}
+
+extension SQLRow2: Equatable where C0: Equatable, C1: Equatable {
+
+}
+
+extension SQLRow2: Hashable where C0: Hashable, C1: Hashable {
+
+}
+
+
+///
+/// A three-column ad hoc row projection. See ``SQLRow2``.
+///
+@SQLResult
+public struct SQLRow3<C0, C1, C2> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+    public var _2: C2
+}
+
+extension SQLRow3: Equatable where C0: Equatable, C1: Equatable, C2: Equatable {
+
+}
+
+extension SQLRow3: Hashable where C0: Hashable, C1: Hashable, C2: Hashable {
+
+}
+
+
+///
+/// A four-column ad hoc row projection. See ``SQLRow2``.
+///
+@SQLResult
+public struct SQLRow4<C0, C1, C2, C3> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+    public var _2: C2
+    public var _3: C3
+}
+
+extension SQLRow4: Equatable where C0: Equatable, C1: Equatable, C2: Equatable, C3: Equatable {
+
+}
+
+extension SQLRow4: Hashable where C0: Hashable, C1: Hashable, C2: Hashable, C3: Hashable {
+
+}
+
+
+///
+/// A five-column ad hoc row projection. See ``SQLRow2``.
+///
+@SQLResult
+public struct SQLRow5<C0, C1, C2, C3, C4> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression, C4: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+    public var _2: C2
+    public var _3: C3
+    public var _4: C4
+}
+
+extension SQLRow5: Equatable where C0: Equatable, C1: Equatable, C2: Equatable, C3: Equatable, C4: Equatable {
+
+}
+
+extension SQLRow5: Hashable where C0: Hashable, C1: Hashable, C2: Hashable, C3: Hashable, C4: Hashable {
+
+}
+
+
+///
+/// A six-column ad hoc row projection. See ``SQLRow2``.
+///
+@SQLResult
+public struct SQLRow6<C0, C1, C2, C3, C4, C5> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression, C2: XLLiteral & XLExpression, C3: XLLiteral & XLExpression, C4: XLLiteral & XLExpression, C5: XLLiteral & XLExpression {
+
+    public var _0: C0
+    public var _1: C1
+    public var _2: C2
+    public var _3: C3
+    public var _4: C4
+    public var _5: C5
+}
+
+extension SQLRow6: Equatable where C0: Equatable, C1: Equatable, C2: Equatable, C3: Equatable, C4: Equatable, C5: Equatable {
+
+}
+
+extension SQLRow6: Hashable where C0: Hashable, C1: Hashable, C2: Hashable, C3: Hashable, C4: Hashable, C5: Hashable {
+
+}
+#endif

--- a/Sources/SwiftQL/SwiftQL.docc/Queries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/Queries.md
@@ -168,6 +168,55 @@ let query = sql { schema in
 > Tip: Use `Join.Cross` or `Join.Inner` to perform a cross or inner 
 join respectively.
 
+### Ad hoc rows with `#row`
+
+Declaring a `@SQLResult` type is the right choice when a projection is reused
+or its columns deserve real names. For a quick, one-off projection that is
+used in a single query, the `#row(...)` macro builds the same kind of column
+set without declaring a type first:
+
+<!-- test: XLDocumentationTests.testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs -->
+```swift
+let query = sql { schema in
+    let person = schema.table(Person.self)
+    let occupation = schema.nullableTable(Occupation.self)
+    Select(#row(person.name, occupation.name))
+    From(person)
+    Join.Left(occupation, on: occupation.id == person.occupationId)
+}
+```
+
+`#row` accepts between one and six column expressions. A single column
+decodes into ``SQLScalarResult``; two to six columns decode into the matching
+`SQLRow2`...`SQLRow6` type, whose fields are named positionally (`_0`, `_1`,
+...) since the columns have no caller-chosen name:
+
+<!-- test: XLDocumentationTests.testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs -->
+```swift
+let query = sql { schema in
+    let person = schema.table(Person.self)
+    let occupation = schema.nullableTable(Occupation.self)
+    let row = #row(person.name, occupation.name)
+    Select(row)
+    From(person)
+    Join.Left(occupation, on: occupation.id == person.occupationId)
+    Where(row._0 != "Fred")
+}
+```
+
+> Tip: Reach for a named `@SQLResult` type once a projection's columns need
+> descriptive names, or once the projection is reused across more than one
+> query.
+
+> Important: `#row`'s two-to-six column shapes (`SQLRow2`...`SQLRow6`) require
+> Swift 6.0 or later. On the pinned Swift 5.9.2 compatibility cell, decoding
+> a result type with 2 or more generic parameters through `fetchAll()` or
+> `publish()` crashes the compiler's IR generation — a confirmed
+> `swift-frontend` bug, not a SwiftQL limitation. `#row` with exactly one
+> column (`SQLScalarResult`) is unaffected and available everywhere. See
+> [Compatibility](https://github.com/lukevanin/swiftql/blob/main/COMPATIBILITY.md)
+> for the supported-compiler matrix.
+
 ## Group By
 
 Use the group by clause to return aggregate results, or results where a single

--- a/Tests/SQLMacrosTests/SQLRowMacroTests.swift
+++ b/Tests/SQLMacrosTests/SQLRowMacroTests.swift
@@ -1,0 +1,151 @@
+//
+//  SQLRowMacroTests.swift
+//  SwiftQL
+//
+//  Macro-expansion tests for the `#row` freestanding expression macro: the supported one- through
+//  six-column shapes, and the diagnostics for misuse.
+//
+
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import SQLMacros
+
+
+private func makeRowTestMacros() -> [String: Macro.Type] {
+    ["row": SQLRowMacro.self]
+}
+
+
+final class SQLRowMacroExpansionTests: XCTestCase {
+
+    func test_oneColumn_expandsToScalarResultColumns() {
+        assertMacroExpansion(
+            """
+            let row = #row(person.id)
+            """,
+            expandedSource: """
+            let row = SQLScalarResult.columns(scalarValue: person.id)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_twoColumns_expandsToSQLRow2Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(person.id, person.name)
+            """,
+            expandedSource: """
+            let row = SQLRow2.columns(_0: person.id, _1: person.name)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_threeColumns_expandsToSQLRow3Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(person.id, person.name, person.age)
+            """,
+            expandedSource: """
+            let row = SQLRow3.columns(_0: person.id, _1: person.name, _2: person.age)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_fourColumns_expandsToSQLRow4Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(a, b, c, d)
+            """,
+            expandedSource: """
+            let row = SQLRow4.columns(_0: a, _1: b, _2: c, _3: d)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_fiveColumns_expandsToSQLRow5Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(a, b, c, d, e)
+            """,
+            expandedSource: """
+            let row = SQLRow5.columns(_0: a, _1: b, _2: c, _3: d, _4: e)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_sixColumns_expandsToSQLRow6Columns() {
+        assertMacroExpansion(
+            """
+            let row = #row(a, b, c, d, e, f)
+            """,
+            expandedSource: """
+            let row = SQLRow6.columns(_0: a, _1: b, _2: c, _3: d, _4: e, _5: f)
+            """,
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_zeroColumns_emitsDiagnostic() {
+        assertMacroExpansion(
+            """
+            let row = #row()
+            """,
+            expandedSource: """
+            let row = ()
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'#row' requires at least one column expression, such as '#row(person.id)'.",
+                    line: 1,
+                    column: 11
+                )
+            ],
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_tooManyColumns_emitsDiagnostic() {
+        assertMacroExpansion(
+            """
+            let row = #row(a, b, c, d, e, f, g)
+            """,
+            expandedSource: """
+            let row = ()
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'#row' supports at most 6 columns; declare a named result with '@SQLResult' for wider projections.",
+                    line: 1,
+                    column: 11
+                )
+            ],
+            macros: makeRowTestMacros()
+        )
+    }
+
+    func test_labeledArgument_emitsDiagnostic() {
+        assertMacroExpansion(
+            """
+            let row = #row(scalarValue: person.id)
+            """,
+            expandedSource: """
+            let row = SQLScalarResult.columns(scalarValue: person.id)
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "'#row' does not accept labeled arguments; pass column expressions positionally, such as '#row(person.id, person.name)'.",
+                    line: 1,
+                    column: 16
+                )
+            ],
+            macros: makeRowTestMacros()
+        )
+    }
+}

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -793,6 +793,41 @@ final class XLDocumentationTests: XCTestCase {
         ])
     }
 
+    // #row's 2+-column shapes require Swift 6.0+; see SQLRowMacro.swift and
+    // COMPATIBILITY.md for why (#408).
+    #if compiler(>=6.0)
+    func testExample_RowMacro() throws {
+        let statement = sql { schema in
+            let person = schema.table(Person.self)
+            let occupation = schema.nullableTable(Occupation.self)
+            Select(#row(person.name, occupation.name))
+            From(person)
+            Join.Left(occupation, on: occupation.id == person.occupationId)
+        }
+        let sql = encoder.makeSQL(statement).sql
+        XCTAssertEqual(sql, "SELECT t0.name AS _0, t1.name AS _1 FROM Person AS t0 LEFT JOIN Occupation AS t1 ON (t1.id IS t0.occupationId)")
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(rows.map { $0._0 }, ["John Doe", "Jane Doe", "Yogi Bear"])
+        XCTAssertEqual(rows.map { $0._1 }, ["Engineer", "Scientist", nil])
+    }
+
+    func testExample_RowMacro_ReferencedInWhereClause() throws {
+        let statement = sql { schema in
+            let person = schema.table(Person.self)
+            let occupation = schema.nullableTable(Occupation.self)
+            let row = #row(person.name, occupation.name)
+            Select(row)
+            From(person)
+            Join.Left(occupation, on: occupation.id == person.occupationId)
+            Where(row._0 != "Fred")
+        }
+        let sql = encoder.makeSQL(statement).sql
+        XCTAssertEqual(sql, "SELECT t0.name AS _0, t1.name AS _1 FROM Person AS t0 LEFT JOIN Occupation AS t1 ON (t1.id IS t0.occupationId) WHERE (_0 != 'Fred')")
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertEqual(rows.map { $0._0 }, ["John Doe", "Jane Doe", "Yogi Bear"])
+    }
+    #endif
+
     func testExample_LeftJoin_Functional_NullRows() throws {
         let statement = sqlQuery { schema in
             let person = schema.table(Person.self)
@@ -2100,6 +2135,10 @@ extension XLDocumentationTests {
 
     func testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs() throws {
         try testExample_LeftJoin_Statement_NullRows()
+        #if compiler(>=6.0)
+        try testExample_RowMacro()
+        try testExample_RowMacro_ReferencedInWhereClause()
+        #endif
         try testExample_Subquery()
 
         let _: (XLExecutionTests) -> () throws -> Void = XLExecutionTests.testGroupConcatVariants

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -2178,6 +2178,36 @@ final class XLExecutionTests: XCTestCase {
     }
 
 
+    // MARK: - #row (#408)
+
+    /// `#row`'s one-column shape (`SQLScalarResult`, a single generic
+    /// parameter) is available on every compatibility cell, unlike the
+    /// two-to-six column shapes gated to Swift 6.0+ in SQLRowMacro.swift.
+    /// Deliberately not gated, so this actually runs on the Swift 5.9 cells
+    /// too.
+    func testRowMacroOneColumnDecodesThroughFetchAll() throws {
+        try createTestTable()
+        try insertTest(TestTable(id: "bar", value: 42))
+
+        let statement = sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(#row(table.value))
+            From(table)
+        }
+        // XCTAssertTrue, not XCTAssertEqual: confirmed in a Docker repro
+        // against the pinned Swift 5.9.2 toolchain that XCTAssertEqual's
+        // generic <T: Equatable> signature triggers an IRGen reabstraction
+        // crash here (a property of this test's specific code shape, not of
+        // #row or the production decode path — testStringToDataRoundTrip
+        // below uses XCTAssertEqual against a fetchAll()-decoded
+        // SQLScalarResult<Data> array without incident). XCTAssertTrue's
+        // fixed Bool signature needs no such reabstraction.
+        let rows = try database.makeRequest(with: statement).fetchAll()
+        XCTAssertTrue(rows.count == 1)
+        XCTAssertTrue(rows[0].scalarValue == 42)
+    }
+
+
     // MARK: - Helpers
 
     private func createTestTable() throws {

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -2203,8 +2203,11 @@ final class XLExecutionTests: XCTestCase {
         // SQLScalarResult<Data> array without incident). XCTAssertTrue's
         // fixed Bool signature needs no such reabstraction.
         let rows = try database.makeRequest(with: statement).fetchAll()
-        XCTAssertTrue(rows.count == 1)
-        XCTAssertTrue(rows[0].scalarValue == 42)
+        guard let onlyRow = rows.first, rows.count == 1 else {
+            XCTFail("Expected exactly one row, got \(rows.count)")
+            return
+        }
+        XCTAssertTrue(onlyRow.scalarValue == 42)
     }
 
 

--- a/Tests/SQLTests/SQLRowExecutionTests.swift
+++ b/Tests/SQLTests/SQLRowExecutionTests.swift
@@ -78,16 +78,20 @@ final class SQLRowExecutionTests: XCTestCase {
         try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
         try database.makeRequest(with: sqlInsert(TestTable(id: "bar", value: 42))).execute()
 
+        // Fulfill on every path — failure, mismatch, or success — so a
+        // regression fails immediately with its real message instead of
+        // hanging until the timeout.
         let expectation = expectation(description: "published rows")
         database.makeRequest(with: makeTwoColumnStatement()).publish()
             .sink(
                 receiveCompletion: { completion in
                     if case .failure(let error) = completion {
                         XCTFail("Unexpected publisher failure: \(error)")
+                        expectation.fulfill()
                     }
                 },
                 receiveValue: { rows in
-                    guard rows.map({ $0._0 }) == ["bar"] else { return }
+                    XCTAssertEqual(rows.map { $0._0 }, ["bar"])
                     expectation.fulfill()
                 }
             )

--- a/Tests/SQLTests/SQLRowExecutionTests.swift
+++ b/Tests/SQLTests/SQLRowExecutionTests.swift
@@ -78,19 +78,29 @@ final class SQLRowExecutionTests: XCTestCase {
         try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
         try database.makeRequest(with: sqlInsert(TestTable(id: "bar", value: 42))).execute()
 
-        // Fulfill on every path — failure, mismatch, or success — so a
-        // regression fails immediately with its real message instead of
-        // hanging until the timeout.
+        // Fulfill on every path — failure, finishing with no value, mismatch,
+        // or success — so a regression fails immediately with its real
+        // message instead of hanging until the timeout. Over-fulfillment is
+        // allowed since a live query may emit more than one snapshot.
         let expectation = expectation(description: "published rows")
+        expectation.assertForOverFulfill = false
+        var receivedValue = false
         database.makeRequest(with: makeTwoColumnStatement()).publish()
             .sink(
                 receiveCompletion: { completion in
-                    if case .failure(let error) = completion {
+                    switch completion {
+                    case .failure(let error):
                         XCTFail("Unexpected publisher failure: \(error)")
                         expectation.fulfill()
+                    case .finished:
+                        if !receivedValue {
+                            XCTFail("Publisher finished without emitting a value")
+                            expectation.fulfill()
+                        }
                     }
                 },
                 receiveValue: { rows in
+                    receivedValue = true
                     XCTAssertEqual(rows.map { $0._0 }, ["bar"])
                     expectation.fulfill()
                 }

--- a/Tests/SQLTests/SQLRowExecutionTests.swift
+++ b/Tests/SQLTests/SQLRowExecutionTests.swift
@@ -1,0 +1,111 @@
+//
+//  SQLRowExecutionTests.swift
+//
+//
+//  Real-SQLite coverage for the `#row` ad hoc row projection macro (#408,
+//  follow-up to #20). Gated to Swift 6.0+ — see SQLRowMacro.swift and
+//  COMPATIBILITY.md for why `#row`'s 2+-column shapes are unavailable on the
+//  pinned Swift 5.9.2 compatibility cell.
+//
+
+#if compiler(>=6.0)
+import Foundation
+import XCTest
+import GRDB
+#if canImport(Combine)
+import Combine
+#else
+import OpenCombine
+#endif
+import SwiftQL
+
+
+final class SQLRowExecutionTests: XCTestCase {
+
+    var databasePool: DatabasePool!
+    var database: GRDBDatabase!
+    var cancellables: Set<AnyCancellable> = []
+
+    override func setUp() {
+        let formatter = XLiteFormatter(identifierFormattingOptions: .mysqlCompatible)
+        let directory = FileManager.default.temporaryDirectory
+        let fileURL = directory
+            .appendingPathComponent(UUID().uuidString, isDirectory: false)
+            .appendingPathExtension("sqlite")
+        databasePool = try! DatabasePool(path: fileURL.path)
+        database = try! GRDBDatabase(databasePool: databasePool, formatter: formatter, logger: nil)
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        database = nil
+        databasePool = nil
+    }
+
+    private func makeTwoColumnStatement() -> any XLQueryStatement<SQLRow2<String, Int>> {
+        sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(#row(table.id, table.value))
+            From(table)
+            OrderBy(table.id.ascending())
+        }
+    }
+
+    /// `#row`'s 2+-column shape (`SQLRow2`) decoding through `fetchAll()` is
+    /// exactly the case that crashed swift-frontend on Swift 5.9.2 (#408):
+    /// a 2-generic-parameter result type crossing GRDB's pooled read
+    /// connection boundary.
+    func testRowMacroDecodesTwoColumnsThroughFetchAll() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "bar", value: 42))).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "foo", value: 7))).execute()
+
+        let rows = try database.makeRequest(with: makeTwoColumnStatement()).fetchAll()
+        XCTAssertEqual(rows.map { $0._0 }, ["bar", "foo"])
+        XCTAssertEqual(rows.map { $0._1 }, [42, 7])
+    }
+
+    func testRowMacroDecodesTwoColumnsThroughFetchOne() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "bar", value: 42))).execute()
+
+        let row = try database.makeRequest(with: makeTwoColumnStatement()).fetchOne()
+        XCTAssertEqual(row?._0, "bar")
+        XCTAssertEqual(row?._1, 42)
+    }
+
+    func testRowMacroDecodesTwoColumnsThroughPublish() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "bar", value: 42))).execute()
+
+        let expectation = expectation(description: "published rows")
+        database.makeRequest(with: makeTwoColumnStatement()).publish()
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("Unexpected publisher failure: \(error)")
+                    }
+                },
+                receiveValue: { rows in
+                    guard rows.map({ $0._0 }) == ["bar"] else { return }
+                    expectation.fulfill()
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 2)
+    }
+
+    func testRowMacroDecodesOneColumnThroughScalarResult() throws {
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "bar", value: 42))).execute()
+
+        let statement = sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(#row(table.value))
+            From(table)
+        }
+        let row = try database.makeRequest(with: statement).fetchOne()
+        XCTAssertEqual(row?.scalarValue, 42)
+    }
+}
+#endif


### PR DESCRIPTION
Closes #408. Closes #20.

## Summary

Restores PR #383's `#row` freestanding macro (reverted by `4db1f34d` after a Swift 5.9.2 IRGen crash), gated to Swift 6.0+ instead of shipping unconditionally.

## What I found

I investigated #408's proposed root-cause fix (option A): restructuring `GRDBRequest.decodeRows(packet:)` to accumulate into an outer array and return `Void` from the `withReadConnection` closure, instead of returning `[Row]` directly. **This does eliminate that specific crash** — kept in this PR as a general, zero-cost improvement that protects every multi-generic-parameter result type from that boundary, not just `#row`'s (`GRDBSQLDatabase.swift`).

**It does not fully solve the problem, though.** I reproduced the crash in Docker (`swift:5.9.2-jammy`, the pinned SQLite 3.53.3 amalgamation, and the CI workflow's exact `GRDBCUSTOMSQLITE`/`SQLITE_ENABLE_SNAPSHOT` compiler wrapper — same repro recipe as the original investigation) and confirmed empirically that `publish()`/`publishOne()` hit the same IRGen bug **independently**: I stubbed both bodies to a bare `fatalError()` — no real closures, no Combine operators at all — and the build **still crashed**. That's because `GRDBRequest<Row>`'s conformance to `XLRequest` requires the compiler to emit those witness methods for whatever `Row` it's instantiated with, and it's the `AnyPublisher<[Row], Error>`/`AnyPublisher<Row?, Error>` **return type itself** — needed unconditionally to satisfy the protocol — that can't avoid the crash, regardless of how the body is written or where decoding happens (`pool.read`, `ValueObservation`, or a Combine operator closure all crash identically).

This is a materially different, and more fundamental, finding than the original issue anticipated: the bug isn't confined to one crossing point that a single restructuring fixes.

Given that, ad hoc rows with 2+ generic parameters (`SQLRow2`...`SQLRow6`) are only available on Swift 6.0+ (option C from the issue). The single-column shape (`SQLScalarResult`, one generic parameter) is unaffected and available everywhere — matching `SQLScalarResult`'s existing proven-safe usage throughout the test suite today.

## Changes

- `Sources/SwiftQL/SQLRowResult.swift`, `Sources/SwiftQL/SQLRowMacro.swift`: restored from #383, wrapped in `#if compiler(>=6.0)`.
- `Sources/SQLMacros/SQLRowMacro.swift` (the macro plugin implementation) and its registration in `SQLMacro.swift`: restored **unchanged, no gating needed** — the plugin only rewrites syntax at expansion time and never itself gets specialized against `SQLRow2...6`.
- `Sources/SwiftQL/GRDBSQLDatabase.swift`: the `decodeRows(packet:)` boundary fix described above.
- `Tests/SQLMacrosTests/SQLRowMacroTests.swift`: restored unchanged — these are pure macro-expansion string-comparison tests (`assertMacroExpansion`), unaffected by the runtime crash since they never type-check the expanded code.
- `Tests/SQLTests/SQLRowExecutionTests.swift`: new real-SQLite coverage, gated to Swift 6.0+, exercising the exact crash scenario — `fetchAll()`, `fetchOne()`, and `publish()` through a 2-column `#row`. All pass.
- `COMPATIBILITY.md`: documented the gap under a new "Swift 5.9 API surface gaps" section — this is the package's first source-level API divergence across compiler cells.
- `Queries.md`: restored the `#row` doc section from #383, with an added availability note.

## Test plan

- [x] `swift build --build-tests` (host, Swift 6.x) — zero warnings, zero errors
- [x] `swift test` (full package, host) — all green, including new `#row` execution tests (`fetchAll`/`fetchOne`/`publish`) and macro-expansion tests
- [x] **Docker repro on `swift:5.9.2-jammy`** with the pinned SQLite 3.53.3 amalgamation and the CI workflow's exact compiler wrapper: confirmed the crash reproduces on the original (unfixed, ungated) code; confirmed the `decodeRows` fix alone isn't sufficient (`publish`/`publishOne` crash independently, even stubbed); confirmed `swift build --build-tests` succeeds cleanly (**exit 0**) with `#row`'s 2+-column shapes gated away as shipped in this PR
