### PR TITLE
Add JSON Codable codec support for SQLite TEXT/BLOB columns

### DIFF
--- a/Sources/SwiftQL/JSONValueCodec.swift
+++ b/Sources/SwiftQL/JSONValueCodec.swift
@@ -1,32 +1,6 @@
 import Foundation
 
 
-/// SQLite storage representation produced by a JSON `Codable` codec.
-///
-/// `TEXT` and `BLOB` are not interchangeable. They are distinct SQLite
-/// storage classes with distinct stable ``XLValueCodecIdentity`` values, so a
-/// codec built for one storage never silently accepts or reinterprets bytes
-/// produced for the other; a mismatch fails with
-/// `XLValueCodecError.storageMismatch`.
-public enum XLJSONValueCodecStorage: String, Hashable, Sendable {
-
-    /// UTF-8 encoded JSON text, stored as SQLite `TEXT`.
-    case text
-
-    /// Raw JSON bytes, stored as SQLite `BLOB`.
-    case blob
-
-    var storageClass: XLSQLiteStorageClass {
-        switch self {
-        case .text:
-            return .text
-        case .blob:
-            return .blob
-        }
-    }
-}
-
-
 /// An immutable, `Sendable` snapshot of the `JSONEncoder`/`JSONDecoder`
 /// strategies used by ``XLJSONValueCodec`` factories.
 ///

--- a/Sources/SwiftQL/JSONValueCodec.swift
+++ b/Sources/SwiftQL/JSONValueCodec.swift
@@ -1,0 +1,374 @@
+import Foundation
+
+
+/// SQLite storage representation produced by a JSON `Codable` codec.
+///
+/// `TEXT` and `BLOB` are not interchangeable. They are distinct SQLite
+/// storage classes with distinct stable ``XLValueCodecIdentity`` values, so a
+/// codec built for one storage never silently accepts or reinterprets bytes
+/// produced for the other; a mismatch fails with
+/// `XLValueCodecError.storageMismatch`.
+public enum XLJSONValueCodecStorage: String, Hashable, Sendable {
+
+    /// UTF-8 encoded JSON text, stored as SQLite `TEXT`.
+    case text
+
+    /// Raw JSON bytes, stored as SQLite `BLOB`.
+    case blob
+
+    var storageClass: XLSQLiteStorageClass {
+        switch self {
+        case .text:
+            return .text
+        case .blob:
+            return .blob
+        }
+    }
+}
+
+
+/// An immutable, `Sendable` snapshot of the `JSONEncoder`/`JSONDecoder`
+/// strategies used by ``XLJSONValueCodec`` factories.
+///
+/// Only strategies that have a stable `Sendable` value-type representation
+/// are exposed. A live `JSONEncoder`/`JSONDecoder` instance is never
+/// captured or shared across calls: every encode and decode builds a fresh
+/// encoder or decoder from this snapshot, so there is no process-global or
+/// shared mutable JSON configuration. A mapping that needs a closure-based
+/// strategy (for example a custom date formatter) is out of scope for this
+/// factory; construct an `XLValueCodec` directly for that case.
+public struct XLJSONCodecConfiguration: Hashable, Sendable {
+
+    /// Mirrors the `Sendable`-safe cases of `JSONEncoder.KeyEncodingStrategy`.
+    public enum KeyEncodingStrategy: Hashable, Sendable {
+        case useDefaultKeys
+        case convertToSnakeCase
+    }
+
+    /// Mirrors the `Sendable`-safe cases of `JSONDecoder.KeyDecodingStrategy`.
+    public enum KeyDecodingStrategy: Hashable, Sendable {
+        case useDefaultKeys
+        case convertFromSnakeCase
+    }
+
+    /// Mirrors the `Sendable`-safe cases of `JSONEncoder.DateEncodingStrategy`.
+    public enum DateEncodingStrategy: Hashable, Sendable {
+        case deferredToDate
+        case secondsSince1970
+        case millisecondsSince1970
+        case iso8601
+    }
+
+    /// Mirrors the `Sendable`-safe cases of `JSONDecoder.DateDecodingStrategy`.
+    public enum DateDecodingStrategy: Hashable, Sendable {
+        case deferredToDate
+        case secondsSince1970
+        case millisecondsSince1970
+        case iso8601
+    }
+
+    /// Mirrors the `Sendable`-safe cases of `JSONEncoder.DataEncodingStrategy`.
+    public enum DataEncodingStrategy: Hashable, Sendable {
+        case base64
+        case deferredToData
+    }
+
+    /// Mirrors the `Sendable`-safe cases of `JSONDecoder.DataDecodingStrategy`.
+    public enum DataDecodingStrategy: Hashable, Sendable {
+        case base64
+        case deferredToData
+    }
+
+    public var keyEncodingStrategy: KeyEncodingStrategy
+
+    public var keyDecodingStrategy: KeyDecodingStrategy
+
+    public var dateEncodingStrategy: DateEncodingStrategy
+
+    public var dateDecodingStrategy: DateDecodingStrategy
+
+    public var dataEncodingStrategy: DataEncodingStrategy
+
+    public var dataDecodingStrategy: DataDecodingStrategy
+
+    /// Sorts object keys while encoding so two calls that encode equal
+    /// values produce byte-identical JSON.
+    ///
+    /// This is a canonicalization aid for stable storage and comparison, not
+    /// a schema guarantee: it only orders keys that `Value`'s `Encodable`
+    /// implementation already writes. Defaults to `true`.
+    public var sortsKeys: Bool
+
+    public init(
+        keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys,
+        keyDecodingStrategy: KeyDecodingStrategy = .useDefaultKeys,
+        dateEncodingStrategy: DateEncodingStrategy = .deferredToDate,
+        dateDecodingStrategy: DateDecodingStrategy = .deferredToDate,
+        dataEncodingStrategy: DataEncodingStrategy = .base64,
+        dataDecodingStrategy: DataDecodingStrategy = .base64,
+        sortsKeys: Bool = true
+    ) {
+        self.keyEncodingStrategy = keyEncodingStrategy
+        self.keyDecodingStrategy = keyDecodingStrategy
+        self.dateEncodingStrategy = dateEncodingStrategy
+        self.dateDecodingStrategy = dateDecodingStrategy
+        self.dataEncodingStrategy = dataEncodingStrategy
+        self.dataDecodingStrategy = dataDecodingStrategy
+        self.sortsKeys = sortsKeys
+    }
+
+    func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        switch keyEncodingStrategy {
+        case .useDefaultKeys:
+            encoder.keyEncodingStrategy = .useDefaultKeys
+        case .convertToSnakeCase:
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+        }
+        switch dateEncodingStrategy {
+        case .deferredToDate:
+            encoder.dateEncodingStrategy = .deferredToDate
+        case .secondsSince1970:
+            encoder.dateEncodingStrategy = .secondsSince1970
+        case .millisecondsSince1970:
+            encoder.dateEncodingStrategy = .millisecondsSince1970
+        case .iso8601:
+            encoder.dateEncodingStrategy = .iso8601
+        }
+        switch dataEncodingStrategy {
+        case .base64:
+            encoder.dataEncodingStrategy = .base64
+        case .deferredToData:
+            encoder.dataEncodingStrategy = .deferredToData
+        }
+        if sortsKeys {
+            encoder.outputFormatting.insert(.sortedKeys)
+        }
+        return encoder
+    }
+
+    func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        switch keyDecodingStrategy {
+        case .useDefaultKeys:
+            decoder.keyDecodingStrategy = .useDefaultKeys
+        case .convertFromSnakeCase:
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+        }
+        switch dateDecodingStrategy {
+        case .deferredToDate:
+            decoder.dateDecodingStrategy = .deferredToDate
+        case .secondsSince1970:
+            decoder.dateDecodingStrategy = .secondsSince1970
+        case .millisecondsSince1970:
+            decoder.dateDecodingStrategy = .millisecondsSince1970
+        case .iso8601:
+            decoder.dateDecodingStrategy = .iso8601
+        }
+        switch dataDecodingStrategy {
+        case .base64:
+            decoder.dataDecodingStrategy = .base64
+        case .deferredToData:
+            decoder.dataDecodingStrategy = .deferredToData
+        }
+        return decoder
+    }
+}
+
+
+/// Structured failures raised while transcoding a JSON `Codable` value.
+///
+/// These are thrown from inside a codec's encode/decode closures. The
+/// contextual codec boundary in `SwiftQLCore` (`XLValueCodec.encode(_:using:context:)`
+/// and `.decode(_:using:context:)`) catches them and wraps them, together
+/// with the active codec key and `XLValueCodingContext`, into
+/// `XLValueCodecError.encodingFailed` or `.decodingFailed`. Conforming to
+/// `CustomStringConvertible` keeps the underlying `EncodingError`/
+/// `DecodingError` text inside that wrapped message instead of losing it to
+/// the default `Error` description.
+public enum XLJSONValueCodecError: Error, CustomStringConvertible, Sendable {
+
+    /// `JSONEncoder` failed to encode the application value.
+    case encodingFailed(valueType: String, underlying: String)
+
+    /// `JSONDecoder` failed to decode the application value.
+    case decodingFailed(valueType: String, underlying: String)
+
+    /// Stored `TEXT` bytes were not valid UTF-8, so they cannot be handed to
+    /// `JSONDecoder`.
+    case invalidUTF8TextRepresentation(valueType: String)
+
+    public var description: String {
+        switch self {
+        case .encodingFailed(let valueType, let underlying):
+            return "JSON encoding of \(valueType) failed: \(underlying)"
+        case .decodingFailed(let valueType, let underlying):
+            return "JSON decoding of \(valueType) failed: \(underlying)"
+        case .invalidUTF8TextRepresentation(let valueType):
+            return "Stored JSON TEXT for \(valueType) was not valid UTF-8."
+        }
+    }
+}
+
+
+/// Factory for contextual SQLite JSON `Codable` codecs.
+///
+/// SwiftQL has no built-in JSON column type. SQLite itself stores JSON as
+/// `TEXT` or `BLOB` bytes; SwiftQL does not validate JSON, drive SQLite's
+/// `json1` functions, or create generated/indexed columns on the caller's
+/// behalf. `XLJSONValueCodec` builds an `XLValueCodec` that converts an
+/// application `Codable` value to and from one of those two storage
+/// representations using a snapshotted ``XLJSONCodecConfiguration``. Register
+/// the result with `XLValueCodecRegistry.registering(_:)` like any other
+/// contextual codec; optionality composes the same way it does for every
+/// other codec, through `encodeOptional`/`decodeOptional` on the resolved
+/// codec or coding configuration, never inside these closures.
+///
+/// This factory is deliberately SQLite-specific. PostgreSQL's native `JSONB`
+/// representation is different and out of scope here (tracked separately as
+/// issue #137). The private `Value <-> Data` transcoding used by both
+/// `text(key:valueTypeIdentifier:configuration:)` and
+/// `blob(key:valueTypeIdentifier:configuration:)` below is isolated from
+/// `XLSQLiteValue`/`XLSQLiteStorageClass`, so a future PostgreSQL dialect
+/// could reuse the same `Codable` transcoding behind a JSONB-native lowering
+/// without changing this SQLite mapping.
+public enum XLJSONValueCodec {
+
+    /// Creates a codec that stores `Value` as SQLite `TEXT` containing UTF-8 JSON.
+    ///
+    /// - Parameters:
+    ///   - key: The stable name and version of the persisted representation.
+    ///     Treat a change to `key.id`, `key.version`, `valueTypeIdentifier`,
+    ///     or the chosen storage (`.text` here, `.blob` below) as a data
+    ///     migration: these are the stable components schema and query
+    ///     fingerprints use.
+    ///   - valueTypeIdentifier: The stable identity of the Swift value's
+    ///     persisted meaning.
+    ///   - configuration: The immutable `JSONEncoder`/`JSONDecoder` strategy
+    ///     snapshot used for every encode and decode made through this codec.
+    public static func text<Value: Codable>(
+        key: XLValueCodecKey,
+        valueTypeIdentifier: XLValueTypeIdentifier,
+        configuration: XLJSONCodecConfiguration = XLJSONCodecConfiguration()
+    ) -> XLValueCodec<Value, XLSQLiteDialect> {
+        XLValueCodec(
+            key: key,
+            valueTypeIdentifier: valueTypeIdentifier,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: XLValueStorageIdentifier(
+                rawValue: XLSQLiteStorageClass.text.rawValue
+            ),
+            encode: { value, _, _ in
+                let data = try _XLJSONTranscoder.encode(value, using: configuration)
+                guard let text = String(data: data, encoding: .utf8) else {
+                    throw XLJSONValueCodecError.invalidUTF8TextRepresentation(
+                        valueType: String(reflecting: Value.self)
+                    )
+                }
+                return .text(text)
+            },
+            decode: { dialectValue, _, _ in
+                // `XLValueCodec.decode` validates the incoming storage class
+                // against `identity.storageIdentifier` before this closure
+                // runs, so `dialectValue` is always `.text` here.
+                guard case .text(let text) = dialectValue else {
+                    throw XLJSONValueCodecError.invalidUTF8TextRepresentation(
+                        valueType: String(reflecting: Value.self)
+                    )
+                }
+                return try _XLJSONTranscoder.decode(
+                    Value.self,
+                    from: Data(text.utf8),
+                    using: configuration
+                )
+            }
+        )
+    }
+
+    /// Creates a codec that stores `Value` as SQLite `BLOB` JSON bytes.
+    ///
+    /// - Parameters:
+    ///   - key: The stable name and version of the persisted representation.
+    ///     Treat a change to `key.id`, `key.version`, `valueTypeIdentifier`,
+    ///     or the chosen storage (`.blob` here, `.text` above) as a data
+    ///     migration: these are the stable components schema and query
+    ///     fingerprints use.
+    ///   - valueTypeIdentifier: The stable identity of the Swift value's
+    ///     persisted meaning.
+    ///   - configuration: The immutable `JSONEncoder`/`JSONDecoder` strategy
+    ///     snapshot used for every encode and decode made through this codec.
+    public static func blob<Value: Codable>(
+        key: XLValueCodecKey,
+        valueTypeIdentifier: XLValueTypeIdentifier,
+        configuration: XLJSONCodecConfiguration = XLJSONCodecConfiguration()
+    ) -> XLValueCodec<Value, XLSQLiteDialect> {
+        XLValueCodec(
+            key: key,
+            valueTypeIdentifier: valueTypeIdentifier,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: XLValueStorageIdentifier(
+                rawValue: XLSQLiteStorageClass.blob.rawValue
+            ),
+            encode: { value, _, _ in
+                .blob(try _XLJSONTranscoder.encode(value, using: configuration))
+            },
+            decode: { dialectValue, _, _ in
+                // `XLValueCodec.decode` validates the incoming storage class
+                // against `identity.storageIdentifier` before this closure
+                // runs, so `dialectValue` is always `.blob` here.
+                guard case .blob(let data) = dialectValue else {
+                    throw XLJSONValueCodecError.decodingFailed(
+                        valueType: String(reflecting: Value.self),
+                        underlying: "expected BLOB storage"
+                    )
+                }
+                return try _XLJSONTranscoder.decode(
+                    Value.self,
+                    from: data,
+                    using: configuration
+                )
+            }
+        )
+    }
+}
+
+
+/// Dialect-agnostic `Codable` <-> `Data` transcoding shared by the SQLite
+/// `text` and `blob` factories above.
+///
+/// Keeping this half free of `XLSQLiteValue`/`XLSQLiteStorageClass` is what
+/// lets a future dialect-native JSONB mapping reuse it without duplicating
+/// `JSONEncoder`/`JSONDecoder` error handling.
+private enum _XLJSONTranscoder {
+
+    static func encode<Value: Encodable>(
+        _ value: Value,
+        using configuration: XLJSONCodecConfiguration
+    ) throws -> Data {
+        do {
+            return try configuration.makeEncoder().encode(value)
+        }
+        catch let error as EncodingError {
+            throw XLJSONValueCodecError.encodingFailed(
+                valueType: String(reflecting: Value.self),
+                underlying: String(describing: error)
+            )
+        }
+    }
+
+    static func decode<Value: Decodable>(
+        _ valueType: Value.Type,
+        from data: Data,
+        using configuration: XLJSONCodecConfiguration
+    ) throws -> Value {
+        do {
+            return try configuration.makeDecoder().decode(Value.self, from: data)
+        }
+        catch let error as DecodingError {
+            throw XLJSONValueCodecError.decodingFailed(
+                valueType: String(reflecting: Value.self),
+                underlying: String(describing: error)
+            )
+        }
+    }
+}

