### PR TITLE
Add configurable SQLite Date TEXT codecs

### DIFF
--- a/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
@@ -313,10 +313,15 @@ private let xlDateTextCalendar: Calendar = {
 /// Compiled once and reused: `NSRegularExpression` performs no internal
 /// mutation while matching, so sharing a compiled pattern across calls and
 /// threads is safe, unlike a shared `DateFormatter`.
+///
+/// The `Z`/`±HH:MM` offset suffix is mandatory, not optional: every codec
+/// this file builds always renders one (see `xlOffsetSuffix`), and text with
+/// no offset at all is genuinely ambiguous about the instant it names rather
+/// than merely differently formatted, so it is rejected instead of parsed.
 private let xlDateTextPattern: NSRegularExpression = {
     // Fixed, hand-verified literal pattern; this initializer cannot fail.
     try! NSRegularExpression(
-        pattern: #"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|[+-]\d{2}:\d{2})?$"#
+        pattern: #"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|[+-]\d{2}:\d{2})$"#
     )
 }()
 

--- a/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
@@ -6,11 +6,12 @@ import SwiftQLCore
 ///
 /// Every codec built here stores a fixed-width, zero-padded
 /// `YYYY-MM-DDTHH:MM:SS[.fff...][Z|±HH:MM]` string derived from a proleptic
-/// Gregorian calendar pinned to UTC internally, with only the *rendered*
-/// offset controlled by ``XLDateTextFormat``. No formatter, calendar, or time
-/// zone is read from process-global or user-default state: every value that
-/// affects the encoded bytes is either a fixed constant below or an explicit
-/// field on `XLDateTextFormat`.
+/// Gregorian calendar. ``XLDateTextFormat``'s fixed offset controls both the
+/// wall-clock year/month/day/hour/minute/second fields (the calendar is
+/// evaluated in that offset, not pinned to UTC) and the rendered `Z`/`±HH:MM`
+/// suffix. No formatter, calendar, or time zone is read from process-global
+/// or user-default state: every value that affects the encoded bytes is
+/// either a fixed constant below or an explicit field on `XLDateTextFormat`.
 ///
 /// ## Storage and indexing
 ///

--- a/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
@@ -160,37 +160,44 @@ public enum XLDateTextCodec {
             throw XLDateTextCodecError.unsupportedDate(date)
         }
 
-        // Round to the configured precision, in exact integer "ticks" since
-        // the epoch, before extracting calendar fields — instead of
-        // truncating a `Double` nanosecond component, or flooring to a whole
-        // second when there is no fractional component to display. `Date`
-        // stores time as a `Double` count of seconds; at magnitudes far from
-        // the epoch the nearest representable `Double` to an "obvious"
-        // fractional value (for example `1_700_000_000.123`) already lands a
-        // few hundred nanoseconds below it. Rounding to the nearest tick, at
-        // whatever precision this format keeps, recovers the intended tick
-        // because that residual is far smaller than half a tick. Integer
-        // (not floating-point) tick arithmetic keeps the whole-second/
-        // fractional-tick split exact and consistently rounded — including
-        // carrying a tick that rounds up into the next second, and rounding
-        // (not flooring) to the nearest whole second when
-        // `fractionalSecondDigits == 0`. See ``XLDateTextFormat`` for the
-        // precision/date-range tradeoff this implies.
+        // Split into an exact whole-second `Double` and a `[0, 1)`
+        // fractional remainder, then round only that small remainder to the
+        // configured precision — instead of truncating a nanosecond
+        // component, flooring to a whole second when there is no fractional
+        // component to display, or scaling the *entire* interval by
+        // `10^fractionalSecondDigits` before rounding. `Date` stores time as
+        // a `Double` count of seconds; at magnitudes far from the epoch the
+        // nearest representable `Double` to an "obvious" fractional value
+        // (for example `1_700_000_000.123`) already lands a few hundred
+        // nanoseconds below it. Rounding recovers the intended tick because
+        // that residual is far smaller than half a tick at any precision
+        // this format supports. Scaling only the remainder — never more
+        // than `scale` in magnitude, at most `1e9` for nine fractional
+        // digits — also keeps this arithmetic overflow-free regardless of
+        // how far `date` is from the epoch; scaling the whole interval
+        // first would overflow `Int64` for a high-precision format on a
+        // date only a few centuries from 1970, long before the year-range
+        // check below would reject it. See ``XLDateTextFormat`` for the
+        // precision/date-range tradeoff this still implies for decoding.
+        let wholeSecondsFloor = rawInterval.rounded(.down)
+        let fraction = rawInterval - wholeSecondsFloor
         let scale = xlPowerOfTen(format.fractionalSecondDigits)
-        let scaledInterval = rawInterval * Double(scale)
-        guard scaledInterval.isFinite, abs(scaledInterval) < 9e18 else {
-            throw XLDateTextCodecError.unsupportedDate(date)
+        let scaledFraction = (fraction * Double(scale)).rounded(.toNearestOrAwayFromZero)
+
+        var wholeSeconds = wholeSecondsFloor
+        var fractionTicks = Int(scaledFraction)
+        if fractionTicks >= scale {
+            // The fractional remainder rounded up to a full next second
+            // rather than a representable fractional tick.
+            wholeSeconds += 1
+            fractionTicks = 0
         }
-        let totalTicks = Int64(scaledInterval.rounded(.toNearestOrAwayFromZero))
-        let scale64 = Int64(scale)
-        let (wholeSecondsTicks, fractionTicks64) = xlFloorDivMod(totalTicks, scale64)
-        let fractionTicks = Int(fractionTicks64)
 
         var calendar = xlDateTextCalendar
         calendar.timeZone = xlFixedTimeZone(offsetSeconds: format.utcOffsetSeconds)
         let components = calendar.dateComponents(
             [.era, .year, .month, .day, .hour, .minute, .second],
-            from: Date(timeIntervalSince1970: Double(wholeSecondsTicks))
+            from: Date(timeIntervalSince1970: wholeSeconds)
         )
         guard
             let era = components.era, era == xlCommonEra,
@@ -446,19 +453,4 @@ private func xlPowerOfTen(_ exponent: Int) -> Int {
         result *= 10
     }
     return result
-}
-
-
-/// Floor division and its matching (always nonnegative, less than
-/// `divisor`) remainder, for a positive `divisor`. Swift's built-in `/` and
-/// `%` truncate toward zero, which would give a negative pre-epoch tick a
-/// negative or wraparound-invalid remainder instead of a valid "ticks into
-/// this second" value.
-private func xlFloorDivMod(_ value: Int64, _ divisor: Int64) -> (Int64, Int64) {
-    let quotient = value / divisor
-    let remainder = value % divisor
-    guard remainder != 0, (remainder < 0) != (divisor < 0) else {
-        return (quotient, remainder)
-    }
-    return (quotient - 1, remainder + divisor)
 }

--- a/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
@@ -1,0 +1,436 @@
+import Foundation
+import SwiftQLCore
+
+
+/// Named SQLite `TEXT` codecs for Foundation `Date`.
+///
+/// Every codec built here stores a fixed-width, zero-padded
+/// `YYYY-MM-DDTHH:MM:SS[.fff...][Z|±HH:MM]` string derived from a proleptic
+/// Gregorian calendar pinned to UTC internally, with only the *rendered*
+/// offset controlled by ``XLDateTextFormat``. No formatter, calendar, or time
+/// zone is read from process-global or user-default state: every value that
+/// affects the encoded bytes is either a fixed constant below or an explicit
+/// field on `XLDateTextFormat`.
+///
+/// ## Storage and indexing
+///
+/// The standard preset's text is fixed-width (24 bytes: 4-digit year through
+/// millisecond precision, `Z` offset) and every field is zero-padded, so
+/// SQLite's default `BINARY` text collation orders it identically to
+/// chronological order for every date in the supported range. A custom
+/// format only preserves that property when it also keeps every field
+/// fixed-width and zero-padded with a fixed offset; SwiftQL does not verify
+/// this for a caller-supplied format, so treat lexicographic ordering of a
+/// custom format as unproven until you have checked it yourself.
+///
+/// ## Migration
+///
+/// Changing `fractionalSecondDigits`, `utcOffsetSeconds`, or
+/// `usesZuluDesignatorForUTC` changes the bytes this codec produces. Give the
+/// new format's codec a new ``XLValueCodecKey`` (or bump the version of an
+/// existing one) and migrate stored rows explicitly; SwiftQL never reformats
+/// existing text on your behalf.
+///
+/// ## SQLite date/time functions
+///
+/// The standard preset's `YYYY-MM-DDTHH:MM:SS.SSSZ` text is one of the
+/// time-string formats SQLite's `date`, `time`, `datetime`, `julianday`, and
+/// `strftime` functions parse directly, so it can be passed to those
+/// functions, and to `<`, `<=`, `>`, `>=`, `BETWEEN`, and `ORDER BY`, without
+/// a dialect conversion expression. A custom format built from
+/// ``XLDateTextFormat`` stays directly usable as long as it keeps the
+/// `YYYY-MM-DDTHH:MM:SS[.SSS][Z|±HH:MM]` field order and separators, which is
+/// everything `XLDateTextFormat` can express; it only varies fractional
+/// digits and the fixed offset. Wiring an SQL-level `julianday`/`strftime`
+/// conversion helper into SwiftQL's expression builders is out of scope for
+/// this codec and tracked separately from value coding.
+public enum XLDateTextCodec {
+
+    /// The stable Swift-value identity shared by every codec this type
+    /// builds. It never changes: the codec key is what distinguishes one
+    /// stored representation from another.
+    public static let valueTypeIdentifier = XLValueTypeIdentifier(
+        rawValue: "swiftql.value.foundation-date"
+    )
+
+    /// The standard preset's stable key: UTC, millisecond precision, `Z`
+    /// designator. Bump the version, or mint a new id, before changing the
+    /// format this key names.
+    public static let standardKey = XLValueCodecKey(
+        id: "swiftql.codec.date-text.iso8601",
+        version: 1
+    )
+
+    /// The standard preset's fixed format: UTC, millisecond precision, `Z`.
+    public static let standardFormat: XLDateTextFormat = {
+        // Fixed literal inputs; this initializer cannot fail for them.
+        try! XLDateTextFormat(
+            fractionalSecondDigits: 3,
+            utcOffsetSeconds: 0,
+            usesZuluDesignatorForUTC: true
+        )
+    }()
+
+    /// The earliest `Date` the standard preset (and any format using its
+    /// four-digit year field) can represent: `0001-01-01T00:00:00.000Z`.
+    public static let minimumSupportedDate: Date = {
+        try! decode(
+            "0001-01-01T00:00:00.000Z",
+            format: standardFormat,
+            context: xlSupportedDateBoundsContext
+        )
+    }()
+
+    /// The latest `Date` the standard preset (and any format using its
+    /// four-digit year field) can represent, truncated to millisecond
+    /// precision: `9999-12-31T23:59:59.999Z`.
+    public static let maximumSupportedDate: Date = {
+        try! decode(
+            "9999-12-31T23:59:59.999Z",
+            format: standardFormat,
+            context: xlSupportedDateBoundsContext
+        )
+    }()
+
+    /// The versioned, SQLite-compatible standard preset: UTC, millisecond
+    /// precision, `Z` designator, canonical zero-padded output.
+    ///
+    /// Register this codec's key in a database's `defaultCodecKeys` to make
+    /// it the database-wide default for `Date`, or select it explicitly with
+    /// `XLValueCodecSelection(explicitCodecKey:)` at a call site.
+    public static var standard: XLValueCodec<Date, XLSQLiteDialect> {
+        custom(
+            key: standardKey,
+            valueTypeIdentifier: valueTypeIdentifier,
+            format: standardFormat
+        )
+    }
+
+    /// Builds a named, paired Date-as-TEXT codec from an explicit immutable
+    /// format.
+    ///
+    /// Two calls with equal `format` values behave identically; nothing here
+    /// depends on `Locale.current`, `TimeZone.current`, or any other
+    /// process-local default. Give each distinct `(key, format)` pairing its
+    /// own stable `key` — reusing a key for a different format silently
+    /// changes what already-stored text means.
+    ///
+    /// - Parameters:
+    ///   - key: The codec's stable, versioned identity.
+    ///   - valueTypeIdentifier: The stable identity of the Swift value's
+    ///     persisted meaning. Reuse ``valueTypeIdentifier`` so multiple named
+    ///     `Date` codecs remain interchangeable database defaults for the
+    ///     same conceptual value, distinguished only by `key`.
+    ///   - format: The immutable formatting configuration.
+    public static func custom(
+        key: XLValueCodecKey,
+        valueTypeIdentifier: XLValueTypeIdentifier = XLDateTextCodec.valueTypeIdentifier,
+        format: XLDateTextFormat
+    ) -> XLValueCodec<Date, XLSQLiteDialect> {
+        XLValueCodec<Date, XLSQLiteDialect>(
+            key: key,
+            valueTypeIdentifier: valueTypeIdentifier,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: XLValueStorageIdentifier(
+                rawValue: XLSQLiteStorageClass.text.rawValue
+            ),
+            encode: { date, _, context in
+                .text(try encode(date, format: format, context: context))
+            },
+            decode: { value, _, context in
+                guard case .text(let text) = value else {
+                    throw XLDateTextCodecError.unexpectedStorage(
+                        XLValueStorageIdentifier(rawValue: value.storageType.rawValue)
+                    )
+                }
+                return try decode(text, format: format, context: context)
+            }
+        )
+    }
+
+    // MARK: - Encoding
+
+    static func encode(
+        _ date: Date,
+        format: XLDateTextFormat,
+        context: XLValueCodingContext
+    ) throws -> String {
+        let rawInterval = date.timeIntervalSince1970
+        guard rawInterval.isFinite else {
+            throw XLDateTextCodecError.unsupportedDate(date)
+        }
+
+        // Round to the configured precision, in exact integer "ticks" since
+        // the epoch, before extracting calendar fields — instead of
+        // truncating a `Double` nanosecond component, or flooring to a whole
+        // second when there is no fractional component to display. `Date`
+        // stores time as a `Double` count of seconds; at magnitudes far from
+        // the epoch the nearest representable `Double` to an "obvious"
+        // fractional value (for example `1_700_000_000.123`) already lands a
+        // few hundred nanoseconds below it. Rounding to the nearest tick, at
+        // whatever precision this format keeps, recovers the intended tick
+        // because that residual is far smaller than half a tick. Integer
+        // (not floating-point) tick arithmetic keeps the whole-second/
+        // fractional-tick split exact and consistently rounded — including
+        // carrying a tick that rounds up into the next second, and rounding
+        // (not flooring) to the nearest whole second when
+        // `fractionalSecondDigits == 0`. See ``XLDateTextFormat`` for the
+        // precision/date-range tradeoff this implies.
+        let scale = xlPowerOfTen(format.fractionalSecondDigits)
+        let scaledInterval = rawInterval * Double(scale)
+        guard scaledInterval.isFinite, abs(scaledInterval) < 9e18 else {
+            throw XLDateTextCodecError.unsupportedDate(date)
+        }
+        let totalTicks = Int64(scaledInterval.rounded(.toNearestOrAwayFromZero))
+        let scale64 = Int64(scale)
+        let (wholeSecondsTicks, fractionTicks64) = xlFloorDivMod(totalTicks, scale64)
+        let fractionTicks = Int(fractionTicks64)
+
+        var calendar = xlDateTextCalendar
+        calendar.timeZone = xlFixedTimeZone(offsetSeconds: format.utcOffsetSeconds)
+        let components = calendar.dateComponents(
+            [.era, .year, .month, .day, .hour, .minute, .second],
+            from: Date(timeIntervalSince1970: Double(wholeSecondsTicks))
+        )
+        guard
+            let era = components.era, era == xlCommonEra,
+            let year = components.year, (1...9999).contains(year),
+            let month = components.month,
+            let day = components.day,
+            let hour = components.hour,
+            let minute = components.minute,
+            let second = components.second
+        else {
+            throw XLDateTextCodecError.unsupportedDate(date)
+        }
+
+        var text = "\(xlZeroPadded(year, width: 4))-\(xlZeroPadded(month, width: 2))-\(xlZeroPadded(day, width: 2))"
+        text += "T\(xlZeroPadded(hour, width: 2)):\(xlZeroPadded(minute, width: 2)):\(xlZeroPadded(second, width: 2))"
+
+        if format.fractionalSecondDigits > 0 {
+            text += ".\(xlZeroPadded(fractionTicks, width: format.fractionalSecondDigits))"
+        }
+
+        text += xlOffsetSuffix(
+            offsetSeconds: format.utcOffsetSeconds,
+            usesZuluDesignatorForUTC: format.usesZuluDesignatorForUTC
+        )
+        return text
+    }
+
+    // MARK: - Decoding
+
+    static func decode(
+        _ text: String,
+        format: XLDateTextFormat,
+        context: XLValueCodingContext
+    ) throws -> Date {
+        guard let fields = xlParseDateText(text) else {
+            throw XLDateTextCodecError.invalidText(text)
+        }
+
+        var calendar = xlDateTextCalendar
+        calendar.timeZone = xlFixedTimeZone(offsetSeconds: fields.offsetSeconds)
+
+        var components = DateComponents()
+        components.year = fields.year
+        components.month = fields.month
+        components.day = fields.day
+        components.hour = fields.hour
+        components.minute = fields.minute
+        components.second = fields.second
+        components.nanosecond = fields.nanosecond
+
+        guard let date = calendar.date(from: components) else {
+            throw XLDateTextCodecError.invalidText(text)
+        }
+
+        // `Calendar.date(from:)` normalizes out-of-range fields (for example
+        // day 32) instead of failing. Re-deriving components from the
+        // resulting date and comparing catches that silent normalization so
+        // invalid calendar dates are reported, not rounded forward.
+        let roundTrip = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: date
+        )
+        guard
+            roundTrip.year == fields.year,
+            roundTrip.month == fields.month,
+            roundTrip.day == fields.day,
+            roundTrip.hour == fields.hour,
+            roundTrip.minute == fields.minute,
+            roundTrip.second == fields.second
+        else {
+            throw XLDateTextCodecError.invalidText(text)
+        }
+
+        return date
+    }
+}
+
+
+/// The proleptic Gregorian/ISO-8601 "AD"/"CE" era index. A `.year` component
+/// alone is ambiguous at the year-1 boundary: one second before
+/// `0001-01-01T00:00:00Z` also reports `year == 1`, in era `0` ("BC")
+/// instead of era `1`. Checking the era alongside the year is what actually
+/// rejects dates before the supported range.
+private let xlCommonEra = 1
+
+
+/// Used only to compute ``XLDateTextCodec/minimumSupportedDate`` and
+/// ``XLDateTextCodec/maximumSupportedDate`` at initialization time; never
+/// surfaced to a caller.
+private let xlSupportedDateBoundsContext = XLValueCodingContext(
+    site: .configuration,
+    path: XLValueCodingPath("swiftql.date-text.supported-bounds")
+)
+
+
+/// A fixed, locale-independent proleptic Gregorian calendar. `Calendar` is an
+/// immutable value type; a mutable local copy (its `timeZone` set per call)
+/// is taken from this constant, never shared or mutated concurrently.
+private let xlDateTextCalendar: Calendar = {
+    var calendar = Calendar(identifier: .iso8601)
+    calendar.timeZone = TimeZone(identifier: "UTC")!
+    return calendar
+}()
+
+
+/// Compiled once and reused: `NSRegularExpression` performs no internal
+/// mutation while matching, so sharing a compiled pattern across calls and
+/// threads is safe, unlike a shared `DateFormatter`.
+private let xlDateTextPattern: NSRegularExpression = {
+    // Fixed, hand-verified literal pattern; this initializer cannot fail.
+    try! NSRegularExpression(
+        pattern: #"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|[+-]\d{2}:\d{2})?$"#
+    )
+}()
+
+
+private struct XLParsedDateTextFields {
+    let year: Int
+    let month: Int
+    let day: Int
+    let hour: Int
+    let minute: Int
+    let second: Int
+    let nanosecond: Int
+    let offsetSeconds: Int
+}
+
+
+private func xlParseDateText(_ text: String) -> XLParsedDateTextFields? {
+    let range = NSRange(text.startIndex..., in: text)
+    guard let match = xlDateTextPattern.firstMatch(in: text, range: range) else {
+        return nil
+    }
+
+    func group(_ index: Int) -> String? {
+        guard let matchRange = Range(match.range(at: index), in: text) else {
+            return nil
+        }
+        return String(text[matchRange])
+    }
+
+    guard
+        let yearText = group(1), let year = Int(yearText),
+        let monthText = group(2), let month = Int(monthText),
+        let dayText = group(3), let day = Int(dayText),
+        let hourText = group(4), let hour = Int(hourText),
+        let minuteText = group(5), let minute = Int(minuteText),
+        let secondText = group(6), let second = Int(secondText)
+    else {
+        return nil
+    }
+    guard year >= 1, (1...12).contains(month), hour < 24, minute < 60, second < 60 else {
+        return nil
+    }
+
+    var nanosecond = 0
+    if let fractionText = group(7) {
+        let padded = fractionText + String(repeating: "0", count: 9 - fractionText.count)
+        guard let parsed = Int(padded) else {
+            return nil
+        }
+        nanosecond = parsed
+    }
+
+    var offsetSeconds = 0
+    if let offsetText = group(8), offsetText != "Z" {
+        let sign = offsetText.hasPrefix("-") ? -1 : 1
+        let digits = offsetText.dropFirst()
+        let hourPart = digits.prefix(2)
+        let minutePart = digits.suffix(2)
+        guard
+            let offsetHour = Int(hourPart),
+            let offsetMinute = Int(minutePart),
+            offsetHour < 24, offsetMinute < 60
+        else {
+            return nil
+        }
+        offsetSeconds = sign * (offsetHour * 3600 + offsetMinute * 60)
+    }
+
+    return XLParsedDateTextFields(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+        nanosecond: nanosecond,
+        offsetSeconds: offsetSeconds
+    )
+}
+
+
+private func xlFixedTimeZone(offsetSeconds: Int) -> TimeZone {
+    // A fixed-offset zone never has a daylight-saving transition, so this
+    // always succeeds for the range `XLDateTextFormat` accepts.
+    TimeZone(secondsFromGMT: offsetSeconds) ?? TimeZone(identifier: "UTC")!
+}
+
+
+private func xlOffsetSuffix(offsetSeconds: Int, usesZuluDesignatorForUTC: Bool) -> String {
+    if offsetSeconds == 0, usesZuluDesignatorForUTC {
+        return "Z"
+    }
+    let sign = offsetSeconds < 0 ? "-" : "+"
+    let magnitude = abs(offsetSeconds)
+    let hours = magnitude / 3600
+    let minutes = (magnitude % 3600) / 60
+    return "\(sign)\(xlZeroPadded(hours, width: 2)):\(xlZeroPadded(minutes, width: 2))"
+}
+
+
+private func xlZeroPadded(_ value: Int, width: Int) -> String {
+    let text = String(value)
+    guard text.count < width else {
+        return text
+    }
+    return String(repeating: "0", count: width - text.count) + text
+}
+
+
+private func xlPowerOfTen(_ exponent: Int) -> Int {
+    var result = 1
+    for _ in 0 ..< exponent {
+        result *= 10
+    }
+    return result
+}
+
+
+/// Floor division and its matching (always nonnegative, less than
+/// `divisor`) remainder, for a positive `divisor`. Swift's built-in `/` and
+/// `%` truncate toward zero, which would give a negative pre-epoch tick a
+/// negative or wraparound-invalid remainder instead of a valid "ticks into
+/// this second" value.
+private func xlFloorDivMod(_ value: Int64, _ divisor: Int64) -> (Int64, Int64) {
+    let quotient = value / divisor
+    let remainder = value % divisor
+    guard remainder != 0, (remainder < 0) != (divisor < 0) else {
+        return (quotient, remainder)
+    }
+    return (quotient - 1, remainder + divisor)
+}

