### PR TITLE
Prototype normalised query-plan capture and shape classification (#391)

### DIFF
--- a/Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md
+++ b/Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md
@@ -43,11 +43,13 @@ plus `unclassified` as the honest fallback for genuinely unrecognised text.
 
 ## Classification
 
-`EQPPlanShapeClassifier.classify(rows:statementID:)` builds the tree with a
-single top-down pass: EQP always emits a parent row before its children
-(SQLite's own guarantee), so children are classified after — and with
-knowledge of — their parent's already-known shape. That parent-awareness is
-needed for exactly one distinction:
+`EQPPlanShapeClassifier.classify(rows:statementID:)` first indexes rows by
+`parent` id, then recursively builds the tree top-down from the roots
+(`parent == 0`) through that index — so, unlike the row list itself, this
+does not depend on rows arriving in any particular order. Building top-down
+means a node's children are classified after — and with knowledge of — their
+parent's already-known shape. That parent-awareness is needed for exactly
+one distinction:
 
 ### Correlated vs. uncorrelated scalar subquery
 

--- a/Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md
+++ b/Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md
@@ -1,0 +1,139 @@
+# Normalised query-plan capture and shape classification (issue #391)
+
+Milestone 29, "Spike: SQLite query-plan analysis and index advice." This
+document is the prototype write-up issue #391 asks for: a normalised plan
+tree built from raw EQP rows, plus a classifier that turns each node into a
+named shape. It builds directly on [#390's EQP variance evidence and
+capture pipeline](SQLiteEQPVariance.md) rather than duplicating it.
+
+## Non-goals
+
+Research target only (`SwiftQLSQLitePlanShapePrototype`), per this issue's
+hard constraints: no public SwiftQL API, no shipping report schema, no
+build-plugin work, no index creation or snapshot mutation. Classification is
+a pure function of captured rows plus recorded SQLite provenance — nothing
+here opens a database connection.
+
+## Model
+
+- **`EQPPlanNode`** (`EQPPlanShapeModels.swift`): `detail` (raw, always
+  preserved), `shape` (`EQPPlanShapeKind`), `attributes`
+  (`EQPPlanShapeAttributes`), `children`.
+- **`EQPPlan`**: a statement's normalised plan is a *forest* of `EQPPlanNode`
+  roots, not a single tree — most statements have more than one top-level
+  node (e.g. a table scan alongside a sibling `USE TEMP B-TREE FOR ORDER BY`).
+  No timestamp, host, or SQLite-version field: the same rows always
+  normalise to the same plan, a requirement this issue states explicitly.
+- **`EQPPlanShapeAttributes`**: `table`, `indexName`, `constrainedColumns`,
+  `isCovering`, `isAutomatic` — populated only where the shape carries them.
+
+### Why more than the seven required shapes
+
+The issue requires classifying "at least" seven shapes. The real #390
+corpus's captures also contain compound-query, CTE-coroutine, and recursive-
+CTE structural nodes that are none of those seven — forcing them into one
+would be exactly the coercion this issue forbids ("never coerce an unknown
+shape into a known one"). `EQPPlanShapeKind` therefore has 17 cases: the
+seven required shapes, plus ten more precisely-named patterns actually
+observed in the real corpus (`covering_index_scan`, `list_subquery`,
+`co_routine_subquery_or_cte`, `compound_query_strategy`,
+`recursive_cte_step`, `constant_row_scan`, `bloom_filter`,
+`temp_b_tree_for_distinct_aggregate`, `temp_b_tree_for_compound_operation`),
+plus `unclassified` as the honest fallback for genuinely unrecognised text.
+
+## Classification
+
+`EQPPlanShapeClassifier.classify(rows:statementID:)` builds the tree with a
+single top-down pass: EQP always emits a parent row before its children
+(SQLite's own guarantee), so children are classified after — and with
+knowledge of — their parent's already-known shape. That parent-awareness is
+needed for exactly one distinction:
+
+### Correlated vs. uncorrelated scalar subquery
+
+SQLite's raw EQP text does not literally say "correlated" — both cases print
+identically as `SCALAR SUBQUERY N`. The only signal available from the
+captured rows is structural: a scalar subquery SQLite can evaluate once
+(uncorrelated) is hoisted as a sibling of the driving row source, with
+`parent == 0`; one it must re-evaluate per outer row (correlated) is nested
+as a child of whatever row-producing node supplies the correlation — a table
+scan, index search, or another per-row-loop shape. `isRowLoopingShape`
+implements this rule. It is a heuristic on tree structure, not a guarantee:
+the real corpus contains no correlated scalar subquery to validate it
+against (every `SCALAR SUBQUERY` node in both checked-in plan evidence files
+classifies as plain `scalar_subquery`, 1 occurrence, 0
+`correlated_scalar_subquery`), so this distinction is exercised only by a
+clearly-labelled synthetic fixture (`testSyntheticCorrelatedScalarSubqueryUsesParentShapeHeuristic`).
+
+### Structured attribute extraction
+
+`SEARCH`/`SCAN` detail text is parsed into table, access method, and
+constraint clause, then further classified:
+
+| Raw pattern | Shape | Notes |
+|---|---|---|
+| `SCAN <table>` | `full_table_scan` | |
+| `SCAN <table> USING COVERING INDEX <name>` | `covering_index_scan` | full scan optimized via a covering index; still visits every row |
+| `SEARCH <table> USING INDEX <name> (<constraint>)` | `index_search` | `constrainedColumns` parsed from `<constraint>` |
+| `SEARCH <table> USING INTEGER PRIMARY KEY (<constraint>)` | `index_search` | `indexName = "INTEGER PRIMARY KEY"` |
+| `SEARCH <table> USING COVERING INDEX <name> (<constraint>)` | `index_search` | `isCovering = true` |
+| `SEARCH <table> USING AUTOMATIC [PARTIAL] COVERING INDEX (<constraint>)` | `automatic_covering_index` | SQLite's on-the-fly ephemeral index — distinct from a real named index, including a named `sqlite_autoindex_*`; requires the literal `AUTOMATIC` marker |
+| any other `SEARCH`/`SCAN … USING …` | `unclassified` | table still captured for audit; access method not guessed |
+
+## Evidence
+
+Classified both checked-in #390 captures
+(`capture_apple-system-3.51.0.json`, `capture_homebrew-3.53.2.json`) end to
+end; results checked in as `plans_apple-system-3.51.0.json` and
+`plans_homebrew-3.53.2.json`.
+
+| Shape | apple-system-3.51.0 | homebrew-3.53.2 |
+|---|---:|---:|
+| `full_table_scan` | 114 | 114 |
+| `index_search` | 64 | 64 |
+| `covering_index_scan` | 17 | 17 |
+| `constant_row_scan` | 93 | 93 |
+| `co_routine_subquery_or_cte` | 14 | 14 |
+| `recursive_cte_step` | 8 | 8 |
+| `bloom_filter` | 5 | 5 |
+| `list_subquery` | 5 | 5 |
+| `scalar_subquery` | 1 | 1 |
+| `temp_b_tree_for_group_by` | 10 | 10 |
+| `temp_b_tree_for_distinct_aggregate` | 6 | 6 |
+| `compound_query_strategy` | 33 | 42 |
+| `temp_b_tree_for_order_by` | 20 | 29 |
+| `temp_b_tree_for_compound_operation` | 9 | 0 |
+| `automatic_covering_index` | 0 | 0 |
+| `correlated_scalar_subquery` | 0 | 0 |
+| `unclassified` | **0** | **0** |
+
+**Zero unclassified nodes on either build, across all 214 real statements.**
+The three rows that differ between builds are exactly #390's Finding 2 (the
+9 CTE × compound-operator cases): 3.51.0's `<OP> USING TEMP B-TREE` node
+becomes 3.53.2's `USE TEMP B-TREE FOR ORDER BY` (accounting for the +9/+9
+shift), while `compound_query_strategy`'s count rises from 33 to 42 because
+the newer `MERGE (<OP>)`/`LEFT`/`RIGHT` shape has more nodes than the older
+`COMPOUND QUERY`/`LEFT-MOST SUBQUERY` shape for the same 9 statements. This
+is the classifier correctly *naming* the variance #390 measured, not
+disagreeing with it.
+
+### Determinism and id-renumbering robustness
+
+- `testClassificationIsDeterministicAcrossRepeatedRuns`: classifying the same
+  captured rows twice produces byte-identical `EQPPlan` values.
+- `testIDRenumberedJoinStatementNormalisesIdenticallyAcrossBuilds`: the
+  five-table Northwind join (#390 Finding 1 — its raw `id`/`parent` values
+  differ between builds) produces a **byte-identical** normalised plan on
+  both builds, because `EQPPlanNode` never encodes `id`/`parent`. This is the
+  concrete proof that #390's recommendation ("never use `id`/`parent` as a
+  diagnostic key") is followed here, not just stated.
+
+## Reproducing this evidence
+
+```bash
+swift run SwiftQLSQLitePlanShapeCLI classify \
+  --capture path/to/capture.json --output plans.json
+```
+
+Prints a shape-count summary to stdout and writes the full classified forest,
+per statement, as canonical JSON.

--- a/Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md
+++ b/Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md
@@ -45,11 +45,15 @@ plus `unclassified` as the honest fallback for genuinely unrecognised text.
 
 `EQPPlanShapeClassifier.classify(rows:statementID:)` first indexes rows by
 `parent` id, then recursively builds the tree top-down from the roots
-(`parent == 0`) through that index — so, unlike the row list itself, this
-does not depend on rows arriving in any particular order. Building top-down
-means a node's children are classified after — and with knowledge of — their
-parent's already-known shape. That parent-awareness is needed for exactly
-one distinction:
+(`parent == 0`) through that index. Parent-child adjacency comes entirely
+from each row's own `parent` field, not from its position in the row list.
+Sibling order is not independent of input order, though: children of the
+same parent (and the top-level roots) keep the relative order they had in
+the input rows, so this is deterministic for a given capture but not
+permutation-invariant against an arbitrary reordering of the same rows.
+Building top-down means a node's children are classified after — and with
+knowledge of — their parent's already-known shape. That parent-awareness is
+needed for exactly one distinction:
 
 ### Correlated vs. uncorrelated scalar subquery
 

--- a/Package.swift
+++ b/Package.swift
@@ -163,6 +163,25 @@ let package = Package(
             path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteEQPVarianceCLI"
         ),
 
+        // Package-private research engine for issue #391 (milestone 29 spike).
+        // Prototypes a normalised query-plan tree and named shape classifier
+        // over the #390 EQP capture pipeline's raw rows. Deliberately outside
+        // the package's public products: research target only, no report
+        // schema or public API.
+        .target(
+            name: "SwiftQLSQLitePlanShapePrototype",
+            dependencies: [
+                "SwiftQLSQLiteEQPVariancePrototype",
+            ],
+            path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype"
+        ),
+
+        .executableTarget(
+            name: "SwiftQLSQLitePlanShapeCLI",
+            dependencies: ["SwiftQLSQLitePlanShapePrototype"],
+            path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapeCLI"
+        ),
+
         // A test target used to develop the macro implementation.
         .testTarget(
             name: "SwiftQLCoreTests",
@@ -260,6 +279,16 @@ let package = Package(
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],
             path: "Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests",
+            resources: [.copy("Evidence")]
+        ),
+
+        .testTarget(
+            name: "SwiftQLSQLitePlanShapePrototypeTests",
+            dependencies: [
+                "SwiftQLSQLitePlanShapePrototype",
+                "SwiftQLSQLiteEQPVariancePrototype",
+            ],
+            path: "Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests",
             resources: [.copy("Evidence")]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -178,7 +178,10 @@ let package = Package(
 
         .executableTarget(
             name: "SwiftQLSQLitePlanShapeCLI",
-            dependencies: ["SwiftQLSQLitePlanShapePrototype"],
+            dependencies: [
+                "SwiftQLSQLitePlanShapePrototype",
+                "SwiftQLSQLiteEQPVariancePrototype",
+            ],
             path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapeCLI"
         ),
 

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapeCLI/main.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapeCLI/main.swift
@@ -1,0 +1,80 @@
+import Foundation
+import SwiftQLSQLiteEQPVariancePrototype
+import SwiftQLSQLitePlanShapePrototype
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+
+private let usage = """
+    Usage:
+      SwiftQLSQLitePlanShapeCLI classify --capture <path> --output <path>
+
+    Reads an EQPCaptureRun (from SwiftQLSQLiteEQPVarianceCLI capture or
+    capture_eqp.py) and writes the normalised, classified plan tree for every
+    statement as canonical JSON, plus a shape-count summary on stdout.
+    """
+
+
+private func writeStandardError(_ message: String) {
+    guard let data = "\(message)\n".data(using: .utf8) else {
+        return
+    }
+    FileHandle.standardError.write(data)
+}
+
+
+private func flagValue(_ name: String, in arguments: [String]) -> String? {
+    guard let index = arguments.firstIndex(of: name), index + 1 < arguments.count else {
+        return nil
+    }
+    return arguments[index + 1]
+}
+
+
+private func countShapes(_ node: EQPPlanNode, into counts: inout [EQPPlanShapeKind: Int]) {
+    counts[node.shape, default: 0] += 1
+    for child in node.children {
+        countShapes(child, into: &counts)
+    }
+}
+
+
+do {
+    let arguments = Array(CommandLine.arguments.dropFirst())
+    guard arguments.first == "classify",
+          let capturePath = flagValue("--capture", in: arguments),
+          let outputPath = flagValue("--output", in: arguments) else {
+        writeStandardError(usage)
+        exit(2)
+    }
+
+    let run = try JSONDecoder().decode(
+        EQPCaptureRun.self,
+        from: Data(contentsOf: URL(fileURLWithPath: capturePath))
+    )
+
+    let plans = run.statements.map { statement in
+        EQPPlanShapeClassifier.classify(rows: statement.rows, statementID: statement.statementID)
+    }
+
+    let data = try EQPVarianceCanonicalJSON.encode(plans)
+    try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+
+    var counts: [EQPPlanShapeKind: Int] = [:]
+    for plan in plans {
+        for root in plan.roots {
+            countShapes(root, into: &counts)
+        }
+    }
+    for (shape, count) in counts.sorted(by: { $0.key.rawValue < $1.key.rawValue }) {
+        print("\(shape.rawValue): \(count)")
+    }
+} catch {
+    writeStandardError(String(describing: error))
+    writeStandardError(usage)
+    exit(2)
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeClassifier.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeClassifier.swift
@@ -6,11 +6,15 @@ import SwiftQLSQLiteEQPVariancePrototype
 /// classifies every node into a named shape.
 ///
 /// First indexes rows by `parent` id, then recursively builds the tree
-/// top-down from the roots (`parent == 0`) through that index — so, unlike
-/// the row list itself, this does not depend on rows arriving in any
-/// particular order. Classification is a pure function of the row's own
-/// `detail` text plus its already-known parent shape (needed only to
-/// distinguish a correlated scalar subquery, see `isRowLoopingShape`); it
+/// top-down from the roots (`parent == 0`) through that index. Parent-child
+/// adjacency comes entirely from each row's own `parent` field, not from its
+/// position in the row list. Sibling order is not independent of input order,
+/// though: children of the same parent (and the top-level roots) keep the
+/// relative order they had in the input rows, so this is deterministic for a
+/// given capture but not permutation-invariant against an arbitrary
+/// reordering of the same rows. Classification is a pure function of the
+/// row's own `detail` text plus its already-known parent shape (needed only
+/// to distinguish a correlated scalar subquery, see `isRowLoopingShape`); it
 /// never depends on SQLite version, host, or any other provenance field.
 package enum EQPPlanShapeClassifier {
     package static func classify(rows: [EQPRow], statementID: String) -> EQPPlan {

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeClassifier.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeClassifier.swift
@@ -1,0 +1,219 @@
+import Foundation
+import SwiftQLSQLiteEQPVariancePrototype
+
+
+/// Builds a normalised plan tree from one statement's raw EQP rows and
+/// classifies every node into a named shape.
+///
+/// EQP always emits a parent row before its children (SQLite's own
+/// guarantee), so a single top-down pass — classify a row, then its children
+/// — is enough to build the tree without a second traversal. Classification
+/// is a pure function of the row's own `detail` text plus its already-known
+/// parent shape (needed only to distinguish a correlated scalar subquery,
+/// see `isRowLoopingShape`); it never depends on SQLite version, host, or
+/// any other provenance field.
+package enum EQPPlanShapeClassifier {
+    package static func classify(rows: [EQPRow], statementID: String) -> EQPPlan {
+        var childrenByParent: [Int64: [EQPRow]] = [:]
+        for row in rows {
+            childrenByParent[row.parent, default: []].append(row)
+        }
+        let roots = (childrenByParent[0] ?? []).map {
+            buildNode($0, parentShape: nil, childrenByParent: childrenByParent)
+        }
+        return EQPPlan(statementID: statementID, roots: roots)
+    }
+
+    private static func buildNode(
+        _ row: EQPRow,
+        parentShape: EQPPlanShapeKind?,
+        childrenByParent: [Int64: [EQPRow]]
+    ) -> EQPPlanNode {
+        let (shape, attributes) = classifyDetail(row.detail, parentShape: parentShape)
+        let children = (childrenByParent[row.id] ?? []).map {
+            buildNode($0, parentShape: shape, childrenByParent: childrenByParent)
+        }
+        return EQPPlanNode(detail: row.detail, shape: shape, attributes: attributes, children: children)
+    }
+
+    /// `internal` (not `private`) so classifier tests can exercise detail
+    /// strings directly, without needing a full row tree for every case.
+    static func classifyDetail(
+        _ detail: String,
+        parentShape: EQPPlanShapeKind?
+    ) -> (EQPPlanShapeKind, EQPPlanShapeAttributes) {
+        if detail == "SCAN CONSTANT ROW" {
+            return (.constantRowScan, .none)
+        }
+        if detail == "CREATE BLOOM FILTER" {
+            return (.bloomFilter, .none)
+        }
+        if detail == "SETUP" || detail == "RECURSIVE STEP" {
+            return (.recursiveCTEStep, .none)
+        }
+        if detail == "COMPOUND QUERY" || detail == "LEFT-MOST SUBQUERY"
+            || detail == "LEFT" || detail == "RIGHT"
+            || detail == "UNION ALL" || detail.hasPrefix("MERGE (") {
+            return (.compoundQueryStrategy, .none)
+        }
+        if detail == "USE TEMP B-TREE FOR ORDER BY" {
+            return (.tempBTreeForOrderBy, .none)
+        }
+        if detail == "USE TEMP B-TREE FOR GROUP BY" {
+            return (.tempBTreeForGroupBy, .none)
+        }
+        if detail.hasPrefix("USE TEMP B-TREE FOR "), detail.hasSuffix("(DISTINCT)") {
+            return (.tempBTreeForDistinctAggregate, .none)
+        }
+        if detail.hasSuffix(" USING TEMP B-TREE"),
+           ["UNION", "EXCEPT", "INTERSECT"].contains(String(detail.dropLast(" USING TEMP B-TREE".count))) {
+            return (.tempBTreeForCompoundOperation, .none)
+        }
+        if detail.hasPrefix("CO-ROUTINE ") {
+            return (.coRoutineSubqueryOrCTE, .none)
+        }
+        if detail.hasPrefix("MATERIALIZE ") {
+            return (.materializedSubqueryOrCTE, .none)
+        }
+        if detail.hasPrefix("SCALAR SUBQUERY") {
+            let shape: EQPPlanShapeKind = isRowLoopingShape(parentShape) ? .correlatedScalarSubquery : .scalarSubquery
+            return (shape, .none)
+        }
+        if detail.hasPrefix("LIST SUBQUERY") {
+            return (.listSubquery, .none)
+        }
+        if let parsed = parseSearchOrScan(detail) {
+            return classifySearchOrScan(parsed)
+        }
+        return (.unclassified, .none)
+    }
+
+    /// A scalar subquery SQLite can evaluate once (uncorrelated) is hoisted
+    /// as a sibling of the driving row source, with `parent == 0`. One it
+    /// must re-evaluate per outer row (correlated) is nested as a child of
+    /// whatever row-producing node supplies the correlation — a table scan,
+    /// index search, or another per-row-loop shape. This is a heuristic on
+    /// EQP's tree structure, not a guarantee: it has no real-corpus
+    /// counter-example in this repo's evidence, but is not proven exhaustive
+    /// against every SQLite version or query shape.
+    private static func isRowLoopingShape(_ shape: EQPPlanShapeKind?) -> Bool {
+        guard let shape else {
+            return false
+        }
+        switch shape {
+        case .fullTableScan, .coveringIndexScan, .indexSearch, .automaticCoveringIndex,
+             .coRoutineSubqueryOrCTE, .recursiveCTEStep:
+            return true
+        case .tempBTreeForOrderBy, .tempBTreeForGroupBy, .tempBTreeForDistinctAggregate,
+             .tempBTreeForCompoundOperation, .scalarSubquery, .correlatedScalarSubquery,
+             .listSubquery, .materializedSubqueryOrCTE, .compoundQueryStrategy,
+             .constantRowScan, .bloomFilter, .unclassified:
+            return false
+        }
+    }
+
+    private struct ParsedAccess {
+        let isSearch: Bool
+        let table: String
+        let using: String?
+        let constraint: String?
+    }
+
+    private static func parseSearchOrScan(_ detail: String) -> ParsedAccess? {
+        let isSearch: Bool
+        let prefixLength: Int
+        if detail.hasPrefix("SEARCH ") {
+            isSearch = true
+            prefixLength = "SEARCH ".count
+        } else if detail.hasPrefix("SCAN ") {
+            isSearch = false
+            prefixLength = "SCAN ".count
+        } else {
+            return nil
+        }
+
+        var remainder = String(detail.dropFirst(prefixLength))
+        if let joinRange = remainder.range(of: " LEFT-JOIN") {
+            remainder = String(remainder[remainder.startIndex..<joinRange.lowerBound])
+        }
+
+        guard let usingRange = remainder.range(of: " USING ") else {
+            return ParsedAccess(isSearch: isSearch, table: remainder, using: nil, constraint: nil)
+        }
+
+        let table = String(remainder[remainder.startIndex..<usingRange.lowerBound])
+        var usingClause = String(remainder[usingRange.upperBound...])
+        var constraint: String?
+        if let parenStart = usingClause.firstIndex(of: "("), usingClause.hasSuffix(")") {
+            constraint = String(usingClause[usingClause.index(after: parenStart)..<usingClause.index(before: usingClause.endIndex)])
+            usingClause = String(usingClause[usingClause.startIndex..<parenStart])
+                .trimmingCharacters(in: .whitespaces)
+        }
+        return ParsedAccess(isSearch: isSearch, table: table, using: usingClause, constraint: constraint)
+    }
+
+    private static func classifySearchOrScan(
+        _ parsed: ParsedAccess
+    ) -> (EQPPlanShapeKind, EQPPlanShapeAttributes) {
+        guard let using = parsed.using else {
+            let shape: EQPPlanShapeKind = parsed.isSearch ? .indexSearch : .fullTableScan
+            return (shape, EQPPlanShapeAttributes(table: parsed.table))
+        }
+
+        let columns = parsed.constraint.map(constrainedColumns(from:)) ?? []
+
+        if using == "INTEGER PRIMARY KEY" || using == "PRIMARY KEY" {
+            return (
+                .indexSearch,
+                EQPPlanShapeAttributes(table: parsed.table, indexName: using, constrainedColumns: columns)
+            )
+        }
+        if using.hasPrefix("AUTOMATIC COVERING INDEX") || using.hasPrefix("AUTOMATIC PARTIAL COVERING INDEX") {
+            return (
+                .automaticCoveringIndex,
+                EQPPlanShapeAttributes(
+                    table: parsed.table,
+                    constrainedColumns: columns,
+                    isCovering: true,
+                    isAutomatic: true
+                )
+            )
+        }
+        if using.hasPrefix("COVERING INDEX ") {
+            let name = String(using.dropFirst("COVERING INDEX ".count))
+            let shape: EQPPlanShapeKind = parsed.isSearch ? .indexSearch : .coveringIndexScan
+            return (
+                shape,
+                EQPPlanShapeAttributes(table: parsed.table, indexName: name, constrainedColumns: columns, isCovering: true)
+            )
+        }
+        if using.hasPrefix("INDEX ") {
+            let name = String(using.dropFirst("INDEX ".count))
+            return (
+                .indexSearch,
+                EQPPlanShapeAttributes(table: parsed.table, indexName: name, constrainedColumns: columns)
+            )
+        }
+
+        // An unrecognised "USING ..." form: preserve the parsed table for
+        // audit, but do not guess a shape for text this classifier has
+        // never seen — that would be exactly the coercion #391 forbids.
+        return (.unclassified, EQPPlanShapeAttributes(table: parsed.table))
+    }
+
+    private static func constrainedColumns(from constraint: String) -> [String] {
+        constraint
+            .components(separatedBy: " AND ")
+            .compactMap { clause -> String? in
+                let trimmed = clause.trimmingCharacters(in: .whitespaces)
+                for comparisonOperator in [">=", "<=", "<>", "!=", "=", "<", ">"] {
+                    if let range = trimmed.range(of: comparisonOperator) {
+                        let column = String(trimmed[trimmed.startIndex..<range.lowerBound])
+                            .trimmingCharacters(in: .whitespaces)
+                        return column.isEmpty ? nil : column
+                    }
+                }
+                return trimmed.isEmpty ? nil : trimmed
+            }
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeClassifier.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeClassifier.swift
@@ -5,13 +5,13 @@ import SwiftQLSQLiteEQPVariancePrototype
 /// Builds a normalised plan tree from one statement's raw EQP rows and
 /// classifies every node into a named shape.
 ///
-/// EQP always emits a parent row before its children (SQLite's own
-/// guarantee), so a single top-down pass — classify a row, then its children
-/// — is enough to build the tree without a second traversal. Classification
-/// is a pure function of the row's own `detail` text plus its already-known
-/// parent shape (needed only to distinguish a correlated scalar subquery,
-/// see `isRowLoopingShape`); it never depends on SQLite version, host, or
-/// any other provenance field.
+/// First indexes rows by `parent` id, then recursively builds the tree
+/// top-down from the roots (`parent == 0`) through that index — so, unlike
+/// the row list itself, this does not depend on rows arriving in any
+/// particular order. Classification is a pure function of the row's own
+/// `detail` text plus its already-known parent shape (needed only to
+/// distinguish a correlated scalar subquery, see `isRowLoopingShape`); it
+/// never depends on SQLite version, host, or any other provenance field.
 package enum EQPPlanShapeClassifier {
     package static func classify(rows: [EQPRow], statementID: String) -> EQPPlan {
         var childrenByParent: [Int64: [EQPRow]] = [:]

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeModels.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeModels.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftQLSQLiteEQPVariancePrototype
 
 
 /// A named EQP plan-node shape. Deliberately more granular than the seven

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeModels.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapePrototype/EQPPlanShapeModels.swift
@@ -1,0 +1,114 @@
+import Foundation
+import SwiftQLSQLiteEQPVariancePrototype
+
+
+/// A named EQP plan-node shape. Deliberately more granular than the seven
+/// shapes issue #391 requires (`fullTableScan`, `indexSearch`,
+/// `automaticCoveringIndex`, `tempBTreeForOrderBy`, `tempBTreeForGroupBy`,
+/// `correlatedScalarSubquery`, `materializedSubqueryOrCTE`): the #390 corpus's
+/// real captures also contain compound-query, CTE-coroutine, and
+/// recursive-CTE structural nodes that are not any of those seven, and
+/// forcing them into one would be exactly the coercion this issue forbids.
+/// Naming every distinct pattern precisely, with `unclassified` reserved for
+/// genuinely unrecognised detail text, keeps every classification honest.
+package enum EQPPlanShapeKind: String, Codable, Equatable, Sendable {
+    case fullTableScan = "full_table_scan"
+    case coveringIndexScan = "covering_index_scan"
+    case indexSearch = "index_search"
+    case automaticCoveringIndex = "automatic_covering_index"
+    case tempBTreeForOrderBy = "temp_b_tree_for_order_by"
+    case tempBTreeForGroupBy = "temp_b_tree_for_group_by"
+    case tempBTreeForDistinctAggregate = "temp_b_tree_for_distinct_aggregate"
+    case tempBTreeForCompoundOperation = "temp_b_tree_for_compound_operation"
+    case scalarSubquery = "scalar_subquery"
+    case correlatedScalarSubquery = "correlated_scalar_subquery"
+    case listSubquery = "list_subquery"
+    case coRoutineSubqueryOrCTE = "co_routine_subquery_or_cte"
+    case materializedSubqueryOrCTE = "materialized_subquery_or_cte"
+    case compoundQueryStrategy = "compound_query_strategy"
+    case recursiveCTEStep = "recursive_cte_step"
+    case constantRowScan = "constant_row_scan"
+    case bloomFilter = "bloom_filter"
+    case unclassified
+}
+
+
+/// Structured detail extracted from a node's raw text, populated only where
+/// the shape carries it. Every field is optional/empty rather than defaulted
+/// to a placeholder, so absence is visible in the encoded evidence.
+package struct EQPPlanShapeAttributes: Codable, Equatable, Sendable {
+    package let table: String?
+    package let indexName: String?
+    package let constrainedColumns: [String]
+    package let isCovering: Bool
+    package let isAutomatic: Bool
+
+    package init(
+        table: String? = nil,
+        indexName: String? = nil,
+        constrainedColumns: [String] = [],
+        isCovering: Bool = false,
+        isAutomatic: Bool = false
+    ) {
+        self.table = table
+        self.indexName = indexName
+        self.constrainedColumns = constrainedColumns
+        self.isCovering = isCovering
+        self.isAutomatic = isAutomatic
+    }
+
+    package static let none = EQPPlanShapeAttributes()
+
+    private enum CodingKeys: String, CodingKey {
+        case table
+        case indexName = "index_name"
+        case constrainedColumns = "constrained_columns"
+        case isCovering = "is_covering"
+        case isAutomatic = "is_automatic"
+    }
+}
+
+
+/// One classified node in the normalised plan tree. The raw `detail` string
+/// is always retained alongside its classification so a misclassification is
+/// auditable rather than silent, per this issue's required approach.
+package struct EQPPlanNode: Codable, Equatable, Sendable {
+    package let detail: String
+    package let shape: EQPPlanShapeKind
+    package let attributes: EQPPlanShapeAttributes
+    package let children: [EQPPlanNode]
+
+    package init(
+        detail: String,
+        shape: EQPPlanShapeKind,
+        attributes: EQPPlanShapeAttributes,
+        children: [EQPPlanNode]
+    ) {
+        self.detail = detail
+        self.shape = shape
+        self.attributes = attributes
+        self.children = children
+    }
+}
+
+
+/// The normalised plan for one statement: a forest of `EQPPlanNode` roots (a
+/// single statement commonly has more than one top-level node, e.g. a table
+/// scan alongside a sibling "USE TEMP B-TREE FOR ORDER BY"). A pure function
+/// of the captured rows: no timestamp, host, or SQLite-version field, so the
+/// same rows always normalise to the same plan regardless of which build
+/// captured them.
+package struct EQPPlan: Codable, Equatable, Sendable {
+    package let statementID: String
+    package let roots: [EQPPlanNode]
+
+    package init(statementID: String, roots: [EQPPlanNode]) {
+        self.statementID = statementID
+        self.roots = roots
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case statementID = "statement_id"
+        case roots
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/EQPPlanShapeClassifierTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/EQPPlanShapeClassifierTests.swift
@@ -1,0 +1,206 @@
+import XCTest
+import SwiftQLSQLiteEQPVariancePrototype
+@testable import SwiftQLSQLitePlanShapePrototype
+
+
+final class EQPPlanShapeClassifierTests: XCTestCase {
+    // MARK: - Real #390 evidence
+
+    /// The strongest evidence this classifier can offer: every one of the
+    /// 214 real statements' EQP rows, captured from a real SQLite build
+    /// against the pinned Northwind snapshot, classifies to a named shape —
+    /// not one falls through to `.unclassified`.
+    func testEveryRealCaptureRowClassifiesWithoutFallingBackToUnclassified() throws {
+        let run = try loadCapture("capture_apple-system-3.51.0.json")
+        var unclassifiedDetails: [String] = []
+
+        for statement in run.statements {
+            let plan = EQPPlanShapeClassifier.classify(rows: statement.rows, statementID: statement.statementID)
+            for root in plan.roots {
+                collectUnclassified(root, into: &unclassifiedDetails)
+            }
+        }
+
+        XCTAssertTrue(
+            unclassifiedDetails.isEmpty,
+            "unexpected unclassified detail(s): \(unclassifiedDetails)"
+        )
+    }
+
+    func testClassificationIsDeterministicAcrossRepeatedRuns() throws {
+        let run = try loadCapture("capture_apple-system-3.51.0.json")
+        let statement = try XCTUnwrap(run.statements.first)
+
+        let first = EQPPlanShapeClassifier.classify(rows: statement.rows, statementID: statement.statementID)
+        let second = EQPPlanShapeClassifier.classify(rows: statement.rows, statementID: statement.statementID)
+        XCTAssertEqual(first, second)
+    }
+
+    /// Reconciles with #390 Finding 1: the five-table join's EQP rows have
+    /// different raw `id`/`parent` values between the two real SQLite builds
+    /// (apple-system-3.51.0 vs homebrew-3.53.2), but the classifier's
+    /// normalised plan — which never encodes `id`/`parent` — is byte-for-byte
+    /// identical, because the table/index/constraint structure genuinely did
+    /// not change.
+    func testIDRenumberedJoinStatementNormalisesIdenticallyAcrossBuilds() throws {
+        let appleRun = try loadCapture("capture_apple-system-3.51.0.json")
+        let homebrewRun = try loadCapture("capture_homebrew-3.53.2.json")
+        let statementID = "c390.northwind.join.customer-order-employee-product"
+
+        let appleRows = try XCTUnwrap(appleRun.statements.first { $0.statementID == statementID }).rows
+        let homebrewRows = try XCTUnwrap(homebrewRun.statements.first { $0.statementID == statementID }).rows
+        XCTAssertNotEqual(appleRows, homebrewRows, "precondition: raw rows must actually differ (id renumbering)")
+
+        let applePlan = EQPPlanShapeClassifier.classify(rows: appleRows, statementID: statementID)
+        let homebrewPlan = EQPPlanShapeClassifier.classify(rows: homebrewRows, statementID: statementID)
+        XCTAssertEqual(applePlan, homebrewPlan)
+
+        // Also pins the extracted structured detail for this real statement,
+        // proving "index search with the index identity and constrained
+        // columns" against actual SQLite output, not a synthetic example.
+        let searches = applePlan.roots.filter { $0.shape == .indexSearch }
+        XCTAssertEqual(searches.count, 5, "one SEARCH per joined table: o, c, e, d, p")
+        XCTAssertTrue(searches.contains {
+            $0.attributes.table == "c"
+                && $0.attributes.indexName == "sqlite_autoindex_Customers_1"
+                && $0.attributes.constrainedColumns == ["CustomerID"]
+        })
+        XCTAssertTrue(searches.contains {
+            $0.attributes.table == "o"
+                && $0.attributes.indexName == "INTEGER PRIMARY KEY"
+                && $0.attributes.constrainedColumns == ["rowid"]
+        })
+    }
+
+    /// Reconciles with #390 Finding 2: the two builds render a CTE ×
+    /// UNION/EXCEPT/INTERSECT compound query with a materially different
+    /// structure (legacy `COMPOUND QUERY`/`<OP> USING TEMP B-TREE` vs.
+    /// `MERGE (<OP>)`/`USE TEMP B-TREE FOR ORDER BY`). Both classify fully
+    /// (no `unclassified`), which is the point: the classifier's job is to
+    /// name what changed, not to claim it didn't.
+    func testCompoundQueryVarianceClassifiesFullyOnBothBuildsButDiffers() throws {
+        let appleRun = try loadCapture("capture_apple-system-3.51.0.json")
+        let homebrewRun = try loadCapture("capture_homebrew-3.53.2.json")
+        let statementID = "c191.v1.cte.ordinary-nullable.union"
+
+        let appleRows = try XCTUnwrap(appleRun.statements.first { $0.statementID == statementID }).rows
+        let homebrewRows = try XCTUnwrap(homebrewRun.statements.first { $0.statementID == statementID }).rows
+
+        let applePlan = EQPPlanShapeClassifier.classify(rows: appleRows, statementID: statementID)
+        let homebrewPlan = EQPPlanShapeClassifier.classify(rows: homebrewRows, statementID: statementID)
+
+        XCTAssertNotEqual(applePlan, homebrewPlan)
+        for plan in [applePlan, homebrewPlan] {
+            for root in plan.roots {
+                var unclassified: [String] = []
+                collectUnclassified(root, into: &unclassified)
+                XCTAssertTrue(unclassified.isEmpty)
+            }
+        }
+
+        let appleShapes = Set(allShapes(in: applePlan))
+        let homebrewShapes = Set(allShapes(in: homebrewPlan))
+        XCTAssertTrue(appleShapes.contains(.tempBTreeForCompoundOperation))
+        XCTAssertFalse(homebrewShapes.contains(.tempBTreeForCompoundOperation))
+        XCTAssertTrue(appleShapes.contains(.compoundQueryStrategy))
+        XCTAssertTrue(homebrewShapes.contains(.compoundQueryStrategy))
+    }
+
+    // MARK: - Synthetic fixtures: shapes not observed in the real 3.51.0/3.53.2 pair
+
+    /// Illustrative only: the real corpus's WHERE clauses always hit either
+    /// the rowid or an existing named index, so `automatic_index` (SQLite's
+    /// on-the-fly ephemeral index) was never exercised.
+    func testSyntheticAutomaticCoveringIndexIsClassified() {
+        let (shape, attributes) = EQPPlanShapeClassifier.classifyDetail(
+            "SEARCH t1 USING AUTOMATIC COVERING INDEX (x=?)",
+            parentShape: nil
+        )
+        XCTAssertEqual(shape, .automaticCoveringIndex)
+        XCTAssertEqual(attributes.table, "t1")
+        XCTAssertEqual(attributes.constrainedColumns, ["x"])
+        XCTAssertTrue(attributes.isAutomatic)
+        XCTAssertTrue(attributes.isCovering)
+    }
+
+    /// Illustrative only: no case in the real corpus references a CTE more
+    /// than once in a way that makes SQLite choose materialization over a
+    /// coroutine.
+    func testSyntheticMaterializedCTEIsClassified() {
+        let (shape, _) = EQPPlanShapeClassifier.classifyDetail("MATERIALIZE cte0", parentShape: nil)
+        XCTAssertEqual(shape, .materializedSubqueryOrCTE)
+    }
+
+    /// Illustrative only: every scalar subquery in the real corpus is
+    /// uncorrelated (see `scalar_subquery: 1, correlated_scalar_subquery: 0`
+    /// in both checked-in plan evidence files). This exercises the
+    /// parent-shape heuristic directly: a "SCALAR SUBQUERY" node nested
+    /// under a row-looping parent (a table scan or index search) is
+    /// classified as correlated; the same detail text under a non-looping
+    /// parent (or no parent) is not.
+    func testSyntheticCorrelatedScalarSubqueryUsesParentShapeHeuristic() {
+        let (uncorrelated, _) = EQPPlanShapeClassifier.classifyDetail("SCALAR SUBQUERY 1", parentShape: nil)
+        XCTAssertEqual(uncorrelated, .scalarSubquery)
+
+        let (correlated, _) = EQPPlanShapeClassifier.classifyDetail(
+            "SCALAR SUBQUERY 1",
+            parentShape: .fullTableScan
+        )
+        XCTAssertEqual(correlated, .correlatedScalarSubquery)
+    }
+
+    /// Proves the fallback path itself: a detail string this classifier
+    /// genuinely does not recognise must surface as `.unclassified` with the
+    /// raw text preserved, never coerced into one of the named shapes.
+    func testTrulyUnrecognisedDetailSurfacesAsUnclassified() {
+        let nonsense = "BOGUS FUTURE SQLITE OPCODE #12345"
+        let (shape, attributes) = EQPPlanShapeClassifier.classifyDetail(nonsense, parentShape: nil)
+        XCTAssertEqual(shape, .unclassified)
+        XCTAssertNil(attributes.table)
+
+        let node = EQPPlanNode(detail: nonsense, shape: shape, attributes: attributes, children: [])
+        XCTAssertEqual(node.detail, nonsense, "raw detail must be preserved even when unclassified")
+    }
+
+    func testUnrecognisedUsingClauseIsUnclassifiedNotCoerced() {
+        let (shape, attributes) = EQPPlanShapeClassifier.classifyDetail(
+            "SEARCH t0 USING SOME FUTURE ACCESS METHOD (x=?)",
+            parentShape: nil
+        )
+        XCTAssertEqual(shape, .unclassified)
+        XCTAssertEqual(attributes.table, "t0", "table is still captured for audit even when the access method is unrecognised")
+    }
+}
+
+
+private func collectUnclassified(_ node: EQPPlanNode, into details: inout [String]) {
+    if node.shape == .unclassified {
+        details.append(node.detail)
+    }
+    for child in node.children {
+        collectUnclassified(child, into: &details)
+    }
+}
+
+
+private func allShapes(_ node: EQPPlanNode) -> [EQPPlanShapeKind] {
+    [node.shape] + node.children.flatMap(allShapes)
+}
+
+
+private func allShapes(in plan: EQPPlan) -> [EQPPlanShapeKind] {
+    plan.roots.flatMap(allShapes)
+}
+
+
+func loadCapture(_ name: String) throws -> EQPCaptureRun {
+    guard let url = Bundle.module.url(forResource: name, withExtension: nil, subdirectory: "Evidence") else {
+        throw EQPPlanShapeFixtureError.missingResource(name)
+    }
+    return try JSONDecoder().decode(EQPCaptureRun.self, from: Data(contentsOf: url))
+}
+
+
+enum EQPPlanShapeFixtureError: Error {
+    case missingResource(String)
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/EQPPlanShapeClassifierTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/EQPPlanShapeClassifierTests.swift
@@ -9,22 +9,54 @@ final class EQPPlanShapeClassifierTests: XCTestCase {
     /// The strongest evidence this classifier can offer: every one of the
     /// 214 real statements' EQP rows, captured from a real SQLite build
     /// against the pinned Northwind snapshot, classifies to a named shape —
-    /// not one falls through to `.unclassified`.
+    /// not one falls through to `.unclassified`. Checked against both real
+    /// builds, not just one: the two builds render materially different
+    /// text for the same statements (#390 Finding 2), so a regression that
+    /// only breaks classification of the newer `MERGE (...)`-style wording
+    /// would otherwise slip through unnoticed.
     func testEveryRealCaptureRowClassifiesWithoutFallingBackToUnclassified() throws {
-        let run = try loadCapture("capture_apple-system-3.51.0.json")
-        var unclassifiedDetails: [String] = []
+        for captureFile in ["capture_apple-system-3.51.0.json", "capture_homebrew-3.53.2.json"] {
+            let run = try loadCapture(captureFile)
+            var unclassifiedDetails: [String] = []
 
-        for statement in run.statements {
-            let plan = EQPPlanShapeClassifier.classify(rows: statement.rows, statementID: statement.statementID)
-            for root in plan.roots {
-                collectUnclassified(root, into: &unclassifiedDetails)
+            for statement in run.statements {
+                let plan = EQPPlanShapeClassifier.classify(rows: statement.rows, statementID: statement.statementID)
+                for root in plan.roots {
+                    collectUnclassified(root, into: &unclassifiedDetails)
+                }
             }
-        }
 
-        XCTAssertTrue(
-            unclassifiedDetails.isEmpty,
-            "unexpected unclassified detail(s): \(unclassifiedDetails)"
-        )
+            XCTAssertTrue(
+                unclassifiedDetails.isEmpty,
+                "\(captureFile): unexpected unclassified detail(s): \(unclassifiedDetails)"
+            )
+        }
+    }
+
+    /// Guards the checked-in `plans_*.json` evidence against silent drift:
+    /// re-classifying each checked-in capture must still produce exactly the
+    /// checked-in plan output. This has no version-skew caveat (unlike
+    /// #390's equivalent check) because classification only ever reads the
+    /// rows already captured in these files — it never opens a database
+    /// connection, so it is not sensitive to which SQLite build this test
+    /// happens to run on.
+    func testCheckedInPlanEvidenceMatchesFreshClassification() throws {
+        let pairs = [
+            ("capture_apple-system-3.51.0.json", "plans_apple-system-3.51.0.json"),
+            ("capture_homebrew-3.53.2.json", "plans_homebrew-3.53.2.json"),
+        ]
+        for (captureFile, plansFile) in pairs {
+            let run = try loadCapture(captureFile)
+            let freshPlans = run.statements
+                .map { EQPPlanShapeClassifier.classify(rows: $0.rows, statementID: $0.statementID) }
+                .sorted { $0.statementID < $1.statementID }
+
+            let plansURL = try pinnedEvidenceURL(named: plansFile)
+            let pinnedPlans = try JSONDecoder().decode([EQPPlan].self, from: Data(contentsOf: plansURL))
+                .sorted { $0.statementID < $1.statementID }
+
+            XCTAssertEqual(freshPlans, pinnedPlans, "\(plansFile) is stale relative to \(captureFile)")
+        }
     }
 
     func testClassificationIsDeterministicAcrossRepeatedRuns() throws {
@@ -194,10 +226,16 @@ private func allShapes(in plan: EQPPlan) -> [EQPPlanShapeKind] {
 
 
 func loadCapture(_ name: String) throws -> EQPCaptureRun {
+    let url = try pinnedEvidenceURL(named: name)
+    return try JSONDecoder().decode(EQPCaptureRun.self, from: Data(contentsOf: url))
+}
+
+
+func pinnedEvidenceURL(named name: String) throws -> URL {
     guard let url = Bundle.module.url(forResource: name, withExtension: nil, subdirectory: "Evidence") else {
         throw EQPPlanShapeFixtureError.missingResource(name)
     }
-    return try JSONDecoder().decode(EQPCaptureRun.self, from: Data(contentsOf: url))
+    return url
 }
 
 

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/Evidence/capture_apple-system-3.51.0.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/Evidence/capture_apple-system-3.51.0.json
@@ -1,0 +1,5115 @@
+{
+  "capture_method" : "grdb-in-process",
+  "label" : "apple-system-3.51.0",
+  "runtime_metadata" : {
+    "collations" : [
+      "BINARY",
+      "NOCASE",
+      "RTRIM",
+      "swiftCaseInsensitiveCompare",
+      "swiftCompare",
+      "swiftLocalizedCaseInsensitiveCompare",
+      "swiftLocalizedCompare",
+      "swiftLocalizedStandardCompare"
+    ],
+    "compile_options" : [
+      "ATOMIC_INTRINSICS=1",
+      "BUG_COMPATIBLE_20160819",
+      "CCCRYPT256",
+      "CODEC=see-cccrypt",
+      "COMPILER=clang-21.0.0",
+      "DEFAULT_AUTOVACUUM",
+      "DEFAULT_CACHE_SIZE=2000",
+      "DEFAULT_CKPTFULLFSYNC",
+      "DEFAULT_FILE_FORMAT=4",
+      "DEFAULT_JOURNAL_SIZE_LIMIT=32768",
+      "DEFAULT_LOOKASIDE=1200,102",
+      "DEFAULT_MEMSTATUS=0",
+      "DEFAULT_MMAP_SIZE=0",
+      "DEFAULT_PAGE_SIZE=4096",
+      "DEFAULT_PCACHE_INITSZ=20",
+      "DEFAULT_RECURSIVE_TRIGGERS",
+      "DEFAULT_SECTOR_SIZE=4096",
+      "DEFAULT_SYNCHRONOUS=2",
+      "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+      "DEFAULT_WAL_SYNCHRONOUS=1",
+      "DEFAULT_WORKER_THREADS=0",
+      "DIRECT_OVERFLOW_READ",
+      "DQS=3",
+      "ENABLE_API_ARMOR",
+      "ENABLE_BYTECODE_VTAB",
+      "ENABLE_COLUMN_METADATA",
+      "ENABLE_DBSTAT_VTAB",
+      "ENABLE_FTS3",
+      "ENABLE_FTS3_PARENTHESIS",
+      "ENABLE_FTS3_TOKENIZER",
+      "ENABLE_FTS4",
+      "ENABLE_FTS5",
+      "ENABLE_LOCKING_STYLE=1",
+      "ENABLE_MATH_FUNCTIONS",
+      "ENABLE_NORMALIZE",
+      "ENABLE_PREUPDATE_HOOK",
+      "ENABLE_RTREE",
+      "ENABLE_SESSION",
+      "ENABLE_SETLK_TIMEOUT",
+      "ENABLE_SNAPSHOT",
+      "ENABLE_SQLLOG",
+      "ENABLE_STMT_SCANSTATUS",
+      "ENABLE_UNKNOWN_SQL_FUNCTION",
+      "ENABLE_UPDATE_DELETE_LIMIT",
+      "HAS_CODEC_RESTRICTED",
+      "HAVE_ISNAN",
+      "MALLOC_SOFT_LIMIT=1024",
+      "MAX_ATTACHED=10",
+      "MAX_COLUMN=2000",
+      "MAX_COMPOUND_SELECT=500",
+      "MAX_DEFAULT_PAGE_SIZE=8192",
+      "MAX_EXPR_DEPTH=1000",
+      "MAX_FUNCTION_ARG=127",
+      "MAX_LENGTH=2147483645",
+      "MAX_LIKE_PATTERN_LENGTH=50000",
+      "MAX_MMAP_SIZE=1073741824",
+      "MAX_PAGE_COUNT=1073741823",
+      "MAX_PAGE_SIZE=65536",
+      "MAX_SQL_LENGTH=1000000000",
+      "MAX_TRIGGER_DEPTH=1000",
+      "MAX_VARIABLE_NUMBER=500000",
+      "MAX_VDBE_OP=250000000",
+      "MAX_WORKER_THREADS=8",
+      "MUTEX_UNFAIR",
+      "OMIT_AUTORESET",
+      "OMIT_LOAD_EXTENSION",
+      "STMTJRNL_SPILL=131072",
+      "SYSTEM_MALLOC",
+      "TEMP_STORE=1",
+      "THREADSAFE=2",
+      "USE_URI"
+    ],
+    "extension_names" : [
+
+    ],
+    "functions" : [
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "->"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "->>"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "abs"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "acos"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "acosh"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "asin"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "asinh"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "atan"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "atan2"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "atanh"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "avg"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "bm25"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ceil"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ceiling"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "changes"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "char"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "coalesce"
+      },
+      {
+        "argument_count" : -3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "concat"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "concat_ws"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "cos"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "cosh"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "count"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "count"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "cume_dist"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "current_date"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "current_time"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "current_timestamp"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "date"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "datetime"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "degrees"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "dense_rank"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "exp"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "first_value"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "floor"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "format"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 524288,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts3_tokenizer"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 524288,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts3_tokenizer"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_get_locale"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_insttoken"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 3145728,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_locale"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_source_id"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "glob"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "group_concat"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "group_concat"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "hex"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "highlight"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_exponent"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_from_blob"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_inc"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_mantissa"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_to_blob"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "if"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ifnull"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "iif"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "instr"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_array"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_array_length"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_array_length"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_error_position"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_extract"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "json_group_array"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "json_group_object"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_insert"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_object"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_patch"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_pretty"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_pretty"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_quote"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_remove"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_replace"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_set"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_type"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_type"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_valid"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_valid"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_array"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_extract"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "jsonb_group_array"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "jsonb_group_object"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_insert"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_object"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_patch"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_remove"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_replace"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_set"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "julianday"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lag"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lag"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lag"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "last_insert_rowid"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "last_value"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lead"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lead"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lead"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "length"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "like"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "like"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "likelihood"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "likely"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ln"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log10"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log2"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "lower"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ltrim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ltrim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "match"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "matchinfo"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "matchinfo"
+      },
+      {
+        "argument_count" : -3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "max"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "max"
+      },
+      {
+        "argument_count" : -3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "min"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "min"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "mod"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "nth_value"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "ntile"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "nullif"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "octet_length"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "offsets"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "optimize"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "percent_rank"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "pi"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "pow"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "power"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "printf"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "quote"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "radians"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "random"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "randomblob"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "rank"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "replace"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "round"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "round"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "row_number"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "rtreecheck"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "rtreedepth"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "rtreenode"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "rtrim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "rtrim"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sign"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sin"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sinh"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "snippet"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_compileoption_get"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_compileoption_used"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_log"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_source_id"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_version"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqrt"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "strftime"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "string_agg"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substr"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substr"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substring"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "subtype"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "sum"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftcapitalizedstring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlocalizedcapitalizedstring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlocalizedlowercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlocalizeduppercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlowercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftuppercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "tan"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "tanh"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "time"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "timediff"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "total"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "total_changes"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "trim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "trim"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "trunc"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "typeof"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unhex"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unhex"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unicode"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unistr"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unistr_quote"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unixepoch"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unknown"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unlikely"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "upper"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "uuid"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "uuid_blob"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "uuid_str"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "zeroblob"
+      }
+    ],
+    "module_names" : [
+      "bytecode",
+      "dbstat",
+      "fts3",
+      "fts3tokenize",
+      "fts4",
+      "fts4aux",
+      "fts5",
+      "fts5vocab",
+      "json_each",
+      "json_tree",
+      "rtree",
+      "rtree_i32",
+      "tables_used"
+    ],
+    "schema_fnv1a_64" : "e2c8fadbd38c2313",
+    "schema_row_count" : 37,
+    "sqlite_source_id" : "2025-06-12 13:14:41 f0ca7bba1c5e232e5d279fad6338121ab55af0c8c68c84cdfb18ba5114dcaapl",
+    "sqlite_version" : "3.51.0"
+  },
+  "statements" : [
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "EXCEPT USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.except"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "INTERSECT USING TEMP B-TREE",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 18
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.intersect"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.union"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 9,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION ALL",
+          "id" : 15,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 15
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.union-all"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "EXCEPT USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.except"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "INTERSECT USING TEMP B-TREE",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 18
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.intersect"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.union"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 9,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION ALL",
+          "id" : 15,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 15
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.union-all"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 8
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 20,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 21,
+          "notused" : 216,
+          "parent" : 20
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 31,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "EXCEPT USING TEMP B-TREE",
+          "id" : 38,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 39,
+          "notused" : 0,
+          "parent" : 38
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.except"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 8
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 20,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 21,
+          "notused" : 216,
+          "parent" : 20
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 31,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "INTERSECT USING TEMP B-TREE",
+          "id" : 39,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 40,
+          "notused" : 0,
+          "parent" : 39
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.intersect"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 8
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 20,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 21,
+          "notused" : 216,
+          "parent" : 20
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 31,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION USING TEMP B-TREE",
+          "id" : 38,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 39,
+          "notused" : 0,
+          "parent" : 38
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.union"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 7,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 7
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 20,
+          "notused" : 216,
+          "parent" : 19
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 30,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION ALL",
+          "id" : 36,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 37,
+          "notused" : 0,
+          "parent" : 36
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.union-all"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.cast-text-blob"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.cast-text-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.comparable-min"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.date-unixepoch"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.indexed-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.json-array-length"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.json-valid"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.numeric-abs"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.numeric-floor"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.numeric-round"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.operator-arithmetic-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.operator-glob"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.string-printf"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "MERGE (UNION)",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 4
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "RIGHT",
+          "id" : 28,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN t1",
+          "id" : 31,
+          "notused" : 216,
+          "parent" : 28
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 40,
+          "notused" : 0,
+          "parent" : 28
+        }
+      ],
+      "statement_id" : "c191.v1.northwind.compound-customer-supplier-cities"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "CO-ROUTINE cte0",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id" : 9,
+          "notused" : 62,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 52,
+          "notused" : 82,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.northwind.cte-order-subtotals"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 46,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 9,
+          "notused" : 209,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 11,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 9,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 14,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 22,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 7,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 7,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 11,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 9,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 22,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 3,
+          "notused" : 44,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 9,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 5,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 7,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 11,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 45,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id" : 6,
+          "notused" : 45,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.j-left"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 12,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 18,
+          "notused" : 44,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 23,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 66,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.s-subquery-alias.j-inner.w-repeated-binding.g-customer-id.h-count-greater-than-one.o-descending.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.s-table-alias"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 5,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.j-inner"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.s-subquery-alias"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 12,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id" : 16,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 21,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 69,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.j-left"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 10,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 5,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.j-inner"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 11,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 25,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 27,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 12,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 6,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 11,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 13,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 51,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.o-ascending.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 10,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-null-comparison.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-null-comparison.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 14,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.l-five"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-repeated-binding.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 14,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-repeated-binding.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR avg(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-average-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR count(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-count-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR group_concat(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-group-concat-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR max(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-max-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR min(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-min-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR sum(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-sum-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-blob-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-bool-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-integer-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-integer-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-blob-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-bool-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-integer-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-integer-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-real-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-real-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-text-blob"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-text-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-text-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-real-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-real-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-text-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.comparable-max"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.json-array-length-path"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.numeric-round-no-places"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.numeric-round-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.string-printf-array"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.boolean-and-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.boolean-not-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.boolean-or-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.coalesce-storage-classes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.coalescing-operator"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-both-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-left-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-right-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.equality-optional-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.equality-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.inequality-optional-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-both-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-left-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-right-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-division-boundaries"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.optional-predicates"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-both-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-left-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-right-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-division-boundaries"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-concatenation-null"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-concatenation-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-glob-case-sensitivity"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-glob-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-glob-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-like-ascii-case-folding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-like-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-like-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.unary-nesting"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.unary-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 1",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-query-builder-empty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 1",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-query-builder-nonempty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 1",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t1 USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 12,
+          "notused" : 39,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 22,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-query-functional-nonempty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 2",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-table-empty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 2",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-table-nonempty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN Orders",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 47,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.aggregate.grouped-having"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "MERGE (UNION)",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN Customers",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 4
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "RIGHT",
+          "id" : 28,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN Suppliers",
+          "id" : 31,
+          "notused" : 216,
+          "parent" : 28
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 40,
+          "notused" : 0,
+          "parent" : 28
+        }
+      ],
+      "statement_id" : "c390.northwind.compound.customer-supplier-cities"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "CO-ROUTINE order_subtotals",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH Order Details USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id" : 9,
+          "notused" : 62,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN order_subtotals",
+          "id" : 51,
+          "notused" : 82,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.cte.order-subtotals"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH o USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 9,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH c USING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 12,
+          "notused" : 46,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 18,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH d USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id" : 21,
+          "notused" : 62,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH p USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 27,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 44,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.join.customer-order-employee-product"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN e",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id" : 6,
+          "notused" : 45,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.join.left-null-manager"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN Products",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCALAR SUBQUERY 1",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN Products",
+          "id" : 13,
+          "notused" : 216,
+          "parent" : 8
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 29,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.subquery.products-above-average"
+    }
+  ]
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/Evidence/capture_homebrew-3.53.2.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/Evidence/capture_homebrew-3.53.2.json
@@ -1,0 +1,5173 @@
+{
+  "capture_method": "python3-sqlite3-module",
+  "label": "homebrew-3.53.2",
+  "runtime_metadata": {
+    "collations": [
+      "BINARY",
+      "NOCASE",
+      "RTRIM"
+    ],
+    "compile_options": [
+      "ATOMIC_INTRINSICS=1",
+      "COMPILER=clang-21.0.0",
+      "DEFAULT_AUTOVACUUM",
+      "DEFAULT_CACHE_SIZE=-2000",
+      "DEFAULT_FILE_FORMAT=4",
+      "DEFAULT_JOURNAL_SIZE_LIMIT=-1",
+      "DEFAULT_MMAP_SIZE=0",
+      "DEFAULT_PAGE_SIZE=4096",
+      "DEFAULT_PCACHE_INITSZ=20",
+      "DEFAULT_RECURSIVE_TRIGGERS",
+      "DEFAULT_SECTOR_SIZE=4096",
+      "DEFAULT_SYNCHRONOUS=2",
+      "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+      "DEFAULT_WAL_SYNCHRONOUS=2",
+      "DEFAULT_WORKER_THREADS=0",
+      "DIRECT_OVERFLOW_READ",
+      "ENABLE_API_ARMOR",
+      "ENABLE_COLUMN_METADATA",
+      "ENABLE_DBSTAT_VTAB",
+      "ENABLE_FTS3",
+      "ENABLE_FTS3_PARENTHESIS",
+      "ENABLE_FTS5",
+      "ENABLE_GEOPOLY",
+      "ENABLE_MATH_FUNCTIONS",
+      "ENABLE_MEMORY_MANAGEMENT",
+      "ENABLE_PERCENTILE",
+      "ENABLE_PREUPDATE_HOOK",
+      "ENABLE_RTREE",
+      "ENABLE_SESSION",
+      "ENABLE_STAT4",
+      "ENABLE_UNLOCK_NOTIFY",
+      "MALLOC_SOFT_LIMIT=1024",
+      "MAX_ATTACHED=10",
+      "MAX_COLUMN=2000",
+      "MAX_COMPOUND_SELECT=500",
+      "MAX_DEFAULT_PAGE_SIZE=8192",
+      "MAX_EXPR_DEPTH=1000",
+      "MAX_FUNCTION_ARG=1000",
+      "MAX_LENGTH=1000000000",
+      "MAX_LIKE_PATTERN_LENGTH=50000",
+      "MAX_MMAP_SIZE=0x7fff0000",
+      "MAX_PAGE_COUNT=0xfffffffe",
+      "MAX_PAGE_SIZE=65536",
+      "MAX_SQL_LENGTH=1000000000",
+      "MAX_TRIGGER_DEPTH=1000",
+      "MAX_VARIABLE_NUMBER=250000",
+      "MAX_VDBE_OP=250000000",
+      "MAX_WORKER_THREADS=8",
+      "MUTEX_PTHREADS",
+      "SYSTEM_MALLOC",
+      "TEMP_STORE=1",
+      "THREADSAFE=1",
+      "USE_URI"
+    ],
+    "extension_names": [],
+    "functions": [
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "->"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "->>"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "abs"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "acos"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "acosh"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "asin"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "asinh"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "atan"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "atan2"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "atanh"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "avg"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "bm25"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ceil"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ceiling"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "changes"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "char"
+      },
+      {
+        "argument_count": -4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "coalesce"
+      },
+      {
+        "argument_count": -3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "concat"
+      },
+      {
+        "argument_count": -4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "concat_ws"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "cos"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "cosh"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "count"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "count"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "cume_dist"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "current_date"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "current_time"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "current_timestamp"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "date"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "datetime"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "degrees"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "dense_rank"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "exp"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "first_value"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "floor"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "format"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts3_tokenizer"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts3_tokenizer"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5_get_locale"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5_insttoken"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 3145728,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5_locale"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "fts5_source_id"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_area"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_bbox"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_blob"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_ccw"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_contains_point"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_debug"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "a",
+        "name": "geopoly_group_bbox"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_json"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_overlap"
+      },
+      {
+        "argument_count": 4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_regular"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_svg"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_within"
+      },
+      {
+        "argument_count": 7,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "geopoly_xform"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "glob"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "group_concat"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "group_concat"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "hex"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "highlight"
+      },
+      {
+        "argument_count": -4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "if"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ifnull"
+      },
+      {
+        "argument_count": -4,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "iif"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "instr"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_array"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_array_insert"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_array_length"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_array_length"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_error_position"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_extract"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "json_group_array"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "json_group_object"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_insert"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_object"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_patch"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_pretty"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_pretty"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_quote"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_remove"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_replace"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_set"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_type"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_type"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_valid"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "json_valid"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_array"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_array_insert"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_extract"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "jsonb_group_array"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "jsonb_group_object"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_insert"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_object"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_patch"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_remove"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_replace"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "jsonb_set"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "julianday"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lag"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lag"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lag"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "last_insert_rowid"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "last_value"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lead"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lead"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "lead"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "length"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "like"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "like"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "likelihood"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "likely"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ln"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "load_extension"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 524288,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "load_extension"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "log"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "log"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "log10"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "log2"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "lower"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ltrim"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "ltrim"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "match"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "matchinfo"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "matchinfo"
+      },
+      {
+        "argument_count": -3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "max"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "max"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "median"
+      },
+      {
+        "argument_count": -3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "min"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "min"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "mod"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "nth_value"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "ntile"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "nullif"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "octet_length"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "offsets"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "optimize"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "percent_rank"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "percentile"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "percentile_cont"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "percentile_disc"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "pi"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "pow"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "power"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "printf"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "quote"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "radians"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "random"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "randomblob"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "rank"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "replace"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "round"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "round"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "row_number"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "rtreecheck"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "rtreedepth"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "rtreenode"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "rtrim"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "rtrim"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sign"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sin"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sinh"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 0,
+        "is_built_in": false,
+        "kind": "s",
+        "name": "snippet"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_compileoption_get"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_compileoption_used"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_log"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_source_id"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqlite_version"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "sqrt"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "strftime"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "string_agg"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "substr"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "substr"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "substring"
+      },
+      {
+        "argument_count": 3,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "substring"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 3147776,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "subtype"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "sum"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "tan"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "tanh"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "time"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "timediff"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "w",
+        "name": "total"
+      },
+      {
+        "argument_count": 0,
+        "encoding": "utf8",
+        "flags": 2097152,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "total_changes"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "trim"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "trim"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "trunc"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "typeof"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unhex"
+      },
+      {
+        "argument_count": 2,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unhex"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unicode"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unistr"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unistr_quote"
+      },
+      {
+        "argument_count": -1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unixepoch"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "unlikely"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "upper"
+      },
+      {
+        "argument_count": 1,
+        "encoding": "utf8",
+        "flags": 2099200,
+        "is_built_in": true,
+        "kind": "s",
+        "name": "zeroblob"
+      }
+    ],
+    "module_names": [
+      "dbstat",
+      "fts3",
+      "fts3tokenize",
+      "fts4",
+      "fts4aux",
+      "fts5",
+      "fts5vocab",
+      "geopoly",
+      "rtree",
+      "rtree_i32"
+    ],
+    "schema_fnv1a_64": "e2c8fadbd38c2313",
+    "schema_row_count": 37,
+    "sqlite_source_id": "2026-06-03 19:12:13 d6e03d8c777cfa2d35e3b60d8ec3e0187f3e9f99d8e2ee9cac695fd6fcdf1a24",
+    "sqlite_version": "3.53.2"
+  },
+  "statements": [
+    {
+      "rows": [
+        {
+          "detail": "MERGE (EXCEPT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE nullable_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN nullable_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-nullable.except"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (INTERSECT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE nullable_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN nullable_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-nullable.intersect"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE nullable_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN nullable_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-nullable.union"
+    },
+    {
+      "rows": [
+        {
+          "detail": "COMPOUND QUERY",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT-MOST SUBQUERY",
+          "id": 2,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "CO-ROUTINE nullable_seed",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 5,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN nullable_rows",
+          "id": 9,
+          "notused": 16,
+          "parent": 2
+        },
+        {
+          "detail": "UNION ALL",
+          "id": 15,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 16,
+          "notused": 0,
+          "parent": 15
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-nullable.union-all"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (EXCEPT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE required_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN required_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-required.except"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (INTERSECT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE required_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN required_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-required.intersect"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE required_seed",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 7,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN required_rows",
+          "id": 12,
+          "notused": 16,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 30,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-required.union"
+    },
+    {
+      "rows": [
+        {
+          "detail": "COMPOUND QUERY",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT-MOST SUBQUERY",
+          "id": 2,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "CO-ROUTINE required_seed",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 5,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN required_rows",
+          "id": 9,
+          "notused": 16,
+          "parent": 2
+        },
+        {
+          "detail": "UNION ALL",
+          "id": 15,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 16,
+          "notused": 0,
+          "parent": 15
+        }
+      ],
+      "statement_id": "c191.v1.cte.ordinary-required.union-all"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (EXCEPT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE integer_sequence",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SETUP",
+          "id": 9,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 10,
+          "notused": 0,
+          "parent": 9
+        },
+        {
+          "detail": "RECURSIVE STEP",
+          "id": 21,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 22,
+          "notused": 216,
+          "parent": 21
+        },
+        {
+          "detail": "SCAN recursive_rows",
+          "id": 33,
+          "notused": 215,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 49,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 51,
+          "notused": 0,
+          "parent": 49
+        }
+      ],
+      "statement_id": "c191.v1.cte.recursive-required.except"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (INTERSECT)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE integer_sequence",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SETUP",
+          "id": 9,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 10,
+          "notused": 0,
+          "parent": 9
+        },
+        {
+          "detail": "RECURSIVE STEP",
+          "id": 21,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 22,
+          "notused": 216,
+          "parent": 21
+        },
+        {
+          "detail": "SCAN recursive_rows",
+          "id": 33,
+          "notused": 215,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 49,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 51,
+          "notused": 0,
+          "parent": 49
+        }
+      ],
+      "statement_id": "c191.v1.cte.recursive-required.intersect"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "CO-ROUTINE integer_sequence",
+          "id": 6,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SETUP",
+          "id": 9,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 10,
+          "notused": 0,
+          "parent": 9
+        },
+        {
+          "detail": "RECURSIVE STEP",
+          "id": 21,
+          "notused": 0,
+          "parent": 6
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 22,
+          "notused": 216,
+          "parent": 21
+        },
+        {
+          "detail": "SCAN recursive_rows",
+          "id": 33,
+          "notused": 215,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 49,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 51,
+          "notused": 0,
+          "parent": 49
+        }
+      ],
+      "statement_id": "c191.v1.cte.recursive-required.union"
+    },
+    {
+      "rows": [
+        {
+          "detail": "COMPOUND QUERY",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT-MOST SUBQUERY",
+          "id": 2,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "CO-ROUTINE integer_sequence",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SETUP",
+          "id": 7,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 8,
+          "notused": 0,
+          "parent": 7
+        },
+        {
+          "detail": "RECURSIVE STEP",
+          "id": 19,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 20,
+          "notused": 216,
+          "parent": 19
+        },
+        {
+          "detail": "SCAN recursive_rows",
+          "id": 30,
+          "notused": 215,
+          "parent": 2
+        },
+        {
+          "detail": "UNION ALL",
+          "id": 36,
+          "notused": 0,
+          "parent": 1
+        },
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 37,
+          "notused": 0,
+          "parent": 36
+        }
+      ],
+      "statement_id": "c191.v1.cte.recursive-required.union-all"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.cast-text-blob"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.cast-text-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.comparable-min"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.date-unixepoch"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.indexed-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.json-array-length"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.json-valid"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.numeric-abs"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.numeric-floor"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.numeric-round"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.operator-arithmetic-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.operator-glob"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.expression.string-printf"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 16,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN t1",
+          "id": 31,
+          "notused": 216,
+          "parent": 28
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c191.v1.northwind.compound-customer-supplier-cities"
+    },
+    {
+      "rows": [
+        {
+          "detail": "CO-ROUTINE cte0",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id": 9,
+          "notused": 62,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 52,
+          "notused": 82,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.northwind.cte-order-subtotals"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 46,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 9,
+          "notused": 209,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 11,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 9,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 14,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 22,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 7,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 5,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 7,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-null-comparison"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 11,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 9,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-cross.w-repeated-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 6,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 6,
+          "notused": 44,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 16,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 6,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 22,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 3,
+          "notused": 44,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 9,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 6,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 5,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 7,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-null-comparison"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 11,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-inner.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 45,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 2,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.j-left.w-repeated-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 6,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.j-cross"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id": 6,
+          "notused": 45,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.j-left"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 12,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 18,
+          "notused": 44,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 23,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 66,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.s-subquery-alias.j-inner.w-repeated-binding.g-customer-id.h-count-greater-than-one.o-descending.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.s-table-alias"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-null-comparison"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-aggregate-count.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 5,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.j-cross"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 5,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.j-inner"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.s-subquery-alias"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 12,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id": 16,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 21,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 69,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 2,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.p-nullable-region.w-repeated-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 5,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.j-cross"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.j-left"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 10,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 2,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-null-comparison"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN source_orders",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-subquery-alias.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id": 5,
+          "notused": 209,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.j-cross"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 5,
+          "notused": 44,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.j-inner"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-empty-in"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-in-list"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-injection-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 2,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-literal"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 2,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-named-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-precedence"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN orders_case",
+          "id": 2,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.s-table-alias.w-repeated-binding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 11,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-empty-in.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 6,
+          "notused": 61,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 25,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 6,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 27,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 61,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-in-list.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 6,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 6,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 12,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-injection-binding.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 6,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 6,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 3,
+          "notused": 33,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-literal.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 6,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 8,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-named-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 11,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 13,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 51,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-named-binding.g-customer-id.o-ascending.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 10,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-named-binding.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id": 3,
+          "notused": 196,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-named-binding.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-null-comparison.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-null-comparison.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 6,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 14,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.l-five"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 6,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.l-five.x-two"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 16,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-precedence.o-descending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-repeated-binding.o-ascending"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 14,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c191.v1.select.w-repeated-binding.o-collated"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR avg(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-average-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR count(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-count-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR group_concat(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-group-concat-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR max(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-max-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR min(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-min-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "USE TEMP B-TREE FOR sum(DISTINCT)",
+          "id": 3,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN t0",
+          "id": 5,
+          "notused": 216,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.aggregate-sum-distinct"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-blob-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-bool-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-integer-real"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-integer-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-blob-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-bool-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-integer-real"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-integer-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-real-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-real-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-text-blob"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-text-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-optional-text-real"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-real-integer"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-real-text"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.cast-text-real"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.comparable-max"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.json-array-length-path"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.numeric-round-no-places"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.numeric-round-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c286.v1.expression.string-printf-array"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.boolean-and-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.boolean-not-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.boolean-or-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.coalesce-storage-classes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.coalescing-operator"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.comparison-both-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.comparison-left-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.comparison-required"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.comparison-right-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.equality-optional-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.equality-required"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.inequality-optional-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-both-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-left-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-null-propagation"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-required"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-arithmetic-right-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.integer-division-boundaries"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.optional-predicates"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-both-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-left-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-null-propagation"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-required"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-arithmetic-right-optional"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.real-division-boundaries"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-concatenation-null"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-concatenation-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-glob-case-sensitivity"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-glob-null-propagation"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-glob-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-like-ascii-case-folding"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-like-null-propagation"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.text-like-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.unary-nesting"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN CONSTANT ROW",
+          "id": 1,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c287.v1.expression.unary-shapes"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 1",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 33,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 19,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-query-builder-empty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 1",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 33,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 19,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-query-builder-nonempty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 1",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t1 USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 12,
+          "notused": 39,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 22,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-query-functional-nonempty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 2",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 33,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 19,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-table-empty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN t0",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "LIST SUBQUERY 2",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 33,
+          "parent": 9
+        },
+        {
+          "detail": "CREATE BLOOM FILTER",
+          "id": 19,
+          "notused": 0,
+          "parent": 9
+        }
+      ],
+      "statement_id": "c288.v1.subquery.in-table-nonempty"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN Orders",
+          "id": 7,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR GROUP BY",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 47,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.aggregate.grouped-having"
+    },
+    {
+      "rows": [
+        {
+          "detail": "MERGE (UNION)",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "LEFT",
+          "id": 4,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN Customers",
+          "id": 7,
+          "notused": 216,
+          "parent": 4
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 16,
+          "notused": 0,
+          "parent": 4
+        },
+        {
+          "detail": "RIGHT",
+          "id": 28,
+          "notused": 0,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN Suppliers",
+          "id": 31,
+          "notused": 216,
+          "parent": 28
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 40,
+          "notused": 0,
+          "parent": 28
+        }
+      ],
+      "statement_id": "c390.northwind.compound.customer-supplier-cities"
+    },
+    {
+      "rows": [
+        {
+          "detail": "CO-ROUTINE order_subtotals",
+          "id": 2,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH Order Details USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id": 9,
+          "notused": 62,
+          "parent": 2
+        },
+        {
+          "detail": "SCAN order_subtotals",
+          "id": 51,
+          "notused": 82,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.cte.order-subtotals"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SEARCH o USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 12,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH c USING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id": 15,
+          "notused": 46,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 21,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH d USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id": 24,
+          "notused": 62,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH p USING INTEGER PRIMARY KEY (rowid=?)",
+          "id": 30,
+          "notused": 45,
+          "parent": 0
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 47,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.join.customer-order-employee-product"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN e",
+          "id": 4,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id": 6,
+          "notused": 45,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.join.left-null-manager"
+    },
+    {
+      "rows": [
+        {
+          "detail": "SCAN Products",
+          "id": 3,
+          "notused": 216,
+          "parent": 0
+        },
+        {
+          "detail": "SCALAR SUBQUERY 1",
+          "id": 9,
+          "notused": 0,
+          "parent": 0
+        },
+        {
+          "detail": "SCAN Products",
+          "id": 14,
+          "notused": 216,
+          "parent": 9
+        },
+        {
+          "detail": "USE TEMP B-TREE FOR ORDER BY",
+          "id": 30,
+          "notused": 0,
+          "parent": 0
+        }
+      ],
+      "statement_id": "c390.northwind.subquery.products-above-average"
+    }
+  ]
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/Evidence/plans_apple-system-3.51.0.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/Evidence/plans_apple-system-3.51.0.json
@@ -1,0 +1,6862 @@
+[
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE nullable_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "nullable_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN nullable_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "EXCEPT USING TEMP B-TREE",
+            "shape" : "temp_b_tree_for_compound_operation"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.except"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE nullable_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "nullable_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN nullable_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "INTERSECT USING TEMP B-TREE",
+            "shape" : "temp_b_tree_for_compound_operation"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.intersect"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE nullable_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "nullable_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN nullable_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "UNION USING TEMP B-TREE",
+            "shape" : "temp_b_tree_for_compound_operation"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.union"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE nullable_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "nullable_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN nullable_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "UNION ALL",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.union-all"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE required_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "required_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN required_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "EXCEPT USING TEMP B-TREE",
+            "shape" : "temp_b_tree_for_compound_operation"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.except"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE required_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "required_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN required_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "INTERSECT USING TEMP B-TREE",
+            "shape" : "temp_b_tree_for_compound_operation"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.intersect"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE required_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "required_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN required_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "UNION USING TEMP B-TREE",
+            "shape" : "temp_b_tree_for_compound_operation"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.union"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE required_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "required_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN required_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "UNION ALL",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.union-all"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN CONSTANT ROW",
+                        "shape" : "constant_row_scan"
+                      }
+                    ],
+                    "detail" : "SETUP",
+                    "shape" : "recursive_cte_step"
+                  },
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false,
+                          "table" : "t0"
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN t0",
+                        "shape" : "full_table_scan"
+                      }
+                    ],
+                    "detail" : "RECURSIVE STEP",
+                    "shape" : "recursive_cte_step"
+                  }
+                ],
+                "detail" : "CO-ROUTINE integer_sequence",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "recursive_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN recursive_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "EXCEPT USING TEMP B-TREE",
+            "shape" : "temp_b_tree_for_compound_operation"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.except"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN CONSTANT ROW",
+                        "shape" : "constant_row_scan"
+                      }
+                    ],
+                    "detail" : "SETUP",
+                    "shape" : "recursive_cte_step"
+                  },
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false,
+                          "table" : "t0"
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN t0",
+                        "shape" : "full_table_scan"
+                      }
+                    ],
+                    "detail" : "RECURSIVE STEP",
+                    "shape" : "recursive_cte_step"
+                  }
+                ],
+                "detail" : "CO-ROUTINE integer_sequence",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "recursive_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN recursive_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "INTERSECT USING TEMP B-TREE",
+            "shape" : "temp_b_tree_for_compound_operation"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.intersect"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN CONSTANT ROW",
+                        "shape" : "constant_row_scan"
+                      }
+                    ],
+                    "detail" : "SETUP",
+                    "shape" : "recursive_cte_step"
+                  },
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false,
+                          "table" : "t0"
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN t0",
+                        "shape" : "full_table_scan"
+                      }
+                    ],
+                    "detail" : "RECURSIVE STEP",
+                    "shape" : "recursive_cte_step"
+                  }
+                ],
+                "detail" : "CO-ROUTINE integer_sequence",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "recursive_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN recursive_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "UNION USING TEMP B-TREE",
+            "shape" : "temp_b_tree_for_compound_operation"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.union"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN CONSTANT ROW",
+                        "shape" : "constant_row_scan"
+                      }
+                    ],
+                    "detail" : "SETUP",
+                    "shape" : "recursive_cte_step"
+                  },
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false,
+                          "table" : "t0"
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN t0",
+                        "shape" : "full_table_scan"
+                      }
+                    ],
+                    "detail" : "RECURSIVE STEP",
+                    "shape" : "recursive_cte_step"
+                  }
+                ],
+                "detail" : "CO-ROUTINE integer_sequence",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "recursive_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN recursive_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "UNION ALL",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.union-all"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.cast-text-blob"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.cast-text-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.comparable-min"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.date-unixepoch"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.indexed-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.json-array-length"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.json-valid"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.numeric-abs"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.numeric-floor"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.numeric-round"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.operator-arithmetic-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.operator-glob"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.string-printf"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "t0"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN t0",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "t1"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN t1",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (UNION)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.northwind.compound-customer-supplier-cities"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "OrderID"
+              ],
+              "index_name" : "sqlite_autoindex_Order Details_1",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+            "shape" : "index_search"
+          }
+        ],
+        "detail" : "CO-ROUTINE cte0",
+        "shape" : "co_routine_subquery_or_cte"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.northwind.cte-order-subtotals"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-null-comparison"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-repeated-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-null-comparison"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-repeated-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.j-cross"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "employees_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.j-left"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.s-subquery-alias.j-inner.w-repeated-binding.g-customer-id.h-count-greater-than-one.o-descending.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.s-table-alias"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-null-comparison"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.j-cross"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.j-inner"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.s-subquery-alias"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "employees_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-repeated-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.j-cross"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.j-left"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-null-comparison"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.j-cross"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.j-inner"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-repeated-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.o-ascending.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-null-comparison.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-null-comparison.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.l-five"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-repeated-binding.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-repeated-binding.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR avg(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-average-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR count(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-count-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR group_concat(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-group-concat-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR max(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-max-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR min(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-min-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR sum(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-sum-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-blob-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-bool-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-integer-real"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-integer-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-blob-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-bool-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-integer-real"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-integer-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-real-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-real-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-text-blob"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-text-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-text-real"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-real-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-real-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-text-real"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.comparable-max"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.json-array-length-path"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.numeric-round-no-places"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.numeric-round-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.string-printf-array"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.boolean-and-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.boolean-not-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.boolean-or-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.coalesce-storage-classes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.coalescing-operator"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-both-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-left-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-required"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-right-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.equality-optional-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.equality-required"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.inequality-optional-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-both-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-left-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-null-propagation"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-required"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-right-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-division-boundaries"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.optional-predicates"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-both-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-left-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-null-propagation"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-required"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-right-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-division-boundaries"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-concatenation-null"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-concatenation-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-glob-case-sensitivity"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-glob-null-propagation"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-glob-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-like-ascii-case-folding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-like-null-propagation"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-like-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.unary-nesting"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.unary-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "rowid"
+              ],
+              "index_name" : "INTEGER PRIMARY KEY",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 1",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-query-builder-empty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "rowid"
+              ],
+              "index_name" : "INTEGER PRIMARY KEY",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 1",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-query-builder-nonempty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "CustomerID"
+              ],
+              "index_name" : "sqlite_autoindex_Customers_1",
+              "is_automatic" : false,
+              "is_covering" : true,
+              "table" : "t1"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t1 USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 1",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-query-functional-nonempty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "rowid"
+              ],
+              "index_name" : "INTEGER PRIMARY KEY",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 2",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-table-empty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "rowid"
+              ],
+              "index_name" : "INTEGER PRIMARY KEY",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 2",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-table-nonempty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "Orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN Orders",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c390.northwind.aggregate.grouped-having"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "Customers"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN Customers",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "Suppliers"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN Suppliers",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (UNION)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c390.northwind.compound.customer-supplier-cities"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "OrderID"
+              ],
+              "index_name" : "sqlite_autoindex_Order Details_1",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "Order Details"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH Order Details USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+            "shape" : "index_search"
+          }
+        ],
+        "detail" : "CO-ROUTINE order_subtotals",
+        "shape" : "co_routine_subquery_or_cte"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "order_subtotals"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN order_subtotals",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c390.northwind.cte.order-subtotals"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "o"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH o USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "c"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH c USING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "e"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "OrderID"
+          ],
+          "index_name" : "sqlite_autoindex_Order Details_1",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "d"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH d USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "p"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH p USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c390.northwind.join.customer-order-employee-product"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "e"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN e",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "m"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c390.northwind.join.left-null-manager"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "Products"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN Products",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "Products"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SCAN Products",
+            "shape" : "full_table_scan"
+          }
+        ],
+        "detail" : "SCALAR SUBQUERY 1",
+        "shape" : "scalar_subquery"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c390.northwind.subquery.products-above-average"
+  }
+]

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/Evidence/plans_homebrew-3.53.2.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests/Evidence/plans_homebrew-3.53.2.json
@@ -1,0 +1,6988 @@
+[
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE nullable_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "nullable_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN nullable_rows",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (EXCEPT)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.except"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE nullable_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "nullable_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN nullable_rows",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (INTERSECT)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.intersect"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE nullable_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "nullable_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN nullable_rows",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (UNION)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.union"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE nullable_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "nullable_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN nullable_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "UNION ALL",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-nullable.union-all"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE required_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "required_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN required_rows",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (EXCEPT)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.except"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE required_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "required_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN required_rows",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (INTERSECT)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.intersect"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE required_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "required_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN required_rows",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (UNION)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.union"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+
+                    ],
+                    "detail" : "SCAN CONSTANT ROW",
+                    "shape" : "constant_row_scan"
+                  }
+                ],
+                "detail" : "CO-ROUTINE required_seed",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "required_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN required_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "UNION ALL",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.ordinary-required.union-all"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN CONSTANT ROW",
+                        "shape" : "constant_row_scan"
+                      }
+                    ],
+                    "detail" : "SETUP",
+                    "shape" : "recursive_cte_step"
+                  },
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false,
+                          "table" : "t0"
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN t0",
+                        "shape" : "full_table_scan"
+                      }
+                    ],
+                    "detail" : "RECURSIVE STEP",
+                    "shape" : "recursive_cte_step"
+                  }
+                ],
+                "detail" : "CO-ROUTINE integer_sequence",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "recursive_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN recursive_rows",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (EXCEPT)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.except"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN CONSTANT ROW",
+                        "shape" : "constant_row_scan"
+                      }
+                    ],
+                    "detail" : "SETUP",
+                    "shape" : "recursive_cte_step"
+                  },
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false,
+                          "table" : "t0"
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN t0",
+                        "shape" : "full_table_scan"
+                      }
+                    ],
+                    "detail" : "RECURSIVE STEP",
+                    "shape" : "recursive_cte_step"
+                  }
+                ],
+                "detail" : "CO-ROUTINE integer_sequence",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "recursive_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN recursive_rows",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (INTERSECT)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.intersect"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN CONSTANT ROW",
+                        "shape" : "constant_row_scan"
+                      }
+                    ],
+                    "detail" : "SETUP",
+                    "shape" : "recursive_cte_step"
+                  },
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false,
+                          "table" : "t0"
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN t0",
+                        "shape" : "full_table_scan"
+                      }
+                    ],
+                    "detail" : "RECURSIVE STEP",
+                    "shape" : "recursive_cte_step"
+                  }
+                ],
+                "detail" : "CO-ROUTINE integer_sequence",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "recursive_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN recursive_rows",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (UNION)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.union"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN CONSTANT ROW",
+                        "shape" : "constant_row_scan"
+                      }
+                    ],
+                    "detail" : "SETUP",
+                    "shape" : "recursive_cte_step"
+                  },
+                  {
+                    "attributes" : {
+                      "constrained_columns" : [
+
+                      ],
+                      "is_automatic" : false,
+                      "is_covering" : false
+                    },
+                    "children" : [
+                      {
+                        "attributes" : {
+                          "constrained_columns" : [
+
+                          ],
+                          "is_automatic" : false,
+                          "is_covering" : false,
+                          "table" : "t0"
+                        },
+                        "children" : [
+
+                        ],
+                        "detail" : "SCAN t0",
+                        "shape" : "full_table_scan"
+                      }
+                    ],
+                    "detail" : "RECURSIVE STEP",
+                    "shape" : "recursive_cte_step"
+                  }
+                ],
+                "detail" : "CO-ROUTINE integer_sequence",
+                "shape" : "co_routine_subquery_or_cte"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "recursive_rows"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN recursive_rows",
+                "shape" : "full_table_scan"
+              }
+            ],
+            "detail" : "LEFT-MOST SUBQUERY",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN CONSTANT ROW",
+                "shape" : "constant_row_scan"
+              }
+            ],
+            "detail" : "UNION ALL",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "COMPOUND QUERY",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.cte.recursive-required.union-all"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.cast-text-blob"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.cast-text-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.comparable-min"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.date-unixepoch"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.indexed-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.json-array-length"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.json-valid"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.numeric-abs"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.numeric-floor"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.numeric-round"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.operator-arithmetic-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.operator-glob"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.expression.string-printf"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "t0"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN t0",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "t1"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN t1",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (UNION)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c191.v1.northwind.compound-customer-supplier-cities"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "OrderID"
+              ],
+              "index_name" : "sqlite_autoindex_Order Details_1",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+            "shape" : "index_search"
+          }
+        ],
+        "detail" : "CO-ROUTINE cte0",
+        "shape" : "co_routine_subquery_or_cte"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.northwind.cte-order-subtotals"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-null-comparison"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-cross.w-repeated-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-null-comparison"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-inner.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.j-left.w-repeated-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.j-cross"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "employees_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.j-left"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.s-subquery-alias.j-inner.w-repeated-binding.g-customer-id.h-count-greater-than-one.o-descending.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.s-table-alias"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-null-comparison"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-aggregate-count.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.j-cross"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.j-inner"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.s-subquery-alias"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "employees_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.p-nullable-region.w-repeated-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.j-cross"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.j-left"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-null-comparison"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "source_orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN source_orders",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-subquery-alias.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_cross"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+        "shape" : "covering_index_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.j-cross"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : true,
+          "table" : "customers_join"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.j-inner"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-empty-in"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-in-list"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-injection-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-literal"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-named-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-precedence"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "orders_case"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN orders_case",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.s-table-alias.w-repeated-binding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-empty-in.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-in-list.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-injection-binding.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-literal.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.o-ascending.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-named-binding.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-null-comparison.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-null-comparison.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.g-customer-id.h-count-greater-than-one"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.l-five"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.l-five.x-two"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-precedence.o-descending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-repeated-binding.o-ascending"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c191.v1.select.w-repeated-binding.o-collated"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR avg(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-average-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR count(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-count-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR group_concat(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-group-concat-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR max(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-max-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR min(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH t0",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-min-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR sum(DISTINCT)",
+        "shape" : "temp_b_tree_for_distinct_aggregate"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.aggregate-sum-distinct"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-blob-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-bool-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-integer-real"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-integer-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-blob-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-bool-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-integer-real"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-integer-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-real-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-real-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-text-blob"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-text-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-optional-text-real"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-real-integer"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-real-text"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.cast-text-real"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.comparable-max"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.json-array-length-path"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.numeric-round-no-places"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.numeric-round-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c286.v1.expression.string-printf-array"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.boolean-and-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.boolean-not-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.boolean-or-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.coalesce-storage-classes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.coalescing-operator"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-both-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-left-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-required"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.comparison-right-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.equality-optional-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.equality-required"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.inequality-optional-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-both-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-left-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-null-propagation"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-required"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-arithmetic-right-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.integer-division-boundaries"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.optional-predicates"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-both-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-left-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-null-propagation"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-required"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-arithmetic-right-optional"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.real-division-boundaries"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-concatenation-null"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-concatenation-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-glob-case-sensitivity"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-glob-null-propagation"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-glob-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-like-ascii-case-folding"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-like-null-propagation"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.text-like-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.unary-nesting"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN CONSTANT ROW",
+        "shape" : "constant_row_scan"
+      }
+    ],
+    "statement_id" : "c287.v1.expression.unary-shapes"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "rowid"
+              ],
+              "index_name" : "INTEGER PRIMARY KEY",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 1",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-query-builder-empty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "rowid"
+              ],
+              "index_name" : "INTEGER PRIMARY KEY",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 1",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-query-builder-nonempty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "CustomerID"
+              ],
+              "index_name" : "sqlite_autoindex_Customers_1",
+              "is_automatic" : false,
+              "is_covering" : true,
+              "table" : "t1"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t1 USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 1",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-query-functional-nonempty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "rowid"
+              ],
+              "index_name" : "INTEGER PRIMARY KEY",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 2",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-table-empty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "t0"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN t0",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "rowid"
+              ],
+              "index_name" : "INTEGER PRIMARY KEY",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "t0"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+            "shape" : "index_search"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+
+            ],
+            "detail" : "CREATE BLOOM FILTER",
+            "shape" : "bloom_filter"
+          }
+        ],
+        "detail" : "LIST SUBQUERY 2",
+        "shape" : "list_subquery"
+      }
+    ],
+    "statement_id" : "c288.v1.subquery.in-table-nonempty"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "Orders"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN Orders",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR GROUP BY",
+        "shape" : "temp_b_tree_for_group_by"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c390.northwind.aggregate.grouped-having"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "Customers"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN Customers",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "LEFT",
+            "shape" : "compound_query_strategy"
+          },
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false
+            },
+            "children" : [
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false,
+                  "table" : "Suppliers"
+                },
+                "children" : [
+
+                ],
+                "detail" : "SCAN Suppliers",
+                "shape" : "full_table_scan"
+              },
+              {
+                "attributes" : {
+                  "constrained_columns" : [
+
+                  ],
+                  "is_automatic" : false,
+                  "is_covering" : false
+                },
+                "children" : [
+
+                ],
+                "detail" : "USE TEMP B-TREE FOR ORDER BY",
+                "shape" : "temp_b_tree_for_order_by"
+              }
+            ],
+            "detail" : "RIGHT",
+            "shape" : "compound_query_strategy"
+          }
+        ],
+        "detail" : "MERGE (UNION)",
+        "shape" : "compound_query_strategy"
+      }
+    ],
+    "statement_id" : "c390.northwind.compound.customer-supplier-cities"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+                "OrderID"
+              ],
+              "index_name" : "sqlite_autoindex_Order Details_1",
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "Order Details"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SEARCH Order Details USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+            "shape" : "index_search"
+          }
+        ],
+        "detail" : "CO-ROUTINE order_subtotals",
+        "shape" : "co_routine_subquery_or_cte"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "order_subtotals"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN order_subtotals",
+        "shape" : "full_table_scan"
+      }
+    ],
+    "statement_id" : "c390.northwind.cte.order-subtotals"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "o"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH o USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "CustomerID"
+          ],
+          "index_name" : "sqlite_autoindex_Customers_1",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "c"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH c USING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "e"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "OrderID"
+          ],
+          "index_name" : "sqlite_autoindex_Order Details_1",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "d"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH d USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "p"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH p USING INTEGER PRIMARY KEY (rowid=?)",
+        "shape" : "index_search"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c390.northwind.join.customer-order-employee-product"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "e"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN e",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+            "rowid"
+          ],
+          "index_name" : "INTEGER PRIMARY KEY",
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "m"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+        "shape" : "index_search"
+      }
+    ],
+    "statement_id" : "c390.northwind.join.left-null-manager"
+  },
+  {
+    "roots" : [
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false,
+          "table" : "Products"
+        },
+        "children" : [
+
+        ],
+        "detail" : "SCAN Products",
+        "shape" : "full_table_scan"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+          {
+            "attributes" : {
+              "constrained_columns" : [
+
+              ],
+              "is_automatic" : false,
+              "is_covering" : false,
+              "table" : "Products"
+            },
+            "children" : [
+
+            ],
+            "detail" : "SCAN Products",
+            "shape" : "full_table_scan"
+          }
+        ],
+        "detail" : "SCALAR SUBQUERY 1",
+        "shape" : "scalar_subquery"
+      },
+      {
+        "attributes" : {
+          "constrained_columns" : [
+
+          ],
+          "is_automatic" : false,
+          "is_covering" : false
+        },
+        "children" : [
+
+        ],
+        "detail" : "USE TEMP B-TREE FOR ORDER BY",
+        "shape" : "temp_b_tree_for_order_by"
+      }
+    ],
+    "statement_id" : "c390.northwind.subquery.products-above-average"
+  }
+]


