### PR TITLE
Add SQLite numeric Date codec presets (#62)

### DIFF
--- a/Sources/SwiftQL/SQLiteNumericDateCodecs.swift
+++ b/Sources/SwiftQL/SQLiteNumericDateCodecs.swift
@@ -18,10 +18,13 @@ public enum XLSQLiteNumericDateCodecError: Error, Equatable, Sendable, Localized
     /// never truncates or wraps a value that does not fit.
     case millisecondsOutOfRange(preset: String, timeIntervalSince1970: Double)
 
-    /// A stored `REAL` value was NaN or infinite when decoding. SQLite
-    /// bindings normalize a NaN parameter to SQL `NULL`, but a computed SQL
-    /// expression (for example, an overflowing multiplication) can still
-    /// produce a stored non-finite `REAL`.
+    /// A stored `REAL` value was NaN or infinite when decoding, or a finite
+    /// stored value produced a non-finite result once the preset converted
+    /// it back to unix seconds (for example, ``XLSQLiteNumericDateCodec/JulianDay``
+    /// decoding a very large but finite julian-day number). SQLite bindings
+    /// normalize a NaN parameter to SQL `NULL`, but a computed SQL expression
+    /// (for example, an overflowing multiplication) can still produce a
+    /// stored non-finite `REAL`.
     case nonFiniteStoredValue(preset: String, value: XLNonFiniteRealValue)
 
     public var errorDescription: String? {
@@ -243,8 +246,14 @@ public enum XLSQLiteNumericDateCodec {
     ///   ``UnixSeconds`` for the same input, on the order of microseconds
     ///   near the present day. It matches the numeric convention `julianday()`
     ///   already uses, which is the point of choosing it.
-    /// - Range: any finite `Double` seconds value is representable; there is
-    ///   no overflow case for this preset.
+    /// - Range: encoding accepts any finite `Double` seconds value (the
+    ///   corresponding julian-day number never overflows a `Double`).
+    ///   Decoding is narrower: converting a stored julian-day number back to
+    ///   unix seconds multiplies by 86,400, so a stored value large enough to
+    ///   overflow that multiplication throws
+    ///   ``XLSQLiteNumericDateCodecError/nonFiniteStoredValue(preset:value:)``
+    ///   rather than returning a `Date` backed by a non-finite time interval.
+    ///   This bound is far outside any date a real application would store.
     /// - Ordering: numeric `REAL` ordering matches chronological ordering.
     ///   Julian day numbers for real-world dates stay positive; only dates
     ///   before -4713-11-24 would produce a negative value.
@@ -314,6 +323,16 @@ public enum XLSQLiteNumericDateCodec {
                     )
                 }
                 let seconds = (julianDay - unixEpochJulianDay) * secondsPerDay
+                // The stored julian-day REAL was finite, but converting a
+                // sufficiently large finite value back to unix seconds can
+                // still overflow to infinity. Fail structurally instead of
+                // returning a Date backed by a non-finite time interval.
+                if let nonFinite = XLNonFiniteRealValue(seconds) {
+                    throw XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                        preset: key.id,
+                        value: nonFinite
+                    )
+                }
                 return Date(timeIntervalSince1970: seconds)
             }
         )

--- a/Sources/SwiftQL/SQLiteNumericDateCodecs.swift
+++ b/Sources/SwiftQL/SQLiteNumericDateCodecs.swift
@@ -1,0 +1,341 @@
+import Foundation
+
+
+/// Structured failures from SwiftQL's numeric SQLite `Date` codec presets.
+///
+/// These are distinct from ``XLValueCodecError``: they describe why one of
+/// this file's encode or decode closures could not produce a value, before
+/// that closure's throw is wrapped as `XLValueCodecError.encodingFailed` or
+/// `.decodingFailed` with the active codec key and coding context.
+public enum XLSQLiteNumericDateCodecError: Error, Equatable, Sendable, LocalizedError {
+
+    /// `Date.timeIntervalSince1970` was NaN or infinite. SQLite has no exact
+    /// numeric representation for a non-finite value, and silently storing
+    /// `NULL` or a saturated number would change the caller's value.
+    case nonFiniteDate(preset: String, value: XLNonFiniteRealValue)
+
+    /// The millisecond count overflowed `Int64` after rounding. This preset
+    /// never truncates or wraps a value that does not fit.
+    case millisecondsOutOfRange(preset: String, timeIntervalSince1970: Double)
+
+    /// A stored `REAL` value was NaN or infinite when decoding. SQLite binds
+    /// normalize a NaN parameter to SQL `NULL`, but a computed SQL expression
+    /// (for example, an overflowing multiplication) can still produce a
+    /// stored non-finite `REAL`.
+    case nonFiniteStoredValue(preset: String, value: XLNonFiniteRealValue)
+
+    public var errorDescription: String? {
+        switch self {
+        case .nonFiniteDate(let preset, let value):
+            return "Cannot encode a \(value) Date as \(preset): SQLite has no exact numeric representation for a non-finite value."
+        case .millisecondsOutOfRange(let preset, let timeIntervalSince1970):
+            return "Cannot encode Date(timeIntervalSince1970: \(timeIntervalSince1970)) as \(preset): the millisecond count overflows Int64."
+        case .nonFiniteStoredValue(let preset, let value):
+            return "Cannot decode \(preset): the stored REAL is \(value), which is not a finite Date."
+        }
+    }
+}
+
+
+/// Named, versioned SQLite `NUMERIC` storage presets for Foundation `Date`.
+///
+/// Each preset is a self-contained ``XLValueCodec`` targeting ``XLSQLiteDialect``.
+/// None is installed as an implicit default: register the presets an
+/// application actually uses with ``XLValueCodecRegistry/registering(_:)``,
+/// then select one explicitly, either as a database/query default via
+/// `XLValueCodingConfiguration.defaultCodecKeys` or per parameter/result site
+/// via `XLValueCodecSelection`/`XLQueryCodecSelection`. There is no
+/// property-level codec selection yet (tracked separately); this file only
+/// supports database- and query-level selection.
+///
+/// Unix seconds, Unix milliseconds, and Julian day are three different
+/// numbers for the same instant. Treat a change from one preset to another,
+/// on a column that already has rows, as a data migration: rewrite the
+/// existing values, don't just swap the codec.
+///
+/// Companion issue #61 defines a text (`ISO-8601`) SQLite `Date` preset. See
+/// <doc:NumericDateCodecs> for a side-by-side comparison and migration notes.
+public enum XLSQLiteNumericDateCodec {
+
+    /// The stable Swift-value identity shared by every preset in this file.
+    /// It does not participate in codec selection or ambiguity grouping
+    /// (that is keyed by the Swift `Date` and `XLSQLiteDialect` types); it is
+    /// retained metadata describing what the persisted number means.
+    public static let valueTypeIdentifier = XLValueTypeIdentifier(
+        rawValue: "com.swiftql.date.numeric"
+    )
+
+    /// `Date` stored as a SQLite `INTEGER` count of milliseconds since the
+    /// Unix epoch (1970-01-01T00:00:00Z), rounded to the nearest millisecond
+    /// (round-half-away-from-zero).
+    ///
+    /// - Storage class: `INTEGER`.
+    /// - Epoch: 1970-01-01T00:00:00Z, i.e. `Date(timeIntervalSince1970: 0)` encodes to `0`.
+    /// - Unit: milliseconds.
+    /// - Rounding: sub-millisecond fractions of a second round to the nearest
+    ///   millisecond; the maximum round-trip error introduced by this preset
+    ///   alone is 0.5 ms.
+    /// - Precision loss: any precision finer than one millisecond is
+    ///   discarded. `Date` itself is backed by a `Double` of seconds, so
+    ///   total round-trip error also includes `Double`'s own representation
+    ///   error for the input `Date`.
+    /// - Range: encoding throws
+    ///   ``XLSQLiteNumericDateCodecError/millisecondsOutOfRange(preset:timeIntervalSince1970:)``
+    ///   if the rounded millisecond count does not fit in `Int64`
+    ///   (approximately ±292,471,208 years from the epoch); this is far
+    ///   outside any date `Foundation` treats as meaningful.
+    /// - Ordering: numeric `INTEGER` ordering matches chronological ordering,
+    ///   including negative values for dates before the epoch.
+    /// - Indexing: a standard SQLite index on this column sorts correctly
+    ///   with no zero-padding or fixed-width formatting required, unlike a
+    ///   text preset.
+    /// - Non-finite input: encoding a `Date` whose `timeIntervalSince1970` is
+    ///   NaN or infinite throws
+    ///   ``XLSQLiteNumericDateCodecError/nonFiniteDate(preset:value:)``.
+    /// - Storage-class coercion: decoding a value SQLite did not store as
+    ///   `INTEGER` (for example, because the destination column's declared
+    ///   type affinity let a `REAL` or `TEXT` value through) throws
+    ///   `XLValueCodecError.storageMismatch` before this preset's decode
+    ///   closure runs. Declare the destination column `INTEGER` to avoid
+    ///   affinity-driven coercion.
+    public enum UnixMilliseconds {
+
+        public static let key = XLValueCodecKey(
+            id: "com.swiftql.date.unix-milliseconds",
+            version: 1
+        )
+
+        public static let storageIdentifier = XLValueStorageIdentifier(
+            rawValue: XLSQLiteStorageClass.integer.rawValue
+        )
+
+        public static let codec: XLValueCodec<Date, XLSQLiteDialect> = XLValueCodec(
+            key: key,
+            valueTypeIdentifier: XLSQLiteNumericDateCodec.valueTypeIdentifier,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: storageIdentifier,
+            encode: { date, _, _ in
+                let seconds = date.timeIntervalSince1970
+                guard let nonFinite = XLNonFiniteRealValue(seconds) else {
+                    let roundedMilliseconds = (seconds * 1000)
+                        .rounded(.toNearestOrAwayFromZero)
+                    guard let milliseconds = Int64(exactly: roundedMilliseconds) else {
+                        throw XLSQLiteNumericDateCodecError.millisecondsOutOfRange(
+                            preset: key.id,
+                            timeIntervalSince1970: seconds
+                        )
+                    }
+                    return .integer(milliseconds)
+                }
+                throw XLSQLiteNumericDateCodecError.nonFiniteDate(
+                    preset: key.id,
+                    value: nonFinite
+                )
+            },
+            decode: { value, _, _ in
+                guard case .integer(let milliseconds) = value else {
+                    // Unreachable: `XLValueCodec.decode` already validated the
+                    // storage class matches `storageIdentifier` before this
+                    // closure runs.
+                    throw XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                        preset: key.id,
+                        value: .notANumber
+                    )
+                }
+                return Date(timeIntervalSince1970: TimeInterval(milliseconds) / 1000)
+            }
+        )
+    }
+
+    /// `Date` stored as a SQLite `REAL` count of seconds since the Unix epoch
+    /// (1970-01-01T00:00:00Z) — the same value `Date.timeIntervalSince1970`
+    /// returns.
+    ///
+    /// - Storage class: `REAL`.
+    /// - Epoch: 1970-01-01T00:00:00Z, i.e. `Date(timeIntervalSince1970: 0)` encodes to `0.0`.
+    /// - Unit: seconds, with the full fractional (subsecond) precision a
+    ///   `Double` carries.
+    /// - Rounding: none. The `Double` seconds value is stored as-is.
+    /// - Precision loss: SQLite's `REAL` is an IEEE 754 double, the same
+    ///   representation `Date` uses internally, so this preset introduces no
+    ///   additional loss beyond `Double`'s own ~15-17 significant decimal
+    ///   digits; round-trip error is at the unit-in-the-last-place level and
+    ///   grows slowly as magnitude grows further from the epoch.
+    /// - Range: any finite `Double` seconds value is representable; there is
+    ///   no overflow case for this preset.
+    /// - Ordering: numeric `REAL` ordering matches chronological ordering,
+    ///   including negative values for dates before the epoch.
+    /// - Indexing: a standard SQLite index on this column sorts correctly
+    ///   with no zero-padding or fixed-width formatting required, unlike a
+    ///   text preset.
+    /// - Non-finite input: encoding a `Date` whose `timeIntervalSince1970` is
+    ///   NaN or infinite throws
+    ///   ``XLSQLiteNumericDateCodecError/nonFiniteDate(preset:value:)``. This
+    ///   also protects against SQLite's own binding behavior, which would
+    ///   otherwise normalize a bound NaN to SQL `NULL`.
+    /// - Storage-class coercion: decoding a value SQLite did not store as
+    ///   `REAL` throws `XLValueCodecError.storageMismatch` before this
+    ///   preset's decode closure runs. Declare the destination column `REAL`
+    ///   to avoid affinity-driven coercion (an `INTEGER`-affinity column can
+    ///   silently store a whole-number `REAL` as `INTEGER`).
+    public enum UnixSeconds {
+
+        public static let key = XLValueCodecKey(
+            id: "com.swiftql.date.unix-seconds",
+            version: 1
+        )
+
+        public static let storageIdentifier = XLValueStorageIdentifier(
+            rawValue: XLSQLiteStorageClass.real.rawValue
+        )
+
+        public static let codec: XLValueCodec<Date, XLSQLiteDialect> = XLValueCodec(
+            key: key,
+            valueTypeIdentifier: XLSQLiteNumericDateCodec.valueTypeIdentifier,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: storageIdentifier,
+            encode: { date, _, _ in
+                let seconds = date.timeIntervalSince1970
+                if let nonFinite = XLNonFiniteRealValue(seconds) {
+                    throw XLSQLiteNumericDateCodecError.nonFiniteDate(
+                        preset: key.id,
+                        value: nonFinite
+                    )
+                }
+                return .real(seconds)
+            },
+            decode: { value, _, _ in
+                guard case .real(let seconds) = value else {
+                    // Unreachable: storage class is validated before this
+                    // closure runs.
+                    throw XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                        preset: key.id,
+                        value: .notANumber
+                    )
+                }
+                if let nonFinite = XLNonFiniteRealValue(seconds) {
+                    throw XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                        preset: key.id,
+                        value: nonFinite
+                    )
+                }
+                return Date(timeIntervalSince1970: seconds)
+            }
+        )
+    }
+
+    /// `Date` stored as a SQLite `REAL` Julian day number, using the same
+    /// linear relationship SQLite's own `julianday()` function uses:
+    /// `julianDay = unixSeconds / 86400.0 + 2440587.5`.
+    ///
+    /// - Storage class: `REAL`.
+    /// - Epoch: the Julian day count itself is astronomical (day 0 is
+    ///   -4713-11-24T12:00:00Z, proleptic Gregorian); `2440587.5` is the
+    ///   Julian day number of the Unix epoch, so
+    ///   `Date(timeIntervalSince1970: 0)` encodes to `2440587.5`.
+    /// - Unit: days, with a fractional part for the time of day.
+    /// - Rounding: none. The computed `Double` is stored as-is.
+    /// - Precision loss: adding the `2440587.5` day offset consumes several
+    ///   bits of the `Double` mantissa that would otherwise represent
+    ///   sub-day precision, so this preset loses more precision than
+    ///   ``UnixSeconds`` for the same input, on the order of microseconds
+    ///   near the present day. It matches the numeric convention `julianday()`
+    ///   already uses, which is the point of choosing it.
+    /// - Range: any finite `Double` seconds value is representable; there is
+    ///   no overflow case for this preset.
+    /// - Ordering: numeric `REAL` ordering matches chronological ordering.
+    ///   Julian day numbers for real-world dates stay positive; only dates
+    ///   before -4713-11-24 would produce a negative value.
+    /// - Indexing: a standard SQLite index on this column sorts correctly
+    ///   with no zero-padding or fixed-width formatting required, unlike a
+    ///   text preset.
+    /// - Non-finite input: encoding a `Date` whose `timeIntervalSince1970` is
+    ///   NaN or infinite throws
+    ///   ``XLSQLiteNumericDateCodecError/nonFiniteDate(preset:value:)``.
+    /// - Storage-class coercion: decoding a value SQLite did not store as
+    ///   `REAL` throws `XLValueCodecError.storageMismatch` before this
+    ///   preset's decode closure runs.
+    public enum JulianDay {
+
+        /// The Julian day number of the Unix epoch (1970-01-01T00:00:00Z).
+        public static let unixEpochJulianDay: Double = 2_440_587.5
+
+        /// The number of seconds in one day, used to convert between Unix
+        /// seconds and a fractional Julian day count.
+        public static let secondsPerDay: Double = 86_400
+
+        public static let key = XLValueCodecKey(
+            id: "com.swiftql.date.julian-day",
+            version: 1
+        )
+
+        public static let storageIdentifier = XLValueStorageIdentifier(
+            rawValue: XLSQLiteStorageClass.real.rawValue
+        )
+
+        public static let codec: XLValueCodec<Date, XLSQLiteDialect> = XLValueCodec(
+            key: key,
+            valueTypeIdentifier: XLSQLiteNumericDateCodec.valueTypeIdentifier,
+            dialectIdentifier: XLSQLiteDialect.identity,
+            storageIdentifier: storageIdentifier,
+            encode: { date, _, _ in
+                let seconds = date.timeIntervalSince1970
+                if let nonFinite = XLNonFiniteRealValue(seconds) {
+                    throw XLSQLiteNumericDateCodecError.nonFiniteDate(
+                        preset: key.id,
+                        value: nonFinite
+                    )
+                }
+                let julianDay = seconds / secondsPerDay + unixEpochJulianDay
+                if let nonFinite = XLNonFiniteRealValue(julianDay) {
+                    throw XLSQLiteNumericDateCodecError.nonFiniteDate(
+                        preset: key.id,
+                        value: nonFinite
+                    )
+                }
+                return .real(julianDay)
+            },
+            decode: { value, _, _ in
+                guard case .real(let julianDay) = value else {
+                    // Unreachable: storage class is validated before this
+                    // closure runs.
+                    throw XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                        preset: key.id,
+                        value: .notANumber
+                    )
+                }
+                if let nonFinite = XLNonFiniteRealValue(julianDay) {
+                    throw XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                        preset: key.id,
+                        value: nonFinite
+                    )
+                }
+                let seconds = (julianDay - unixEpochJulianDay) * secondsPerDay
+                return Date(timeIntervalSince1970: seconds)
+            }
+        )
+    }
+}
+
+
+extension XLValueCodecRegistry {
+
+    /// Registers every numeric SQLite `Date` preset defined by
+    /// ``XLSQLiteNumericDateCodec``: ``XLSQLiteNumericDateCodec/UnixMilliseconds``,
+    /// ``XLSQLiteNumericDateCodec/UnixSeconds``, and
+    /// ``XLSQLiteNumericDateCodec/JulianDay``.
+    ///
+    /// This is a convenience for applications that want every preset
+    /// available for explicit per-database, per-query, or per-parameter
+    /// selection. It never adds a default: none of these presets becomes the
+    /// implicit codec for `Date` just by being registered. Pass one preset's
+    /// key in `defaultCodecKeys`, or select a preset explicitly with
+    /// `XLValueCodecSelection`/`XLQueryCodecSelection`, before encoding or
+    /// decoding a `Date` without an explicit selector.
+    public func registeringSQLiteNumericDateCodecs() throws -> Self {
+        try self
+            .registering(XLSQLiteNumericDateCodec.UnixMilliseconds.codec)
+            .registering(XLSQLiteNumericDateCodec.UnixSeconds.codec)
+            .registering(XLSQLiteNumericDateCodec.JulianDay.codec)
+    }
+}