--- a/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
@@ -71,8 +71,16 @@ public enum XLDateTextCodec {
         )
     }()
 
-    /// The earliest `Date` the standard preset (and any format using its
-    /// four-digit year field) can represent: `0001-01-01T00:00:00.000Z`.
+    /// The earliest `Date` the standard (UTC) preset can represent:
+    /// `0001-01-01T00:00:00.000Z`.
+    ///
+    /// A custom format's own earliest representable instant differs by its
+    /// fixed offset: the year-range check in ``encode(_:format:context:)``
+    /// applies to the year *in that offset*, not in UTC, so a positive
+    /// offset's earliest instant is earlier than this value in UTC terms
+    /// (and a negative offset's is later). This value is exact only for
+    /// ``standardFormat`` and any other format that also uses a `0`-second
+    /// offset.
     public static let minimumSupportedDate: Date = {
         try! decode(
             "0001-01-01T00:00:00.000Z",
@@ -81,9 +89,12 @@ public enum XLDateTextCodec {
         )
     }()
 
-    /// The latest `Date` the standard preset (and any format using its
-    /// four-digit year field) can represent, truncated to millisecond
-    /// precision: `9999-12-31T23:59:59.999Z`.
+    /// The latest `Date` the standard (UTC) preset can represent, truncated
+    /// to millisecond precision: `9999-12-31T23:59:59.999Z`.
+    ///
+    /// The same offset caveat as ``minimumSupportedDate`` applies: this
+    /// value is exact only for ``standardFormat`` and any other format that
+    /// also uses a `0`-second offset.
     public static let maximumSupportedDate: Date = {
         try! decode(
             "9999-12-31T23:59:59.999Z",
@@ -169,12 +180,18 @@ public enum XLDateTextCodec {
         // a `Double` count of seconds; at magnitudes far from the epoch the
         // nearest representable `Double` to an "obvious" fractional value
         // (for example `1_700_000_000.123`) already lands a few hundred
-        // nanoseconds below it. Rounding recovers the intended tick because
-        // that residual is far smaller than half a tick at any precision
-        // this format supports. Scaling only the remainder — never more
-        // than `scale` in magnitude, at most `1e9` for nine fractional
-        // digits — also keeps this arithmetic overflow-free regardless of
-        // how far `date` is from the epoch; scaling the whole interval
+        // nanoseconds below it. Rounding recovers the intended tick at
+        // millisecond precision and coarser, where that few-hundred-
+        // nanosecond residual is comfortably smaller than half a tick. At
+        // nine fractional digits (one-nanosecond ticks) the residual is the
+        // same order of magnitude as the tick itself, so nanosecond-exact
+        // round-tripping of a hand-written literal far from the epoch is
+        // not guaranteed at that precision — an inherent `Double` limit,
+        // not a flaw this rounding strategy could fix. Scaling only the
+        // remainder — never more than `scale` in magnitude, at most `1e9`
+        // for nine fractional digits — also keeps this arithmetic
+        // overflow-free regardless of how far `date` is from the epoch;
+        // scaling the whole interval
         // first would overflow `Int64` for a high-precision format on a
         // date only a few centuries from 1970, long before the year-range
         // check below would reject it. See ``XLDateTextFormat`` for the

--- a/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextCodec.swift
@@ -228,6 +228,17 @@ public enum XLDateTextCodec {
         guard let fields = xlParseDateText(text) else {
             throw XLDateTextCodecError.invalidText(text)
         }
+        // A named codec is a deterministic representation: text this codec
+        // did not itself produce (a different fractional-digit count or a
+        // different fixed offset) is rejected rather than silently accepted,
+        // so drift away from the codec's configured format surfaces as a
+        // decode error instead of hiding inside a "valid enough" parse.
+        guard
+            fields.fractionDigitCount == format.fractionalSecondDigits,
+            fields.offsetSeconds == format.utcOffsetSeconds
+        else {
+            throw XLDateTextCodecError.invalidText(text)
+        }
 
         var calendar = xlDateTextCalendar
         calendar.timeZone = xlFixedTimeZone(offsetSeconds: fields.offsetSeconds)
@@ -291,7 +302,10 @@ private let xlSupportedDateBoundsContext = XLValueCodingContext(
 /// is taken from this constant, never shared or mutated concurrently.
 private let xlDateTextCalendar: Calendar = {
     var calendar = Calendar(identifier: .iso8601)
-    calendar.timeZone = TimeZone(identifier: "UTC")!
+    // A fixed zero-second offset is guaranteed to succeed, unlike an
+    // identifier lookup, which depends on the platform time zone database
+    // containing an entry named "UTC".
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
     return calendar
 }()
 
@@ -315,6 +329,10 @@ private struct XLParsedDateTextFields {
     let minute: Int
     let second: Int
     let nanosecond: Int
+    /// The number of fractional-second digits actually present in the
+    /// parsed text (`0` when there was no `.` component at all), as opposed
+    /// to `nanosecond`, which is always zero-padded out to nine digits.
+    let fractionDigitCount: Int
     let offsetSeconds: Int
 }
 
@@ -347,12 +365,14 @@ private func xlParseDateText(_ text: String) -> XLParsedDateTextFields? {
     }
 
     var nanosecond = 0
+    var fractionDigitCount = 0
     if let fractionText = group(7) {
         let padded = fractionText + String(repeating: "0", count: 9 - fractionText.count)
         guard let parsed = Int(padded) else {
             return nil
         }
         nanosecond = parsed
+        fractionDigitCount = fractionText.count
     }
 
     var offsetSeconds = 0
@@ -379,6 +399,7 @@ private func xlParseDateText(_ text: String) -> XLParsedDateTextFields? {
         minute: minute,
         second: second,
         nanosecond: nanosecond,
+        fractionDigitCount: fractionDigitCount,
         offsetSeconds: offsetSeconds
     )
 }
@@ -386,8 +407,10 @@ private func xlParseDateText(_ text: String) -> XLParsedDateTextFields? {
 
 private func xlFixedTimeZone(offsetSeconds: Int) -> TimeZone {
     // A fixed-offset zone never has a daylight-saving transition, so this
-    // always succeeds for the range `XLDateTextFormat` accepts.
-    TimeZone(secondsFromGMT: offsetSeconds) ?? TimeZone(identifier: "UTC")!
+    // always succeeds for the range `XLDateTextFormat` accepts. The fallback
+    // is itself a fixed offset (not an identifier lookup) so it carries no
+    // platform time zone database dependency either.
+    TimeZone(secondsFromGMT: offsetSeconds) ?? TimeZone(secondsFromGMT: 0)!
 }
 
 

--- a/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
@@ -16,7 +16,9 @@ public enum XLDateTextCodecError: Error, Equatable, Sendable, LocalizedError {
     /// The dialect value was not the storage class this codec expects.
     case unexpectedStorage(XLValueStorageIdentifier)
 
-    /// The date's proleptic-Gregorian year falls outside the codec's fixed
+    /// Encoding could not produce text for this `Date`: either
+    /// `date.timeIntervalSince1970` is not finite, or its proleptic-Gregorian
+    /// year (in the codec's fixed offset) falls outside the codec's fixed
     /// four-digit year range (`0001`...`9999`).
     case unsupportedDate(Date)
 
@@ -35,7 +37,7 @@ public enum XLDateTextCodecError: Error, Equatable, Sendable, LocalizedError {
         case .unexpectedStorage(let storage):
             return "Expected SQLite TEXT storage, received \(storage)."
         case .unsupportedDate(let date):
-            return "\(date) falls outside the supported year range 0001...9999."
+            return "\(date) is not finite, or falls outside the supported year range 0001...9999."
         case .unsupportedPrecision(let digits):
             return "Fractional-second precision \(digits) is not in 0...9."
         case .unsupportedOffsetSeconds(let seconds):

--- a/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
@@ -10,7 +10,11 @@ import Foundation
 /// caller, so this type only needs to describe what went wrong locally.
 public enum XLDateTextCodecError: Error, Equatable, Sendable, LocalizedError {
 
-    /// The stored text does not match the fixed grammar this codec parses.
+    /// Decoding rejected this stored text: it does not match the fixed
+    /// grammar this codec parses, it names a calendar date that does not
+    /// exist (for example November 31), or its fractional-digit count or
+    /// offset does not match this codec's own configured
+    /// ``XLDateTextFormat``.
     case invalidText(String)
 
     /// The dialect value was not the storage class this codec expects.
@@ -33,7 +37,9 @@ public enum XLDateTextCodecError: Error, Equatable, Sendable, LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .invalidText(let text):
-            return "\"\(text)\" does not match the configured Date TEXT grammar."
+            return "\"\(text)\" is not valid for the configured Date TEXT codec: it does not match the "
+                + "grammar, names a calendar date that does not exist (for example November 31), or its "
+                + "fractional-digit count or offset does not match this codec's configured format."
         case .unexpectedStorage(let storage):
             return "Expected SQLite TEXT storage, received \(storage)."
         case .unsupportedDate(let date):
@@ -41,7 +47,8 @@ public enum XLDateTextCodecError: Error, Equatable, Sendable, LocalizedError {
         case .unsupportedPrecision(let digits):
             return "Fractional-second precision \(digits) is not in 0...9."
         case .unsupportedOffsetSeconds(let seconds):
-            return "UTC offset \(seconds) seconds is not a valid fixed offset."
+            return "UTC offset \(seconds) seconds is not a valid fixed offset: it must be a whole "
+                + "number of minutes strictly between -24h and +24h."
         }
     }
 }

--- a/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
@@ -25,7 +25,7 @@ public enum XLDateTextCodecError: Error, Equatable, Sendable, LocalizedError {
     case unsupportedPrecision(fractionalSecondDigits: Int)
 
     /// `XLDateTextFormat` was asked for a UTC offset that is not a whole
-    /// number of seconds strictly between -24h and +24h.
+    /// number of minutes strictly between -24h and +24h.
     case unsupportedOffsetSeconds(Int)
 
     public var errorDescription: String? {

--- a/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
@@ -71,7 +71,10 @@ public struct XLDateTextFormat: Hashable, Sendable {
     ///
     /// `0` is UTC. There is no default derived from the running process's
     /// current time zone: callers state the offset their storage format
-    /// requires.
+    /// requires. Must be a whole number of minutes: the encoded `±HH:MM`
+    /// suffix can only express minute granularity, so a sub-minute offset
+    /// would compute wall-clock fields with a shift the rendered suffix
+    /// cannot represent, silently breaking the round trip.
     public let utcOffsetSeconds: Int
 
     /// Whether an offset of `0` is rendered as the literal `Z` designator
@@ -84,7 +87,8 @@ public struct XLDateTextFormat: Hashable, Sendable {
     ///   - fractionalSecondDigits: Digits of fractional-second precision
     ///     retained in encoded text, `0...9`. Defaults to `3` (milliseconds).
     ///   - utcOffsetSeconds: The fixed UTC offset embedded in encoded text,
-    ///     strictly between -24h and +24h. Defaults to `0` (UTC).
+    ///     strictly between -24h and +24h and a whole number of minutes.
+    ///     Defaults to `0` (UTC).
     ///   - usesZuluDesignatorForUTC: Whether a `0`-second offset renders as
     ///     `Z`. Defaults to `true`.
     /// - Throws: ``XLDateTextCodecError/unsupportedPrecision(fractionalSecondDigits:)``
@@ -100,7 +104,11 @@ public struct XLDateTextFormat: Hashable, Sendable {
                 fractionalSecondDigits: fractionalSecondDigits
             )
         }
-        guard utcOffsetSeconds > -86_400, utcOffsetSeconds < 86_400 else {
+        guard
+            utcOffsetSeconds > -86_400,
+            utcOffsetSeconds < 86_400,
+            utcOffsetSeconds % 60 == 0
+        else {
             throw XLDateTextCodecError.unsupportedOffsetSeconds(utcOffsetSeconds)
         }
         self.fractionalSecondDigits = fractionalSecondDigits

--- a/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
+++ b/Sources/SwiftQL/Codecs/XLDateTextFormat.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+
+/// Deterministic failures raised while encoding or decoding a Date-as-TEXT
+/// codec built from ``XLDateTextFormat``.
+///
+/// These are the errors thrown by the codec's own `encode`/`decode` closures.
+/// `XLValueCodec` wraps them with codec identity and coding-path context as
+/// `XLValueCodecError.encodingFailed` / `.decodingFailed` before they reach a
+/// caller, so this type only needs to describe what went wrong locally.
+public enum XLDateTextCodecError: Error, Equatable, Sendable, LocalizedError {
+
+    /// The stored text does not match the fixed grammar this codec parses.
+    case invalidText(String)
+
+    /// The dialect value was not the storage class this codec expects.
+    case unexpectedStorage(XLValueStorageIdentifier)
+
+    /// The date's proleptic-Gregorian year falls outside the codec's fixed
+    /// four-digit year range (`0001`...`9999`).
+    case unsupportedDate(Date)
+
+    /// `XLDateTextFormat` was asked for a fractional-second digit count
+    /// outside `0...9`.
+    case unsupportedPrecision(fractionalSecondDigits: Int)
+
+    /// `XLDateTextFormat` was asked for a UTC offset that is not a whole
+    /// number of seconds strictly between -24h and +24h.
+    case unsupportedOffsetSeconds(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidText(let text):
+            return "\"\(text)\" does not match the configured Date TEXT grammar."
+        case .unexpectedStorage(let storage):
+            return "Expected SQLite TEXT storage, received \(storage)."
+        case .unsupportedDate(let date):
+            return "\(date) falls outside the supported year range 0001...9999."
+        case .unsupportedPrecision(let digits):
+            return "Fractional-second precision \(digits) is not in 0...9."
+        case .unsupportedOffsetSeconds(let seconds):
+            return "UTC offset \(seconds) seconds is not a valid fixed offset."
+        }
+    }
+}
+
+
+/// Explicit, immutable formatting rules for one Date-as-TEXT representation.
+///
+/// A format never reads `TimeZone.current`, `Locale.current`, or any other
+/// process- or user-dependent default: every rule that affects the encoded
+/// bytes is a value stored on this struct. Two codecs built from equal
+/// formats always produce byte-identical text for the same `Date`.
+///
+/// The offset is a fixed number of seconds, not a named `TimeZone` identifier.
+/// Named zones observe daylight-saving transitions, which would make the same
+/// wall-clock offset text mean different instants on different days; a fixed
+/// offset keeps the encoded text a deterministic function of the `Date` alone.
+public struct XLDateTextFormat: Hashable, Sendable {
+
+    /// Number of fractional-second digits retained in encoded text.
+    ///
+    /// `0` omits the fractional component and its separating `.` entirely.
+    /// Encoding rounds to the nearest tick at this precision (carrying into
+    /// the next second when a value rounds up to a full second), rather than
+    /// truncating. See ``XLDateTextCodec`` for why rounding, not truncation,
+    /// is what makes an ordinary millisecond-resolution `Date` round-trip.
+    public let fractionalSecondDigits: Int
+
+    /// The fixed UTC offset, in seconds, embedded in encoded text.
+    ///
+    /// `0` is UTC. There is no default derived from the running process's
+    /// current time zone: callers state the offset their storage format
+    /// requires.
+    public let utcOffsetSeconds: Int
+
+    /// Whether an offset of `0` is rendered as the literal `Z` designator
+    /// instead of `+00:00`.
+    public let usesZuluDesignatorForUTC: Bool
+
+    /// Creates an immutable Date-as-TEXT format.
+    ///
+    /// - Parameters:
+    ///   - fractionalSecondDigits: Digits of fractional-second precision
+    ///     retained in encoded text, `0...9`. Defaults to `3` (milliseconds).
+    ///   - utcOffsetSeconds: The fixed UTC offset embedded in encoded text,
+    ///     strictly between -24h and +24h. Defaults to `0` (UTC).
+    ///   - usesZuluDesignatorForUTC: Whether a `0`-second offset renders as
+    ///     `Z`. Defaults to `true`.
+    /// - Throws: ``XLDateTextCodecError/unsupportedPrecision(fractionalSecondDigits:)``
+    ///   or ``XLDateTextCodecError/unsupportedOffsetSeconds(_:)`` for values
+    ///   outside their supported ranges.
+    public init(
+        fractionalSecondDigits: Int = 3,
+        utcOffsetSeconds: Int = 0,
+        usesZuluDesignatorForUTC: Bool = true
+    ) throws {
+        guard (0...9).contains(fractionalSecondDigits) else {
+            throw XLDateTextCodecError.unsupportedPrecision(
+                fractionalSecondDigits: fractionalSecondDigits
+            )
+        }
+        guard utcOffsetSeconds > -86_400, utcOffsetSeconds < 86_400 else {
+            throw XLDateTextCodecError.unsupportedOffsetSeconds(utcOffsetSeconds)
+        }
+        self.fractionalSecondDigits = fractionalSecondDigits
+        self.utcOffsetSeconds = utcOffsetSeconds
+        self.usesZuluDesignatorForUTC = usesZuluDesignatorForUTC
+    }
+}

--- a/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
+++ b/Sources/SwiftQL/SwiftQL.docc/CustomTypes.md
@@ -107,6 +107,101 @@ or storage identifier as a schema/data migration. These values are also the
 stable components available to schema and query fingerprinting; do not derive
 durable identity from Swift runtime type names or hashes.
 
+### Standard SQLite Date TEXT codec
+
+`XLDateTextCodec` ships a ready-made pair of `Date`-as-`TEXT` codecs so most
+applications never have to hand-write the `decimalDateCodec` shown above.
+`XLDateTextCodec.standard` is a versioned preset: fixed proleptic-Gregorian
+calendar, UTC offset, millisecond fractional precision, and a `Z`-suffixed
+`YYYY-MM-DDTHH:MM:SS.SSSZ` text — matching one of the time-string formats
+SQLite's own `date`, `time`, `datetime`, `julianday`, and `strftime` functions
+already parse, and comparable with `<`, `>`, `BETWEEN`, and `ORDER BY` without
+a dialect conversion expression. Nothing about the preset reads
+`Locale.current`, `TimeZone.current`, or any other process- or user-dependent
+default.
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+let standardDateRegistry = try XLValueCodecRegistry()
+    .registering(XLDateTextCodec.standard)
+let standardDateCoding = try XLValueCodingConfiguration(
+    registry: standardDateRegistry,
+    defaultCodecKeys: [XLDateTextCodec.standardKey]
+)
+let standardEncoded = try standardDateCoding.encode(
+    Date(timeIntervalSince1970: 1_700_000_000.123),
+    using: XLSQLiteDialect(),
+    context: XLValueCodingContext(
+        site: .parameter,
+        path: XLValueCodingPath("event.occurredAt")
+    )
+)
+// .text("2023-11-14T22:13:20.123Z")
+```
+
+Because the standard preset's text is fixed-width and zero-padded in every
+field, SQLite's default `BINARY` collation orders it identically to
+chronological order for every date it can represent: proleptic-Gregorian
+years `0001` through `9999`
+(`XLDateTextCodec.minimumSupportedDate` ... `XLDateTextCodec.maximumSupportedDate`).
+A `Date` outside that range fails to encode with a structured
+`XLDateTextCodecError.unsupportedDate` wrapped in
+`XLValueCodecError.encodingFailed`; SwiftQL never silently clamps or wraps it
+into a representable year.
+
+An application that needs a different fixed offset or fractional precision —
+but not a different locale, calendar, or arbitrary field order — builds its
+own named codec from an explicit `XLDateTextFormat` instead of writing
+encode/decode closures by hand:
+
+<!-- test: XLDocumentationTests.testDocumentationCustomTypeRoundTrips -->
+```swift
+let secondsOnlyFormat = try XLDateTextFormat(
+    fractionalSecondDigits: 0,
+    utcOffsetSeconds: 0
+)
+let secondsOnlyDateCodec = XLDateTextCodec.custom(
+    key: XLValueCodecKey(id: "com.example.date.seconds-only", version: 1),
+    format: secondsOnlyFormat
+)
+```
+
+`XLDateTextFormat`'s offset is a fixed number of seconds, not a named
+`TimeZone` identifier: a named zone observes daylight-saving transitions,
+which would make the same offset text mean different instants on different
+days. `XLDateTextCodec` never promises lexicographic-equals-chronological
+ordering for a custom format the way it does for the standard preset — that
+property only holds when every field stays fixed-width and zero-padded with a
+fixed offset, and SwiftQL does not verify that for a caller-supplied format.
+
+Both codecs can be registered together and coexist, the same way
+`decimalDateCodec` and `integerDateCodec` coexist above: registering two
+codecs for the same stable value-type identifier is fine, but making more
+than one of them a database default at once is a rejected `duplicateDefault`
+(see "Selection and errors" below). Each property, parameter, or result site
+that needs the non-default codec selects it explicitly with
+`XLValueCodecSelection(explicitCodecKey:)`; `XLDateTextCodec` does not add a
+new selection mechanism beyond the one already shown for `decimalDateCodec`
+and `integerDateCodec`.
+
+A custom `XLDateTextFormat` stays directly usable by SQLite's date/time
+functions and comparison operators too, as long as it keeps the
+`YYYY-MM-DDTHH:MM:SS[.SSS][Z|±HH:MM]` field order and separators — the only
+things `XLDateTextFormat` varies are the fractional digit count and the fixed
+offset, and SQLite's time-string grammar accepts both a `Z` and an explicit
+`±HH:MM` suffix. Value coding stays deliberately separate from SQL-level date
+arithmetic: `XLDateTextCodec` does not wire a `julianday`/`strftime`
+conversion helper into SwiftQL's expression builders, so a query that needs
+one composes it with a raw SQL date/time function call at the call site; that
+expression-builder integration is tracked separately from value coding.
+
+Changing `fractionalSecondDigits`, `utcOffsetSeconds`, or
+`usesZuluDesignatorForUTC` changes the bytes a codec produces. Give the new
+format its own `XLValueCodecKey` (or bump an existing key's version) and
+migrate stored rows explicitly, the same as any other codec key or version
+change described above; `XLDateTextCodec` never reformats existing text on
+your behalf.
+
 ### Selection and errors
 
 Codec selection uses one deterministic order:

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1775,6 +1775,61 @@ extension XLDocumentationTests {
             path: XLValueCodingPath("invoice.dueDate")
         )
 
+        let standardDateRegistry = try XLValueCodecRegistry()
+            .registering(XLDateTextCodec.standard)
+        let standardDateCoding = try XLValueCodingConfiguration(
+            registry: standardDateRegistry,
+            defaultCodecKeys: [XLDateTextCodec.standardKey]
+        )
+        let standardEncoded = try standardDateCoding.encode(
+            Date(timeIntervalSince1970: 1_700_000_000.123),
+            using: dialect,
+            context: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("event.occurredAt")
+            )
+        )
+        XCTAssertEqual(standardEncoded, .text("2023-11-14T22:13:20.123Z"))
+        XCTAssertThrowsError(
+            try standardDateCoding.encode(
+                XLDateTextCodec.minimumSupportedDate.addingTimeInterval(-1),
+                using: dialect,
+                context: parameterContext
+            )
+        ) { error in
+            guard case .encodingFailed? = error as? XLValueCodecError else {
+                return XCTFail("Expected an encodingFailed wrapper, received \(error).")
+            }
+        }
+
+        let secondsOnlyFormat = try XLDateTextFormat(
+            fractionalSecondDigits: 0,
+            utcOffsetSeconds: 0
+        )
+        let secondsOnlyDateCodec = XLDateTextCodec.custom(
+            key: XLValueCodecKey(id: "com.example.date.seconds-only", version: 1),
+            format: secondsOnlyFormat
+        )
+        let coexistingDateRegistry = try XLValueCodecRegistry()
+            .registering(XLDateTextCodec.standard)
+            .registering(secondsOnlyDateCodec)
+        // Neither is a default here: both target the same stable value-type
+        // identifier, so each call selects its codec explicitly instead.
+        let coexistingDateCoding = try XLValueCodingConfiguration(
+            registry: coexistingDateRegistry
+        )
+        XCTAssertEqual(
+            try coexistingDateCoding.encode(
+                Date(timeIntervalSince1970: 1_700_000_000),
+                using: dialect,
+                context: parameterContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: secondsOnlyDateCodec.identity.key
+                )
+            ),
+            .text("2023-11-14T22:13:20Z")
+        )
+
         XCTAssertEqual(
             try codingConfiguration.encode(
                 date,

--- a/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
@@ -327,6 +327,7 @@ final class DateTextCodecContractTests: XCTestCase {
             "2023-11-31T00:00:00.000Z",  // November has 30 days
             "2023-11-14T25:00:00.000Z",  // hour 25
             "2023-11-14 22:13:20.000Z",  // missing 'T' separator
+            "2023-11-14T22:13:20.123",  // missing offset/Z: an ambiguous instant
             "",
         ] {
             XCTAssertThrowsError(

--- a/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
@@ -1,0 +1,436 @@
+import Foundation
+import XCTest
+@testable import SwiftQL
+
+
+/// Pure encode/decode contract coverage for ``XLDateTextCodec``, independent
+/// of any real SQLite connection. Real GRDB/SQLite round trips live in
+/// `DateTextCodecGRDBTests.swift`.
+final class DateTextCodecContractTests: XCTestCase {
+
+    private let dialect = XLSQLiteDialect()
+
+    private let parameterContext = XLValueCodingContext(
+        site: .parameter,
+        path: XLValueCodingPath(["fixture", "when"])
+    )
+
+    private let resultContext = XLValueCodingContext(
+        site: .result,
+        path: XLValueCodingPath(["fixture", "when"])
+    )
+
+    // MARK: - Canonical bytes
+
+    func testStandardPresetEncodesFixedWidthZeroPaddedUTCMillisecondText() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+        let date = Date(timeIntervalSince1970: 1_700_000_000.123)
+
+        XCTAssertEqual(
+            try configuration.encode(date, using: dialect, context: parameterContext),
+            .text("2023-11-14T22:13:20.123Z")
+        )
+    }
+
+    func testStandardPresetRoundsSubMillisecondPrecisionToTheNearestMillisecond() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+        // Rounds down within the same second: 999.4 microseconds past the
+        // millisecond boundary is closer to .999 than to .1000.
+        let withoutCarry = Date(timeIntervalSince1970: 1_700_000_000.9994)
+        XCTAssertEqual(
+            try configuration.encode(withoutCarry, using: dialect, context: parameterContext),
+            .text("2023-11-14T22:13:20.999Z")
+        )
+    }
+
+    func testStandardPresetCarriesARoundedMillisecondIntoTheNextSecond() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+        // 999.6 ms rounds up to a full next second, not to a nonexistent
+        // ".1000" fractional value.
+        let date = Date(timeIntervalSince1970: 1_700_000_000.9996)
+
+        XCTAssertEqual(
+            try configuration.encode(date, using: dialect, context: parameterContext),
+            .text("2023-11-14T22:13:21.000Z")
+        )
+    }
+
+    func testStandardPresetRoundTripsThroughEncodeAndDecode() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+        let date = Date(timeIntervalSince1970: 1_700_000_000.5)
+
+        let encoded = try configuration.encode(date, using: dialect, context: parameterContext)
+        let decoded: Date = try configuration.decode(
+            Date.self,
+            from: encoded,
+            using: dialect,
+            context: resultContext
+        )
+        // Truncated to millisecond precision by the standard preset.
+        XCTAssertEqual(decoded.timeIntervalSince1970, 1_700_000_000.5, accuracy: 0.001)
+    }
+
+    // MARK: - Explicit fixed offsets
+
+    func testCustomFormatEmbedsAConfiguredFixedOffsetInsteadOfZ() throws {
+        let format = try XLDateTextFormat(
+            fractionalSecondDigits: 0,
+            utcOffsetSeconds: 2 * 3600 + 30 * 60,
+            usesZuluDesignatorForUTC: true
+        )
+        let codec = XLDateTextCodec.custom(
+            key: XLValueCodecKey(id: "test.date-text.plus-0230", version: 1),
+            format: format
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(codec),
+            defaultCodecKeys: [codec.identity.key]
+        )
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+        XCTAssertEqual(
+            try configuration.encode(date, using: dialect, context: parameterContext),
+            .text("2023-11-15T00:43:20+02:30")
+        )
+        let decoded: Date = try configuration.decode(
+            Date.self,
+            from: .text("2023-11-15T00:43:20+02:30"),
+            using: dialect,
+            context: resultContext
+        )
+        XCTAssertEqual(decoded, date)
+    }
+
+    func testZeroOffsetRendersPlusZeroWhenZuluDesignatorIsDisabled() throws {
+        let format = try XLDateTextFormat(
+            fractionalSecondDigits: 0,
+            utcOffsetSeconds: 0,
+            usesZuluDesignatorForUTC: false
+        )
+        let codec = XLDateTextCodec.custom(
+            key: XLValueCodecKey(id: "test.date-text.explicit-plus-zero", version: 1),
+            format: format
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(codec),
+            defaultCodecKeys: [codec.identity.key]
+        )
+
+        XCTAssertEqual(
+            try configuration.encode(
+                Date(timeIntervalSince1970: 0),
+                using: dialect,
+                context: parameterContext
+            ),
+            .text("1970-01-01T00:00:00+00:00")
+        )
+    }
+
+    func testNegativeOffsetsRoundTrip() throws {
+        let format = try XLDateTextFormat(
+            fractionalSecondDigits: 3,
+            utcOffsetSeconds: -8 * 3600
+        )
+        let codec = XLDateTextCodec.custom(
+            key: XLValueCodecKey(id: "test.date-text.minus-0800", version: 1),
+            format: format
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(codec),
+            defaultCodecKeys: [codec.identity.key]
+        )
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let encoded = try configuration.encode(date, using: dialect, context: parameterContext)
+        XCTAssertEqual(encoded, .text("2023-11-14T14:13:20.000-08:00"))
+        XCTAssertEqual(
+            try configuration.decode(
+                Date.self,
+                from: encoded,
+                using: dialect,
+                context: resultContext
+            ),
+            date
+        )
+    }
+
+    // MARK: - Precision
+
+    func testFractionalSecondDigitsZeroOmitsTheFractionalComponent() throws {
+        let format = try XLDateTextFormat(fractionalSecondDigits: 0)
+        let codec = XLDateTextCodec.custom(
+            key: XLValueCodecKey(id: "test.date-text.seconds", version: 1),
+            format: format
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(codec),
+            defaultCodecKeys: [codec.identity.key]
+        )
+
+        XCTAssertEqual(
+            try configuration.encode(
+                Date(timeIntervalSince1970: 1_700_000_000.999),
+                using: dialect,
+                context: parameterContext
+            ),
+            // Rounds to the nearest whole second, carrying past :20.
+            .text("2023-11-14T22:13:21Z")
+        )
+    }
+
+    func testFractionalSecondDigitsNineRetainsNanosecondPrecision() throws {
+        let format = try XLDateTextFormat(fractionalSecondDigits: 9)
+        let codec = XLDateTextCodec.custom(
+            key: XLValueCodecKey(id: "test.date-text.nanoseconds", version: 1),
+            format: format
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(codec),
+            defaultCodecKeys: [codec.identity.key]
+        )
+
+        let encoded = try configuration.encode(
+            Date(timeIntervalSince1970: 1_700_000_000.123456),
+            using: dialect,
+            context: parameterContext
+        )
+        guard case .text(let text) = encoded else {
+            return XCTFail("Expected TEXT storage")
+        }
+        XCTAssertTrue(text.hasPrefix("2023-11-14T22:13:20.123456"), text)
+        XCTAssertTrue(text.hasSuffix("Z"))
+    }
+
+    func testUnsupportedFractionalSecondDigitsIsRejectedAtFormatConstruction() {
+        XCTAssertThrowsError(try XLDateTextFormat(fractionalSecondDigits: 10)) { error in
+            XCTAssertEqual(
+                error as? XLDateTextCodecError,
+                .unsupportedPrecision(fractionalSecondDigits: 10)
+            )
+        }
+        XCTAssertThrowsError(try XLDateTextFormat(fractionalSecondDigits: -1)) { error in
+            XCTAssertEqual(
+                error as? XLDateTextCodecError,
+                .unsupportedPrecision(fractionalSecondDigits: -1)
+            )
+        }
+    }
+
+    func testUnsupportedOffsetIsRejectedAtFormatConstruction() {
+        XCTAssertThrowsError(try XLDateTextFormat(utcOffsetSeconds: 86_400)) { error in
+            XCTAssertEqual(
+                error as? XLDateTextCodecError,
+                .unsupportedOffsetSeconds(86_400)
+            )
+        }
+        XCTAssertThrowsError(try XLDateTextFormat(utcOffsetSeconds: -86_400)) { error in
+            XCTAssertEqual(
+                error as? XLDateTextCodecError,
+                .unsupportedOffsetSeconds(-86_400)
+            )
+        }
+    }
+
+    // MARK: - Minimum and maximum supported dates
+
+    func testMinimumAndMaximumSupportedDatesRoundTrip() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+
+        XCTAssertEqual(
+            try configuration.encode(
+                XLDateTextCodec.minimumSupportedDate,
+                using: dialect,
+                context: parameterContext
+            ),
+            .text("0001-01-01T00:00:00.000Z")
+        )
+        XCTAssertEqual(
+            try configuration.encode(
+                XLDateTextCodec.maximumSupportedDate,
+                using: dialect,
+                context: parameterContext
+            ),
+            .text("9999-12-31T23:59:59.999Z")
+        )
+    }
+
+    func testYearsOutsideTheSupportedRangeFailToEncode() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+        let beforeMinimum = XLDateTextCodec.minimumSupportedDate.addingTimeInterval(-1)
+        let afterMaximum = XLDateTextCodec.maximumSupportedDate.addingTimeInterval(1)
+
+        for outOfRange in [beforeMinimum, afterMaximum] {
+            XCTAssertThrowsError(
+                try configuration.encode(outOfRange, using: dialect, context: parameterContext)
+            ) { error in
+                guard case .encodingFailed? = error as? XLValueCodecError else {
+                    return XCTFail("Expected an encodingFailed wrapper, received \(error).")
+                }
+            }
+        }
+    }
+
+    // MARK: - Ordering
+
+    func testStandardPresetTextOrderingMatchesChronologicalOrdering() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+        let dates = [
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 1_700_000_000.001),
+            Date(timeIntervalSince1970: 1_700_000_000.5),
+            Date(timeIntervalSince1970: 1_700_000_001),
+            Date(timeIntervalSince1970: -1_000_000_000),
+        ]
+        let sortedByDate = dates.sorted()
+        let encodedTexts = try sortedByDate.map { date -> String in
+            guard case .text(let text) = try configuration.encode(
+                date,
+                using: dialect,
+                context: parameterContext
+            ) else {
+                throw XCTSkip("Expected TEXT storage")
+            }
+            return text
+        }
+
+        XCTAssertEqual(encodedTexts, encodedTexts.sorted())
+    }
+
+    // MARK: - Errors
+
+    func testInvalidTextFailsToDecodeWithCodecAndContext() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+
+        for invalidText in [
+            "not-a-date",
+            "2023-13-01T00:00:00.000Z",  // month 13
+            "2023-11-31T00:00:00.000Z",  // November has 30 days
+            "2023-11-14T25:00:00.000Z",  // hour 25
+            "2023-11-14 22:13:20.000Z",  // missing 'T' separator
+            "",
+        ] {
+            XCTAssertThrowsError(
+                try configuration.decode(
+                    Date.self,
+                    from: .text(invalidText),
+                    using: dialect,
+                    context: resultContext
+                ),
+                invalidText
+            ) { error in
+                guard case .decodingFailed(let codec, let context, _)? = error as? XLValueCodecError else {
+                    return XCTFail("\(invalidText): expected a decodingFailed wrapper, received \(error).")
+                }
+                XCTAssertEqual(codec, XLDateTextCodec.standardKey)
+                XCTAssertEqual(context, resultContext)
+            }
+        }
+    }
+
+    func testStorageClassMismatchIsReportedBeforeTheCodecClosureRuns() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+
+        XCTAssertThrowsError(
+            try configuration.decode(
+                Date.self,
+                from: .integer(1_700_000_000),
+                using: dialect,
+                context: resultContext
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLValueCodecError,
+                .storageMismatch(
+                    codec: XLDateTextCodec.standardKey,
+                    expected: XLValueStorageIdentifier(
+                        rawValue: XLSQLiteStorageClass.text.rawValue
+                    ),
+                    actual: XLValueStorageIdentifier(
+                        rawValue: XLSQLiteStorageClass.integer.rawValue
+                    ),
+                    context: resultContext
+                )
+            )
+        }
+    }
+
+    func testNullIsRejectedByTheNonoptionalCodecButAcceptedByEncodeOptional() throws {
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+
+        XCTAssertThrowsError(
+            try configuration.decode(
+                Date.self,
+                from: .null,
+                using: dialect,
+                context: resultContext
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLValueCodecError,
+                .unexpectedNull(codec: XLDateTextCodec.standardKey, context: resultContext)
+            )
+        }
+        XCTAssertEqual(
+            try configuration.encodeOptional(
+                Optional<Date>.none,
+                using: dialect,
+                context: parameterContext
+            ),
+            .null
+        )
+        let decoded: Date? = try configuration.decodeOptional(
+            Date.self,
+            from: .null,
+            using: dialect,
+            context: resultContext
+        )
+        XCTAssertNil(decoded)
+    }
+
+    // MARK: - Two named codecs coexisting as database defaults
+
+    func testStandardAndCustomCodecsCoexistAndAreSelectedExplicitly() throws {
+        let customFormat = try XLDateTextFormat(fractionalSecondDigits: 0, utcOffsetSeconds: 0)
+        let customCodec = XLDateTextCodec.custom(
+            key: XLValueCodecKey(id: "test.date-text.coexisting-custom", version: 1),
+            format: customFormat
+        )
+        let registry = try XLValueCodecRegistry()
+            .registering(XLDateTextCodec.standard)
+            .registering(customCodec)
+        // Neither is a default: both `Date` codecs target the same stable
+        // value-type identifier, so registering both as defaults would be a
+        // rejected `duplicateDefault`. Two properties select explicitly instead.
+        let configuration = try XLValueCodingConfiguration(registry: registry)
+        let date = Date(timeIntervalSince1970: 1_700_000_000.777)
+
+        XCTAssertEqual(
+            try configuration.encode(
+                date,
+                using: dialect,
+                context: parameterContext,
+                selection: XLValueCodecSelection(explicitCodecKey: XLDateTextCodec.standardKey)
+            ),
+            .text("2023-11-14T22:13:20.777Z")
+        )
+        XCTAssertEqual(
+            try configuration.encode(
+                date,
+                using: dialect,
+                context: parameterContext,
+                selection: XLValueCodecSelection(explicitCodecKey: customCodec.identity.key)
+            ),
+            // Seconds-only precision rounds .777 up to the next whole second.
+            .text("2023-11-14T22:13:21Z")
+        )
+    }
+
+    private func makeConfiguration(
+        defaultKey: XLValueCodecKey
+    ) throws -> XLValueCodingConfiguration {
+        try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(XLDateTextCodec.standard),
+            defaultCodecKeys: [defaultKey]
+        )
+    }
+}

--- a/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
@@ -201,6 +201,37 @@ final class DateTextCodecContractTests: XCTestCase {
         XCTAssertTrue(text.hasSuffix("Z"))
     }
 
+    func testNanosecondPrecisionEncodesDatesAtTheYearBoundaryWithoutOverflow() throws {
+        // Regression test: encoding used to scale the *entire* epoch
+        // interval by 10^fractionalSecondDigits before rounding, which
+        // overflowed Int64 for a date only a few centuries from 1970 at
+        // nanosecond precision — long before the codec's own year-range
+        // check would reject it. `minimumSupportedDate`/`maximumSupportedDate`
+        // are themselves close to the epoch-scaled overflow threshold the
+        // old implementation had, so they are exactly the dates that used
+        // to fail here even though they are otherwise in range.
+        let format = try XLDateTextFormat(fractionalSecondDigits: 9)
+        let codec = XLDateTextCodec.custom(
+            key: XLValueCodecKey(id: "test.date-text.nanoseconds-boundary", version: 1),
+            format: format
+        )
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(codec),
+            defaultCodecKeys: [codec.identity.key]
+        )
+
+        for date in [
+            XLDateTextCodec.minimumSupportedDate,
+            XLDateTextCodec.maximumSupportedDate,
+            Date(timeIntervalSince1970: 0),
+        ] {
+            XCTAssertNoThrow(
+                try configuration.encode(date, using: dialect, context: parameterContext),
+                "\(date)"
+            )
+        }
+    }
+
     func testUnsupportedFractionalSecondDigitsIsRejectedAtFormatConstruction() {
         XCTAssertThrowsError(try XLDateTextFormat(fractionalSecondDigits: 10)) { error in
             XCTAssertEqual(

--- a/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
@@ -231,6 +231,26 @@ final class DateTextCodecContractTests: XCTestCase {
         }
     }
 
+    func testSubMinuteOffsetIsRejectedAtFormatConstruction() {
+        // The encoded `±HH:MM` suffix can only express minute granularity;
+        // a sub-minute offset would compute wall-clock fields with a shift
+        // the rendered suffix cannot represent.
+        XCTAssertThrowsError(try XLDateTextFormat(utcOffsetSeconds: 1)) { error in
+            XCTAssertEqual(
+                error as? XLDateTextCodecError,
+                .unsupportedOffsetSeconds(1)
+            )
+        }
+        XCTAssertThrowsError(try XLDateTextFormat(utcOffsetSeconds: 3_601)) { error in
+            XCTAssertEqual(
+                error as? XLDateTextCodecError,
+                .unsupportedOffsetSeconds(3_601)
+            )
+        }
+        // A whole-minute offset remains valid.
+        XCTAssertNoThrow(try XLDateTextFormat(utcOffsetSeconds: 60))
+    }
+
     // MARK: - Minimum and maximum supported dates
 
     func testMinimumAndMaximumSupportedDatesRoundTrip() throws {
@@ -325,6 +345,48 @@ final class DateTextCodecContractTests: XCTestCase {
                 XCTAssertEqual(context, resultContext)
             }
         }
+    }
+
+    func testDecodeRejectsTextWhoseFractionalDigitsOrOffsetDoNotMatchTheConfiguredFormat() throws {
+        // A named codec is a deterministic representation: text with a
+        // different fractional-digit count or fixed offset than this
+        // codec's own configured format is format drift, not a value this
+        // codec should silently accept.
+        let configuration = try makeConfiguration(defaultKey: XLDateTextCodec.standardKey)
+
+        for mismatchedText in [
+            "2023-11-14T22:13:20Z",  // standard format expects 3 fractional digits, not 0
+            "2023-11-14T22:13:20.00Z",  // 2 fractional digits, not 3
+            "2023-11-14T22:13:20.000000Z",  // 6 fractional digits, not 3
+            "2023-11-14T22:13:20.000+02:00",  // standard format is UTC-only
+        ] {
+            XCTAssertThrowsError(
+                try configuration.decode(
+                    Date.self,
+                    from: .text(mismatchedText),
+                    using: dialect,
+                    context: resultContext
+                ),
+                mismatchedText
+            ) { error in
+                guard case .decodingFailed? = error as? XLValueCodecError else {
+                    return XCTFail(
+                        "\(mismatchedText): expected a decodingFailed wrapper, received \(error)."
+                    )
+                }
+            }
+        }
+
+        // Explicit `+00:00` is numerically the same offset as `Z`, so it is
+        // accepted even though the standard preset always renders `Z`.
+        XCTAssertNoThrow(
+            try configuration.decode(
+                Date.self,
+                from: .text("2023-11-14T22:13:20.123+00:00"),
+                using: dialect,
+                context: resultContext
+            )
+        )
     }
 
     func testStorageClassMismatchIsReportedBeforeTheCodecClosureRuns() throws {

--- a/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift
@@ -66,7 +66,7 @@ final class DateTextCodecContractTests: XCTestCase {
             using: dialect,
             context: resultContext
         )
-        // Truncated to millisecond precision by the standard preset.
+        // Rounded to millisecond precision by the standard preset.
         XCTAssertEqual(decoded.timeIntervalSince1970, 1_700_000_000.5, accuracy: 0.001)
     }
 

--- a/Tests/SwiftQLCodecIntegrationTests/DateTextCodecGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/DateTextCodecGRDBTests.swift
@@ -424,7 +424,7 @@ final class DateTextCodecGRDBTests: XCTestCase {
             for: driver,
             sql: "INSERT INTO corrupt (moment) VALUES ('not-a-date')"
         )
-        let insertWrongStorage = logicalStatement(
+        let selectWrongStorage = logicalStatement(
             for: driver,
             sql: "SELECT 1700000000"
         )
@@ -460,7 +460,7 @@ final class DateTextCodecGRDBTests: XCTestCase {
         // A storage-class mismatch (INTEGER where the codec declared TEXT) is
         // rejected before the codec's own decode closure ever runs.
         let integerRow = try driver.withReadConnection { connection in
-            try XCTUnwrap(connection.fetchOne(connection.prepare(insertWrongStorage)))
+            try XCTUnwrap(connection.fetchOne(connection.prepare(selectWrongStorage)))
         }
         XCTAssertThrowsError(
             try configuration.decode(

--- a/Tests/SwiftQLCodecIntegrationTests/DateTextCodecGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/DateTextCodecGRDBTests.swift
@@ -1,0 +1,528 @@
+import Foundation
+import GRDB
+import XCTest
+@testable import SwiftQL
+
+
+/// Real SQLite round trips for ``XLDateTextCodec``. Pure encode/decode logic
+/// that needs no database connection lives in `DateTextCodecContractTests.swift`.
+final class DateTextCodecGRDBTests: XCTestCase {
+
+    // MARK: - Standard preset: literal, insert, update, select, NULL, decode
+
+    func testStandardPresetRoundTripsInsertUpdateSelectAndOptionalNullThroughRealSQLite() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(XLDateTextCodec.standard),
+            defaultCodecKeys: [XLDateTextCodec.standardKey]
+        )
+        let dialect = XLSQLiteDialect()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.pool, dialect: dialect)
+        let inserted = Date(timeIntervalSince1970: 1_700_000_000.123)
+        let updated = Date(timeIntervalSince1970: 1_700_000_500.5)
+        let parameterContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(["events", "occurred_at"])
+        )
+
+        let create = logicalStatement(
+            for: driver,
+            sql: """
+                CREATE TABLE events (
+                    id INTEGER PRIMARY KEY,
+                    occurred_at TEXT NOT NULL,
+                    closed_at TEXT
+                )
+                """
+        )
+        let insert = logicalStatement(
+            for: driver,
+            sql: """
+                INSERT INTO events (id, occurred_at, closed_at)
+                VALUES (:id, :occurred_at, :closed_at)
+                """
+        )
+        let update = logicalStatement(
+            for: driver,
+            sql: "UPDATE events SET occurred_at = :occurred_at WHERE id = :id"
+        )
+        let select = logicalStatement(
+            for: driver,
+            sql: "SELECT occurred_at, typeof(occurred_at), closed_at, typeof(closed_at) FROM events WHERE id = :id"
+        )
+
+        let insertedValue = try configuration.encode(
+            inserted,
+            using: dialect,
+            context: parameterContext
+        )
+        let nullValue = try configuration.encodeOptional(
+            Optional<Date>.none,
+            using: dialect,
+            context: parameterContext
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+
+            var insertStatement = try connection.prepare(insert)
+            insertStatement = try connection.bind(.integer(1), to: .named("id"), in: insertStatement)
+            insertStatement = try connection.bind(
+                insertedValue,
+                to: .named("occurred_at"),
+                in: insertStatement
+            )
+            insertStatement = try connection.bind(
+                nullValue,
+                to: .named("closed_at"),
+                in: insertStatement
+            )
+            try connection.execute(insertStatement)
+        }
+
+        let firstRow = try driver.withReadConnection { connection -> [XLSQLiteValue] in
+            var selectStatement = try connection.prepare(select)
+            selectStatement = try connection.bind(.integer(1), to: .named("id"), in: selectStatement)
+            return try XCTUnwrap(connection.fetchOne(selectStatement))
+        }
+        XCTAssertEqual(firstRow[0], .text("2023-11-14T22:13:20.123Z"))
+        XCTAssertEqual(firstRow[1], .text("text"))
+        XCTAssertEqual(firstRow[2], .null)
+        XCTAssertEqual(firstRow[3], .text("null"))
+        // Millisecond-precision text round-trips to millisecond accuracy, not
+        // bit-identically: `Date` itself cannot exactly represent an
+        // arbitrary literal like `1_700_000_000.123` at this magnitude, so
+        // the nearest representable `Double` already differs from the
+        // stored text's exact meaning by a sub-microsecond residual.
+        XCTAssertEqual(
+            try configuration.decode(
+                Date.self,
+                from: firstRow[0],
+                using: dialect,
+                context: XLValueCodingContext(site: .result, path: parameterContext.path)
+            ).timeIntervalSince1970,
+            inserted.timeIntervalSince1970,
+            accuracy: 0.001
+        )
+        let decodedClosedAt: Date? = try configuration.decodeOptional(
+            Date.self,
+            from: firstRow[2],
+            using: dialect,
+            context: XLValueCodingContext(site: .result, path: parameterContext.path)
+        )
+        XCTAssertNil(decodedClosedAt)
+
+        let updatedValue = try configuration.encode(updated, using: dialect, context: parameterContext)
+        try driver.withWriteConnection { connection in
+            var updateStatement = try connection.prepare(update)
+            updateStatement = try connection.bind(.integer(1), to: .named("id"), in: updateStatement)
+            updateStatement = try connection.bind(
+                updatedValue,
+                to: .named("occurred_at"),
+                in: updateStatement
+            )
+            try connection.execute(updateStatement)
+        }
+
+        let updatedRow = try driver.withReadConnection { connection -> [XLSQLiteValue] in
+            var selectStatement = try connection.prepare(select)
+            selectStatement = try connection.bind(.integer(1), to: .named("id"), in: selectStatement)
+            return try XCTUnwrap(connection.fetchOne(selectStatement))
+        }
+        XCTAssertEqual(updatedRow[0], .text("2023-11-14T22:21:40.500Z"))
+        XCTAssertEqual(
+            try configuration.decode(
+                Date.self,
+                from: updatedRow[0],
+                using: dialect,
+                context: XLValueCodingContext(site: .result, path: parameterContext.path)
+            ).timeIntervalSince1970,
+            updated.timeIntervalSince1970,
+            accuracy: 0.001
+        )
+    }
+
+    // MARK: - Standard preset: literal + binding through the request facade
+
+    func testStandardPresetRoundTripsThroughContextualBindingAndTheRequestFacade() throws {
+        let directoryURL = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(XLDateTextCodec.standard),
+            defaultCodecKeys: [XLDateTextCodec.standardKey]
+        )
+        let database = try GRDBDatabase(
+            url: directoryURL.appendingPathComponent("fixture.sqlite"),
+            codingConfiguration: configuration,
+            logger: nil
+        )
+        let cutoff = Date(timeIntervalSince1970: 1_700_000_000)
+        let cutoffParameter = try database.contextualBinding(
+            Date.self,
+            expressedAs: String.self,
+            named: "cutoff"
+        )
+        let request = database.makeRequest(with: sql { _ in Select(cutoffParameter) })
+        let bindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: request.parameterLayout,
+            bindings: [try cutoffParameter.encode(cutoff, in: request.parameterLayout)]
+        ).validatingComplete()
+
+        XCTAssertEqual(try request.fetchOne(bindings: bindings), "2023-11-14T22:13:20.000Z")
+    }
+
+    // MARK: - Ordering
+
+    func testStandardPresetOrdersLexicographicallyLikeChronologicalOrderThroughSQLite() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(XLDateTextCodec.standard),
+            defaultCodecKeys: [XLDateTextCodec.standardKey]
+        )
+        let dialect = XLSQLiteDialect()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.pool, dialect: dialect)
+        let context = XLValueCodingContext(site: .parameter, path: XLValueCodingPath("moments"))
+        let dates = [
+            Date(timeIntervalSince1970: 1_700_000_000.5),
+            Date(timeIntervalSince1970: -1_000_000_000),
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 1_700_000_000.001),
+            Date(timeIntervalSince1970: 253_000_000_000),
+        ]
+
+        let create = logicalStatement(
+            for: driver,
+            sql: "CREATE TABLE moments (moment TEXT NOT NULL)"
+        )
+        let insert = logicalStatement(
+            for: driver,
+            sql: "INSERT INTO moments (moment) VALUES (:moment)"
+        )
+        let selectOrdered = logicalStatement(
+            for: driver,
+            sql: "SELECT moment FROM moments ORDER BY moment ASC"
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+            for date in dates {
+                var statement = try connection.prepare(insert)
+                let value = try configuration.encode(date, using: dialect, context: context)
+                statement = try connection.bind(value, to: .named("moment"), in: statement)
+                try connection.execute(statement)
+            }
+        }
+
+        let orderedRows = try driver.withReadConnection { connection -> [[XLSQLiteValue]] in
+            var rows: [[XLSQLiteValue]] = []
+            try connection.forEachRow(connection.prepare(selectOrdered)) { values in
+                rows.append(values)
+                return .advance
+            }
+            return rows
+        }
+        let orderedTexts: [String] = try orderedRows.map {
+            guard case .text(let text) = $0[0] else {
+                throw XCTSkip("Expected TEXT storage")
+            }
+            return text
+        }
+        let expectedTexts = try dates.sorted().map { date -> String in
+            guard case .text(let text) = try configuration.encode(date, using: dialect, context: context) else {
+                throw XCTSkip("Expected TEXT storage")
+            }
+            return text
+        }
+
+        XCTAssertEqual(orderedTexts, expectedTexts)
+    }
+
+    // MARK: - SQLite date/time function interaction
+
+    func testStandardPresetTextIsDirectlyReadableBySQLiteDateTimeFunctions() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(XLDateTextCodec.standard),
+            defaultCodecKeys: [XLDateTextCodec.standardKey]
+        )
+        let dialect = XLSQLiteDialect()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.pool, dialect: dialect)
+        let context = XLValueCodingContext(site: .parameter, path: XLValueCodingPath("readings"))
+        let date = Date(timeIntervalSince1970: 1_700_000_000.123)
+
+        let create = logicalStatement(
+            for: driver,
+            sql: "CREATE TABLE readings (taken_at TEXT NOT NULL)"
+        )
+        let insert = logicalStatement(
+            for: driver,
+            sql: "INSERT INTO readings (taken_at) VALUES (:taken_at)"
+        )
+        // `date`, `strftime`, and `julianday` all parse the standard preset's
+        // text directly; `>` and `BETWEEN` compare it against SQL date-string
+        // literals without a dialect conversion expression.
+        let select = logicalStatement(
+            for: driver,
+            sql: """
+                SELECT
+                    date(taken_at),
+                    strftime('%Y-%m-%d %H:%M:%f', taken_at),
+                    julianday(taken_at) > julianday('2023-01-01T00:00:00.000Z'),
+                    taken_at > '2023-01-01T00:00:00.000Z',
+                    taken_at BETWEEN '2023-01-01T00:00:00.000Z' AND '2024-01-01T00:00:00.000Z'
+                FROM readings
+                """
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+            var statement = try connection.prepare(insert)
+            let value = try configuration.encode(date, using: dialect, context: context)
+            statement = try connection.bind(value, to: .named("taken_at"), in: statement)
+            try connection.execute(statement)
+        }
+
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(connection.fetchOne(connection.prepare(select)))
+        }
+        XCTAssertEqual(row[0], .text("2023-11-14"))
+        XCTAssertEqual(row[1], .text("2023-11-14 22:13:20.123"))
+        XCTAssertEqual(row[2], .integer(1))
+        XCTAssertEqual(row[3], .integer(1))
+        XCTAssertEqual(row[4], .integer(1))
+    }
+
+    // MARK: - A named custom codec coexists with the standard preset
+
+    func testStandardAndCustomCodecsCoexistForTwoDatePropertiesInOneSchema() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let secondsOnlyFormat = try XLDateTextFormat(fractionalSecondDigits: 0)
+        let secondsOnlyKey = XLValueCodecKey(id: "test.date-text.seconds-only", version: 1)
+        let secondsOnlyCodec = XLDateTextCodec.custom(key: secondsOnlyKey, format: secondsOnlyFormat)
+        let registry = try XLValueCodecRegistry()
+            .registering(XLDateTextCodec.standard)
+            .registering(secondsOnlyCodec)
+        // Both codecs target the same stable Swift value-type identity, so
+        // neither can be a database default at the same time (that would be
+        // a rejected `duplicateDefault`); each property selects explicitly.
+        let configuration = try XLValueCodingConfiguration(registry: registry)
+        let dialect = XLSQLiteDialect()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.pool, dialect: dialect)
+        let startedContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(["sessions", "started_at"])
+        )
+        let completedContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(["sessions", "completed_at"])
+        )
+        let started = Date(timeIntervalSince1970: 1_700_000_000.123)
+        let completed = Date(timeIntervalSince1970: 1_700_000_061)
+
+        let startedValue = try configuration.encode(
+            started,
+            using: dialect,
+            context: startedContext,
+            selection: XLValueCodecSelection(explicitCodecKey: XLDateTextCodec.standardKey)
+        )
+        let completedValue = try configuration.encode(
+            completed,
+            using: dialect,
+            context: completedContext,
+            selection: XLValueCodecSelection(explicitCodecKey: secondsOnlyKey)
+        )
+
+        let create = logicalStatement(
+            for: driver,
+            sql: """
+                CREATE TABLE sessions (
+                    started_at TEXT NOT NULL,
+                    completed_at TEXT NOT NULL
+                )
+                """
+        )
+        let insert = logicalStatement(
+            for: driver,
+            sql: "INSERT INTO sessions (started_at, completed_at) VALUES (:started_at, :completed_at)"
+        )
+        let select = logicalStatement(
+            for: driver,
+            sql: "SELECT started_at, completed_at FROM sessions"
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+            var statement = try connection.prepare(insert)
+            statement = try connection.bind(startedValue, to: .named("started_at"), in: statement)
+            statement = try connection.bind(completedValue, to: .named("completed_at"), in: statement)
+            try connection.execute(statement)
+        }
+
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(connection.fetchOne(connection.prepare(select)))
+        }
+        XCTAssertEqual(row[0], .text("2023-11-14T22:13:20.123Z"))
+        XCTAssertEqual(row[1], .text("2023-11-14T22:14:21Z"))
+
+        // Millisecond precision round-trips to millisecond accuracy (see the
+        // comment in the insert/update/select test above for why exact
+        // `Date` equality is not the right assertion here).
+        XCTAssertEqual(
+            try configuration.decode(
+                Date.self,
+                from: row[0],
+                using: dialect,
+                context: XLValueCodingContext(site: .result, path: startedContext.path),
+                selection: XLValueCodecSelection(explicitCodecKey: XLDateTextCodec.standardKey)
+            ).timeIntervalSince1970,
+            started.timeIntervalSince1970,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            try configuration.decode(
+                Date.self,
+                from: row[1],
+                using: dialect,
+                context: XLValueCodingContext(site: .result, path: completedContext.path),
+                selection: XLValueCodecSelection(explicitCodecKey: secondsOnlyKey)
+            ),
+            completed
+        )
+    }
+
+    // MARK: - Structured errors carry codec and property context
+
+    func testInvalidStoredTextFailsToDecodeWithCodecAndPropertyContext() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try XLValueCodingConfiguration(
+            registry: try XLValueCodecRegistry().registering(XLDateTextCodec.standard),
+            defaultCodecKeys: [XLDateTextCodec.standardKey]
+        )
+        let dialect = XLSQLiteDialect()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.pool, dialect: dialect)
+        let resultContext = XLValueCodingContext(
+            site: .result,
+            path: XLValueCodingPath(["corrupt", "when"])
+        )
+
+        let create = logicalStatement(
+            for: driver,
+            sql: "CREATE TABLE corrupt (moment TEXT NOT NULL)"
+        )
+        let insertGarbage = logicalStatement(
+            for: driver,
+            sql: "INSERT INTO corrupt (moment) VALUES ('not-a-date')"
+        )
+        let insertWrongStorage = logicalStatement(
+            for: driver,
+            sql: "SELECT 1700000000"
+        )
+        let select = logicalStatement(
+            for: driver,
+            sql: "SELECT moment FROM corrupt"
+        )
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(connection.prepare(create))
+            try connection.execute(connection.prepare(insertGarbage))
+        }
+        let storedRow = try driver.withReadConnection { connection in
+            try XCTUnwrap(connection.fetchOne(connection.prepare(select)))
+        }
+
+        XCTAssertThrowsError(
+            try configuration.decode(
+                Date.self,
+                from: storedRow[0],
+                using: dialect,
+                context: resultContext
+            )
+        ) { error in
+            guard case .decodingFailed(let codec, let context, let message)? = error as? XLValueCodecError else {
+                return XCTFail("Expected decodingFailed, received \(error).")
+            }
+            XCTAssertEqual(codec, XLDateTextCodec.standardKey)
+            XCTAssertEqual(context, resultContext)
+            XCTAssertTrue(message.contains("not-a-date"), message)
+        }
+
+        // A storage-class mismatch (INTEGER where the codec declared TEXT) is
+        // rejected before the codec's own decode closure ever runs.
+        let integerRow = try driver.withReadConnection { connection in
+            try XCTUnwrap(connection.fetchOne(connection.prepare(insertWrongStorage)))
+        }
+        XCTAssertThrowsError(
+            try configuration.decode(
+                Date.self,
+                from: integerRow[0],
+                using: dialect,
+                context: resultContext
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? XLValueCodecError,
+                .storageMismatch(
+                    codec: XLDateTextCodec.standardKey,
+                    expected: XLValueStorageIdentifier(rawValue: XLSQLiteStorageClass.text.rawValue),
+                    actual: XLValueStorageIdentifier(rawValue: XLSQLiteStorageClass.integer.rawValue),
+                    context: resultContext
+                )
+            )
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func logicalStatement(
+        for driver: GRDBDatabaseDriver,
+        sql: String
+    ) -> XLLogicalPreparedStatement {
+        XLLogicalPreparedStatement(
+            databaseIdentifier: driver.databaseIdentifier,
+            dialectRequirement: XLDialectRequirement(identity: XLSQLiteDialect.identity),
+            sql: sql
+        )
+    }
+
+    private func makeFixture() throws -> DateTextCodecFixture {
+        let directoryURL = try makeDirectory()
+        return DateTextCodecFixture(
+            directoryURL: directoryURL,
+            pool: try DatabasePool(
+                path: directoryURL.appendingPathComponent("database.sqlite").path
+            )
+        )
+    }
+
+    private func makeDirectory() throws -> URL {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftql-date-text-codec-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: false
+        )
+        return directoryURL
+    }
+}
+
+
+private struct DateTextCodecFixture {
+    let directoryURL: URL
+    let pool: DatabasePool
+
+    func tearDown() {
+        try? pool.close()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+}


### PR DESCRIPTION
Closes #61

## Summary

- Adds `XLDateTextCodec` / `XLDateTextFormat` (`Sources/SwiftQL/Codecs/`), built entirely on the immutable contextual value-codec registry from #188 — no changes to `ValueCodec.swift` or `GRDBSQLDatabase.swift` were needed.
  - `XLDateTextCodec.standard`: a versioned, SQLite-compatible preset — fixed proleptic-Gregorian calendar, UTC offset, millisecond fractional precision, `Z`-suffixed `YYYY-MM-DDTHH:MM:SS.SSSZ` text. Directly parseable by SQLite's `date`/`time`/`datetime`/`julianday`/`strftime` and comparable with `<`/`BETWEEN`/`ORDER BY` without a dialect conversion expression.
  - `XLDateTextCodec.custom(key:format:)`: builds a named codec from an explicit, immutable `XLDateTextFormat` (fractional-second digit count, fixed UTC offset in seconds, `Z`-vs-`+00:00` rendering) for applications that need a different fixed offset or precision without inventing their own encode/decode closures.
  - No process-global or shared mutable `DateFormatter`; no locale/calendar/timezone-dependent default (offsets are fixed seconds, not named `TimeZone` identifiers, so there's no DST ambiguity).
- Encoding rounds `Date`'s `Double`-backed seconds to the configured precision using exact `Int64` tick arithmetic (with carry into the next second), rather than truncating a floating-point nanosecond component or flooring to a whole second. This matters because `Date`'s `Double` representation of an "obvious" literal like `1_700_000_000.123` already differs from it by a few hundred nanoseconds at that magnitude — truncating would silently read back one tick short.
- The standard preset's proleptic-Gregorian year range is `0001`...`9999` (`XLDateTextCodec.minimumSupportedDate` / `.maximumSupportedDate`); dates outside it fail to encode with a structured error instead of being silently clamped. (This needed an explicit BC/AD era check — `Calendar`'s bare `.year` component is ambiguous at the year-1 boundary.)
- DocC: new "Standard SQLite Date TEXT codec" section in `CustomTypes.md`, with runnable examples wired into the existing `testDocumentationCustomTypeRoundTrips` doctest (`Tests/SQLTests/SQLExampleTests.swift`).

## Tests

- `Tests/SwiftQLCodecIntegrationTests/DateTextCodecContractTests.swift` — pure encode/decode contract tests, no database: canonical bytes, rounding/carry behavior, fixed offsets (positive/negative/no-`Z`), fractional precision `0...9`, min/max supported dates and out-of-range rejection, lexicographic-matches-chronological ordering, invalid text / storage-mismatch / null-handling errors, two codecs coexisting via explicit selection.
- `Tests/SwiftQLCodecIntegrationTests/DateTextCodecGRDBTests.swift` — real GRDB/SQLite round trips: insert/update/select/NULL through the low-level driver, literal+binding through the `contextualBinding`/request facade, `ORDER BY`-verified ordering, SQLite date/time-function and comparison-operator interaction (`date()`, `strftime()`, `julianday()`, `>`, `BETWEEN`), a standard + a custom named codec coexisting for two `Date` properties in one schema, and structured invalid-text/storage-mismatch errors carrying codec + property context.

## Evidence / validation

- `swift build` (whole package): 0 warnings, 0 errors.
- `swift build --build-tests -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency`: 0 warnings, 0 errors (complete strict-concurrency checking).
- `swift test` (whole package): 963 tests, 0 failures.
- `swift test --filter DateTextCodec`: 24/24 new tests passing.
- `swift test --filter testDocumentationCustomTypeRoundTrips` and `--filter SQLDocumentationCatalogTests`: passing (doctest catalog bookkeeping intact).

## Scope notes

- Property/result/parameter-level codec *selection* (issue #66) is not available yet, per the issue's own scope note — this PR uses only database/query-level `defaultCodecKeys` plus explicit `XLValueCodecSelection`, matching the pattern already used for the `decimalDateCodec`/`integerDateCodec` example in `CustomTypes.md`.
- No SQL-level `julianday`/`strftime` expression-builder helper is added — value coding stays separate from SQL date/time operators, which are owned by other issues (#63/#64); this is documented explicitly in `XLDateTextCodec`'s doc comment and in `CustomTypes.md`.