--- a/Sources/SwiftQL/JSONValueCodec.swift
+++ b/Sources/SwiftQL/JSONValueCodec.swift
@@ -188,15 +188,13 @@ public struct XLJSONCodecConfiguration: Hashable, Sendable {
 /// the default `Error` description.
 public enum XLJSONValueCodecError: Error, CustomStringConvertible, Sendable {
 
-    /// `JSONEncoder` failed to encode the application value.
+    /// `JSONEncoder` failed to encode the application value, or the
+    /// `Codable` implementation itself threw while encoding.
     case encodingFailed(valueType: String, underlying: String)
 
-    /// `JSONDecoder` failed to decode the application value.
+    /// `JSONDecoder` failed to decode the application value, or the
+    /// `Codable` implementation itself threw while decoding.
     case decodingFailed(valueType: String, underlying: String)
-
-    /// Stored `TEXT` bytes were not valid UTF-8, so they cannot be handed to
-    /// `JSONDecoder`.
-    case invalidUTF8TextRepresentation(valueType: String)
 
     public var description: String {
         switch self {
@@ -204,8 +202,6 @@ public enum XLJSONValueCodecError: Error, CustomStringConvertible, Sendable {
             return "JSON encoding of \(valueType) failed: \(underlying)"
         case .decodingFailed(let valueType, let underlying):
             return "JSON decoding of \(valueType) failed: \(underlying)"
-        case .invalidUTF8TextRepresentation(let valueType):
-            return "Stored JSON TEXT for \(valueType) was not valid UTF-8."
         }
     }
 }
@@ -260,20 +256,18 @@ public enum XLJSONValueCodec {
             ),
             encode: { value, _, _ in
                 let data = try _XLJSONTranscoder.encode(value, using: configuration)
-                guard let text = String(data: data, encoding: .utf8) else {
-                    throw XLJSONValueCodecError.invalidUTF8TextRepresentation(
-                        valueType: String(reflecting: Value.self)
-                    )
-                }
-                return .text(text)
+                // `JSONEncoder` always produces UTF-8 bytes, so this
+                // conversion cannot fail; `String(decoding:as:)` reflects
+                // that instead of introducing an unreachable throw.
+                return .text(String(decoding: data, as: UTF8.self))
             },
             decode: { dialectValue, _, _ in
                 // `XLValueCodec.decode` validates the incoming storage class
                 // against `identity.storageIdentifier` before this closure
                 // runs, so `dialectValue` is always `.text` here.
                 guard case .text(let text) = dialectValue else {
-                    throw XLJSONValueCodecError.invalidUTF8TextRepresentation(
-                        valueType: String(reflecting: Value.self)
+                    preconditionFailure(
+                        "XLValueCodec validated TEXT storage before invoking this closure."
                     )
                 }
                 return try _XLJSONTranscoder.decode(
@@ -317,9 +311,8 @@ public enum XLJSONValueCodec {
                 // against `identity.storageIdentifier` before this closure
                 // runs, so `dialectValue` is always `.blob` here.
                 guard case .blob(let data) = dialectValue else {
-                    throw XLJSONValueCodecError.decodingFailed(
-                        valueType: String(reflecting: Value.self),
-                        underlying: "expected BLOB storage"
+                    preconditionFailure(
+                        "XLValueCodec validated BLOB storage before invoking this closure."
                     )
                 }
                 return try _XLJSONTranscoder.decode(
@@ -348,7 +341,11 @@ private enum _XLJSONTranscoder {
         do {
             return try configuration.makeEncoder().encode(value)
         }
-        catch let error as EncodingError {
+        catch {
+            // Catches `EncodingError` from `JSONEncoder` itself as well as
+            // any other error a custom `encode(to:)` implementation throws,
+            // so every failure gets the same "JSON encoding of ... failed"
+            // wrapping instead of only the `EncodingError` case.
             throw XLJSONValueCodecError.encodingFailed(
                 valueType: String(reflecting: Value.self),
                 underlying: String(describing: error)
@@ -364,7 +361,11 @@ private enum _XLJSONTranscoder {
         do {
             return try configuration.makeDecoder().decode(Value.self, from: data)
         }
-        catch let error as DecodingError {
+        catch {
+            // Catches `DecodingError` from `JSONDecoder` itself as well as
+            // any other error a custom `init(from:)` implementation throws,
+            // so every failure gets the same "JSON decoding of ... failed"
+            // wrapping instead of only the `DecodingError` case.
             throw XLJSONValueCodecError.decodingFailed(
                 valueType: String(reflecting: Value.self),
                 underlying: String(describing: error)

--- a/Sources/SwiftQL/JSONValueCodec.swift
+++ b/Sources/SwiftQL/JSONValueCodec.swift
@@ -79,17 +79,17 @@ public struct XLJSONCodecConfiguration: Hashable, Sendable {
         case deferredToData
     }
 
-    public var keyEncodingStrategy: KeyEncodingStrategy
+    public let keyEncodingStrategy: KeyEncodingStrategy
 
-    public var keyDecodingStrategy: KeyDecodingStrategy
+    public let keyDecodingStrategy: KeyDecodingStrategy
 
-    public var dateEncodingStrategy: DateEncodingStrategy
+    public let dateEncodingStrategy: DateEncodingStrategy
 
-    public var dateDecodingStrategy: DateDecodingStrategy
+    public let dateDecodingStrategy: DateDecodingStrategy
 
-    public var dataEncodingStrategy: DataEncodingStrategy
+    public let dataEncodingStrategy: DataEncodingStrategy
 
-    public var dataDecodingStrategy: DataDecodingStrategy
+    public let dataDecodingStrategy: DataDecodingStrategy
 
     /// Sorts object keys while encoding so two calls that encode equal
     /// values produce byte-identical JSON.
@@ -97,7 +97,7 @@ public struct XLJSONCodecConfiguration: Hashable, Sendable {
     /// This is a canonicalization aid for stable storage and comparison, not
     /// a schema guarantee: it only orders keys that `Value`'s `Encodable`
     /// implementation already writes. Defaults to `true`.
-    public var sortsKeys: Bool
+    public let sortsKeys: Bool
 
     public init(
         keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys,
@@ -271,7 +271,6 @@ public enum XLJSONValueCodec {
                     )
                 }
                 return try _XLJSONTranscoder.decode(
-                    Value.self,
                     from: Data(text.utf8),
                     using: configuration
                 )
@@ -316,7 +315,6 @@ public enum XLJSONValueCodec {
                     )
                 }
                 return try _XLJSONTranscoder.decode(
-                    Value.self,
                     from: data,
                     using: configuration
                 )
@@ -354,7 +352,6 @@ private enum _XLJSONTranscoder {
     }
 
     static func decode<Value: Decodable>(
-        _ valueType: Value.Type,
         from data: Data,
         using configuration: XLJSONCodecConfiguration
     ) throws -> Value {

--- a/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
@@ -347,6 +347,252 @@ way an explicit `XLValueCodecSelection` fails elsewhere in this
 document -- with the same `XLValueCodecError` cases, at the same "explicit"
 precedence tier, before any row is touched.
 
+## JSON `Codable` columns
+
+SQLite has no native JSON column type. It stores JSON as `TEXT` or `BLOB`
+bytes, and SwiftQL does not drive SQLite's `json1` functions, validate JSON,
+or create generated/indexed columns on the caller's behalf: those remain the
+application's or a future issue's responsibility. `XLJSONValueCodec` is a
+factory, built on the same contextual codec API described above, that
+converts an application `Codable` value to and from one of those two storage
+representations. It stores no `JSONEncoder`/`JSONDecoder` instance globally
+or between calls; `XLJSONCodecConfiguration` snapshots the relevant
+`Sendable` strategies once, and every encode or decode builds a fresh encoder
+or decoder from that snapshot.
+
+The example below defines a nested `Codable` value with a struct, an array,
+an optional, and an enum field, then registers two `XLJSONValueCodec`
+codecs for it: one storing canonical, sorted-key `TEXT`, the other storing
+the same JSON bytes as `BLOB`. `TEXT` and `BLOB` are different storage
+classes with different stable identities; selecting the wrong one for a
+stored column fails with `XLValueCodecError.storageMismatch` rather than
+silently reinterpreting bytes.
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+struct ContactAddress: Codable, Equatable {
+    var street: String
+    var city: String
+}
+
+enum ContactMethod: Codable, Equatable {
+    case email(String)
+    case phone(String)
+}
+
+struct CustomerProfile: Codable, Equatable {
+    var name: String
+    var tags: [String]
+    var address: ContactAddress?
+    var contact: ContactMethod
+    var loyaltyPoints: Int
+
+    enum CodingKeys: String, CodingKey {
+        case name, tags, address, contact, loyaltyPoints
+    }
+
+    init(
+        name: String,
+        tags: [String],
+        address: ContactAddress?,
+        contact: ContactMethod,
+        loyaltyPoints: Int = 0
+    ) {
+        self.name = name
+        self.tags = tags
+        self.address = address
+        self.contact = contact
+        self.loyaltyPoints = loyaltyPoints
+    }
+
+    // Schema evolution: `loyaltyPoints` was added after JSON rows already
+    // existed. Older stored JSON that omits the key still decodes, using an
+    // explicit application default instead of failing.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        tags = try container.decode([String].self, forKey: .tags)
+        address = try container.decodeIfPresent(ContactAddress.self, forKey: .address)
+        contact = try container.decode(ContactMethod.self, forKey: .contact)
+        loyaltyPoints = try container.decodeIfPresent(Int.self, forKey: .loyaltyPoints) ?? 0
+    }
+}
+
+let profileType = XLValueTypeIdentifier(rawValue: "com.example.customer-profile")
+let profileTextKey = XLValueCodecKey(id: "com.example.customer-profile.text", version: 1)
+let profileBlobKey = XLValueCodecKey(id: "com.example.customer-profile.blob", version: 1)
+
+let profileTextCodec = XLJSONValueCodec.text(
+    key: profileTextKey,
+    valueTypeIdentifier: profileType
+) as XLValueCodec<CustomerProfile, XLSQLiteDialect>
+let profileBlobCodec = XLJSONValueCodec.blob(
+    key: profileBlobKey,
+    valueTypeIdentifier: profileType
+) as XLValueCodec<CustomerProfile, XLSQLiteDialect>
+
+let profileRegistry = try XLValueCodecRegistry()
+    .registering(profileTextCodec)
+    .registering(profileBlobCodec)
+let profileCoding = try XLValueCodingConfiguration(
+    registry: profileRegistry,
+    defaultCodecKeys: [profileTextKey]
+)
+```
+
+Both codecs handle only the nonoptional `CustomerProfile`. Optionality is not
+reinvented here: `encodeOptional`/`decodeOptional` on the resolved codec or
+coding configuration compose with either storage exactly as they do for the
+`Date` codecs above, mapping Swift `nil` directly to SQL `NULL` without
+calling `JSONEncoder`.
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+let profile = CustomerProfile(
+    name: "Ada Lovelace",
+    tags: ["engineer", "mathematician"],
+    address: ContactAddress(street: "12 Analytical Ave", city: "London"),
+    contact: .email("ada@example.com"),
+    loyaltyPoints: 42
+)
+let profileParameterContext = XLValueCodingContext(
+    site: .parameter,
+    path: XLValueCodingPath("customer.profile")
+)
+
+let textValue = try profileCoding.encode(
+    profile,
+    using: dialect,
+    context: profileParameterContext,
+    selection: XLValueCodecSelection(explicitCodecKey: profileTextKey)
+)
+let blobValue = try profileCoding.encode(
+    profile,
+    using: dialect,
+    context: profileParameterContext,
+    selection: XLValueCodecSelection(explicitCodecKey: profileBlobKey)
+)
+
+let decodedFromText = try profileCoding.decode(
+    CustomerProfile.self,
+    from: textValue,
+    using: dialect,
+    context: resultContext,
+    selection: XLValueCodecSelection(explicitCodecKey: profileTextKey)
+)
+let decodedFromBlob = try profileCoding.decode(
+    CustomerProfile.self,
+    from: blobValue,
+    using: dialect,
+    context: resultContext,
+    selection: XLValueCodecSelection(explicitCodecKey: profileBlobKey)
+)
+```
+
+Malformed or incompatible stored bytes fail with a structured, catchable
+error instead of silently producing a default value. The underlying
+`EncodingError`/`DecodingError` text is preserved inside the wrapped
+`XLValueCodecError.decodingFailed`/`.encodingFailed` message, alongside the
+codec key and coding context that produced it:
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+do {
+    _ = try profileCoding.decode(
+        CustomerProfile.self,
+        from: .text("{this is not valid json"),
+        using: dialect,
+        context: resultContext,
+        selection: XLValueCodecSelection(explicitCodecKey: profileTextKey)
+    )
+    preconditionFailure("Expected a structured decoding failure.")
+}
+catch let XLValueCodecError.decodingFailed(codec, _, message) {
+    precondition(codec == profileTextKey)
+    precondition(message.contains("JSON decoding"))
+}
+```
+
+Two configurations of the same `Codable` type coexist without a wrapper
+struct: register a second codec with a different key and JSON key strategy,
+then select each explicitly. Here `JSONMetric` has no explicit `CodingKeys`,
+so `.convertToSnakeCase` changes the persisted field names without changing
+the Swift type:
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+struct JSONMetric: Codable, Equatable {
+    let sampleCount: Int
+    let averageValue: Double
+}
+
+let metricType = XLValueTypeIdentifier(rawValue: "com.example.json-metric")
+let metricDefaultKeysKey = XLValueCodecKey(id: "com.example.json-metric.default-keys", version: 1)
+let metricSnakeCaseKey = XLValueCodecKey(id: "com.example.json-metric.snake-case", version: 1)
+
+let metricDefaultKeysCodec = XLJSONValueCodec.text(
+    key: metricDefaultKeysKey,
+    valueTypeIdentifier: metricType
+) as XLValueCodec<JSONMetric, XLSQLiteDialect>
+let metricSnakeCaseCodec = XLJSONValueCodec.text(
+    key: metricSnakeCaseKey,
+    valueTypeIdentifier: metricType,
+    configuration: XLJSONCodecConfiguration(
+        keyEncodingStrategy: .convertToSnakeCase,
+        keyDecodingStrategy: .convertFromSnakeCase
+    )
+) as XLValueCodec<JSONMetric, XLSQLiteDialect>
+
+let metricRegistry = try XLValueCodecRegistry()
+    .registering(metricDefaultKeysCodec)
+    .registering(metricSnakeCaseCodec)
+let metricCoding = try XLValueCodingConfiguration(registry: metricRegistry)
+```
+
+Storing both representations through a real database uses the same
+`contextualBinding` API shown for `Date` above. `expressedAs: String.self`
+requires `TEXT` storage; `expressedAs: Data.self` requires `BLOB` storage.
+SwiftQL rejects a mismatch between the chosen literal and the resolved
+codec's storage when the contextual reference is created, before any SQL
+runs:
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+let jsonCodecDatabase = try GRDBDatabase(
+    url: databaseURL,
+    codingConfiguration: profileCoding,
+    logger: nil
+)
+let profileTextParameter = try jsonCodecDatabase.contextualBinding(
+    CustomerProfile.self,
+    expressedAs: String.self,
+    named: "profileText",
+    selection: XLValueCodecSelection(explicitCodecKey: profileTextKey)
+)
+let profileTextQuery = sql { _ in
+    Select(profileTextParameter)
+}
+let profileTextRequest = jsonCodecDatabase.makeRequest(with: profileTextQuery)
+let profileTextBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: profileTextRequest.parameterLayout,
+    bindings: [
+        profileTextParameter.encode(profile, in: profileTextRequest.parameterLayout)
+    ]
+).validatingComplete()
+let storedProfileJSON = try profileTextRequest.fetchOne(bindings: profileTextBindings)
+```
+
+Treat a change to a JSON codec's `key.id`, `key.version`, `valueTypeIdentifier`,
+or chosen storage (`.text` vs `.blob`) as a data migration in the same way as
+any other codec: they are the stable components schema and query
+fingerprints use, and `TEXT` versus `BLOB` bytes for the same `Codable` type
+are not interchangeable at rest. Because `XLJSONValueCodec`'s `Codable`-to-
+`Data` transcoding is isolated from `XLSQLiteValue`/`XLSQLiteStorageClass`, a
+future PostgreSQL dialect (`JSONB`, tracked separately as issue #137) can
+reuse the same transcoding behind a dialect-native lowering without changing
+this SQLite mapping. SwiftQL does not claim that mapping exists yet, and does
+not offer a cross-database JSON abstraction today.
+
 ## Legacy `XLCustomType` wrappers
 
 For existing v1 code, a custom scalar value satisfies the `XLCustomType`

--- a/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
@@ -576,7 +576,7 @@ let profileTextRequest = jsonCodecDatabase.makeRequest(with: profileTextQuery)
 let profileTextBindings = try XLInvocationBindings<XLSQLiteValue>(
     layout: profileTextRequest.parameterLayout,
     bindings: [
-        profileTextParameter.encode(profile, in: profileTextRequest.parameterLayout)
+        try profileTextParameter.encode(profile, in: profileTextRequest.parameterLayout)
     ]
 ).validatingComplete()
 let storedProfileJSON = try profileTextRequest.fetchOne(bindings: profileTextBindings)

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -2003,6 +2003,201 @@ extension XLDocumentationTests {
             invoiceRecord
         )
 
+        // JSON `Codable` columns (mirrors CustomTypes.md's "JSON `Codable`
+        // columns" section).
+        struct ContactAddress: Codable, Equatable {
+            var street: String
+            var city: String
+        }
+
+        enum ContactMethod: Codable, Equatable {
+            case email(String)
+            case phone(String)
+        }
+
+        struct CustomerProfile: Codable, Equatable {
+            var name: String
+            var tags: [String]
+            var address: ContactAddress?
+            var contact: ContactMethod
+            var loyaltyPoints: Int
+
+            enum CodingKeys: String, CodingKey {
+                case name, tags, address, contact, loyaltyPoints
+            }
+
+            init(
+                name: String,
+                tags: [String],
+                address: ContactAddress?,
+                contact: ContactMethod,
+                loyaltyPoints: Int = 0
+            ) {
+                self.name = name
+                self.tags = tags
+                self.address = address
+                self.contact = contact
+                self.loyaltyPoints = loyaltyPoints
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                name = try container.decode(String.self, forKey: .name)
+                tags = try container.decode([String].self, forKey: .tags)
+                address = try container.decodeIfPresent(ContactAddress.self, forKey: .address)
+                contact = try container.decode(ContactMethod.self, forKey: .contact)
+                loyaltyPoints = try container.decodeIfPresent(Int.self, forKey: .loyaltyPoints) ?? 0
+            }
+        }
+
+        let profileType = XLValueTypeIdentifier(rawValue: "com.example.customer-profile")
+        let profileTextKey = XLValueCodecKey(id: "com.example.customer-profile.text", version: 1)
+        let profileBlobKey = XLValueCodecKey(id: "com.example.customer-profile.blob", version: 1)
+
+        let profileTextCodec = XLJSONValueCodec.text(
+            key: profileTextKey,
+            valueTypeIdentifier: profileType
+        ) as XLValueCodec<CustomerProfile, XLSQLiteDialect>
+        let profileBlobCodec = XLJSONValueCodec.blob(
+            key: profileBlobKey,
+            valueTypeIdentifier: profileType
+        ) as XLValueCodec<CustomerProfile, XLSQLiteDialect>
+
+        let profileRegistry = try XLValueCodecRegistry()
+            .registering(profileTextCodec)
+            .registering(profileBlobCodec)
+        let profileCoding = try XLValueCodingConfiguration(
+            registry: profileRegistry,
+            defaultCodecKeys: [profileTextKey]
+        )
+
+        let profile = CustomerProfile(
+            name: "Ada Lovelace",
+            tags: ["engineer", "mathematician"],
+            address: ContactAddress(street: "12 Analytical Ave", city: "London"),
+            contact: .email("ada@example.com"),
+            loyaltyPoints: 42
+        )
+        let profileParameterContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath("customer.profile")
+        )
+
+        let textValue = try profileCoding.encode(
+            profile,
+            using: dialect,
+            context: profileParameterContext,
+            selection: XLValueCodecSelection(explicitCodecKey: profileTextKey)
+        )
+        let blobValue = try profileCoding.encode(
+            profile,
+            using: dialect,
+            context: profileParameterContext,
+            selection: XLValueCodecSelection(explicitCodecKey: profileBlobKey)
+        )
+
+        let decodedFromText = try profileCoding.decode(
+            CustomerProfile.self,
+            from: textValue,
+            using: dialect,
+            context: resultContext,
+            selection: XLValueCodecSelection(explicitCodecKey: profileTextKey)
+        )
+        let decodedFromBlob = try profileCoding.decode(
+            CustomerProfile.self,
+            from: blobValue,
+            using: dialect,
+            context: resultContext,
+            selection: XLValueCodecSelection(explicitCodecKey: profileBlobKey)
+        )
+        XCTAssertEqual(decodedFromText, profile)
+        XCTAssertEqual(decodedFromBlob, profile)
+
+        do {
+            _ = try profileCoding.decode(
+                CustomerProfile.self,
+                from: .text("{this is not valid json"),
+                using: dialect,
+                context: resultContext,
+                selection: XLValueCodecSelection(explicitCodecKey: profileTextKey)
+            )
+            XCTFail("Expected a structured decoding failure.")
+        }
+        catch let XLValueCodecError.decodingFailed(codec, _, message) {
+            XCTAssertEqual(codec, profileTextKey)
+            XCTAssertTrue(message.contains("JSON decoding"))
+        }
+
+        struct JSONMetric: Codable, Equatable {
+            let sampleCount: Int
+            let averageValue: Double
+        }
+
+        let metricType = XLValueTypeIdentifier(rawValue: "com.example.json-metric")
+        let metricDefaultKeysKey = XLValueCodecKey(id: "com.example.json-metric.default-keys", version: 1)
+        let metricSnakeCaseKey = XLValueCodecKey(id: "com.example.json-metric.snake-case", version: 1)
+
+        let metricDefaultKeysCodec = XLJSONValueCodec.text(
+            key: metricDefaultKeysKey,
+            valueTypeIdentifier: metricType
+        ) as XLValueCodec<JSONMetric, XLSQLiteDialect>
+        let metricSnakeCaseCodec = XLJSONValueCodec.text(
+            key: metricSnakeCaseKey,
+            valueTypeIdentifier: metricType,
+            configuration: XLJSONCodecConfiguration(
+                keyEncodingStrategy: .convertToSnakeCase,
+                keyDecodingStrategy: .convertFromSnakeCase
+            )
+        ) as XLValueCodec<JSONMetric, XLSQLiteDialect>
+
+        let metricRegistry = try XLValueCodecRegistry()
+            .registering(metricDefaultKeysCodec)
+            .registering(metricSnakeCaseCodec)
+        let metricCoding = try XLValueCodingConfiguration(registry: metricRegistry)
+        let metric = JSONMetric(sampleCount: 12, averageValue: 3.5)
+        XCTAssertEqual(
+            try metricCoding.decode(
+                JSONMetric.self,
+                from: try metricCoding.encode(
+                    metric,
+                    using: dialect,
+                    context: profileParameterContext,
+                    selection: XLValueCodecSelection(explicitCodecKey: metricSnakeCaseKey)
+                ),
+                using: dialect,
+                context: resultContext,
+                selection: XLValueCodecSelection(explicitCodecKey: metricSnakeCaseKey)
+            ),
+            metric
+        )
+
+        let jsonCodecDatabase = try GRDBDatabase(
+            url: contextualDirectory.appendingPathComponent("json-fixture.sqlite"),
+            codingConfiguration: profileCoding,
+            logger: nil
+        )
+        let profileTextParameter = try jsonCodecDatabase.contextualBinding(
+            CustomerProfile.self,
+            expressedAs: String.self,
+            named: "profileText",
+            selection: XLValueCodecSelection(explicitCodecKey: profileTextKey)
+        )
+        let profileTextQuery = sql { _ in
+            Select(profileTextParameter)
+        }
+        let profileTextRequest = jsonCodecDatabase.makeRequest(with: profileTextQuery)
+        let profileTextBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: profileTextRequest.parameterLayout,
+            bindings: [
+                profileTextParameter.encode(profile, in: profileTextRequest.parameterLayout)
+            ]
+        ).validatingComplete()
+        let storedProfileJSON = try profileTextRequest.fetchOne(bindings: profileTextBindings)
+        guard case .text(let expectedProfileJSON) = textValue else {
+            return XCTFail("Expected TEXT storage")
+        }
+        XCTAssertEqual(storedProfileJSON, expectedProfileJSON)
+
         try testExample_Date()
         try testExample_DateConstant()
         try testExample_DateParameter()

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -2189,7 +2189,7 @@ extension XLDocumentationTests {
         let profileTextBindings = try XLInvocationBindings<XLSQLiteValue>(
             layout: profileTextRequest.parameterLayout,
             bindings: [
-                profileTextParameter.encode(profile, in: profileTextRequest.parameterLayout)
+                try profileTextParameter.encode(profile, in: profileTextRequest.parameterLayout)
             ]
         ).validatingComplete()
         let storedProfileJSON = try profileTextRequest.fetchOne(bindings: profileTextBindings)

--- a/Tests/SwiftQLCodecIntegrationTests/JSONValueCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/JSONValueCodecContractTests.swift
@@ -1,0 +1,406 @@
+import Foundation
+import XCTest
+@testable import SwiftQL
+
+
+/// Contract-level coverage for ``XLJSONValueCodec``, mirroring
+/// `ValueCodecContractTests` in `SwiftQLCoreTests`: pure value-level checks
+/// against `XLSQLiteDialect` with no real SQLite connection. Real GRDB/SQLite
+/// round trips live in `JSONValueCodecGRDBTests`.
+final class JSONValueCodecContractTests: XCTestCase {
+
+    private let dialect = XLSQLiteDialect()
+
+    private let parameterContext = XLValueCodingContext(
+        site: .parameter,
+        path: XLValueCodingPath(["customer", "profile"])
+    )
+
+    private let resultContext = XLValueCodingContext(
+        site: .result,
+        path: XLValueCodingPath(["customer", "profile"])
+    )
+
+    private let sampleProfile = JSONCodecFixtureProfile(
+        name: "Ada Lovelace",
+        tags: ["engineer", "mathematician"],
+        address: JSONCodecFixtureAddress(street: "12 Analytical Ave", city: "London"),
+        contact: .email("ada@example.com"),
+        loyaltyPoints: 42
+    )
+
+    // MARK: - Round trips
+
+    func testNestedValueRoundTripsAsText() throws {
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(jsonCodecFixtureProfileTextCodec),
+            defaultCodecKeys: [jsonCodecFixtureTextKey]
+        )
+
+        let encoded = try configuration.encode(
+            sampleProfile,
+            using: dialect,
+            context: parameterContext
+        )
+        guard case .text(let json) = encoded else {
+            return XCTFail("Expected TEXT storage, got \(encoded)")
+        }
+        // Canonicalization: sorted keys make the JSON deterministic.
+        XCTAssertTrue(json.hasPrefix("{\"address\""))
+
+        let decoded = try configuration.decode(
+            JSONCodecFixtureProfile.self,
+            from: encoded,
+            using: dialect,
+            context: resultContext
+        )
+        XCTAssertEqual(decoded, sampleProfile)
+    }
+
+    func testNestedValueRoundTripsAsBlob() throws {
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(jsonCodecFixtureProfileBlobCodec),
+            defaultCodecKeys: [jsonCodecFixtureBlobKey]
+        )
+
+        let encoded = try configuration.encode(
+            sampleProfile,
+            using: dialect,
+            context: parameterContext
+        )
+        guard case .blob = encoded else {
+            return XCTFail("Expected BLOB storage, got \(encoded)")
+        }
+
+        let decoded = try configuration.decode(
+            JSONCodecFixtureProfile.self,
+            from: encoded,
+            using: dialect,
+            context: resultContext
+        )
+        XCTAssertEqual(decoded, sampleProfile)
+    }
+
+    // MARK: - TEXT and BLOB are not interchangeable
+
+    func testTextAndBlobCodecsAreNotInterchangeable() throws {
+        let registry = try XLValueCodecRegistry()
+            .registering(jsonCodecFixtureProfileTextCodec)
+            .registering(jsonCodecFixtureProfileBlobCodec)
+        let configuration = try XLValueCodingConfiguration(registry: registry)
+
+        XCTAssertNotEqual(
+            jsonCodecFixtureProfileTextCodec.identity.storageIdentifier,
+            jsonCodecFixtureProfileBlobCodec.identity.storageIdentifier
+        )
+        XCTAssertNotEqual(
+            jsonCodecFixtureProfileTextCodec.identity.stableIdentityComponents,
+            jsonCodecFixtureProfileBlobCodec.identity.stableIdentityComponents
+        )
+
+        let blobEncoded = try configuration.encode(
+            sampleProfile,
+            using: dialect,
+            context: parameterContext,
+            selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureBlobKey)
+        )
+
+        // Asking the TEXT codec to decode BLOB-shaped bytes is a stable,
+        // structured storage-mismatch failure, not a silent reinterpretation.
+        XCTAssertThrowsError(
+            try configuration.decode(
+                JSONCodecFixtureProfile.self,
+                from: blobEncoded,
+                using: dialect,
+                context: resultContext,
+                selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureTextKey)
+            )
+        ) { error in
+            guard case .storageMismatch? = error as? XLValueCodecError else {
+                return XCTFail("Expected storageMismatch, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - NULL and optionality compose outside the codec
+
+    func testOptionalWrappingComposesOutsideTheNonoptionalCodec() throws {
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(jsonCodecFixtureProfileTextCodec),
+            defaultCodecKeys: [jsonCodecFixtureTextKey]
+        )
+
+        XCTAssertEqual(
+            try configuration.encodeOptional(
+                Optional<JSONCodecFixtureProfile>.none,
+                using: dialect,
+                context: parameterContext
+            ),
+            .null
+        )
+        let decodedNil: JSONCodecFixtureProfile? = try configuration.decodeOptional(
+            JSONCodecFixtureProfile.self,
+            from: .null,
+            using: dialect,
+            context: resultContext
+        )
+        XCTAssertNil(decodedNil)
+
+        let decodedSome: JSONCodecFixtureProfile? = try configuration.decodeOptional(
+            JSONCodecFixtureProfile.self,
+            from: try configuration.encode(
+                sampleProfile,
+                using: dialect,
+                context: parameterContext
+            ),
+            using: dialect,
+            context: resultContext
+        )
+        XCTAssertEqual(decodedSome, sampleProfile)
+    }
+
+    // MARK: - Schema evolution and unknown fields
+
+    func testMissingNewerFieldDecodesUsingItsApplicationDefault() throws {
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(jsonCodecFixtureProfileTextCodec),
+            defaultCodecKeys: [jsonCodecFixtureTextKey]
+        )
+        // Encode a value, then simulate JSON written before `loyaltyPoints`
+        // existed by dropping the key from the resulting JSON object. This
+        // uses the codec's own encoder for the enum/nested shape instead of
+        // a hand-written literal, so the fixture never silently drifts from
+        // what the codec actually produces.
+        let profile = JSONCodecFixtureProfile(
+            name: "Grace Hopper",
+            tags: ["engineer"],
+            address: nil,
+            contact: .email("grace@example.com"),
+            loyaltyPoints: 999
+        )
+        let legacyJSON = try removingKeys(
+            ["loyaltyPoints"],
+            from: encodedProfileJSON(profile, using: configuration)
+        )
+
+        let decoded = try configuration.decode(
+            JSONCodecFixtureProfile.self,
+            from: .text(legacyJSON),
+            using: dialect,
+            context: resultContext,
+            selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureTextKey)
+        )
+        XCTAssertEqual(decoded.name, "Grace Hopper")
+        XCTAssertNil(decoded.address)
+        XCTAssertEqual(decoded.loyaltyPoints, 0)
+    }
+
+    func testUnknownFieldsAreIgnoredRatherThanFailing() throws {
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(jsonCodecFixtureProfileTextCodec),
+            defaultCodecKeys: [jsonCodecFixtureTextKey]
+        )
+        let profile = JSONCodecFixtureProfile(
+            name: "Katherine Johnson",
+            tags: [],
+            address: nil,
+            contact: .phone("555-0100"),
+            loyaltyPoints: 10
+        )
+        let jsonWithUnknownField = try addingField(
+            name: "futureField",
+            value: "ignored",
+            to: encodedProfileJSON(profile, using: configuration)
+        )
+
+        let decoded = try configuration.decode(
+            JSONCodecFixtureProfile.self,
+            from: .text(jsonWithUnknownField),
+            using: dialect,
+            context: resultContext,
+            selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureTextKey)
+        )
+        XCTAssertEqual(decoded.name, "Katherine Johnson")
+        XCTAssertEqual(decoded.contact, .phone("555-0100"))
+        XCTAssertEqual(decoded.loyaltyPoints, 10)
+    }
+
+    private func encodedProfileJSON(
+        _ profile: JSONCodecFixtureProfile,
+        using configuration: XLValueCodingConfiguration
+    ) throws -> String {
+        guard case .text(let json) = try configuration.encode(
+            profile,
+            using: dialect,
+            context: parameterContext,
+            selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureTextKey)
+        ) else {
+            throw XCTSkip("Expected TEXT storage")
+        }
+        return json
+    }
+
+    private func removingKeys(_ keys: Set<String>, from json: String) throws -> String {
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        for key in keys {
+            object.removeValue(forKey: key)
+        }
+        let data = try JSONSerialization.data(withJSONObject: object)
+        return try XCTUnwrap(String(data: data, encoding: .utf8))
+    }
+
+    private func addingField(name: String, value: String, to json: String) throws -> String {
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        object[name] = value
+        let data = try JSONSerialization.data(withJSONObject: object)
+        return try XCTUnwrap(String(data: data, encoding: .utf8))
+    }
+
+    // MARK: - Malformed data and structured failures
+
+    func testMalformedJSONFailsWithAStructuredDecodingError() throws {
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(jsonCodecFixtureProfileTextCodec),
+            defaultCodecKeys: [jsonCodecFixtureTextKey]
+        )
+
+        XCTAssertThrowsError(
+            try configuration.decode(
+                JSONCodecFixtureProfile.self,
+                from: .text("{not valid json"),
+                using: dialect,
+                context: resultContext
+            )
+        ) { error in
+            guard case .decodingFailed(let codec, let context, let message)? =
+                error as? XLValueCodecError else {
+                return XCTFail("Expected decodingFailed, got \(error)")
+            }
+            XCTAssertEqual(codec, jsonCodecFixtureTextKey)
+            XCTAssertEqual(context, resultContext)
+            XCTAssertTrue(
+                message.contains("JSON decoding"),
+                "Expected the underlying DecodingError context in: \(message)"
+            )
+        }
+    }
+
+    func testTypeMismatchedJSONFailsWithAStructuredDecodingError() throws {
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(jsonCodecFixtureProfileTextCodec),
+            defaultCodecKeys: [jsonCodecFixtureTextKey]
+        )
+        // "name" should be a string, not a number.
+        let badlyTypedJSON = """
+            {"name":123,"tags":[],"contact":{"email":"x@example.com"},"loyaltyPoints":0}
+            """
+
+        XCTAssertThrowsError(
+            try configuration.decode(
+                JSONCodecFixtureProfile.self,
+                from: .text(badlyTypedJSON),
+                using: dialect,
+                context: resultContext
+            )
+        ) { error in
+            guard case .decodingFailed? = error as? XLValueCodecError else {
+                return XCTFail("Expected decodingFailed, got \(error)")
+            }
+        }
+    }
+
+    func testNonFiniteDoubleFailsWithAStructuredEncodingError() throws {
+        let key = XLValueCodecKey(id: "com.example.tests.json-reading", version: 1)
+        let codec = XLJSONValueCodec.text(
+            key: key,
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "com.example.tests.json-reading")
+        ) as XLValueCodec<JSONCodecFixtureReading, XLSQLiteDialect>
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(codec),
+            defaultCodecKeys: [key]
+        )
+
+        XCTAssertThrowsError(
+            try configuration.encode(
+                JSONCodecFixtureReading(value: .infinity),
+                using: dialect,
+                context: parameterContext
+            )
+        ) { error in
+            guard case .encodingFailed(let errorCodec, let context, let message)? =
+                error as? XLValueCodecError else {
+                return XCTFail("Expected encodingFailed, got \(error)")
+            }
+            XCTAssertEqual(errorCodec, key)
+            XCTAssertEqual(context, parameterContext)
+            XCTAssertTrue(
+                message.contains("JSON encoding"),
+                "Expected the underlying EncodingError context in: \(message)"
+            )
+        }
+    }
+
+    // MARK: - Two configurations for one Swift type, no wrapper structs
+
+    func testTwoKeyStrategyConfigurationsCoexistWithoutWrapperStructs() throws {
+        let registry = try XLValueCodecRegistry()
+            .registering(jsonCodecFixtureMetricDefaultKeysCodec)
+            .registering(jsonCodecFixtureMetricSnakeCaseCodec)
+        let configuration = try XLValueCodingConfiguration(registry: registry)
+        let metric = JSONCodecFixtureMetric(sampleCount: 12, averageValue: 3.5)
+
+        let defaultKeysEncoded = try configuration.encode(
+            metric,
+            using: dialect,
+            context: parameterContext,
+            selection: XLValueCodecSelection(
+                explicitCodecKey: jsonCodecFixtureMetricDefaultKeysKey
+            )
+        )
+        let snakeCaseEncoded = try configuration.encode(
+            metric,
+            using: dialect,
+            context: parameterContext,
+            selection: XLValueCodecSelection(
+                explicitCodecKey: jsonCodecFixtureMetricSnakeCaseKey
+            )
+        )
+
+        guard case .text(let defaultKeysJSON) = defaultKeysEncoded,
+              case .text(let snakeCaseJSON) = snakeCaseEncoded else {
+            return XCTFail("Expected TEXT storage for both codecs.")
+        }
+        XCTAssertTrue(defaultKeysJSON.contains("sampleCount"))
+        XCTAssertTrue(snakeCaseJSON.contains("sample_count"))
+        XCTAssertNotEqual(defaultKeysJSON, snakeCaseJSON)
+
+        XCTAssertEqual(
+            try configuration.decode(
+                JSONCodecFixtureMetric.self,
+                from: defaultKeysEncoded,
+                using: dialect,
+                context: resultContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: jsonCodecFixtureMetricDefaultKeysKey
+                )
+            ),
+            metric
+        )
+        XCTAssertEqual(
+            try configuration.decode(
+                JSONCodecFixtureMetric.self,
+                from: snakeCaseEncoded,
+                using: dialect,
+                context: resultContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: jsonCodecFixtureMetricSnakeCaseKey
+                )
+            ),
+            metric
+        )
+    }
+}

--- a/Tests/SwiftQLCodecIntegrationTests/JSONValueCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/JSONValueCodecContractTests.swift
@@ -229,13 +229,15 @@ final class JSONValueCodecContractTests: XCTestCase {
         _ profile: JSONCodecFixtureProfile,
         using configuration: XLValueCodingConfiguration
     ) throws -> String {
+        // A non-TEXT result here would mean the codec/registry wiring in
+        // this test regressed, so fail the test rather than skip it.
         guard case .text(let json) = try configuration.encode(
             profile,
             using: dialect,
             context: parameterContext,
             selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureTextKey)
         ) else {
-            throw XCTSkip("Expected TEXT storage")
+            throw JSONValueCodecTestFixtureError.expectedTextStorage
         }
         return json
     }
@@ -403,4 +405,9 @@ final class JSONValueCodecContractTests: XCTestCase {
             metric
         )
     }
+}
+
+
+private enum JSONValueCodecTestFixtureError: Error {
+    case expectedTextStorage
 }

--- a/Tests/SwiftQLCodecIntegrationTests/JSONValueCodecFixtures.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/JSONValueCodecFixtures.swift
@@ -1,0 +1,139 @@
+import Foundation
+@testable import SwiftQL
+
+
+/// A representative nested `Codable` value used by the JSON codec contract
+/// and GRDB round-trip tests: a struct with a nested struct, an array, an
+/// optional, and an enum with an associated value.
+struct JSONCodecFixtureAddress: Codable, Equatable {
+    var street: String
+    var city: String
+}
+
+
+enum JSONCodecFixtureContactMethod: Codable, Equatable {
+    case email(String)
+    case phone(String)
+}
+
+
+struct JSONCodecFixtureProfile: Codable, Equatable {
+    var name: String
+    var tags: [String]
+    var address: JSONCodecFixtureAddress?
+    var contact: JSONCodecFixtureContactMethod
+    var loyaltyPoints: Int
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case tags
+        case address
+        case contact
+        case loyaltyPoints
+    }
+
+    init(
+        name: String,
+        tags: [String],
+        address: JSONCodecFixtureAddress?,
+        contact: JSONCodecFixtureContactMethod,
+        loyaltyPoints: Int = 0
+    ) {
+        self.name = name
+        self.tags = tags
+        self.address = address
+        self.contact = contact
+        self.loyaltyPoints = loyaltyPoints
+    }
+
+    // Demonstrates schema evolution: `loyaltyPoints` was added after JSON
+    // rows already existed. Older stored JSON that omits the key still
+    // decodes, using an explicit default instead of failing.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        tags = try container.decode([String].self, forKey: .tags)
+        address = try container.decodeIfPresent(
+            JSONCodecFixtureAddress.self,
+            forKey: .address
+        )
+        contact = try container.decode(
+            JSONCodecFixtureContactMethod.self,
+            forKey: .contact
+        )
+        loyaltyPoints = try container.decodeIfPresent(
+            Int.self,
+            forKey: .loyaltyPoints
+        ) ?? 0
+    }
+}
+
+
+/// A plain-keyed type with no explicit `CodingKeys`, used to show two JSON
+/// codecs for the same Swift type with different key strategies producing
+/// different, independently selectable representations.
+struct JSONCodecFixtureMetric: Codable, Equatable {
+    let sampleCount: Int
+    let averageValue: Double
+}
+
+
+/// A type whose default encoding can fail: `JSONEncoder` rejects non-finite
+/// `Double` values by default, so this exercises the encoder-failure path.
+struct JSONCodecFixtureReading: Codable, Equatable {
+    let value: Double
+}
+
+
+let jsonCodecFixtureProfileType = XLValueTypeIdentifier(
+    rawValue: "com.example.tests.json-profile"
+)
+
+let jsonCodecFixtureTextKey = XLValueCodecKey(
+    id: "com.example.tests.json-profile.text",
+    version: 1
+)
+
+let jsonCodecFixtureBlobKey = XLValueCodecKey(
+    id: "com.example.tests.json-profile.blob",
+    version: 1
+)
+
+let jsonCodecFixtureProfileTextCodec = XLJSONValueCodec.text(
+    key: jsonCodecFixtureTextKey,
+    valueTypeIdentifier: jsonCodecFixtureProfileType
+) as XLValueCodec<JSONCodecFixtureProfile, XLSQLiteDialect>
+
+let jsonCodecFixtureProfileBlobCodec = XLJSONValueCodec.blob(
+    key: jsonCodecFixtureBlobKey,
+    valueTypeIdentifier: jsonCodecFixtureProfileType
+) as XLValueCodec<JSONCodecFixtureProfile, XLSQLiteDialect>
+
+
+let jsonCodecFixtureMetricType = XLValueTypeIdentifier(
+    rawValue: "com.example.tests.json-metric"
+)
+
+let jsonCodecFixtureMetricDefaultKeysKey = XLValueCodecKey(
+    id: "com.example.tests.json-metric.default-keys",
+    version: 1
+)
+
+let jsonCodecFixtureMetricSnakeCaseKey = XLValueCodecKey(
+    id: "com.example.tests.json-metric.snake-case",
+    version: 1
+)
+
+let jsonCodecFixtureMetricDefaultKeysCodec = XLJSONValueCodec.text(
+    key: jsonCodecFixtureMetricDefaultKeysKey,
+    valueTypeIdentifier: jsonCodecFixtureMetricType
+) as XLValueCodec<JSONCodecFixtureMetric, XLSQLiteDialect>
+
+let jsonCodecFixtureMetricSnakeCaseCodec = XLJSONValueCodec.text(
+    key: jsonCodecFixtureMetricSnakeCaseKey,
+    valueTypeIdentifier: jsonCodecFixtureMetricType,
+    configuration: XLJSONCodecConfiguration(
+        keyEncodingStrategy: .convertToSnakeCase,
+        keyDecodingStrategy: .convertFromSnakeCase
+    )
+) as XLValueCodec<JSONCodecFixtureMetric, XLSQLiteDialect>

--- a/Tests/SwiftQLCodecIntegrationTests/JSONValueCodecGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/JSONValueCodecGRDBTests.swift
@@ -1,0 +1,283 @@
+import Foundation
+import GRDB
+import XCTest
+@testable import SwiftQL
+
+
+/// Real GRDB/SQLite round trips for ``XLJSONValueCodec``. Value-level
+/// behavior (round trips, NULL, malformed JSON, schema evolution, and
+/// encoder/decoder failures) is covered without a database connection in
+/// `JSONValueCodecContractTests`; this file confirms the same codecs behave
+/// identically once real SQLite has stored and returned the bytes.
+final class JSONValueCodecGRDBTests: XCTestCase {
+
+    private let sampleProfile = JSONCodecFixtureProfile(
+        name: "Ada Lovelace",
+        tags: ["engineer", "mathematician"],
+        address: JSONCodecFixtureAddress(street: "12 Analytical Ave", city: "London"),
+        contact: .email("ada@example.com"),
+        loyaltyPoints: 42
+    )
+
+    func testProfileRoundTripsAsTextAndBlobThroughRealSQLite() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let registry = try XLValueCodecRegistry()
+            .registering(jsonCodecFixtureProfileTextCodec)
+            .registering(jsonCodecFixtureProfileBlobCodec)
+        let codingConfiguration = try XLValueCodingConfiguration(registry: registry)
+        let dialect = XLSQLiteDialect()
+
+        var driver = GRDBDatabaseDriver(
+            databasePool: fixture.databasePool,
+            dialect: dialect
+        )
+        let create = logicalStatement(
+            for: driver,
+            sql: """
+                CREATE TABLE json_profiles (
+                    profile_text TEXT NOT NULL,
+                    profile_blob BLOB NOT NULL
+                )
+                """
+        )
+        let insert = logicalStatement(
+            for: driver,
+            sql: """
+                INSERT INTO json_profiles (profile_text, profile_blob)
+                VALUES (:profile_text, :profile_blob)
+                """
+        )
+        let select = logicalStatement(
+            for: driver,
+            sql: """
+                SELECT
+                    profile_text, typeof(profile_text),
+                    profile_blob, typeof(profile_blob)
+                FROM json_profiles
+                """
+        )
+
+        let textValue = try codingConfiguration.encode(
+            sampleProfile,
+            using: dialect,
+            context: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("profile_text")
+            ),
+            selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureTextKey)
+        )
+        let blobValue = try codingConfiguration.encode(
+            sampleProfile,
+            using: dialect,
+            context: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("profile_blob")
+            ),
+            selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureBlobKey)
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+            var statement = try connection.prepare(insert)
+            statement = try connection.bind(textValue, to: .named("profile_text"), in: statement)
+            statement = try connection.bind(blobValue, to: .named("profile_blob"), in: statement)
+            try connection.execute(statement)
+        }
+
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(connection.fetchOne(connection.prepare(select)))
+        }
+
+        XCTAssertEqual(row[1], .text("text"))
+        XCTAssertEqual(row[3], .text("blob"))
+
+        let decodedFromText = try codingConfiguration.decode(
+            JSONCodecFixtureProfile.self,
+            from: row[0],
+            using: dialect,
+            context: XLValueCodingContext(site: .result, path: XLValueCodingPath("profile_text")),
+            selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureTextKey)
+        )
+        let decodedFromBlob = try codingConfiguration.decode(
+            JSONCodecFixtureProfile.self,
+            from: row[2],
+            using: dialect,
+            context: XLValueCodingContext(site: .result, path: XLValueCodingPath("profile_blob")),
+            selection: XLValueCodecSelection(explicitCodecKey: jsonCodecFixtureBlobKey)
+        )
+
+        XCTAssertEqual(decodedFromText, sampleProfile)
+        XCTAssertEqual(decodedFromBlob, sampleProfile)
+    }
+
+    func testNullColumnRoundTripsThroughRealSQLiteUsingOptionalComposition() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let registry = try XLValueCodecRegistry().registering(jsonCodecFixtureProfileTextCodec)
+        let codingConfiguration = try XLValueCodingConfiguration(
+            registry: registry,
+            defaultCodecKeys: [jsonCodecFixtureTextKey]
+        )
+        let dialect = XLSQLiteDialect()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let create = logicalStatement(
+            for: driver,
+            sql: "CREATE TABLE optional_profiles (profile TEXT)"
+        )
+        let insert = logicalStatement(
+            for: driver,
+            sql: "INSERT INTO optional_profiles (profile) VALUES (:profile)"
+        )
+        let select = logicalStatement(
+            for: driver,
+            sql: "SELECT profile, typeof(profile) FROM optional_profiles"
+        )
+        let context = XLValueCodingContext(site: .parameter, path: XLValueCodingPath("profile"))
+
+        // Optionality composes outside the nonoptional JSON codec: `nil`
+        // becomes SQL `NULL` without the codec's encode closure running.
+        let nullValue = try codingConfiguration.encodeOptional(
+            Optional<JSONCodecFixtureProfile>.none,
+            using: dialect,
+            context: context
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+            var statement = try connection.prepare(insert)
+            statement = try connection.bind(nullValue, to: .named("profile"), in: statement)
+            try connection.execute(statement)
+        }
+
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(connection.fetchOne(connection.prepare(select)))
+        }
+        XCTAssertEqual(row, [.null, .text("null")])
+
+        let decoded: JSONCodecFixtureProfile? = try codingConfiguration.decodeOptional(
+            JSONCodecFixtureProfile.self,
+            from: row[0],
+            using: dialect,
+            context: XLValueCodingContext(site: .result, path: context.path)
+        )
+        XCTAssertNil(decoded)
+    }
+
+    func testMalformedStoredJSONFailsAtDecodeRatherThanReturningADefaultValue() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let registry = try XLValueCodecRegistry().registering(jsonCodecFixtureProfileTextCodec)
+        let codingConfiguration = try XLValueCodingConfiguration(
+            registry: registry,
+            defaultCodecKeys: [jsonCodecFixtureTextKey]
+        )
+        let dialect = XLSQLiteDialect()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let create = logicalStatement(
+            for: driver,
+            sql: "CREATE TABLE corrupt_profiles (profile TEXT NOT NULL)"
+        )
+        // Bypasses the codec entirely to simulate a row corrupted or
+        // hand-edited outside of SwiftQL, e.g. by direct SQL or an older,
+        // incompatible application version.
+        let insert = logicalStatement(
+            for: driver,
+            sql: "INSERT INTO corrupt_profiles (profile) VALUES ('{this is not json')"
+        )
+        let select = logicalStatement(
+            for: driver,
+            sql: "SELECT profile FROM corrupt_profiles"
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+            try connection.execute(connection.prepare(insert))
+        }
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(connection.fetchOne(connection.prepare(select)))
+        }
+
+        XCTAssertThrowsError(
+            try codingConfiguration.decode(
+                JSONCodecFixtureProfile.self,
+                from: row[0],
+                using: dialect,
+                context: XLValueCodingContext(
+                    site: .result,
+                    path: XLValueCodingPath("profile")
+                )
+            )
+        ) { error in
+            guard case .decodingFailed(let codec, _, let message)? =
+                error as? XLValueCodecError else {
+                return XCTFail("Expected a structured decodingFailed error, got \(error)")
+            }
+            XCTAssertEqual(codec, jsonCodecFixtureTextKey)
+            XCTAssertTrue(message.contains("JSON decoding"))
+        }
+    }
+
+    func testDatabaseSnapshotsTheRegisteredJSONCodecsImmutably() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let registry = try XLValueCodecRegistry().registering(jsonCodecFixtureProfileTextCodec)
+        let codingConfiguration = try XLValueCodingConfiguration(
+            registry: registry,
+            defaultCodecKeys: [jsonCodecFixtureTextKey]
+        )
+        let database = try GRDBDatabase(
+            databasePool: fixture.databasePool,
+            codingConfiguration: codingConfiguration,
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
+
+        XCTAssertEqual(
+            database.codingConfiguration.registry.identities.map(\.key),
+            [jsonCodecFixtureTextKey]
+        )
+        XCTAssertEqual(database.codingConfiguration.defaultCodecKeys, [jsonCodecFixtureTextKey])
+    }
+
+    private func logicalStatement(
+        for driver: GRDBDatabaseDriver,
+        sql: String
+    ) -> XLLogicalPreparedStatement {
+        XLLogicalPreparedStatement(
+            databaseIdentifier: driver.databaseIdentifier,
+            dialectRequirement: XLDialectRequirement(identity: XLSQLiteDialect.identity),
+            sql: sql
+        )
+    }
+
+    private func makeFixture() throws -> JSONCodecFixtureDatabase {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftql-json-codec-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: false
+        )
+        return JSONCodecFixtureDatabase(
+            directoryURL: directoryURL,
+            databasePool: try DatabasePool(
+                path: directoryURL.appendingPathComponent("database.sqlite").path
+            )
+        )
+    }
+}
+
+
+private struct JSONCodecFixtureDatabase {
+    let directoryURL: URL
+    let databasePool: DatabasePool
+
+    func tearDown() {
+        try? databasePool.close()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+}


### PR DESCRIPTION
Closes #65.

## Summary

- Adds `XLJSONValueCodec`, a factory built directly on the #188 immutable contextual value-codec registry (`XLValueCodec`/`XLValueCodecRegistry`/`XLValueCodingConfiguration`), that converts any application `Codable` value to and from SQLite `TEXT` or `BLOB` bytes. `Sources/SwiftQL/JSONValueCodec.swift` is new; `Sources/SwiftQLCore/ValueCodec.swift` and `GRDBSQLDatabase.swift` are untouched — only their existing public API is consumed.
- `XLJSONCodecConfiguration` snapshots the relevant `JSONEncoder`/`JSONDecoder` strategies (key/date/data strategy, key sorting for canonicalization) as an immutable, `Sendable` value type captured at codec construction. No live `JSONEncoder`/`JSONDecoder` instance, and no process-global JSON configuration, is ever shared: every encode/decode call builds a fresh encoder/decoder from the snapshot.
- `TEXT` vs `BLOB` are distinct `XLValueCodecIdentity` storage identifiers (already part of #188's schema/query fingerprint components), so the two representations are never silently interchangeable — selecting the wrong one fails with `XLValueCodecError.storageMismatch`.
- The codec only ever handles the nonoptional `Codable` value. `Optional<T>` composes through the existing `encodeOptional`/`decodeOptional` path on the resolved codec/coding configuration, exactly like every other codec — nothing JSON-specific was added for `NULL`.
- `XLJSONValueCodecError` wraps the underlying `EncodingError`/`DecodingError` text (via `String(describing:)`) and conforms to `CustomStringConvertible`, so that text survives inside the outer `XLValueCodecError.encodingFailed`/`.decodingFailed` message alongside the codec key and coding context — malformed or incompatible data always fails with a structured, catchable error, never a default value.
- The `Codable <-> Data` transcoding (`_XLJSONTranscoder`) is isolated from `XLSQLiteValue`/`XLSQLiteStorageClass`, so a future PostgreSQL `JSONB` mapping (tracked separately as #137) could reuse it behind a dialect-native lowering without touching this SQLite codec. No cross-database JSON abstraction is introduced now.

## Documentation

- `Sources/SwiftQL/SwiftQL.docc/CustomTypes.md` gains a new "JSON `Codable` columns" section, in the same style as the existing `Date` contextual-codec walkthrough: a nested example type (struct + array + optional + enum), TEXT/BLOB registration, storage-mismatch behavior, NULL/optional composition, a structured malformed-JSON failure, two coexisting key-strategy codecs for one Swift type without a wrapper struct, and a real-database `contextualBinding` example — plus migration/fingerprint and future-Postgres notes.
- Confirmed the repo's doctest convention before using it (`Tests/SQLTests/SQLDocumentationCatalogTests.swift` + `SQLExampleTests.swift`'s `XLDocumentationTests`): every fenced Swift example in a `.md` article must be preceded by `<!-- test: XLDocumentationTests.<method> -->` matching that file's one designated test method, or a catalog test fails. All new fences reuse `CustomTypes.md`'s existing marker, `testDocumentationCustomTypeRoundTrips`, and the corresponding Swift code was added to that method in `Tests/SQLTests/SQLExampleTests.swift` so the documented example is real, compiled, executed code — not just prose.

## Evidence / validation

- A representative nested `Codable` value (struct with a nested struct, `[String]`, an `Address?`, and an enum-with-associated-value `ContactMethod`) round-trips through real SQLite as both `TEXT` and `BLOB` (`JSONValueCodecGRDBTests.testProfileRoundTripsAsTextAndBlobThroughRealSQLite`), and at the value level without a database connection (`JSONValueCodecContractTests.testNestedValueRoundTripsAsText`/`AsBlob`).
- `NULL` (`testNullColumnRoundTripsThroughRealSQLiteUsingOptionalComposition`, `testOptionalWrappingComposesOutsideTheNonoptionalCodec`), malformed JSON both at the value level and after a real SQLite round trip of hand-corrupted text (`testMalformedJSONFailsWithAStructuredDecodingError`, `testMalformedStoredJSONFailsAtDecodeRatherThanReturningADefaultValue`), schema evolution — an added field defaults when decoding older JSON that omits it (`testMissingNewerFieldDecodesUsingItsApplicationDefault`) — unknown/extra fields being ignored (`testUnknownFieldsAreIgnoredRatherThanFailing`), and both encoder failure (non-finite `Double`, `testNonFiniteDoubleFailsWithAStructuredEncodingError`) and decoder failure (type-mismatched JSON, `testTypeMismatchedJSONFailsWithAStructuredDecodingError`) are all covered and asserted against the structured `XLValueCodecError` cases.
- Two configurations of the same `Codable` type (default vs. `.convertToSnakeCase` key strategy) coexist and are independently selectable without a wrapper struct (`testTwoKeyStrategyConfigurationsCoexistWithoutWrapperStructs`).
- `TEXT` and `BLOB` codecs for the same type are proven non-interchangeable (`testTextAndBlobCodecsAreNotInterchangeable`).
- `swift build` — full package builds with 0 warnings (verified by touching and rebuilding every new/changed file).
- `swift test` — full suite passes: 953 tests, 0 failures, including the 14 new JSON codec tests and the existing `SQLDocumentationCatalogTests` catalog-consistency checks.

## Test plan

- [x] `swift build` (0 warnings)
- [x] `swift test` (full suite, 953 tests, 0 failures)
- [x] `swift test --filter JSONValueCodecContractTests` (10/10 passed)
- [x] `swift test --filter JSONValueCodecGRDBTests` (4/4 passed)
- [x] `swift test --filter SQLDocumentationCatalogTests` (7/7 passed)
- [x] `swift test --filter "XLDocumentationTests/testDocumentationCustomTypeRoundTrips"` (passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