--- a/Sources/SwiftQL/SQLiteNumericDateCodecs.swift
+++ b/Sources/SwiftQL/SQLiteNumericDateCodecs.swift
@@ -34,7 +34,7 @@ public enum XLSQLiteNumericDateCodecError: Error, Equatable, Sendable, Localized
         case .millisecondsOutOfRange(let preset, let timeIntervalSince1970):
             return "Cannot encode Date(timeIntervalSince1970: \(timeIntervalSince1970)) as \(preset): the millisecond count overflows Int64."
         case .nonFiniteStoredValue(let preset, let value):
-            return "Cannot decode \(preset): the stored REAL is \(value), which is not a finite Date."
+            return "Cannot decode \(preset): decoding produced \(value), which is not a finite Date. Either the stored REAL itself is \(value), or a finite stored REAL became \(value) once this preset converted it to unix seconds."
         }
     }
 }

--- a/Sources/SwiftQL/SQLiteNumericDateCodecs.swift
+++ b/Sources/SwiftQL/SQLiteNumericDateCodecs.swift
@@ -18,10 +18,10 @@ public enum XLSQLiteNumericDateCodecError: Error, Equatable, Sendable, Localized
     /// never truncates or wraps a value that does not fit.
     case millisecondsOutOfRange(preset: String, timeIntervalSince1970: Double)
 