### PR DESCRIPTION
Closes #391.

**Stacked on #412** (this issue depends on #390's corpus/capture pipeline, which hasn't merged into `experiment/query-plan-index-advice` yet). This PR's base should be retargeted to `experiment/query-plan-index-advice` once #412 merges — only the last commit (`5b9efe27`) is this issue's actual diff; everything before it is #412's.

## Summary

- Adds a package-private research target, `SwiftQLSQLitePlanShapePrototype`, that builds a normalised plan tree from #390's raw EQP rows and classifies every node into a named shape. Classification is a pure function of captured rows plus recorded SQLite provenance — no new database access, no index creation, no snapshot mutation.
- `EQPPlanShapeKind` covers the seven shapes this issue requires (full table scan, index search with identity + constrained columns, automatic covering index, temp b-tree for `ORDER BY`/`GROUP BY`, correlated scalar subquery, materialized subquery/CTE) plus ten more precisely-named shapes the real #390 corpus's captures also contain (compound-query structure, CTE co-routines, recursive-CTE steps, bloom filters, etc.) — never coercing an unrecognised shape into a known one; unclassified nodes keep their raw `detail` text for audit.
- Distinguishing a correlated from an uncorrelated scalar subquery uses a parent-shape heuristic (SQLite's raw EQP text doesn't literally say "correlated" — both print as `SCALAR SUBQUERY N`): a subquery nested under a row-looping parent (table scan/index search) is correlated; one attached as a top-level sibling is not. Documented as a heuristic, not a guarantee.

## Evidence

Classified both of #390's checked-in real captures (apple-system-3.51.0, homebrew-3.53.2) end to end — **zero unclassified nodes across all 214 real statements on either build**. The per-shape count differences between builds reconcile exactly with #390's Finding 2 (the 9 CTE compound-query cases). The five-table Northwind join (#390 Finding 1 — its raw `id`/`parent` values differ between builds) normalises to a **byte-identical** plan on both builds, since `EQPPlanNode` never encodes `id`/`parent` — concrete proof that #390's "never key on id/parent" recommendation is actually followed here, not just stated.

Automatic covering index, materialized CTE, and correlated scalar subquery are not exercised by the real corpus (no case needed them); each has a clearly-labelled synthetic fixture instead, same discipline as #390.

Full write-up: [`Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md`](../blob/claude/issue-391-plan-shape-classifier/Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md).

## Test plan

- [x] `swift build` — full package builds clean.
- [x] `swift test` — full suite (836 tests) passes, including 9 new tests covering real-corpus coverage, determinism, the two #390 reconciliation cases, and synthetic fixtures for the three shapes not observed in the real corpus plus the unclassified fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