-    /// A stored `REAL` value was NaN or infinite when decoding. SQLite binds
-    /// normalize a NaN parameter to SQL `NULL`, but a computed SQL expression
-    /// (for example, an overflowing multiplication) can still produce a
-    /// stored non-finite `REAL`.
+    /// A stored `REAL` value was NaN or infinite when decoding. SQLite
+    /// bindings normalize a NaN parameter to SQL `NULL`, but a computed SQL
+    /// expression (for example, an overflowing multiplication) can still
+    /// produce a stored non-finite `REAL`.
     case nonFiniteStoredValue(preset: String, value: XLNonFiniteRealValue)
 
     public var errorDescription: String? {
@@ -136,10 +136,11 @@ public enum XLSQLiteNumericDateCodec {
                 guard case .integer(let milliseconds) = value else {
                     // Unreachable: `XLValueCodec.decode` already validated the
                     // storage class matches `storageIdentifier` before this
-                    // closure runs.
-                    throw XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
-                        preset: key.id,
-                        value: .notANumber
+                    // closure runs. A domain error here would misrepresent
+                    // what actually happened, so fail loudly on the broken
+                    // invariant instead.
+                    preconditionFailure(
+                        "\(key) decode received a non-integer value after storage validation."
                     )
                 }
                 return Date(timeIntervalSince1970: TimeInterval(milliseconds) / 1000)
@@ -207,10 +208,11 @@ public enum XLSQLiteNumericDateCodec {
             decode: { value, _, _ in
                 guard case .real(let seconds) = value else {
                     // Unreachable: storage class is validated before this
-                    // closure runs.
-                    throw XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
-                        preset: key.id,
-                        value: .notANumber
+                    // closure runs. A domain error here would misrepresent
+                    // what actually happened, so fail loudly on the broken
+                    // invariant instead.
+                    preconditionFailure(
+                        "\(key) decode received a non-real value after storage validation."
                     )
                 }
                 if let nonFinite = XLNonFiniteRealValue(seconds) {
@@ -298,10 +300,11 @@ public enum XLSQLiteNumericDateCodec {
             decode: { value, _, _ in
                 guard case .real(let julianDay) = value else {
                     // Unreachable: storage class is validated before this
-                    // closure runs.
-                    throw XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
-                        preset: key.id,
-                        value: .notANumber
+                    // closure runs. A domain error here would misrepresent
+                    // what actually happened, so fail loudly on the broken
+                    // invariant instead.
+                    preconditionFailure(
+                        "\(key) decode received a non-real value after storage validation."
                     )
                 }
                 if let nonFinite = XLNonFiniteRealValue(julianDay) {

--- a/Sources/SwiftQL/SwiftQL.docc/NumericDateCodecs.md
+++ b/Sources/SwiftQL/SwiftQL.docc/NumericDateCodecs.md
@@ -1,0 +1,231 @@
+# Numeric Date Codecs
+
+Store Foundation `Date` values as SQLite `INTEGER` or `REAL` numbers.
+
+## Overview
+
+<doc:CustomTypes> introduces the v1.2 contextual value-codec API with a small,
+doc-only `Date` example. This article documents three named, versioned,
+production `Date` presets that SwiftQL ships for `XLSQLiteDialect`, all
+defined in `XLSQLiteNumericDateCodec`:
+
+- ``XLSQLiteNumericDateCodec/UnixMilliseconds``: `INTEGER` milliseconds since
+  the Unix epoch.
+- ``XLSQLiteNumericDateCodec/UnixSeconds``: `REAL` seconds since the Unix
+  epoch (the same value `Date.timeIntervalSince1970` returns).
+- ``XLSQLiteNumericDateCodec/JulianDay``: `REAL` Julian day number, using the
+  same linear relationship SQLite's own `julianday()` function uses.
+
+None of the three is installed as an implicit default. Property-level codec
+selection (choosing a codec per table column without repeating a selector at
+every call site) is tracked separately and is not available yet; select a
+preset at the database level (`defaultCodecKeys`) or explicitly per parameter
+and result site with `XLValueCodecSelection`.
+
+A companion preset for storing `Date` as SQLite `TEXT` (ISO-8601) is tracked
+separately. See <doc:CustomTypes> for the general contextual-codec API this
+article builds on.
+
+## Choose a preset
+
+Unix seconds, Unix milliseconds, and Julian day are three different numbers
+for the same instant. Register only the presets an application actually uses,
+and treat switching a column from one preset to another as a data migration,
+not a configuration change:
+
+<!-- test: XLDocumentationTests.testDocumentationNumericDateCodecs -->
+```swift
+import Foundation
+import SwiftQL
+
+let numericDateRegistry = try XLValueCodecRegistry()
+    .registeringSQLiteNumericDateCodecs()
+let numericDateCoding = try XLValueCodingConfiguration(
+    registry: numericDateRegistry
+)
+```
+
+`registeringSQLiteNumericDateCodecs()` registers all three presets without
+picking a default, so encoding or decoding a `Date` still requires an
+explicit selector:
+
+<!-- test: XLDocumentationTests.testDocumentationNumericDateCodecs -->
+```swift
+let numericDialect = XLSQLiteDialect()
+let numericDateContext = XLValueCodingContext(
+    site: .parameter,
+    path: XLValueCodingPath("event.loggedAt")
+)
+
+do {
+    _ = try numericDateCoding.encode(
+        Date(timeIntervalSince1970: 0),
+        using: numericDialect,
+        context: numericDateContext
+    )
+} catch let error as XLValueCodecError {
+    // .ambiguousCodec: three registered presets, no default, no selector.
+    print(error)
+}
+```
+
+Select one preset explicitly, either per call:
+
+<!-- test: XLDocumentationTests.testDocumentationNumericDateCodecs -->
+```swift
+let loggedAt = Date(timeIntervalSince1970: 1_700_000_000.25)
+
+let millisecondsValue = try numericDateCoding.encode(
+    loggedAt,
+    using: numericDialect,
+    context: numericDateContext,
+    selection: XLValueCodecSelection(
+        explicitCodecKey: XLSQLiteNumericDateCodec.UnixMilliseconds.key
+    )
+)
+// .integer(1_700_000_000_250)
+
+let secondsValue = try numericDateCoding.encode(
+    loggedAt,
+    using: numericDialect,
+    context: numericDateContext,
+    selection: XLValueCodecSelection(
+        explicitCodecKey: XLSQLiteNumericDateCodec.UnixSeconds.key
+    )
+)
+// .real(1_700_000_000.25)
+
+let julianDayValue = try numericDateCoding.encode(
+    loggedAt,
+    using: numericDialect,
+    context: numericDateContext,
+    selection: XLValueCodecSelection(
+        explicitCodecKey: XLSQLiteNumericDateCodec.JulianDay.key
+    )
+)
+// .real(19675231.483622685...)
+```
+
+or once for an entire database, by listing exactly one preset's key in
+`defaultCodecKeys`:
+
+<!-- test: XLDocumentationTests.testDocumentationNumericDateCodecs -->
+```swift
+let secondsOnlyRegistry = try XLValueCodecRegistry()
+    .registering(XLSQLiteNumericDateCodec.UnixSeconds.codec)
+let secondsOnlyCoding = try XLValueCodingConfiguration(
+    registry: secondsOnlyRegistry,
+    defaultCodecKeys: [XLSQLiteNumericDateCodec.UnixSeconds.key]
+)
+let defaultEncodedSeconds = try secondsOnlyCoding.encode(
+    loggedAt,
+    using: numericDialect,
+    context: numericDateContext
+)
+// .real(1_700_000_000.25), no selector required
+```
+
+Two numeric presets can coexist in the same schema; each column keeps its own
+codec identity, selected explicitly at that column's parameter and result
+sites, exactly as the two-codec example in <doc:CustomTypes> shows for the
+doc-only `Date` codec.
+
+### Storage, precision, and range
+
+| Preset | Storage | Epoch | Unit | Rounding | Range |
+|---|---|---|---|---|---|
+| `UnixMilliseconds` | `INTEGER` | 1970-01-01T00:00:00Z → `0` | milliseconds | nearest ms, round-half-away-from-zero | throws past `Int64` millisecond overflow (≈ ±292,471,208 years) |
+| `UnixSeconds` | `REAL` | 1970-01-01T00:00:00Z → `0.0` | seconds | none | any finite `Double` |
+| `JulianDay` | `REAL` | 1970-01-01T00:00:00Z → `2440587.5` | fractional days | none | any finite `Double` |
+
+`UnixMilliseconds` loses sub-millisecond precision by design (maximum 0.5 ms
+round-trip error from rounding alone). `UnixSeconds` is nearly lossless: its
+`REAL` storage is the same IEEE 754 double `Date` already uses internally, so
+round-trip error stays at the unit-in-the-last-place level. `JulianDay` loses
+more precision than `UnixSeconds` for the same instant, because adding the
+`2440587.5` day offset consumes mantissa bits that would otherwise represent
+sub-day precision — that cost buys direct compatibility with `julianday()`,
+covered below.
+
+All three presets store `Date` as a native SQLite number, so a standard index
+on the column sorts in chronological order with no zero-padding or
+fixed-width formatting, unlike a text preset (see
+[Comparison with the text preset](#comparison-with-the-text-preset)).
+
+### Non-finite, overflow, and malformed values
+
+Every preset rejects a non-finite `Date` (`timeIntervalSince1970` is NaN or
+infinite) at encode time, and rejects a non-finite stored `REAL` at decode
+time, with a structured
+``XLSQLiteNumericDateCodecError/nonFiniteDate(preset:value:)`` or
+``XLSQLiteNumericDateCodecError/nonFiniteStoredValue(preset:value:)``
+wrapped as `XLValueCodecError.encodingFailed`/`.decodingFailed`.
+`UnixMilliseconds` additionally rejects a millisecond count that would
+overflow `Int64` with
+``XLSQLiteNumericDateCodecError/millisecondsOutOfRange(preset:timeIntervalSince1970:)``.
+None of the three presets truncates, saturates, or silently changes a value
+that does not fit.
+
+A value SQLite stored under a different storage class than the selected
+preset declares — for example, `TEXT` that a mismatched or absent column
+affinity let through into a column meant for `UnixMilliseconds` — fails with
+`XLValueCodecError.storageMismatch` before that preset's decode closure runs.
+Declare each destination column with the exact matching SQLite type
+(`INTEGER` for `UnixMilliseconds`, `REAL` for `UnixSeconds` and `JulianDay`)
+to avoid affinity-driven coercion in the first place.
+
+## SQLite date/time-function interoperability
+
+Each preset's stored number relates to SQLite's `julianday()`/`datetime()`
+family differently, and interoperating with them uses ordinary SQL
+expressions — no additional codec machinery:
+
+`JulianDay` stores exactly the numeric convention `date()`/`datetime()`
+already expect for a bare `REAL` argument, so no modifier is needed:
+
+```sql
+SELECT datetime(dueDateJulianDay), date(dueDateJulianDay) FROM invoice;
+```
+
+`UnixSeconds` needs the `'unixepoch'` modifier, since SQLite's date functions
+otherwise treat a bare numeric argument as a Julian day number, not Unix
+seconds:
+
+```sql
+SELECT datetime(loggedAtSeconds, 'unixepoch') FROM event;
+```
+
+`UnixMilliseconds` needs both a conversion to seconds and the `'unixepoch'`
+modifier:
+
+```sql
+SELECT datetime(loggedAtMilliseconds / 1000.0, 'unixepoch') FROM event;
+```
+
+## Comparison with the text preset
+
+A companion ISO-8601 `TEXT` preset (tracked separately) stores `Date` as a
+formatted string. The numeric presets in this article trade that format's
+human readability for properties a `TEXT` column does not get for free:
+
+- **Ordering**: a numeric column sorts chronologically using SQLite's normal
+  numeric comparison. A `TEXT` column sorts chronologically only if every
+  stored string uses the same fixed-width, zero-padded format; an
+  inconsistently formatted string column produces lexicographic, not
+  chronological, order.
+- **Indexing**: the same numeric-vs-lexicographic distinction applies to any
+  index built on the column.
+- **Interoperability**: `julianday()`/`datetime()` consume a numeric column
+  directly (`JulianDay` needs no modifier at all; `UnixSeconds` and
+  `UnixMilliseconds` need the modifiers shown above). A `TEXT` column needs
+  its stored format to be one SQLite's date parser already recognizes.
+- **Storage size**: an `INTEGER` or `REAL` value is typically smaller on disk
+  than a formatted date-time string.
+
+Migrating an existing column between the text preset and a numeric preset, or
+between two numeric presets, is a data migration: rewrite every stored value
+under the new codec's rules, and do not select the new codec for a column
+that still holds values encoded under the old one. The presets' distinct
+`XLValueCodecKey`s exist so that kind of mismatch fails structurally
+(`XLValueCodecError.storageMismatch` or a decode failure) instead of being
+silently misinterpreted.

--- a/Sources/SwiftQL/SwiftQL.docc/NumericDateCodecs.md
+++ b/Sources/SwiftQL/SwiftQL.docc/NumericDateCodecs.md
@@ -136,7 +136,7 @@ doc-only `Date` codec.
 |---|---|---|---|---|---|
 | `UnixMilliseconds` | `INTEGER` | 1970-01-01T00:00:00Z → `0` | milliseconds | nearest ms, round-half-away-from-zero | throws past `Int64` millisecond overflow (≈ ±292,471,208 years) |
 | `UnixSeconds` | `REAL` | 1970-01-01T00:00:00Z → `0.0` | seconds | none | any finite `Double` |
-| `JulianDay` | `REAL` | 1970-01-01T00:00:00Z → `2440587.5` | fractional days | none | any finite `Double` |
+| `JulianDay` | `REAL` | 1970-01-01T00:00:00Z → `2440587.5` | fractional days | none | encodes any finite `Double`; decoding throws past the point where `× 86,400` would overflow |
 
 `UnixMilliseconds` loses sub-millisecond precision by design (maximum 0.5 ms
 round-trip error from rounding alone). `UnixSeconds` is nearly lossless: its
@@ -145,7 +145,12 @@ round-trip error stays at the unit-in-the-last-place level. `JulianDay` loses
 more precision than `UnixSeconds` for the same instant, because adding the
 `2440587.5` day offset consumes mantissa bits that would otherwise represent
 sub-day precision — that cost buys direct compatibility with `julianday()`,
-covered below.
+covered below. `JulianDay`'s decode direction is also narrower than its
+encode direction: converting a stored julian-day number back to unix seconds
+multiplies by 86,400, and a stored value large enough to overflow that
+multiplication fails with a structured decode error instead of producing a
+`Date` backed by a non-finite time interval — a bound far outside any date a
+real application would store.
 
 All three presets store `Date` as a native SQLite number, so a standard index
 on the column sorts in chronological order with no zero-padding or

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -141,4 +141,5 @@ replacing SQLite's runtime type rules.
 - <doc:Enums>
 - <doc:CustomFunctions>
 - <doc:CustomTypes>
+- <doc:NumericDateCodecs>
 - <doc:GenericTableParameters>

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -111,6 +111,10 @@ private let documentationTests = [
         "XLDocumentationTests.testDocumentationDeclaredQueries",
         XLDocumentationTests.testDocumentationDeclaredQueries
     ),
+    DocumentationTestReference(
+        "XLDocumentationTests.testDocumentationNumericDateCodecs",
+        XLDocumentationTests.testDocumentationNumericDateCodecs
+    ),
 ]
 
 
@@ -127,6 +131,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         "GenericTableParameters.md": "XLDocumentationTests.testDocumentationGenericTableParameters",
         "GettingStarted.md": "XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings",
         "LiveQueries.md": "XLDocumentationTests.testDocumentationLiveQueryPublishers",
+        "NumericDateCodecs.md": "XLDocumentationTests.testDocumentationNumericDateCodecs",
         "Queries.md": "XLDocumentationTests.testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs",
         "RealValues.md": "XLDocumentationTests.testDocumentationRealValues",
         "StaticQueries.md": "XLDocumentationTests.testDocumentationStaticQueries",

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -2258,4 +2258,201 @@ extension XLDocumentationTests {
         let _: (XLQueryRenderOnceCacheTests) -> () throws -> Void =
             XLQueryRenderOnceCacheTests.testCachedExecutorServesDifferentArgumentsWithStablePlaceholderSQL
     }
+
+    func testDocumentationNumericDateCodecs() throws {
+        let numericDialect = XLSQLiteDialect()
+        let numericDateContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath("event.loggedAt")
+        )
+        let numericDateRegistry = try XLValueCodecRegistry()
+            .registeringSQLiteNumericDateCodecs()
+        let numericDateCoding = try XLValueCodingConfiguration(
+            registry: numericDateRegistry
+        )
+
+        XCTAssertThrowsError(
+            try numericDateCoding.encode(
+                Date(timeIntervalSince1970: 0),
+                using: numericDialect,
+                context: numericDateContext
+            )
+        ) { error in
+            guard case .ambiguousCodec(_, _, _, _)? = error as? XLValueCodecError else {
+                return XCTFail("Expected an ambiguous-codec error, received \(error).")
+            }
+        }
+
+        let loggedAt = Date(timeIntervalSince1970: 1_700_000_000.25)
+        XCTAssertEqual(
+            try numericDateCoding.encode(
+                loggedAt,
+                using: numericDialect,
+                context: numericDateContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: XLSQLiteNumericDateCodec.UnixMilliseconds.key
+                )
+            ),
+            .integer(1_700_000_000_250)
+        )
+        XCTAssertEqual(
+            try numericDateCoding.encode(
+                loggedAt,
+                using: numericDialect,
+                context: numericDateContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: XLSQLiteNumericDateCodec.UnixSeconds.key
+                )
+            ),
+            .real(1_700_000_000.25)
+        )
+        XCTAssertEqual(
+            try numericDateCoding.encode(
+                loggedAt,
+                using: numericDialect,
+                context: numericDateContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: XLSQLiteNumericDateCodec.JulianDay.key
+                )
+            ),
+            .real(1_700_000_000.25 / 86_400 + 2_440_587.5)
+        )
+
+        let secondsOnlyRegistry = try XLValueCodecRegistry()
+            .registering(XLSQLiteNumericDateCodec.UnixSeconds.codec)
+        let secondsOnlyCoding = try XLValueCodingConfiguration(
+            registry: secondsOnlyRegistry,
+            defaultCodecKeys: [XLSQLiteNumericDateCodec.UnixSeconds.key]
+        )
+        let defaultEncodedSeconds = try secondsOnlyCoding.encode(
+            loggedAt,
+            using: numericDialect,
+            context: numericDateContext
+        )
+        XCTAssertEqual(defaultEncodedSeconds, .real(1_700_000_000.25))
+
+        XCTAssertThrowsError(
+            try numericDateCoding.encode(
+                Date(timeIntervalSince1970: .nan),
+                using: numericDialect,
+                context: numericDateContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: XLSQLiteNumericDateCodec.UnixSeconds.key
+                )
+            )
+        ) { error in
+            guard case .encodingFailed(_, _, _)? = error as? XLValueCodecError else {
+                return XCTFail("Expected an encoding-failed error, received \(error).")
+            }
+        }
+
+        let numericDateDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftql-numeric-date-docs-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: numericDateDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: numericDateDirectory) }
+
+        let numericDateDatabase = try GRDBDatabase(
+            url: numericDateDirectory.appendingPathComponent("fixture.sqlite"),
+            codingConfiguration: numericDateCoding,
+            logger: nil
+        )
+
+        // A round trip through real SQLite for one preset, mirroring the
+        // `cutoffDate` example in <doc:CustomTypes>.
+        let loggedAtSeconds = try numericDateDatabase.contextualBinding(
+            Date.self,
+            expressedAs: Double.self,
+            named: "loggedAtSeconds",
+            selection: XLValueCodecSelection(
+                explicitCodecKey: XLSQLiteNumericDateCodec.UnixSeconds.key
+            )
+        )
+        let loggedAtQuery = sql { _ in Select(loggedAtSeconds) }
+        let loggedAtRequest = numericDateDatabase.makeRequest(with: loggedAtQuery)
+        let loggedAtBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: loggedAtRequest.parameterLayout,
+            bindings: [
+                try loggedAtSeconds.encode(loggedAt, in: loggedAtRequest.parameterLayout)
+            ]
+        ).validatingComplete()
+        XCTAssertEqual(
+            try loggedAtRequest.fetchOne(bindings: loggedAtBindings),
+            1_700_000_000.25
+        )
+
+        // Two presets coexist in one database: independent parameters,
+        // independent codec metadata.
+        let createdAtMilliseconds = try numericDateDatabase.contextualBinding(
+            Date.self,
+            expressedAs: Int.self,
+            named: "createdAtMilliseconds",
+            selection: XLValueCodecSelection(
+                explicitCodecKey: XLSQLiteNumericDateCodec.UnixMilliseconds.key
+            )
+        )
+        let updatedAtJulianDay = try numericDateDatabase.contextualBinding(
+            Date.self,
+            expressedAs: Double.self,
+            named: "updatedAtJulianDay",
+            selection: XLValueCodecSelection(
+                explicitCodecKey: XLSQLiteNumericDateCodec.JulianDay.key
+            )
+        )
+        let createdAtQuery = sql { _ in Select(createdAtMilliseconds) }
+        let createdAtRequest = numericDateDatabase.makeRequest(with: createdAtQuery)
+        let createdAtBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: createdAtRequest.parameterLayout,
+            bindings: [
+                try createdAtMilliseconds.encode(loggedAt, in: createdAtRequest.parameterLayout)
+            ]
+        ).validatingComplete()
+        XCTAssertEqual(
+            try createdAtRequest.fetchOne(bindings: createdAtBindings),
+            1_700_000_000_250
+        )
+
+        let updatedAtQuery = sql { _ in Select(updatedAtJulianDay) }
+        let updatedAtRequest = numericDateDatabase.makeRequest(with: updatedAtQuery)
+        let updatedAtBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: updatedAtRequest.parameterLayout,
+            bindings: [
+                try updatedAtJulianDay.encode(loggedAt, in: updatedAtRequest.parameterLayout)
+            ]
+        ).validatingComplete()
+        let updatedAtResult = try XCTUnwrap(
+            try updatedAtRequest.fetchOne(bindings: updatedAtBindings)
+        )
+        XCTAssertEqual(updatedAtResult, 1_700_000_000.25 / 86_400 + 2_440_587.5, accuracy: 1e-6)
+
+        // SQLite date/time-function interoperability: a bare REAL julian-day
+        // value needs no modifier, while unix-seconds and unix-milliseconds
+        // values need an explicit 'unixepoch' modifier (and, for
+        // milliseconds, a conversion to seconds first).
+        let interoperabilityRow = try numericDateDatabase.databasePool.read { db in
+            try Row.fetchOne(
+                db,
+                sql: """
+                    SELECT
+                        datetime(?),
+                        datetime(?, 'unixepoch'),
+                        datetime(? / 1000.0, 'unixepoch')
+                    """,
+                arguments: [
+                    1_700_000_000.25 / 86_400 + 2_440_587.5,
+                    1_700_000_000.25,
+                    1_700_000_000_250,
+                ]
+            )
+        }
+        let interoperabilityRowValue = try XCTUnwrap(interoperabilityRow)
+        let interoperabilityDates: [String] = [
+            interoperabilityRowValue[0],
+            interoperabilityRowValue[1],
+            interoperabilityRowValue[2],
+        ]
+        XCTAssertEqual(interoperabilityDates, Array(repeating: "2023-11-14 22:13:20", count: 3))
+    }
 }

--- a/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecContractTests.swift
@@ -321,7 +321,7 @@ final class SQLiteNumericDateCodecContractTests: XCTestCase {
 
     // MARK: - Storage-class coercion
 
-    func testDecodingTheWrongStorageClassFailsBeforeThePresetSDecodeClosureRuns() {
+    func testDecodingTheWrongStorageClassFailsBeforeThePresetsDecodeClosureRuns() {
         assertCodecError(
             try XLSQLiteNumericDateCodec.UnixMilliseconds.codec.decode(
                 .real(1234),

--- a/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecContractTests.swift
@@ -315,7 +315,19 @@ final class SQLiteNumericDateCodecContractTests: XCTestCase {
             guard case .encodingFailed(_, _, let message)? = error as? XLValueCodecError else {
                 return XCTFail("Expected an encoding-failed error, received \(error).")
             }
-            XCTAssertTrue(message.contains("millisecondsOutOfRange"), message)
+            // `XLValueCodec` wraps a thrown error with `String(describing:)`,
+            // which renders the enum case (not `errorDescription`), so assert
+            // against that exact rendering rather than a loosely-matched
+            // substring.
+            XCTAssertEqual(
+                message,
+                String(
+                    describing: XLSQLiteNumericDateCodecError.millisecondsOutOfRange(
+                        preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key.id,
+                        timeIntervalSince1970: farBeyondInt64Milliseconds.timeIntervalSince1970
+                    )
+                )
+            )
         }
     }
 
@@ -336,7 +348,15 @@ final class SQLiteNumericDateCodecContractTests: XCTestCase {
             guard case .decodingFailed(_, _, let message)? = error as? XLValueCodecError else {
                 return XCTFail("Expected a decoding-failed error, received \(error).")
             }
-            XCTAssertTrue(message.contains("nonFiniteStoredValue"), message)
+            XCTAssertEqual(
+                message,
+                String(
+                    describing: XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                        preset: XLSQLiteNumericDateCodec.JulianDay.key.id,
+                        value: .positiveInfinity
+                    )
+                )
+            )
         }
 
         // A value just below that threshold still decodes successfully.

--- a/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecContractTests.swift
@@ -1,0 +1,517 @@
+import Foundation
+import XCTest
+@testable import SwiftQL
+
+
+/// Pure Swift-level contract tests for the numeric SQLite `Date` presets
+/// defined in `Sources/SwiftQL/SQLiteNumericDateCodecs.swift`. These mirror
+/// `Tests/SwiftQLCoreTests/ValueCodecContractTests.swift`'s style: no real
+/// SQLite connection is involved, only `XLValueCodec`/`XLValueCodingConfiguration`
+/// calls against `XLSQLiteDialect`. Real-database round trips, SQL
+/// comparisons, and date-function interoperability live in
+/// `SQLiteNumericDateCodecGRDBTests.swift` in this same target.
+final class SQLiteNumericDateCodecContractTests: XCTestCase {
+
+    private let dialect = XLSQLiteDialect()
+
+    private let parameterContext = XLValueCodingContext(
+        site: .parameter,
+        path: XLValueCodingPath(["fixture", "date"])
+    )
+
+    private let resultContext = XLValueCodingContext(
+        site: .result,
+        path: XLValueCodingPath(["fixture", "date"])
+    )
+
+    // MARK: - Identity
+
+    func testPresetsHaveDistinctKeysAndDeclaredStorageClasses() {
+        XCTAssertEqual(
+            XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+            XLValueCodecKey(id: "com.swiftql.date.unix-milliseconds", version: 1)
+        )
+        XCTAssertEqual(
+            XLSQLiteNumericDateCodec.UnixSeconds.key,
+            XLValueCodecKey(id: "com.swiftql.date.unix-seconds", version: 1)
+        )
+        XCTAssertEqual(
+            XLSQLiteNumericDateCodec.JulianDay.key,
+            XLValueCodecKey(id: "com.swiftql.date.julian-day", version: 1)
+        )
+
+        let keys = [
+            XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+            XLSQLiteNumericDateCodec.UnixSeconds.key,
+            XLSQLiteNumericDateCodec.JulianDay.key,
+        ]
+        XCTAssertEqual(Set(keys).count, keys.count, "Every preset must have a distinct key.")
+
+        XCTAssertEqual(
+            XLSQLiteNumericDateCodec.UnixMilliseconds.codec.identity.storageIdentifier,
+            XLValueStorageIdentifier(rawValue: XLSQLiteStorageClass.integer.rawValue)
+        )
+        XCTAssertEqual(
+            XLSQLiteNumericDateCodec.UnixSeconds.codec.identity.storageIdentifier,
+            XLValueStorageIdentifier(rawValue: XLSQLiteStorageClass.real.rawValue)
+        )
+        XCTAssertEqual(
+            XLSQLiteNumericDateCodec.JulianDay.codec.identity.storageIdentifier,
+            XLValueStorageIdentifier(rawValue: XLSQLiteStorageClass.real.rawValue)
+        )
+
+        for codec in [
+            XLSQLiteNumericDateCodec.UnixMilliseconds.codec.identity,
+            XLSQLiteNumericDateCodec.UnixSeconds.codec.identity,
+            XLSQLiteNumericDateCodec.JulianDay.codec.identity,
+        ] {
+            XCTAssertEqual(codec.dialectIdentifier, XLSQLiteDialect.identity)
+            XCTAssertEqual(codec.valueTypeIdentifier, XLSQLiteNumericDateCodec.valueTypeIdentifier)
+        }
+    }
+
+    // MARK: - No implicit default
+
+    func testRegisteringAllPresetsNeverCreatesAnImplicitDefault() throws {
+        let registry = try XLValueCodecRegistry().registeringSQLiteNumericDateCodecs()
+        let configuration = try XLValueCodingConfiguration(registry: registry)
+
+        XCTAssertThrowsError(
+            try configuration.encode(
+                Date(timeIntervalSince1970: 0),
+                using: dialect,
+                context: parameterContext
+            )
+        ) { error in
+            guard case .ambiguousCodec(_, _, let candidates, _)? = error as? XLValueCodecError else {
+                return XCTFail("Expected an ambiguous-codec error, received \(error).")
+            }
+            XCTAssertEqual(
+                Set(candidates),
+                Set([
+                    XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+                    XLSQLiteNumericDateCodec.UnixSeconds.key,
+                    XLSQLiteNumericDateCodec.JulianDay.key,
+                ])
+            )
+        }
+    }
+
+    func testExplicitSelectionDisambiguatesAmongAllThreePresets() throws {
+        let registry = try XLValueCodecRegistry().registeringSQLiteNumericDateCodecs()
+        let configuration = try XLValueCodingConfiguration(registry: registry)
+        let date = Date(timeIntervalSince1970: 1_700_000_000.5)
+
+        XCTAssertEqual(
+            try configuration.encode(
+                date,
+                using: dialect,
+                context: parameterContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: XLSQLiteNumericDateCodec.UnixMilliseconds.key
+                )
+            ),
+            .integer(1_700_000_000_500)
+        )
+        XCTAssertEqual(
+            try configuration.encode(
+                date,
+                using: dialect,
+                context: parameterContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: XLSQLiteNumericDateCodec.UnixSeconds.key
+                )
+            ),
+            .real(1_700_000_000.5)
+        )
+        XCTAssertEqual(
+            try configuration.encode(
+                date,
+                using: dialect,
+                context: parameterContext,
+                selection: XLValueCodecSelection(
+                    explicitCodecKey: XLSQLiteNumericDateCodec.JulianDay.key
+                )
+            ),
+            .real(1_700_000_000.5 / 86_400 + 2_440_587.5)
+        )
+    }
+
+    // MARK: - Round trips at documented boundaries
+
+    func testUnixMillisecondsRoundTripsRepresentativeDatesWithinDocumentedBound() throws {
+        for date in Self.representativeDates() {
+            let encoded = try XLSQLiteNumericDateCodec.UnixMilliseconds.codec.encode(
+                date,
+                using: dialect,
+                context: parameterContext
+            )
+            let decoded = try XLSQLiteNumericDateCodec.UnixMilliseconds.codec.decode(
+                encoded,
+                using: dialect,
+                context: resultContext
+            )
+            // Documented bound: rounding to the nearest millisecond introduces
+            // at most 0.5 ms of error; allow a small additional margin for
+            // Date's own Double representation error.
+            XCTAssertEqual(
+                decoded.timeIntervalSince1970,
+                date.timeIntervalSince1970,
+                accuracy: 0.0005 + 1e-9,
+                "unix-milliseconds round trip exceeded its documented 0.5 ms bound for \(date)"
+            )
+        }
+    }
+
+    func testUnixSecondsRoundTripsRepresentativeDatesWithinDocumentedBound() throws {
+        for date in Self.representativeDates() {
+            let encoded = try XLSQLiteNumericDateCodec.UnixSeconds.codec.encode(
+                date,
+                using: dialect,
+                context: parameterContext
+            )
+            let decoded = try XLSQLiteNumericDateCodec.UnixSeconds.codec.decode(
+                encoded,
+                using: dialect,
+                context: resultContext
+            )
+            // Documented bound: no explicit rounding, so error is at the
+            // unit-in-the-last-place level of the input's own Double
+            // representation. Use a small constant multiple of that value's
+            // ULP as a generous, still-tight tolerance.
+            let tolerance = Swift.max(date.timeIntervalSince1970.ulp, .leastNormalMagnitude) * 8
+            XCTAssertEqual(
+                decoded.timeIntervalSince1970,
+                date.timeIntervalSince1970,
+                accuracy: tolerance,
+                "unix-seconds round trip exceeded its documented ULP-level bound for \(date)"
+            )
+        }
+    }
+
+    func testJulianDayRoundTripsRepresentativeDatesWithinDocumentedBound() throws {
+        for date in Self.representativeDates() {
+            let encoded = try XLSQLiteNumericDateCodec.JulianDay.codec.encode(
+                date,
+                using: dialect,
+                context: parameterContext
+            )
+            let decoded = try XLSQLiteNumericDateCodec.JulianDay.codec.decode(
+                encoded,
+                using: dialect,
+                context: resultContext
+            )
+            guard case .real(let julianDay) = encoded else {
+                XCTFail("Expected a REAL julian day value.")
+                continue
+            }
+            // Documented bound: adding the ~2,440,587.5 day offset consumes
+            // mantissa bits, so the error is a multiple of the *julian day*
+            // value's own ULP, amplified back into seconds by the
+            // seconds-per-day factor used to invert the transform.
+            let tolerance = julianDay.ulp * XLSQLiteNumericDateCodec.JulianDay.secondsPerDay * 8
+            XCTAssertEqual(
+                decoded.timeIntervalSince1970,
+                date.timeIntervalSince1970,
+                accuracy: tolerance,
+                "julian-day round trip exceeded its documented ULP-level bound for \(date)"
+            )
+        }
+    }
+
+    /// Near-epoch, far-future, far-past, and seeded-random representative
+    /// dates used to quantify round-trip error, as required by issue #62's
+    /// "Done when" criteria. The random dates use a fixed seed so the suite
+    /// stays deterministic across runs.
+    static func representativeDates() -> [Date] {
+        var generator = SeededGenerator(seed: 62)
+        var dates: [Date] = [
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 0.123_456),
+            Date(timeIntervalSince1970: -0.654_321),
+            Date(timeIntervalSince1970: 1_700_000_000.789),
+            Date(timeIntervalSince1970: 253_402_300_799), // 9999-12-31T23:59:59Z
+            Date(timeIntervalSince1970: -62_135_596_800), // 0001-01-01T00:00:00Z
+        ]
+        for _ in 0 ..< 20 {
+            let seconds = Double.random(
+                in: -62_135_596_800 ... 253_402_300_799,
+                using: &generator
+            )
+            dates.append(Date(timeIntervalSince1970: seconds))
+        }
+        return dates
+    }
+
+    // MARK: - Non-finite input
+
+    func testEncodingNonFiniteDatesFailsForEveryPreset() {
+        let presets: [(name: String, codec: XLValueCodec<Date, XLSQLiteDialect>)] = [
+            ("unix-milliseconds", XLSQLiteNumericDateCodec.UnixMilliseconds.codec),
+            ("unix-seconds", XLSQLiteNumericDateCodec.UnixSeconds.codec),
+            ("julian-day", XLSQLiteNumericDateCodec.JulianDay.codec),
+        ]
+        let nonFiniteDates: [(Date, XLNonFiniteRealValue)] = [
+            (Date(timeIntervalSince1970: .nan), .notANumber),
+            (Date(timeIntervalSince1970: .infinity), .positiveInfinity),
+            (Date(timeIntervalSince1970: -.infinity), .negativeInfinity),
+        ]
+
+        for preset in presets {
+            for (date, classification) in nonFiniteDates {
+                assertEncodingFailed(
+                    try preset.codec.encode(date, using: dialect, context: parameterContext),
+                    codec: preset.codec.identity.key,
+                    message: String(
+                        describing: XLSQLiteNumericDateCodecError.nonFiniteDate(
+                            preset: preset.codec.identity.key.id,
+                            value: classification
+                        )
+                    ),
+                    file: #filePath,
+                    line: #line
+                )
+            }
+        }
+    }
+
+    func testDecodingNonFiniteRealValuesFailsForRealPresets() {
+        for preset in [
+            XLSQLiteNumericDateCodec.UnixSeconds.codec,
+            XLSQLiteNumericDateCodec.JulianDay.codec,
+        ] {
+            for (value, classification) in [
+                (XLSQLiteValue.real(.nan), XLNonFiniteRealValue.notANumber),
+                (XLSQLiteValue.real(.infinity), .positiveInfinity),
+                (XLSQLiteValue.real(-.infinity), .negativeInfinity),
+            ] {
+                assertDecodingFailed(
+                    try preset.decode(value, using: dialect, context: resultContext),
+                    codec: preset.identity.key,
+                    message: String(
+                        describing: XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                            preset: preset.identity.key.id,
+                            value: classification
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    func testUnixMillisecondsRejectsOverflow() {
+        // Any date whose millisecond count cannot fit in Int64 must be
+        // rejected rather than silently wrapped or truncated.
+        let farBeyondInt64Milliseconds = Date(
+            timeIntervalSince1970: Double(Int64.max) / 1000 * 10
+        )
+        XCTAssertThrowsError(
+            try XLSQLiteNumericDateCodec.UnixMilliseconds.codec.encode(
+                farBeyondInt64Milliseconds,
+                using: dialect,
+                context: parameterContext
+            )
+        ) { error in
+            guard case .encodingFailed(_, _, let message)? = error as? XLValueCodecError else {
+                return XCTFail("Expected an encoding-failed error, received \(error).")
+            }
+            XCTAssertTrue(message.contains("millisecondsOutOfRange"), message)
+        }
+    }
+
+    // MARK: - Storage-class coercion
+
+    func testDecodingTheWrongStorageClassFailsBeforeThePresetSDecodeClosureRuns() {
+        assertCodecError(
+            try XLSQLiteNumericDateCodec.UnixMilliseconds.codec.decode(
+                .real(1234),
+                using: dialect,
+                context: resultContext
+            ),
+            equals: .storageMismatch(
+                codec: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+                expected: XLSQLiteNumericDateCodec.UnixMilliseconds.storageIdentifier,
+                actual: XLValueStorageIdentifier(rawValue: XLSQLiteStorageClass.real.rawValue),
+                context: resultContext
+            )
+        )
+        assertCodecError(
+            try XLSQLiteNumericDateCodec.UnixSeconds.codec.decode(
+                .integer(1234),
+                using: dialect,
+                context: resultContext
+            ),
+            equals: .storageMismatch(
+                codec: XLSQLiteNumericDateCodec.UnixSeconds.key,
+                expected: XLSQLiteNumericDateCodec.UnixSeconds.storageIdentifier,
+                actual: XLValueStorageIdentifier(rawValue: XLSQLiteStorageClass.integer.rawValue),
+                context: resultContext
+            )
+        )
+        assertCodecError(
+            try XLSQLiteNumericDateCodec.JulianDay.codec.decode(
+                .text("2440587.5"),
+                using: dialect,
+                context: resultContext
+            ),
+            equals: .storageMismatch(
+                codec: XLSQLiteNumericDateCodec.JulianDay.key,
+                expected: XLSQLiteNumericDateCodec.JulianDay.storageIdentifier,
+                actual: XLValueStorageIdentifier(rawValue: XLSQLiteStorageClass.text.rawValue),
+                context: resultContext
+            )
+        )
+    }
+
+    // MARK: - Optional / NULL
+
+    func testOptionalEncodingAndDecodingMapDirectlyToSQLNull() throws {
+        let registry = try XLValueCodecRegistry()
+            .registering(XLSQLiteNumericDateCodec.UnixSeconds.codec)
+        let configuration = try XLValueCodingConfiguration(
+            registry: registry,
+            defaultCodecKeys: [XLSQLiteNumericDateCodec.UnixSeconds.key]
+        )
+
+        XCTAssertEqual(
+            try configuration.encodeOptional(
+                Optional<Date>.none,
+                using: dialect,
+                context: parameterContext
+            ),
+            .null
+        )
+        let decoded: Date? = try configuration.decodeOptional(
+            Date.self,
+            from: .null,
+            using: dialect,
+            context: resultContext
+        )
+        XCTAssertNil(decoded)
+
+        let date = Date(timeIntervalSince1970: 42)
+        let encoded = try configuration.encodeOptional(
+            date,
+            using: dialect,
+            context: parameterContext
+        )
+        XCTAssertEqual(encoded, .real(42))
+        let decodedDate: Date? = try configuration.decodeOptional(
+            Date.self,
+            from: encoded,
+            using: dialect,
+            context: resultContext
+        )
+        XCTAssertEqual(decodedDate, date)
+    }
+
+    // MARK: - Coexistence
+
+    func testTwoNumericPresetsCoexistWithIndependentMetadataInOneConfiguration() throws {
+        let registry = try XLValueCodecRegistry()
+            .registering(XLSQLiteNumericDateCodec.UnixMilliseconds.codec)
+            .registering(XLSQLiteNumericDateCodec.JulianDay.codec)
+        let configuration = try XLValueCodingConfiguration(registry: registry)
+        let createdAtContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(["event", "createdAtMilliseconds"])
+        )
+        let updatedAtContext = XLValueCodingContext(
+            site: .parameter,
+            path: XLValueCodingPath(["event", "updatedAtJulianDay"])
+        )
+        let date = Date(timeIntervalSince1970: 946_684_800) // 2000-01-01T00:00:00Z
+
+        let createdAtCodec = try configuration.resolvedCodec(
+            for: Date.self,
+            using: dialect,
+            context: createdAtContext,
+            selection: XLValueCodecSelection(
+                explicitCodecKey: XLSQLiteNumericDateCodec.UnixMilliseconds.key
+            )
+        )
+        let updatedAtCodec = try configuration.resolvedCodec(
+            for: Date.self,
+            using: dialect,
+            context: updatedAtContext,
+            selection: XLValueCodecSelection(
+                explicitCodecKey: XLSQLiteNumericDateCodec.JulianDay.key
+            )
+        )
+
+        XCTAssertNotEqual(createdAtCodec.identity.key, updatedAtCodec.identity.key)
+        XCTAssertNotEqual(
+            createdAtCodec.identity.storageIdentifier,
+            updatedAtCodec.identity.storageIdentifier
+        )
+        XCTAssertEqual(try createdAtCodec.encode(date), .integer(946_684_800_000))
+        XCTAssertEqual(try updatedAtCodec.encode(date), .real(2_451_544.5))
+    }
+
+    // MARK: - Assertion helpers
+
+    private func assertCodecError<T>(
+        _ expression: @autoclosure () throws -> T,
+        equals expected: XLValueCodecError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try expression(), file: file, line: line) { error in
+            XCTAssertEqual(error as? XLValueCodecError, expected, file: file, line: line)
+        }
+    }
+
+    private func assertEncodingFailed<T>(
+        _ expression: @autoclosure () throws -> T,
+        codec: XLValueCodecKey,
+        message: String,
+        file: StaticString,
+        line: UInt
+    ) {
+        XCTAssertThrowsError(try expression(), file: file, line: line) { error in
+            XCTAssertEqual(
+                error as? XLValueCodecError,
+                .encodingFailed(codec: codec, context: parameterContext, message: message),
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    private func assertDecodingFailed<T>(
+        _ expression: @autoclosure () throws -> T,
+        codec: XLValueCodecKey,
+        message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try expression(), file: file, line: line) { error in
+            XCTAssertEqual(
+                error as? XLValueCodecError,
+                .decodingFailed(codec: codec, context: resultContext, message: message),
+                file: file,
+                line: line
+            )
+        }
+    }
+}
+
+
+/// A minimal deterministic `RandomNumberGenerator` (splitmix64) so
+/// round-trip-error sampling stays reproducible across CI runs.
+private struct SeededGenerator: RandomNumberGenerator {
+
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}

--- a/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecContractTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecContractTests.swift
@@ -319,6 +319,36 @@ final class SQLiteNumericDateCodecContractTests: XCTestCase {
         }
     }
 
+    func testJulianDayRejectsAFiniteStoredValueThatOverflowsOnDecode() {
+        // A stored julian-day REAL can be finite while still being far too
+        // large for `(julianDay - epoch) * secondsPerDay` to stay finite.
+        // Decoding must fail structurally instead of returning a Date backed
+        // by a non-finite time interval.
+        let finiteButOverflowing = XLSQLiteValue.real(1e304)
+        XCTAssertTrue(finiteButOverflowing.storageType == .real)
+        XCTAssertThrowsError(
+            try XLSQLiteNumericDateCodec.JulianDay.codec.decode(
+                finiteButOverflowing,
+                using: dialect,
+                context: resultContext
+            )
+        ) { error in
+            guard case .decodingFailed(_, _, let message)? = error as? XLValueCodecError else {
+                return XCTFail("Expected a decoding-failed error, received \(error).")
+            }
+            XCTAssertTrue(message.contains("nonFiniteStoredValue"), message)
+        }
+
+        // A value just below that threshold still decodes successfully.
+        XCTAssertNoThrow(
+            try XLSQLiteNumericDateCodec.JulianDay.codec.decode(
+                .real(1e303),
+                using: dialect,
+                context: resultContext
+            )
+        )
+    }
+
     // MARK: - Storage-class coercion
 
     func testDecodingTheWrongStorageClassFailsBeforeThePresetsDecodeClosureRuns() {

--- a/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecGRDBTests.swift
@@ -642,7 +642,19 @@ final class SQLiteNumericDateCodecGRDBTests: XCTestCase {
             guard case .decodingFailed(_, _, let message)? = error as? XLValueCodecError else {
                 return XCTFail("Expected a decoding-failed error, received \(error).")
             }
-            XCTAssertTrue(message.contains("nonFiniteStoredValue"), message)
+            // `XLValueCodec` wraps a thrown error with `String(describing:)`,
+            // which renders the enum case (not `errorDescription`), so assert
+            // against that exact rendering rather than a loosely-matched
+            // substring.
+            XCTAssertEqual(
+                message,
+                String(
+                    describing: XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                        preset: XLSQLiteNumericDateCodec.UnixSeconds.key.id,
+                        value: .positiveInfinity
+                    )
+                )
+            )
         }
     }
 
@@ -679,7 +691,15 @@ final class SQLiteNumericDateCodecGRDBTests: XCTestCase {
             guard case .decodingFailed(_, _, let message)? = error as? XLValueCodecError else {
                 return XCTFail("Expected a decoding-failed error, received \(error).")
             }
-            XCTAssertTrue(message.contains("nonFiniteStoredValue"), message)
+            XCTAssertEqual(
+                message,
+                String(
+                    describing: XLSQLiteNumericDateCodecError.nonFiniteStoredValue(
+                        preset: XLSQLiteNumericDateCodec.JulianDay.key.id,
+                        value: .positiveInfinity
+                    )
+                )
+            )
         }
     }
 

--- a/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecGRDBTests.swift
@@ -1,0 +1,828 @@
+import Foundation
+import GRDB
+import XCTest
+@testable import SwiftQL
+
+
+/// Real GRDB/SQLite round-trip coverage for the numeric `Date` presets in
+/// `Sources/SwiftQL/SQLiteNumericDateCodecs.swift`. This mirrors
+/// `ContextualValueCodecGRDBTests.swift`'s style: a low-level
+/// `GRDBDatabaseDriver` connection prepares and binds raw SQL directly, so
+/// these tests exercise real SQLite storage, affinity, and date/time
+/// functions without depending on the property-level codec selection
+/// mechanism tracked separately in issue #66.
+///
+/// Pure Swift-level codec behavior (identity, ambiguity, non-finite/overflow
+/// errors, storage-mismatch errors, optional/NULL mapping) is covered in
+/// `SQLiteNumericDateCodecContractTests.swift` in this same target; this file
+/// focuses on what only a real database can prove: literal SQL rendering
+/// through bound parameters, INSERT/UPDATE/SELECT, ordering comparisons,
+/// coexistence of two presets in one schema, and `julianday()`/`datetime()`
+/// interoperability.
+final class SQLiteNumericDateCodecGRDBTests: XCTestCase {
+
+    private let dialect = XLSQLiteDialect()
+
+    private func makeConfiguration() throws -> XLValueCodingConfiguration {
+        try XLValueCodingConfiguration(
+            registry: XLValueCodecRegistry().registeringSQLiteNumericDateCodecs()
+        )
+    }
+
+    // MARK: - Insert / update / select / decode round trips
+
+    func testAllThreePresetsRoundTripInsertUpdateSelectThroughRealSQLite() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try makeConfiguration()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(
+                connection.prepare(
+                    logicalStatement(
+                        databaseIdentifier: databaseIdentifier,
+                        sql: """
+                            CREATE TABLE numeric_dates (
+                                id INTEGER PRIMARY KEY,
+                                milliseconds_value INTEGER NOT NULL,
+                                seconds_value REAL NOT NULL,
+                                julian_day_value REAL NOT NULL
+                            )
+                            """
+                    )
+                )
+            )
+        }
+
+        let original = Date(timeIntervalSince1970: 1_700_000_000.25)
+        let insertContext = XLValueCodingContext(site: .parameter, path: XLValueCodingPath("insert"))
+        let milliseconds = try encode(
+            original,
+            preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+            configuration: configuration,
+            context: insertContext
+        )
+        let seconds = try encode(
+            original,
+            preset: XLSQLiteNumericDateCodec.UnixSeconds.key,
+            configuration: configuration,
+            context: insertContext
+        )
+        let julianDay = try encode(
+            original,
+            preset: XLSQLiteNumericDateCodec.JulianDay.key,
+            configuration: configuration,
+            context: insertContext
+        )
+
+        try driver.withWriteConnection { connection in
+            var statement = try connection.prepare(
+                logicalStatement(
+                    databaseIdentifier: databaseIdentifier,
+                    sql: """
+                        INSERT INTO numeric_dates
+                            (id, milliseconds_value, seconds_value, julian_day_value)
+                        VALUES
+                            (1, :milliseconds_value, :seconds_value, :julian_day_value)
+                        """
+                )
+            )
+            statement = try connection.bind(milliseconds, to: .named("milliseconds_value"), in: statement)
+            statement = try connection.bind(seconds, to: .named("seconds_value"), in: statement)
+            statement = try connection.bind(julianDay, to: .named("julian_day_value"), in: statement)
+            try connection.execute(statement)
+        }
+
+        let selected = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(
+                    connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: """
+                                SELECT
+                                    milliseconds_value, typeof(milliseconds_value),
+                                    seconds_value, typeof(seconds_value),
+                                    julian_day_value, typeof(julian_day_value)
+                                FROM numeric_dates WHERE id = 1
+                                """
+                        )
+                    )
+                )
+            )
+        }
+        XCTAssertEqual(selected[1], .text("integer"))
+        XCTAssertEqual(selected[3], .text("real"))
+        XCTAssertEqual(selected[5], .text("real"))
+
+        let resultContext = XLValueCodingContext(site: .result, path: XLValueCodingPath("select"))
+        XCTAssertEqual(
+            try decode(
+                selected[0],
+                preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+                configuration: configuration,
+                context: resultContext
+            ),
+            original
+        )
+        XCTAssertEqual(
+            try decode(
+                selected[2],
+                preset: XLSQLiteNumericDateCodec.UnixSeconds.key,
+                configuration: configuration,
+                context: resultContext
+            ),
+            original
+        )
+        let decodedJulianDay = try decode(
+            selected[4],
+            preset: XLSQLiteNumericDateCodec.JulianDay.key,
+            configuration: configuration,
+            context: resultContext
+        )
+        XCTAssertEqual(decodedJulianDay.timeIntervalSince1970, original.timeIntervalSince1970, accuracy: 0.001)
+
+        // UPDATE with a second date, then re-select and decode.
+        let updated = Date(timeIntervalSince1970: -12_345.5)
+        let updateContext = XLValueCodingContext(site: .parameter, path: XLValueCodingPath("update"))
+        let updatedMilliseconds = try encode(
+            updated,
+            preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+            configuration: configuration,
+            context: updateContext
+        )
+        try driver.withWriteConnection { connection in
+            var statement = try connection.prepare(
+                logicalStatement(
+                    databaseIdentifier: databaseIdentifier,
+                    sql: "UPDATE numeric_dates SET milliseconds_value = :milliseconds_value WHERE id = 1"
+                )
+            )
+            statement = try connection.bind(
+                updatedMilliseconds,
+                to: .named("milliseconds_value"),
+                in: statement
+            )
+            try connection.execute(statement)
+        }
+        let reselected = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(
+                    connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: "SELECT milliseconds_value FROM numeric_dates WHERE id = 1"
+                        )
+                    )
+                )
+            )
+        }
+        XCTAssertEqual(
+            try decode(
+                reselected[0],
+                preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+                configuration: configuration,
+                context: resultContext
+            ),
+            updated
+        )
+    }
+
+    // MARK: - Ordering / comparison
+
+    func testEachPresetPreservesChronologicalOrderingUnderSQLComparison() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try makeConfiguration()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+        let dates = [
+            Date(timeIntervalSince1970: -1_000_000), // before the epoch
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 500_000.75),
+            Date(timeIntervalSince1970: 2_000_000_000),
+        ]
+
+        for preset in [
+            XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+            XLSQLiteNumericDateCodec.UnixSeconds.key,
+            XLSQLiteNumericDateCodec.JulianDay.key,
+        ] {
+            let columnType = preset == XLSQLiteNumericDateCodec.UnixMilliseconds.key
+                ? "INTEGER"
+                : "REAL"
+            try driver.withWriteConnection { connection in
+                try connection.execute(
+                    connection.prepare(
+                        logicalStatement(databaseIdentifier: databaseIdentifier, sql: "DROP TABLE IF EXISTS ordering_probe")
+                    )
+                )
+                try connection.execute(
+                    connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: "CREATE TABLE ordering_probe (value \(columnType) NOT NULL)"
+                        )
+                    )
+                )
+            }
+
+            let context = XLValueCodingContext(site: .parameter, path: XLValueCodingPath("ordering"))
+            // Insert in reverse-chronological order so a correct ORDER BY
+            // proves the numeric encoding, not insertion order.
+            for date in dates.reversed() {
+                let encoded = try encode(
+                    date,
+                    preset: preset,
+                    configuration: configuration,
+                    context: context
+                )
+                try driver.withWriteConnection { connection in
+                    var statement = try connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: "INSERT INTO ordering_probe (value) VALUES (:value)"
+                        )
+                    )
+                    statement = try connection.bind(encoded, to: .named("value"), in: statement)
+                    try connection.execute(statement)
+                }
+            }
+
+            let orderedRows = try driver.withReadConnection { connection in
+                try connection.fetchAll(
+                    connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: "SELECT value FROM ordering_probe ORDER BY value ASC"
+                        )
+                    )
+                )
+            }
+            let resultContext = XLValueCodingContext(site: .result, path: XLValueCodingPath("ordering"))
+            let orderedDates = try orderedRows.map {
+                try decode(
+                    $0[0],
+                    preset: preset,
+                    configuration: configuration,
+                    context: resultContext
+                )
+            }
+            for (decoded, expected) in zip(orderedDates, dates) {
+                XCTAssertEqual(
+                    decoded.timeIntervalSince1970,
+                    expected.timeIntervalSince1970,
+                    accuracy: 0.01,
+                    "\(preset) did not preserve chronological ordering"
+                )
+            }
+        }
+    }
+
+    // MARK: - Optional / NULL
+
+    func testOptionalColumnsRoundTripNullAndPresentValuesThroughRealSQLite() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try makeConfiguration()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(
+                connection.prepare(
+                    logicalStatement(
+                        databaseIdentifier: databaseIdentifier,
+                        sql: "CREATE TABLE optional_dates (id INTEGER PRIMARY KEY, seconds_value REAL)"
+                    )
+                )
+            )
+        }
+
+        let context = XLValueCodingContext(site: .parameter, path: XLValueCodingPath("optional"))
+        let presentDate = Date(timeIntervalSince1970: 100)
+        let presentValue = try configuration.encodeOptional(
+            presentDate,
+            using: dialect,
+            context: context,
+            selection: XLValueCodecSelection(explicitCodecKey: XLSQLiteNumericDateCodec.UnixSeconds.key)
+        )
+        let nullValue = try configuration.encodeOptional(
+            Optional<Date>.none,
+            using: dialect,
+            context: context,
+            selection: XLValueCodecSelection(explicitCodecKey: XLSQLiteNumericDateCodec.UnixSeconds.key)
+        )
+
+        try driver.withWriteConnection { connection in
+            var insertPresent = try connection.prepare(
+                logicalStatement(
+                    databaseIdentifier: databaseIdentifier,
+                    sql: "INSERT INTO optional_dates (id, seconds_value) VALUES (1, :seconds_value)"
+                )
+            )
+            insertPresent = try connection.bind(presentValue, to: .named("seconds_value"), in: insertPresent)
+            try connection.execute(insertPresent)
+
+            var insertNull = try connection.prepare(
+                logicalStatement(
+                    databaseIdentifier: databaseIdentifier,
+                    sql: "INSERT INTO optional_dates (id, seconds_value) VALUES (2, :seconds_value)"
+                )
+            )
+            insertNull = try connection.bind(nullValue, to: .named("seconds_value"), in: insertNull)
+            try connection.execute(insertNull)
+        }
+
+        let rows = try driver.withReadConnection { connection in
+            try connection.fetchAll(
+                connection.prepare(
+                    logicalStatement(
+                        databaseIdentifier: databaseIdentifier,
+                        sql: "SELECT seconds_value FROM optional_dates ORDER BY id ASC"
+                    )
+                )
+            )
+        }
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[1][0], .null)
+
+        let resultContext = XLValueCodingContext(site: .result, path: XLValueCodingPath("optional"))
+        let decodedPresent: Date? = try configuration.decodeOptional(
+            Date.self,
+            from: rows[0][0],
+            using: dialect,
+            context: resultContext,
+            selection: XLValueCodecSelection(explicitCodecKey: XLSQLiteNumericDateCodec.UnixSeconds.key)
+        )
+        let decodedNull: Date? = try configuration.decodeOptional(
+            Date.self,
+            from: rows[1][0],
+            using: dialect,
+            context: resultContext,
+            selection: XLValueCodecSelection(explicitCodecKey: XLSQLiteNumericDateCodec.UnixSeconds.key)
+        )
+        XCTAssertEqual(decodedPresent, presentDate)
+        XCTAssertNil(decodedNull)
+    }
+
+    // MARK: - Coexistence of two representations in one schema
+
+    func testTwoNumericDateColumnsCoexistInOneSchemaWithIndependentCodecs() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try makeConfiguration()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(
+                connection.prepare(
+                    logicalStatement(
+                        databaseIdentifier: databaseIdentifier,
+                        sql: """
+                            CREATE TABLE events (
+                                id INTEGER PRIMARY KEY,
+                                created_at_milliseconds INTEGER NOT NULL,
+                                updated_at_julian_day REAL NOT NULL
+                            )
+                            """
+                    )
+                )
+            )
+        }
+
+        let createdAt = Date(timeIntervalSince1970: 946_684_800) // 2000-01-01T00:00:00Z
+        let updatedAt = Date(timeIntervalSince1970: 1_000_000_000)
+        let context = XLValueCodingContext(site: .parameter, path: XLValueCodingPath("events"))
+        let createdAtValue = try encode(
+            createdAt,
+            preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+            configuration: configuration,
+            context: context
+        )
+        let updatedAtValue = try encode(
+            updatedAt,
+            preset: XLSQLiteNumericDateCodec.JulianDay.key,
+            configuration: configuration,
+            context: context
+        )
+
+        try driver.withWriteConnection { connection in
+            var statement = try connection.prepare(
+                logicalStatement(
+                    databaseIdentifier: databaseIdentifier,
+                    sql: """
+                        INSERT INTO events (id, created_at_milliseconds, updated_at_julian_day)
+                        VALUES (1, :created_at_milliseconds, :updated_at_julian_day)
+                        """
+                )
+            )
+            statement = try connection.bind(
+                createdAtValue,
+                to: .named("created_at_milliseconds"),
+                in: statement
+            )
+            statement = try connection.bind(
+                updatedAtValue,
+                to: .named("updated_at_julian_day"),
+                in: statement
+            )
+            try connection.execute(statement)
+        }
+
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(
+                    connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: """
+                                SELECT created_at_milliseconds, updated_at_julian_day
+                                FROM events WHERE id = 1
+                                """
+                        )
+                    )
+                )
+            )
+        }
+        let resultContext = XLValueCodingContext(site: .result, path: XLValueCodingPath("events"))
+        XCTAssertEqual(
+            try decode(
+                row[0],
+                preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+                configuration: configuration,
+                context: resultContext
+            ),
+            createdAt
+        )
+        let decodedUpdatedAt = try decode(
+            row[1],
+            preset: XLSQLiteNumericDateCodec.JulianDay.key,
+            configuration: configuration,
+            context: resultContext
+        )
+        XCTAssertEqual(
+            decodedUpdatedAt.timeIntervalSince1970,
+            updatedAt.timeIntervalSince1970,
+            accuracy: 0.001
+        )
+    }
+
+    // MARK: - SQLite date/time-function interoperability
+
+    func testJulianDayPresetIsConsumedDirectlyByDateTimeFunctionsWithoutModifiers() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+        // SQLite interprets a bare REAL argument to date()/datetime() as a
+        // Julian day number, which is exactly this preset's storage
+        // convention, so no modifier is required.
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(
+                    connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: "SELECT datetime(2440587.5), date(2440587.5)"
+                        )
+                    )
+                )
+            )
+        }
+        XCTAssertEqual(row[0], .text("1970-01-01 00:00:00"))
+        XCTAssertEqual(row[1], .text("1970-01-01"))
+    }
+
+    func testUnixSecondsPresetRequiresTheUnixepochModifier() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(
+                    connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: "SELECT datetime(1700000000, 'unixepoch'), julianday(1700000000, 'unixepoch')"
+                        )
+                    )
+                )
+            )
+        }
+        XCTAssertEqual(row[0], .text("2023-11-14 22:13:20"))
+        guard case .real(let julianDay) = row[1] else {
+            return XCTFail("Expected a REAL julian day, got \(String(describing: row[1])).")
+        }
+        XCTAssertEqual(julianDay, 1_700_000_000 / 86_400 + 2_440_587.5, accuracy: 1e-6)
+    }
+
+    func testUnixMillisecondsPresetRequiresDivisionBeforeTheUnixepochModifier() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+        // The stored value is milliseconds, so SQL must divide by 1000.0
+        // before applying the 'unixepoch' modifier (which expects seconds).
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(
+                    connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: "SELECT datetime(1700000000000 / 1000.0, 'unixepoch')"
+                        )
+                    )
+                )
+            )
+        }
+        XCTAssertEqual(row[0], .text("2023-11-14 22:13:20"))
+    }
+
+    // MARK: - Malformed / wrong-storage stored values
+
+    func testDecodingAValueSQLiteStoredWithTheWrongTypeAffinityFailsStructurally() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try makeConfiguration()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(
+                connection.prepare(
+                    logicalStatement(
+                        databaseIdentifier: databaseIdentifier,
+                        sql: "CREATE TABLE malformed_dates (milliseconds_value INTEGER)"
+                    )
+                )
+            )
+            // SQLite's INTEGER affinity only converts text that looks like a
+            // number; a non-numeric string is stored verbatim as TEXT.
+            try connection.execute(
+                connection.prepare(
+                    logicalStatement(
+                        databaseIdentifier: databaseIdentifier,
+                        sql: "INSERT INTO malformed_dates (milliseconds_value) VALUES ('not-a-timestamp')"
+                    )
+                )
+            )
+        }
+
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(
+                    connection.prepare(
+                        logicalStatement(
+                            databaseIdentifier: databaseIdentifier,
+                            sql: "SELECT milliseconds_value, typeof(milliseconds_value) FROM malformed_dates"
+                        )
+                    )
+                )
+            )
+        }
+        XCTAssertEqual(row[1], .text("text"))
+
+        let resultContext = XLValueCodingContext(site: .result, path: XLValueCodingPath("malformed"))
+        XCTAssertThrowsError(
+            try decode(
+                row[0],
+                preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+                configuration: configuration,
+                context: resultContext
+            )
+        ) { error in
+            guard case .storageMismatch? = error as? XLValueCodecError else {
+                return XCTFail("Expected a storage-mismatch error, received \(error).")
+            }
+        }
+    }
+
+    func testDecodingAnOverflowingRealExpressionFailsStructurally() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try makeConfiguration()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+        // A computed SQL expression can overflow to IEEE 754 infinity even
+        // though no bound parameter ever carried a non-finite value.
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(
+                    connection.prepare(
+                        logicalStatement(databaseIdentifier: databaseIdentifier, sql: "SELECT 1.0e308 * 1.0e308, typeof(1.0e308 * 1.0e308)")
+                    )
+                )
+            )
+        }
+        XCTAssertEqual(row[1], .text("real"))
+
+        let resultContext = XLValueCodingContext(site: .result, path: XLValueCodingPath("overflow"))
+        XCTAssertThrowsError(
+            try decode(
+                row[0],
+                preset: XLSQLiteNumericDateCodec.UnixSeconds.key,
+                configuration: configuration,
+                context: resultContext
+            )
+        ) { error in
+            guard case .decodingFailed(_, _, let message)? = error as? XLValueCodecError else {
+                return XCTFail("Expected a decoding-failed error, received \(error).")
+            }
+            XCTAssertTrue(message.contains("nonFiniteStoredValue"), message)
+        }
+    }
+
+    // MARK: - Boundary and randomized representative dates
+
+    func testRepresentativeDatesRoundTripThroughRealSQLiteForEveryPreset() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try makeConfiguration()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+
+        try driver.withWriteConnection { connection in
+            try connection.execute(
+                connection.prepare(
+                    logicalStatement(
+                        databaseIdentifier: databaseIdentifier,
+                        sql: """
+                            CREATE TABLE representative_dates (
+                                milliseconds_value INTEGER,
+                                seconds_value REAL,
+                                julian_day_value REAL
+                            )
+                            """
+                    )
+                )
+            )
+        }
+
+        let parameterContext = XLValueCodingContext(site: .parameter, path: XLValueCodingPath("representative"))
+        let resultContext = XLValueCodingContext(site: .result, path: XLValueCodingPath("representative"))
+
+        for date in SQLiteNumericDateCodecContractTests.representativeDates() {
+            let milliseconds = try encode(
+                date,
+                preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+                configuration: configuration,
+                context: parameterContext
+            )
+            let seconds = try encode(
+                date,
+                preset: XLSQLiteNumericDateCodec.UnixSeconds.key,
+                configuration: configuration,
+                context: parameterContext
+            )
+            let julianDay = try encode(
+                date,
+                preset: XLSQLiteNumericDateCodec.JulianDay.key,
+                configuration: configuration,
+                context: parameterContext
+            )
+
+            let row = try driver.withWriteConnection { connection -> [XLSQLiteValue] in
+                var insert = try connection.prepare(
+                    logicalStatement(
+                        databaseIdentifier: databaseIdentifier,
+                        sql: """
+                            INSERT INTO representative_dates
+                                (milliseconds_value, seconds_value, julian_day_value)
+                            VALUES
+                                (:milliseconds_value, :seconds_value, :julian_day_value)
+                            RETURNING
+                                milliseconds_value, seconds_value, julian_day_value
+                            """
+                    )
+                )
+                insert = try connection.bind(milliseconds, to: .named("milliseconds_value"), in: insert)
+                insert = try connection.bind(seconds, to: .named("seconds_value"), in: insert)
+                insert = try connection.bind(julianDay, to: .named("julian_day_value"), in: insert)
+                return try XCTUnwrap(connection.fetchOne(insert))
+            }
+
+            XCTAssertEqual(
+                try decode(
+                    row[0],
+                    preset: XLSQLiteNumericDateCodec.UnixMilliseconds.key,
+                    configuration: configuration,
+                    context: resultContext
+                ).timeIntervalSince1970,
+                date.timeIntervalSince1970,
+                accuracy: 0.0005 + 1e-9,
+                "unix-milliseconds round trip through SQLite exceeded its documented bound for \(date)"
+            )
+            XCTAssertEqual(
+                try decode(
+                    row[1],
+                    preset: XLSQLiteNumericDateCodec.UnixSeconds.key,
+                    configuration: configuration,
+                    context: resultContext
+                ).timeIntervalSince1970,
+                date.timeIntervalSince1970,
+                accuracy: Swift.max(date.timeIntervalSince1970.ulp, .leastNormalMagnitude) * 8,
+                "unix-seconds round trip through SQLite exceeded its documented bound for \(date)"
+            )
+            guard case .real(let julianDayValue) = julianDay else {
+                return XCTFail("Expected a REAL julian day value.")
+            }
+            let julianDayTolerance = julianDayValue.ulp
+                * XLSQLiteNumericDateCodec.JulianDay.secondsPerDay
+                * 8
+            XCTAssertEqual(
+                try decode(
+                    row[2],
+                    preset: XLSQLiteNumericDateCodec.JulianDay.key,
+                    configuration: configuration,
+                    context: resultContext
+                ).timeIntervalSince1970,
+                date.timeIntervalSince1970,
+                accuracy: julianDayTolerance,
+                "julian-day round trip through SQLite exceeded its documented bound for \(date)"
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func encode(
+        _ date: Date,
+        preset: XLValueCodecKey,
+        configuration: XLValueCodingConfiguration,
+        context: XLValueCodingContext
+    ) throws -> XLSQLiteValue {
+        try configuration.encode(
+            date,
+            using: dialect,
+            context: context,
+            selection: XLValueCodecSelection(explicitCodecKey: preset)
+        )
+    }
+
+    private func decode(
+        _ value: XLSQLiteValue,
+        preset: XLValueCodecKey,
+        configuration: XLValueCodingConfiguration,
+        context: XLValueCodingContext
+    ) throws -> Date {
+        try configuration.decode(
+            Date.self,
+            from: value,
+            using: dialect,
+            context: context,
+            selection: XLValueCodecSelection(explicitCodecKey: preset)
+        )
+    }
+
+    private func logicalStatement(
+        databaseIdentifier: XLDatabaseIdentifier,
+        sql: String
+    ) -> XLLogicalPreparedStatement {
+        XLLogicalPreparedStatement(
+            databaseIdentifier: databaseIdentifier,
+            dialectRequirement: XLDialectRequirement(identity: XLSQLiteDialect.identity),
+            sql: sql
+        )
+    }
+
+    private func makeFixture() throws -> NumericDateCodecFixture {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftql-numeric-date-codec-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: false
+        )
+        return NumericDateCodecFixture(
+            directoryURL: directoryURL,
+            databasePool: try DatabasePool(
+                path: directoryURL.appendingPathComponent("database.sqlite").path
+            )
+        )
+    }
+}
+
+
+private struct NumericDateCodecFixture {
+    let directoryURL: URL
+    let databasePool: DatabasePool
+
+    func tearDown() {
+        try? databasePool.close()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+}

--- a/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecGRDBTests.swift
+++ b/Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecGRDBTests.swift
@@ -646,6 +646,43 @@ final class SQLiteNumericDateCodecGRDBTests: XCTestCase {
         }
     }
 
+    func testJulianDayRejectsAFiniteStoredValueThatOverflowsWhenConvertedToUnixSeconds() throws {
+        let fixture = try makeFixture()
+        defer { fixture.tearDown() }
+
+        let configuration = try makeConfiguration()
+        var driver = GRDBDatabaseDriver(databasePool: fixture.databasePool, dialect: dialect)
+        let databaseIdentifier = driver.databaseIdentifier
+        // This REAL value is finite, but converting it from a julian-day
+        // number back to unix seconds (`(value - epoch) * 86400`) overflows
+        // to IEEE 754 infinity.
+        let row = try driver.withReadConnection { connection in
+            try XCTUnwrap(
+                connection.fetchOne(
+                    connection.prepare(
+                        logicalStatement(databaseIdentifier: databaseIdentifier, sql: "SELECT 1.0e304, typeof(1.0e304)")
+                    )
+                )
+            )
+        }
+        XCTAssertEqual(row[1], .text("real"))
+
+        let resultContext = XLValueCodingContext(site: .result, path: XLValueCodingPath("julian-day-overflow"))
+        XCTAssertThrowsError(
+            try decode(
+                row[0],
+                preset: XLSQLiteNumericDateCodec.JulianDay.key,
+                configuration: configuration,
+                context: resultContext
+            )
+        ) { error in
+            guard case .decodingFailed(_, _, let message)? = error as? XLValueCodecError else {
+                return XCTFail("Expected a decoding-failed error, received \(error).")
+            }
+            XCTAssertTrue(message.contains("nonFiniteStoredValue"), message)
+        }
+    }
+
     // MARK: - Boundary and randomized representative dates
 
     func testRepresentativeDatesRoundTripThroughRealSQLiteForEveryPreset() throws {


### PR DESCRIPTION
Closes #62.

## Summary

- Adds `XLSQLiteNumericDateCodec` (`Sources/SwiftQL/SQLiteNumericDateCodecs.swift`), three named, versioned `XLValueCodec<Date, XLSQLiteDialect>` presets built on #188's contextual value-codec API:
  - `UnixMilliseconds` — `INTEGER` milliseconds since the Unix epoch, rounded to the nearest millisecond (round-half-away-from-zero), rejecting values whose millisecond count overflows `Int64`.
  - `UnixSeconds` — `REAL` seconds since the Unix epoch (`Date.timeIntervalSince1970`, stored as-is).
  - `JulianDay` — `REAL` Julian day number, using the same linear relationship SQLite's own `julianday()` uses (`unixSeconds / 86400.0 + 2440587.5`).
- None of the three is an implicit default (registering all three and encoding without a selector throws `.ambiguousCodec`); selection happens through the existing database (`defaultCodecKeys`) or per-call (`XLValueCodecSelection`/`XLQueryCodecSelection`) mechanisms only — no property-level selection (#66) is used.
- Every preset rejects a non-finite `Date` at encode time and a non-finite stored `REAL` at decode time with a structured `XLSQLiteNumericDateCodecError`, wrapped as `XLValueCodecError.encodingFailed`/`.decodingFailed`. Wrong-storage stored values (e.g. `TEXT` where `INTEGER`/`REAL` was declared) fail with `XLValueCodecError.storageMismatch` via the existing generic storage check — no bespoke coercion logic was added.
- `XLValueCodecRegistry.registeringSQLiteNumericDateCodecs()` is a small additive convenience for registering all three presets at once.
- New `Sources/SwiftQL/SwiftQL.docc/NumericDateCodecs.md` article (linked from `SwiftQL.md`'s Topics) documents storage class, epoch, unit, rounding, precision loss, range, ordering, indexing, non-finite/overflow/malformed behavior, SQL date/time-function interoperability, and a comparison with the companion ISO-8601 `TEXT` preset tracked in #61 (not implemented here, per this issue's scope).
- No changes to `Sources/SwiftQLCore/ValueCodec.swift` or `GRDBSQLDatabase.swift`; no new SQL operators/functions.

## Evidence / validation

- `Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecContractTests.swift` — pure Swift-level contract tests (no real database), mirroring `ValueCodecContractTests.swift`'s style: identity/metadata, no-implicit-default/ambiguity, explicit selection, boundary+seeded-random round-trip error bounds per preset (near-epoch, 0001-01-01, 9999-12-31, and 20 deterministic random dates), non-finite encode/decode errors, `Int64` overflow, storage-mismatch, optional/NULL mapping, and two presets coexisting with independent metadata.
- `Tests/SwiftQLCodecIntegrationTests/SQLiteNumericDateCodecGRDBTests.swift` — real GRDB/SQLite round trips: literal/insert/update/select/decode, chronological ordering under `ORDER BY`, optional/NULL through a real nullable column, two presets coexisting in one schema, `julianday()`/`datetime()` interoperability (bare `REAL` for `JulianDay`, `'unixepoch'` modifier for `UnixSeconds`, division + `'unixepoch'` for `UnixMilliseconds`), a real SQLite-stored wrong-affinity value failing structurally, a computed SQL expression overflowing to `REAL` infinity failing structurally on decode, and the same representative-date sampling round-tripped through a real database.
- Doctest: `NumericDateCodecs.md`'s runnable Swift examples are wired into `XLDocumentationTests.testDocumentationNumericDateCodecs` (`Tests/SQLTests/SQLExampleTests.swift`) and registered in `SQLDocumentationCatalogTests`'s catalog, so `testEverySwiftExampleMapsToACompiledDocumentationScenario` enforces the marker/test mapping.

## Test plan

- [x] `swift build` — 0 warnings.
- [x] `swift test` — full suite (962 tests) passes, including 12 new contract tests, 10 new GRDB round-trip tests, and the new documentation test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
