### PR TITLE
Prototype scratch-copy index-candidate generation and re-plan verification (#392)

### DIFF
--- a/Documentation/Architecture/SQLiteIndexAdvisor.md
+++ b/Documentation/Architecture/SQLiteIndexAdvisor.md
@@ -193,6 +193,13 @@ swift run SwiftQLSQLiteIndexAdvisorCLI verify \
 `IndexCandidateGeneratorTests.testRealCorpusCandidatesMatchCheckedInEvidence`
 and `IndexCandidateVerifierTests.testCheckedInVerificationEvidenceMatchesFreshRun`
 re-run this exact pipeline on every `swift test` invocation and assert
-byte-identity with the checked-in evidence — with no version-skew caveat,
-since neither `IndexCandidate` nor `IndexCandidateEvidence` embeds an SQLite
-version field.
+byte-identity with the checked-in evidence. Neither `IndexCandidate` nor
+`IndexCandidateEvidence` embeds an SQLite version field, so unlike #390's
+equivalent check this assertion is unconditional rather than runtime-gated
+— but that reflects what #390 actually measured (these particular
+index-search/full-scan decisions were stable between the two real builds
+tested there), not a guarantee that every SQLite build plans them
+identically forever. EQP choices remain SQLite-version-dependent in
+principle; if this test ever fails on a different host, its failure message
+prints that host's `sqlite_version()`/`sqlite_source_id()` so the
+difference is diagnosable rather than a bare JSON diff.

--- a/Documentation/Architecture/SQLiteIndexAdvisor.md
+++ b/Documentation/Architecture/SQLiteIndexAdvisor.md
@@ -62,10 +62,17 @@ below.
 ### Finding remediable statements
 
 `IndexCandidateGenerator.remediableCandidates(for:plan:)` walks a #391
-classified plan's root nodes for `full_table_scan` shapes, and — where the
-statement's SQL yields a non-empty candidate column list for that node's
-alias, and the alias resolves to a real table — produces a
-`RemediableCandidate`. No signal, no resolvable table, no candidate.
+classified plan's root nodes for `full_table_scan` **or
+`automatic_covering_index`** shapes, and — where the statement's SQL yields
+a non-empty candidate column list for that node's alias, and the alias
+resolves to a real table — produces a `RemediableCandidate`. No signal, no
+resolvable table, no candidate. (`automatic_covering_index` was added here
+for the same reason it was added to the improvement rule below: the
+join-key/range-column finding's fixture has its remediable root classified
+as `automatic_covering_index`, not `full_table_scan`, so the improvement
+rule accepting that shape was unreachable end to end until this scan also
+looked for it — caught by Copilot review, confirmed by
+`IndexCandidateGeneratorTests.testRemediableCandidatesIncludesAutomaticCoveringIndexRoots`.)
 
 ### Deduplication
 
@@ -74,7 +81,13 @@ same `(table, columns)` (recording every contributing statement id, and
 keeping the first occurrence as the concrete statement to verify against),
 then drops any candidate whose column list is an **exact prefix** of
 another surviving candidate on the same table — a wider index already
-serves every query the narrower prefix would have.
+serves every query the narrower prefix would have. A dropped prefix
+candidate's source statement ids are folded into every wider candidate it
+prefixes before being discarded, so a statement that only ever produced the
+narrower prefix is still attributed to the index that now serves it,
+instead of silently disappearing from the evidence (caught by Copilot
+review; confirmed by
+`IndexCandidateGeneratorTests.testDeduplicatePreservesPrefixCandidateSourceStatementIDs`).
 
 ### Scratch-copy verification
 

--- a/Documentation/Architecture/SQLiteIndexAdvisor.md
+++ b/Documentation/Architecture/SQLiteIndexAdvisor.md
@@ -1,0 +1,198 @@
+# Scratch-copy index-candidate generation and re-plan verification (issue #392)
+
+Milestone 29, "Spike: SQLite query-plan analysis and index advice." This
+document is the prototype write-up issue #392 asks for: deriving index
+candidates from a statement's predicates, joins, and sort order, then
+verifying each one by creating it on a scratch copy of the pinned Northwind
+snapshot and re-planning. It builds on [#390's capture pipeline](SQLiteEQPVariance.md)
+and [#391's shape classifier](SQLiteEQPPlanShapeClassifier.md) rather than
+duplicating either.
+
+## Non-goals
+
+Research target only (`SwiftQLSQLiteIndexAdvisorPrototype`), per this
+issue's hard constraints: no public SwiftQL API, no report schema change, no
+build-plugin work, no typed index DDL. Candidate creation runs only against
+a scratch copy of the pinned snapshot, opened by
+`NorthwindFixture.withTemporaryCopy` — never the canonical file and never a
+long-lived application connection. No `sqlite3expert.c`, no custom SQLite
+build. Partial and expression indices are **not implemented** — noted below
+as future candidate-space extensions, not attempted here.
+
+## Methodology
+
+### Deriving candidate columns
+
+`IndexCandidateExtraction` (a narrow, pattern-based extractor, not a SQL
+parser — see its doc comment for exactly what it recognises and what it
+deliberately refuses to guess at) reads, for one table alias in one
+statement's rendered SQL:
+
+- `WHERE`-clause equality and range comparisons (conjuncts joined only by
+  top-level `AND`; a top-level `OR`, or a conjunct that isn't a plain
+  column/operator comparison, yields nothing for that clause rather than a
+  guess).
+- `JOIN … ON` equality (or `IS`, for a nullable left join) key columns.
+- `ORDER BY` columns, ignoring `COLLATE`/`ASC`/`DESC`.
+- The alias→real-table-name map (`tableAliasMap`), which explicitly excludes
+  two situations rather than resolving them wrong: a CTE name masquerading
+  as a table (`WITH "cte0" AS (…) … FROM "cte0" AS "t0"` — `"cte0"` isn't a
+  real table `CREATE INDEX` could target), and an alias reused for a
+  different table in a nested scope (`FROM "Orders" AS "t0" WHERE … IN
+  (SELECT … FROM "Employees" AS "t0" …)` — resolving this correctly needs
+  real scope tracking this extractor doesn't do, so a conflicting rebinding
+  drops the alias entirely).
+
+`IndexCandidateGenerator.candidateColumns(for:in:)` orders the derived
+columns by precedence, per SQLite's own left-to-right composite-index rule:
+**equality columns, then at most one range column** (a second range column
+after the first cannot narrow a B-tree seek any further — SQLite stops
+using the index to narrow at the first range term), **then join-key
+columns, then `ORDER BY` columns** (so the index can also satisfy sort order
+without a temp B-tree). Each column appears once, at its highest-precedence
+position.
+
+### Finding remediable statements
+
+`IndexCandidateGenerator.remediableCandidates(for:plan:)` walks a #391
+classified plan's root nodes for `full_table_scan` shapes, and — where the
+statement's SQL yields a non-empty candidate column list for that node's
+alias, and the alias resolves to a real table — produces a
+`RemediableCandidate`. No signal, no resolvable table, no candidate.
+
+### Deduplication
+
+`IndexCandidateGenerator.deduplicate(_:)` merges candidates with the exact
+same `(table, columns)` (recording every contributing statement id, and
+keeping the first occurrence as the concrete statement to verify against),
+then drops any candidate whose column list is an **exact prefix** of
+another surviving candidate on the same table — a wider index already
+serves every query the narrower prefix would have.
+
+### Scratch-copy verification
+
+`IndexCandidateVerifier.verify(candidate:statement:)` opens one temporary
+copy of the pinned snapshot via `NorthwindFixture.withTemporaryCopy`
+(already used by #390/#391's own tests), captures and classifies the
+**before** plan, executes the candidate's `CREATE INDEX` DDL, captures and
+classifies the **after** plan, and returns both plans plus the candidate's
+DDL and a verdict as a single `IndexCandidateEvidence` value —
+`withTemporaryCopy` removes the scratch copy on every exit path (success, a
+thrown error, or a failure creating the copy itself), which is exactly the
+"discard on every path including failure" this issue requires, reused
+rather than reimplemented.
+
+### The improvement rule
+
+Stated once, applied uniformly to every candidate — no per-case judgment:
+
+> A candidate is kept only when the plan node for the target alias changes
+> from `full_table_scan` to `index_search` or `covering_index_scan`, **and**
+> the after-plan node reports at least one constrained column.
+
+No cost estimate or row-count comparison is used. The pinned snapshot is
+deliberately unanalyzed (no `sqlite_stat1` — see [#390](SQLiteEQPVariance.md)),
+so a cost-based comparison would not be trustworthy evidence; a structural
+shape change, backed by #391's classifier, is the only signal here that
+isn't itself an unfounded guess.
+
+## Evidence
+
+Generating candidates from #390's checked-in `apple-system-3.51.0` capture
+(214 real statements, 114 `full_table_scan` nodes) and deduplicating
+produced exactly **6 candidates**. Verifying all 6 against the pinned
+Northwind snapshot:
+
+| Table | Columns | Source statement | Verdict |
+|---|---|---|---|
+| `Orders` | `CustomerID`, `EmployeeID` | `c191.v1.select.j-left.w-injection-binding` | **✅ improvement** |
+| `Orders` | `OrderID` | `c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending` | ❌ false positive |
+| `Orders` | `CustomerID`, `OrderID` | `c191.v1.select.j-inner.o-ascending` | ❌ false positive |
+| `Orders` | `EmployeeID`, `CustomerID` | `c191.v1.select.p-nullable-region…` | ❌ false positive |
+| `Orders` | `EmployeeID`, `OrderID` | `c191.v1.select.j-left.o-ascending` | ❌ false positive |
+| `Employees` | `ReportsTo`, `EmployeeID` | `c390.northwind.join.left-null-manager` | ❌ false positive |
+
+Checked-in evidence (`Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/`):
+`candidates.json`, `verification.json`.
+
+### The one real improvement
+
+`c191.v1.select.j-left.w-injection-binding` is
+`SELECT t0.orderID FROM Orders AS t0 LEFT JOIN Employees AS employees_join ON (t0.employeeID IS employees_join.employeeID) WHERE (t0.customerID == :customer_input)`
+— a genuine `WHERE` equality filter on `Orders`, the driving table of a
+`LEFT JOIN`. `CREATE INDEX ON Orders (CustomerID, EmployeeID)` changes the
+plan from `full_table_scan` to `index_search`, constrained by `["CustomerID"]`
+— `EmployeeID` rides along in the index (derived from the `LEFT JOIN`'s
+join key, per the precedence rule) but doesn't narrow the seek itself, which
+the evidence records honestly rather than overclaiming.
+
+### The five false positives, and why they're honest, not bugs
+
+All five share one root cause the write-up states plainly: **a join-key
+column is only useful to index when the table being indexed is the
+*looked-up* side of the join, not the driving/outer side being scanned to
+feed it.** Four of the five candidates (`Orders(CustomerID, OrderID)`,
+`Orders(EmployeeID, CustomerID)`, `Orders(EmployeeID, OrderID)`,
+`Employees(ReportsTo, EmployeeID)`) were derived from a join key on a table
+with **no `WHERE` filter of its own** — the table must be scanned in full
+regardless of any index, because the join doesn't reduce how many of its own
+rows need visiting. The candidate generator does not currently distinguish
+a join's driving side from its looked-up side; this is a real, documented
+limitation, not silently patched over.
+
+The sixth pattern is distinct: `Orders(OrderID)`, derived purely from an
+`ORDER BY orderID` term with no `WHERE` clause at all. `OrderID` is already
+the table's `INTEGER PRIMARY KEY` (rowid alias — see #390's evidence), so a
+plain table scan already visits rows in that order for free; the redundant
+secondary index is never chosen; `beforePlan == afterPlan` exactly.
+
+**In every case, the false positive was caught by scratch-copy verification
+itself** — the improvement rule rejected all five without needing a
+special case for "driving side of a join" or "already the primary key." That
+is the point of verifying rather than asserting.
+
+## Coverage and limitations
+
+- **Missing statistics cap advice at shape-derived, not distribution-
+  derived**, exactly as #390 anticipated: this prototype cannot tell a
+  highly-selective equality predicate from a nearly-useless one — it can
+  only observe *whether* SQLite's planner chose to narrow with an index,
+  not *how much* that narrowing helps. The one real improvement found here
+  happens to be a case where narrowing is obviously worthwhile (`CustomerID`
+  equality); a stats-driven advisor might reject candidates this prototype
+  accepts, or vice versa, on a differently-shaped dataset.
+- **Only the driving table's `full_table_scan` roots are considered** —
+  extending detection to remediate a `temp_b_tree_for_order_by`/
+  `temp_b_tree_for_group_by` node (eliminating a sort, not just avoiding a
+  scan), or to inner-joined tables specifically, is straightforward future
+  work using the same #391 shapes, not attempted in this pass.
+- **Partial and expression indices are not implemented.** A partial index
+  (`CREATE INDEX … WHERE …`) could serve some of the false-positive cases
+  above if the filtered subset were small — e.g. an index on `Employees`
+  filtered to `ReportsTo IS NOT NULL` doesn't apply here (the join key issue
+  is structural, not selectivity), but could plausibly help other,
+  differently-shaped statements. An expression index could serve a
+  predicate on a computed value. Both extend the candidate space this
+  prototype's precedence rule already establishes, but adding either is
+  deferred.
+- **No vendored `sqlite3expert`, no custom SQLite build** — every candidate
+  is verified using only public SQLite API (`CREATE INDEX` DDL plus
+  `EXPLAIN QUERY PLAN`), reusing #390/#391's existing capture and
+  classification pipeline unchanged.
+
+## Reproducing this evidence
+
+```bash
+swift run SwiftQLSQLiteIndexAdvisorCLI generate \
+  --capture path/to/capture.json --output candidates.json
+
+swift run SwiftQLSQLiteIndexAdvisorCLI verify \
+  --candidates candidates.json --output verification.json
+```
+
+`IndexCandidateGeneratorTests.testRealCorpusCandidatesMatchCheckedInEvidence`
+and `IndexCandidateVerifierTests.testCheckedInVerificationEvidenceMatchesFreshRun`
+re-run this exact pipeline on every `swift test` invocation and assert
+byte-identity with the checked-in evidence — with no version-skew caveat,
+since neither `IndexCandidate` nor `IndexCandidateEvidence` embeds an SQLite
+version field.

--- a/Documentation/Architecture/SQLiteIndexAdvisor.md
+++ b/Documentation/Architecture/SQLiteIndexAdvisor.md
@@ -29,9 +29,10 @@ deliberately refuses to guess at) reads, for one table alias in one
 statement's rendered SQL:
 
 - `WHERE`-clause equality and range comparisons (conjuncts joined only by
-  top-level `AND`; a top-level `OR`, or a conjunct that isn't a plain
-  column/operator comparison, yields nothing for that clause rather than a
-  guess).
+  top-level `AND`; an `OR` anywhere in the clause — a blunt substring check,
+  deliberately more conservative than "does this `OR` actually change
+  precedence" — or a conjunct that isn't a plain column/operator
+  comparison, yields nothing for that clause rather than a guess).
 - `JOIN … ON` equality (or `IS`, for a nullable left join) key columns.
 - `ORDER BY` columns, ignoring `COLLATE`/`ASC`/`DESC`.
 - The alias→real-table-name map (`tableAliasMap`), which explicitly excludes

--- a/Documentation/Architecture/SQLiteIndexAdvisor.md
+++ b/Documentation/Architecture/SQLiteIndexAdvisor.md
@@ -244,11 +244,14 @@ either shape as the starting point. Both fixes are proven end to end by
   happens to be a case where narrowing is obviously worthwhile (`CustomerID`
   equality); a stats-driven advisor might reject candidates this prototype
   accepts, or vice versa, on a differently-shaped dataset.
-- **Only the driving table's `full_table_scan` roots are considered** —
+- **Only root-level `full_table_scan`/`automatic_covering_index` nodes are
+  considered — never a nested node inside a subquery or CTE.** A plan's
+  roots are a generic forest of top-level nodes (any of the tables involved,
+  plus non-table nodes like a temp B-tree), not just one "driving" table;
   extending detection to remediate a `temp_b_tree_for_order_by`/
   `temp_b_tree_for_group_by` node (eliminating a sort, not just avoiding a
-  scan), or to inner-joined tables specifically, is straightforward future
-  work using the same #391 shapes, not attempted in this pass.
+  scan), or to a remediable node nested inside a subquery, is straightforward
+  future work using the same #391 shapes, not attempted in this pass.
 - **Partial and expression indices are not implemented.** A partial index
   (`CREATE INDEX … WHERE …`) could serve some of the false-positive cases
   above if the filtered subset were small — e.g. an index on `Employees`

--- a/Documentation/Architecture/SQLiteIndexAdvisor.md
+++ b/Documentation/Architecture/SQLiteIndexAdvisor.md
@@ -46,12 +46,18 @@ statement's rendered SQL:
 
 `IndexCandidateGenerator.candidateColumns(for:in:)` orders the derived
 columns by precedence, per SQLite's own left-to-right composite-index rule:
-**equality columns, then at most one range column** (a second range column
+**every equality-constrained column first — a join key is an equality
+constraint too** (SQLite seeks on it per outer row exactly like a `WHERE`
+equality; it just supplies the bound value at run time instead of from the
+statement text) — **then at most one range column** (a second range column
 after the first cannot narrow a B-tree seek any further — SQLite stops
-using the index to narrow at the first range term), **then join-key
-columns, then `ORDER BY` columns** (so the index can also satisfy sort order
-without a temp B-tree). Each column appears once, at its highest-precedence
-position.
+using the index to narrow at the first range term), **then `ORDER BY`
+columns** (so the index can also satisfy sort order without a temp
+B-tree). Each column appears once, at its highest-precedence position.
+
+This ordering is confirmed by a real scratch-copy re-plan, not assumed: see
+[Finding: join keys must precede range columns](#finding-join-keys-must-precede-range-columns)
+below.
 
 ### Finding remediable statements
 
@@ -88,8 +94,11 @@ rather than reimplemented.
 Stated once, applied uniformly to every candidate — no per-case judgment:
 
 > A candidate is kept only when the plan node for the target alias changes
-> from `full_table_scan` to `index_search` or `covering_index_scan`, **and**
-> the after-plan node reports at least one constrained column.
+> from `full_table_scan` **or `automatic_covering_index`** to `index_search`
+> or `covering_index_scan`, **and** the after-plan node reports at least one
+> constrained column.
+
+(`automatic_covering_index` was added to the "before" shapes after the join-key/range-column finding below surfaced a real case where SQLite's own ephemeral index, not a full table scan, was the baseline being improved on.)
 
 No cost estimate or row-count comparison is used. The pinned snapshot is
 deliberately unanalyzed (no `sqlite_stat1` — see [#390](SQLiteEQPVariance.md)),
@@ -151,6 +160,66 @@ secondary index is never chosen; `beforePlan == afterPlan` exactly.
 itself** — the improvement rule rejected all five without needing a
 special case for "driving side of a join" or "already the primary key." That
 is the point of verifying rather than asserting.
+
+### Finding: join keys must precede range columns
+
+The real 214-statement corpus never produced a statement where a table on
+the *looked-up* side of a join carried both a join key and a range
+predicate — so the corpus alone couldn't settle whether a candidate's join
+key should come before or after a range column. Rather than assume either
+ordering (an earlier draft of this prototype used equality → range → join
+→ order-by, which is what the corpus's one real improvement happened to
+produce, coincidentally without ever exercising this exact tiebreak),
+constructing and re-planning a real case settles it:
+
+```sql
+SELECT p.ProductID FROM Categories AS c
+LEFT JOIN Products AS p ON p.CategoryID = c.CategoryID
+WHERE p.UnitPrice > 20 OR p.ProductID IS NULL
+```
+
+`Products` has no existing index beyond its own primary key, and is forced
+onto the looked-up side of the `LEFT JOIN` (the `OR … IS NULL` keeps SQLite
+from converting this into an inner join and reordering the tables).
+SQLite's own baseline plan is its `automatic_covering_index` shape — an
+ephemeral, per-query index on `CategoryID` alone, rebuilt every execution:
+
+```
+SCAN c
+BLOOM FILTER ON p (CategoryID=?)
+SEARCH p USING AUTOMATIC COVERING INDEX (CategoryID=?) LEFT-JOIN
+```
+
+`CREATE INDEX ON Products(CategoryID, UnitPrice)` — join key first — is the
+index SQLite actually adopts, replacing the ephemeral one and dropping the
+bloom-filter step entirely:
+
+```
+SCAN c
+SEARCH p USING COVERING INDEX ix_a (CategoryID=?) LEFT-JOIN
+```
+
+`CREATE INDEX ON Products(UnitPrice, CategoryID)` — range first — is
+**silently ignored**. The after-plan is byte-for-byte identical to the
+baseline, as if the candidate didn't exist:
+
+```
+SCAN c
+BLOOM FILTER ON p (CategoryID=?)
+SEARCH p USING AUTOMATIC COVERING INDEX (CategoryID=?) LEFT-JOIN
+```
+
+This is real, unambiguous confirmation of the general SQLite rule
+`candidateColumns` now implements: **equality-style columns — `WHERE`
+equality and join keys alike — must precede any range column**, because a
+composite index can only be seeded by an equality prefix; nothing after the
+first range column narrows a seek at all. It also surfaced a second,
+directly related gap: the improvement rule's original precondition only
+recognised `full_table_scan` as a remediable "before" shape. Replacing
+SQLite's own ephemeral `automatic_covering_index` with a real, persistent
+one is exactly the same category of improvement, so the rule now accepts
+either shape as the starting point. Both fixes are proven end to end by
+`IndexCandidateVerifierTests.testJoinKeyPrecedesRangeColumnConfirmedByRealScratchCopyReplan`.
 
 ## Coverage and limitations
 

--- a/Package.swift
+++ b/Package.swift
@@ -327,6 +327,7 @@ let package = Package(
                 "SwiftQLSQLiteIndexAdvisorPrototype",
                 "SwiftQLSQLitePlanShapePrototype",
                 "SwiftQLSQLiteEQPVariancePrototype",
+                "SwiftQLSQLiteBuildValidationPrototype",
                 "SwiftQLNorthwindFixtures",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -185,6 +185,32 @@ let package = Package(
             path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLitePlanShapeCLI"
         ),
 
+        // Package-private research engine for issue #392 (milestone 29 spike).
+        // Prototypes index-candidate generation and scratch-copy re-plan
+        // verification over the #390/#391 capture and classification
+        // pipeline. Deliberately outside the package's public products:
+        // research target only, no typed index DDL or public API.
+        .target(
+            name: "SwiftQLSQLiteIndexAdvisorPrototype",
+            dependencies: [
+                "SwiftQLSQLitePlanShapePrototype",
+                "SwiftQLSQLiteEQPVariancePrototype",
+                "SwiftQLNorthwindFixtures",
+                .product(name: "GRDB", package: "GRDB.swift"),
+            ],
+            path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype"
+        ),
+
+        .executableTarget(
+            name: "SwiftQLSQLiteIndexAdvisorCLI",
+            dependencies: [
+                "SwiftQLSQLiteIndexAdvisorPrototype",
+                "SwiftQLSQLitePlanShapePrototype",
+                "SwiftQLSQLiteEQPVariancePrototype",
+            ],
+            path: "Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorCLI"
+        ),
+
         // A test target used to develop the macro implementation.
         .testTarget(
             name: "SwiftQLCoreTests",
@@ -292,6 +318,19 @@ let package = Package(
                 "SwiftQLSQLiteEQPVariancePrototype",
             ],
             path: "Research/SQLiteBuildValidation/Tests/SwiftQLSQLitePlanShapePrototypeTests",
+            resources: [.copy("Evidence")]
+        ),
+
+        .testTarget(
+            name: "SwiftQLSQLiteIndexAdvisorPrototypeTests",
+            dependencies: [
+                "SwiftQLSQLiteIndexAdvisorPrototype",
+                "SwiftQLSQLitePlanShapePrototype",
+                "SwiftQLSQLiteEQPVariancePrototype",
+                "SwiftQLNorthwindFixtures",
+                .product(name: "GRDB", package: "GRDB.swift"),
+            ],
+            path: "Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests",
             resources: [.copy("Evidence")]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -327,7 +327,6 @@ let package = Package(
                 "SwiftQLSQLiteIndexAdvisorPrototype",
                 "SwiftQLSQLitePlanShapePrototype",
                 "SwiftQLSQLiteEQPVariancePrototype",
-                "SwiftQLSQLiteBuildValidationPrototype",
                 "SwiftQLNorthwindFixtures",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ],

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorCLI/main.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorCLI/main.swift
@@ -1,0 +1,151 @@
+import Foundation
+import SwiftQLSQLiteEQPVariancePrototype
+import SwiftQLSQLitePlanShapePrototype
+import SwiftQLSQLiteIndexAdvisorPrototype
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+
+private let usage = """
+    Usage:
+      SwiftQLSQLiteIndexAdvisorCLI generate --capture <path> --output <path>
+      SwiftQLSQLiteIndexAdvisorCLI verify --candidates <path> --output <path>
+
+    generate reads an EQPCaptureRun (from SwiftQLSQLiteEQPVarianceCLI capture
+    or capture_eqp.py), classifies it, derives remediable index candidates,
+    and writes the deduplicated candidates as canonical JSON.
+
+    verify creates each candidate on its own scratch copy of the pinned
+    Northwind snapshot, re-plans, applies the improvement rule, and writes
+    the before/after/verdict evidence as canonical JSON.
+    """
+
+
+private func writeStandardError(_ message: String) {
+    guard let data = "\(message)\n".data(using: .utf8) else {
+        return
+    }
+    FileHandle.standardError.write(data)
+}
+
+
+private func flagValue(_ name: String, in arguments: [String]) -> String? {
+    guard let index = arguments.firstIndex(of: name), index + 1 < arguments.count else {
+        return nil
+    }
+    return arguments[index + 1]
+}
+
+
+do {
+    let arguments = Array(CommandLine.arguments.dropFirst())
+    guard let subcommand = arguments.first else {
+        writeStandardError(usage)
+        exit(2)
+    }
+
+    switch subcommand {
+    case "generate":
+        guard let capturePath = flagValue("--capture", in: arguments),
+              let outputPath = flagValue("--output", in: arguments) else {
+            writeStandardError(usage)
+            exit(2)
+        }
+        let run = try JSONDecoder().decode(
+            EQPCaptureRun.self,
+            from: Data(contentsOf: URL(fileURLWithPath: capturePath))
+        )
+        let corpus = try EQPVarianceCorpus.assemble()
+        let corpusByID = Dictionary(uniqueKeysWithValues: corpus.map { ($0.id, $0) })
+
+        var remediables: [RemediableCandidate] = []
+        for capture in run.statements {
+            guard let statement = corpusByID[capture.statementID] else {
+                continue
+            }
+            let plan = EQPPlanShapeClassifier.classify(rows: capture.rows, statementID: statement.id)
+            remediables.append(contentsOf: IndexCandidateGenerator.remediableCandidates(for: statement, plan: plan))
+        }
+        let candidates = IndexCandidateGenerator.deduplicate(remediables)
+        let data = try EQPVarianceCanonicalJSON.encode(candidates.map(CodableIndexCandidate.init))
+        try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+        print("Derived \(candidates.count) deduplicated candidate(s) from \(remediables.count) remediable statement(s)")
+
+    case "verify":
+        guard let candidatesPath = flagValue("--candidates", in: arguments),
+              let outputPath = flagValue("--output", in: arguments) else {
+            writeStandardError(usage)
+            exit(2)
+        }
+        let candidates = try JSONDecoder().decode(
+            [CodableIndexCandidate].self,
+            from: Data(contentsOf: URL(fileURLWithPath: candidatesPath))
+        )
+        let corpus = try EQPVarianceCorpus.assemble()
+        let corpusByID = Dictionary(uniqueKeysWithValues: corpus.map { ($0.id, $0) })
+
+        var evidence: [IndexCandidateEvidence] = []
+        for candidate in candidates {
+            guard let statement = corpusByID[candidate.representativeStatementID] else {
+                writeStandardError("Skipping \(candidate.table)\(candidate.columns): representative statement not found")
+                continue
+            }
+            let result = try IndexCandidateVerifier.verify(candidate: candidate.asIndexCandidate, statement: statement)
+            evidence.append(result)
+            print("\(candidate.table)\(candidate.columns) -> improvement: \(result.isImprovement) (\(result.improvementReason))")
+        }
+        let data = try EQPVarianceCanonicalJSON.encode(evidence)
+        try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+
+    default:
+        writeStandardError(usage)
+        exit(2)
+    }
+} catch {
+    writeStandardError(String(describing: error))
+    writeStandardError(usage)
+    exit(2)
+}
+
+
+/// `IndexCandidate` is intentionally not `Codable` in the prototype library
+/// (it's a plain in-memory value the generator and verifier pass directly);
+/// this CLI-only wrapper adds the JSON round-trip the `generate`/`verify`
+/// subcommand pipeline needs.
+private struct CodableIndexCandidate: Codable {
+    let table: String
+    let columns: [String]
+    let sourceStatementIDs: [String]
+    let representativeStatementID: String
+    let representativeAlias: String
+
+    init(_ candidate: IndexCandidate) {
+        table = candidate.table
+        columns = candidate.columns
+        sourceStatementIDs = candidate.sourceStatementIDs
+        representativeStatementID = candidate.representativeStatementID
+        representativeAlias = candidate.representativeAlias
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case table
+        case columns
+        case sourceStatementIDs = "source_statement_ids"
+        case representativeStatementID = "representative_statement_id"
+        case representativeAlias = "representative_alias"
+    }
+
+    var asIndexCandidate: IndexCandidate {
+        IndexCandidate(
+            table: table,
+            columns: columns,
+            sourceStatementIDs: sourceStatementIDs,
+            representativeStatementID: representativeStatementID,
+            representativeAlias: representativeAlias
+        )
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
@@ -1,0 +1,522 @@
+import Foundation
+
+
+/// A single `alias.column <op> …` comparison found in a statement's `WHERE`
+/// clause.
+package struct WhereComparison: Equatable, Sendable {
+    package enum ComparisonKind: Sendable {
+        case equality
+        case range
+    }
+
+    package let alias: String
+    package let column: String
+    package let kind: ComparisonKind
+}
+
+
+/// One equality (or `IS`, for a nullable left join) join key: `alias.column`
+/// on one side of a `JOIN … ON` condition.
+package struct JoinKey: Equatable, Sendable {
+    package let alias: String
+    package let column: String
+}
+
+
+/// Extracts index-candidate signal (equality/range predicates, join keys,
+/// `ORDER BY` columns) from a statement's rendered SQL text for one table
+/// alias.
+///
+/// This is deliberately a narrow, pattern-based extractor, not a SQL parser.
+/// The #390/#391 corpus renders SQL in two styles this extractor recognises
+/// — the #191 combinatorial manifest's quoted, parenthesised style
+/// (`("t0"."orderID" == 10248)`) and this repo's own hand-written Northwind
+/// anchor style (`o.OrderID = ?`, no quotes, no wrapping parens) — via a
+/// single identifier scanner that accepts both forms. A `WHERE` clause
+/// containing a top-level `OR`, or a conjunct that isn't a plain
+/// column/operator comparison, yields no comparisons for that clause —
+/// never a guessed or partial one. Statements this extractor can't
+/// confidently read simply produce no candidate, the same "never coerce"
+/// discipline #391 applies to unrecognised plan shapes.
+package enum IndexCandidateExtraction {
+    package static func whereComparisons(for alias: String, in sql: String) -> [WhereComparison] {
+        let sql = normalizeWhitespace(sql)
+        guard let clause = extractClause(sql, after: "WHERE", stoppingAt: ["GROUP BY", "ORDER BY", "LIMIT"]) else {
+            return []
+        }
+        guard !clause.contains(" OR ") else {
+            return []
+        }
+        return splitTopLevelConjuncts(clause).compactMap { conjunct in
+            parseComparison(conjunct, aliasFilter: alias)
+        }
+    }
+
+    package static func orderByColumns(for alias: String, in sql: String) -> [String] {
+        let sql = normalizeWhitespace(sql)
+        guard let clause = extractClause(sql, after: "ORDER BY", stoppingAt: ["LIMIT"]) else {
+            return []
+        }
+        return splitTopLevel(clause, on: ",").compactMap { term in
+            // An ORDER BY term's leading parenthesis (if any) only wraps the
+            // expression, not the trailing COLLATE/ASC/DESC — e.g.
+            // `("t0"."x" COLLATE NOCASE) ASC` — so trim leading "(" alone
+            // rather than requiring the whole term to be paren-wrapped.
+            let trimmed = term.trimmingCharacters(in: .whitespaces).drop { $0 == "(" }
+            var scanner = IdentifierScanner(String(trimmed))
+            guard let pair = scanner.nextIdentifierPair() else {
+                return nil
+            }
+            return pair.alias == alias ? pair.identifier : nil
+        }
+    }
+
+    package static func joinKeys(for alias: String, in sql: String) -> [JoinKey] {
+        let sql = normalizeWhitespace(sql)
+        return joinConditions(in: sql).flatMap { left, right -> [JoinKey] in
+            var keys: [JoinKey] = []
+            if left.alias == alias {
+                keys.append(JoinKey(alias: alias, column: left.identifier))
+            }
+            if right.alias == alias {
+                keys.append(JoinKey(alias: alias, column: right.identifier))
+            }
+            return keys
+        }
+    }
+
+    /// Maps every `FROM`/`JOIN` alias to its real table name — needed
+    /// because `CREATE INDEX` requires the table name, not the alias, and a
+    /// table name can contain a space (`"Order Details"`) while its alias
+    /// never does.
+    /// Only returns bindings this extractor can resolve with confidence.
+    /// Two situations are deliberately excluded rather than guessed at:
+    ///
+    /// - **CTE names.** `WITH "cte0" AS (SELECT …)` looks, to a naive
+    ///   `FROM`/`JOIN … AS …` scan, exactly like a table alias binding once
+    ///   the outer query does `FROM "cte0" AS "t0"` — but `"cte0"` is not a
+    ///   real table, and `CREATE INDEX` on it would fail. CTE names are
+    ///   detected separately (by the `AS (` that immediately follows them,
+    ///   which a table alias never has) and excluded.
+    /// - **Alias reuse across nested scopes.** The same alias name (e.g.
+    ///   `"t0"`) can legitimately be bound to a different table in an outer
+    ///   query and a subquery (`FROM "Orders" AS "t0" WHERE "t0"."x" IN
+    ///   (SELECT … FROM "Employees" AS "t0" …)`). Resolving this correctly
+    ///   requires real scope tracking this extractor doesn't do, so a
+    ///   conflicting rebinding removes the alias from the result entirely
+    ///   rather than silently keeping whichever occurrence was scanned last.
+    package static func tableAliasMap(in sql: String) -> [String: String] {
+        let sql = normalizeWhitespace(sql)
+        let cteNames = self.cteNames(in: sql)
+
+        var bindings: [String: String] = [:]
+        var ambiguousAliases: Set<String> = []
+        for keyword in [" FROM ", " JOIN "] {
+            var searchStart = sql.startIndex
+            while let range = sql.range(of: keyword, range: searchStart..<sql.endIndex) {
+                let remainder = String(sql[range.upperBound...])
+                if let (table, alias) = parseTableAlias(remainder) {
+                    if let existingTable = bindings[alias], existingTable != table {
+                        ambiguousAliases.insert(alias)
+                    } else {
+                        bindings[alias] = table
+                    }
+                }
+                searchStart = range.upperBound
+            }
+        }
+        for alias in ambiguousAliases {
+            bindings.removeValue(forKey: alias)
+        }
+        for (alias, table) in bindings where cteNames.contains(table) {
+            bindings.removeValue(forKey: alias)
+        }
+        return bindings
+    }
+
+    /// A table alias binding is always `<table> AS <alias>` — `AS` followed
+    /// by an identifier. A CTE definition is `<name> AS (<subquery>)` — `AS`
+    /// followed directly by `(`. That distinction, not any keyword context,
+    /// is what identifies a name as a CTE rather than a table.
+    private static func cteNames(in sql: String) -> Set<String> {
+        var names: Set<String> = []
+        var searchRange = sql.startIndex..<sql.endIndex
+        while let asParenRange = sql.range(of: " AS (", range: searchRange) {
+            if let name = name(precedingEndIndex: asParenRange.lowerBound, in: sql) {
+                names.insert(name)
+            }
+            searchRange = asParenRange.upperBound..<sql.endIndex
+        }
+        return names
+    }
+
+    private static func name(precedingEndIndex index: String.Index, in sql: String) -> String? {
+        var end = index
+        while end > sql.startIndex, sql[sql.index(before: end)] == " " {
+            end = sql.index(before: end)
+        }
+        guard end > sql.startIndex else {
+            return nil
+        }
+        if sql[sql.index(before: end)] == "\"" {
+            guard end > sql.index(after: sql.startIndex) else {
+                return nil
+            }
+            var start = sql.index(before: sql.index(before: end))
+            while start > sql.startIndex, sql[start] != "\"" {
+                start = sql.index(before: start)
+            }
+            guard sql[start] == "\"" else {
+                return nil
+            }
+            return String(sql[sql.index(after: start)..<sql.index(before: end)])
+        }
+
+        var start = end
+        while start > sql.startIndex {
+            let previous = sql.index(before: start)
+            guard sql[previous].isLetter || sql[previous].isNumber || sql[previous] == "_" else {
+                break
+            }
+            start = previous
+        }
+        guard start < end else {
+            return nil
+        }
+        return String(sql[start..<end])
+    }
+
+    private static func parseTableAlias(_ text: String) -> (table: String, alias: String)? {
+        var scanner = NameScanner(text)
+        guard let table = scanner.nextName() else {
+            return nil
+        }
+        scanner.skipWhitespace()
+        guard scanner.consume("AS") else {
+            return nil
+        }
+        scanner.skipWhitespace()
+        guard let alias = scanner.nextName() else {
+            return nil
+        }
+        return (table, alias)
+    }
+
+    /// Collapses every run of whitespace (including the newlines and
+    /// indentation this repo's own multi-line anchor statements are written
+    /// with) to a single space, so every other boundary check in this file
+    /// can assume clause keywords are always surrounded by exactly one
+    /// space.
+    private static func normalizeWhitespace(_ sql: String) -> String {
+        sql.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    // MARK: - Clause extraction
+
+    private static let stopKeywordsAfterOn = ["JOIN", "WHERE", "GROUP BY", "ORDER BY", "LIMIT"]
+
+    private static func extractClause(
+        _ sql: String,
+        after keyword: String,
+        stoppingAt stopKeywords: [String]
+    ) -> String? {
+        guard let keywordRange = sql.range(of: " \(keyword) ") else {
+            return nil
+        }
+        var clause = String(sql[keywordRange.upperBound...])
+        for stopKeyword in stopKeywords {
+            if let stopRange = clause.range(of: " \(stopKeyword) ") {
+                clause = String(clause[clause.startIndex..<stopRange.lowerBound])
+            }
+        }
+        return clause.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// Finds every `ON <condition>` clause in the statement and parses it as
+    /// a simple equality (or `IS`) comparison between two qualified
+    /// identifiers. Tolerates both a parenthesised condition (the
+    /// combinatorial corpus's style) and a bare, unparenthesised one ending
+    /// at the next clause keyword (this repo's own anchor-statement style).
+    private static func joinConditions(in sql: String) -> [(IdentifierScanner.Pair, IdentifierScanner.Pair)] {
+        var results: [(IdentifierScanner.Pair, IdentifierScanner.Pair)] = []
+        var searchStart = sql.startIndex
+        while let onRange = sql.range(of: " ON ", range: searchStart..<sql.endIndex) {
+            var remainder = String(sql[onRange.upperBound...])
+            var trimmedLeadingParen = false
+            if remainder.hasPrefix("(") {
+                remainder = String(remainder.dropFirst())
+                trimmedLeadingParen = true
+            }
+            var condition = remainder
+            for stopKeyword in stopKeywordsAfterOn {
+                if let stopRange = condition.range(of: " \(stopKeyword)") {
+                    condition = String(condition[condition.startIndex..<stopRange.lowerBound])
+                }
+            }
+            if trimmedLeadingParen, let closeIndex = condition.firstIndex(of: ")") {
+                condition = String(condition[condition.startIndex..<closeIndex])
+            }
+
+            if let comparison = parseJoinCondition(condition) {
+                results.append(comparison)
+            }
+            searchStart = onRange.upperBound
+        }
+        return results
+    }
+
+    private static let joinOperators = ["==", "=", "IS"]
+
+    private static func parseJoinCondition(
+        _ condition: String
+    ) -> (IdentifierScanner.Pair, IdentifierScanner.Pair)? {
+        var scanner = IdentifierScanner(condition.trimmingCharacters(in: .whitespaces))
+        guard let left = scanner.nextIdentifierPair() else {
+            return nil
+        }
+        scanner.skipWhitespace()
+        guard let operatorToken = joinOperators.first(where: { scanner.peekMatches($0) }) else {
+            return nil
+        }
+        scanner.advance(by: operatorToken.count)
+        scanner.skipWhitespace()
+        guard let right = scanner.nextIdentifierPair() else {
+            return nil
+        }
+        return (left, right)
+    }
+
+    /// Splits `WHERE` clause text on top-level ` AND `, tolerant of the
+    /// combinatorial corpus's rendering style, which wraps the whole clause
+    /// and every conjunct in parentheses (e.g.
+    /// `(("a"."x" >= 1) AND ("a"."x" <= 2))`), as well as an unwrapped,
+    /// unparenthesised single comparison.
+    private static func splitTopLevelConjuncts(_ clause: String) -> [String] {
+        splitTopLevel(unwrapOuterParens(clause), on: " AND ").map(unwrapOuterParens)
+    }
+
+    private static func splitTopLevel(_ text: String, on separator: String) -> [String] {
+        var depth = 0
+        var pieces: [String] = []
+        var current = ""
+        var index = text.startIndex
+        while index < text.endIndex {
+            if text[index] == "(" {
+                depth += 1
+            } else if text[index] == ")" {
+                depth -= 1
+            }
+            if depth == 0, text[index...].hasPrefix(separator) {
+                pieces.append(current)
+                current = ""
+                index = text.index(index, offsetBy: separator.count)
+                continue
+            }
+            current.append(text[index])
+            index = text.index(after: index)
+        }
+        pieces.append(current)
+        return pieces.map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    private static func unwrapOuterParens(_ text: String) -> String {
+        var result = text.trimmingCharacters(in: .whitespaces)
+        while result.hasPrefix("("), result.hasSuffix(")") {
+            let inner = String(result.dropFirst().dropLast())
+            guard isFullyWrapped(inner) else {
+                break
+            }
+            result = inner.trimmingCharacters(in: .whitespaces)
+        }
+        return result
+    }
+
+    /// True only if the leading `(` closes at the very end of `inner` (i.e.
+    /// that pair wraps the whole string), rather than e.g. `(a) AND (b)`
+    /// where the leading `(` closes long before the trailing `)`.
+    private static func isFullyWrapped(_ inner: String) -> Bool {
+        var depth = 0
+        for character in inner {
+            if character == "(" {
+                depth += 1
+            } else if character == ")" {
+                depth -= 1
+                if depth < 0 {
+                    return false
+                }
+            }
+        }
+        return depth == 0
+    }
+
+    // MARK: - Comparison parsing
+
+    private static let comparisonOperators = ["==", "=", ">=", "<=", ">", "<"]
+
+    private static func parseComparison(_ conjunct: String, aliasFilter: String) -> WhereComparison? {
+        var scanner = IdentifierScanner(conjunct)
+        guard let pair = scanner.nextIdentifierPair(), pair.alias == aliasFilter else {
+            return nil
+        }
+        scanner.skipWhitespace()
+        for operatorToken in comparisonOperators where scanner.peekMatches(operatorToken) {
+            let kind: WhereComparison.ComparisonKind = (operatorToken == "==" || operatorToken == "=")
+                ? .equality
+                : .range
+            return WhereComparison(alias: pair.alias, column: pair.identifier, kind: kind)
+        }
+        return nil
+    }
+}
+
+
+/// Scans a leading `alias.identifier` pair from the current position, where
+/// each half is either a bare word (`[A-Za-z_][A-Za-z0-9_]*`) or a
+/// double-quoted identifier (`"any characters except a quote"`). Mirrors the
+/// manual-parsing style already used by `EQPPlanShapeClassifier` rather than
+/// reaching for a regex-based SQL grammar.
+private struct IdentifierScanner {
+    struct Pair: Equatable {
+        let alias: String
+        let identifier: String
+    }
+
+    private let characters: [Character]
+    private var position: Int = 0
+
+    init(_ text: String) {
+        self.characters = Array(text)
+    }
+
+    mutating func nextIdentifierPair() -> Pair? {
+        skipWhitespace()
+        guard let alias = nextIdentifier(), consume(".") else {
+            return nil
+        }
+        guard let identifier = nextIdentifier() else {
+            return nil
+        }
+        return Pair(alias: alias, identifier: identifier)
+    }
+
+    mutating func skipWhitespace() {
+        while position < characters.count, characters[position] == " " {
+            position += 1
+        }
+    }
+
+    func peekMatches(_ token: String) -> Bool {
+        let tokenCharacters = Array(token)
+        guard position + tokenCharacters.count <= characters.count else {
+            return false
+        }
+        return Array(characters[position..<(position + tokenCharacters.count)]) == tokenCharacters
+    }
+
+    mutating func advance(by count: Int) {
+        position += count
+    }
+
+    private mutating func consume(_ token: String) -> Bool {
+        guard peekMatches(token) else {
+            return false
+        }
+        position += token.count
+        return true
+    }
+
+    private mutating func nextIdentifier() -> String? {
+        guard position < characters.count else {
+            return nil
+        }
+        if characters[position] == "\"" {
+            var identifier = ""
+            var index = position + 1
+            while index < characters.count, characters[index] != "\"" {
+                identifier.append(characters[index])
+                index += 1
+            }
+            guard index < characters.count else {
+                return nil
+            }
+            position = index + 1
+            return identifier
+        }
+
+        guard characters[position].isLetter || characters[position] == "_" else {
+            return nil
+        }
+        var identifier = ""
+        var index = position
+        while index < characters.count, characters[index].isLetter || characters[index].isNumber || characters[index] == "_" {
+            identifier.append(characters[index])
+            index += 1
+        }
+        position = index
+        return identifier
+    }
+}
+
+
+/// Scans a single name — either a bare word or a double-quoted identifier
+/// that may contain spaces (`"Order Details"`) — plus literal keywords
+/// (`AS`) between names. Used only for `FROM`/`JOIN … AS …` table-alias
+/// parsing, where (unlike a column reference) the name itself can contain
+/// whitespace.
+private struct NameScanner {
+    private let characters: [Character]
+    private var position: Int = 0
+
+    init(_ text: String) {
+        self.characters = Array(text)
+    }
+
+    mutating func skipWhitespace() {
+        while position < characters.count, characters[position] == " " {
+            position += 1
+        }
+    }
+
+    mutating func consume(_ token: String) -> Bool {
+        let tokenCharacters = Array(token)
+        guard position + tokenCharacters.count <= characters.count,
+              Array(characters[position..<(position + tokenCharacters.count)]) == tokenCharacters else {
+            return false
+        }
+        position += tokenCharacters.count
+        return true
+    }
+
+    mutating func nextName() -> String? {
+        guard position < characters.count else {
+            return nil
+        }
+        if characters[position] == "\"" {
+            var name = ""
+            var index = position + 1
+            while index < characters.count, characters[index] != "\"" {
+                name.append(characters[index])
+                index += 1
+            }
+            guard index < characters.count else {
+                return nil
+            }
+            position = index + 1
+            return name
+        }
+
+        guard characters[position].isLetter || characters[position] == "_" else {
+            return nil
+        }
+        var name = ""
+        var index = position
+        while index < characters.count, characters[index].isLetter || characters[index].isNumber || characters[index] == "_" {
+            name.append(characters[index])
+            index += 1
+        }
+        position = index
+        return name
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
@@ -130,7 +130,8 @@ package enum IndexCandidateExtraction {
         for alias in ambiguousAliases {
             bindings.removeValue(forKey: alias)
         }
-        for (alias, table) in bindings where cteNames.contains(table) {
+        let cteAliases = bindings.filter { cteNames.contains($0.value) }.map(\.key)
+        for alias in cteAliases {
             bindings.removeValue(forKey: alias)
         }
         return bindings

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
@@ -33,7 +33,9 @@ package struct JoinKey: Equatable, Sendable {
 /// (`("t0"."orderID" == 10248)`) and this repo's own hand-written Northwind
 /// anchor style (`o.OrderID = ?`, no quotes, no wrapping parens) — via a
 /// single identifier scanner that accepts both forms. A `WHERE` clause
-/// containing a top-level `OR`, or a conjunct that isn't a plain
+/// containing `OR` *anywhere* — not just at the top level; this check is a
+/// blunt substring test, deliberately more conservative than "does this
+/// `OR` actually change precedence" — or a conjunct that isn't a plain
 /// column/operator comparison, yields no comparisons for that clause —
 /// never a guessed or partial one. Statements this extractor can't
 /// confidently read simply produce no candidate, the same "never coerce"

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
@@ -64,7 +64,7 @@ package enum IndexCandidateExtraction {
             // expression, not the trailing COLLATE/ASC/DESC — e.g.
             // `("t0"."x" COLLATE NOCASE) ASC` — so trim leading "(" alone
             // rather than requiring the whole term to be paren-wrapped.
-            let trimmed = term.trimmingCharacters(in: .whitespaces).drop { $0 == "(" }
+            let trimmed = term.trimmingCharacters(in: .whitespaces).drop(while: { $0 == "(" })
             var scanner = IdentifierScanner(String(trimmed))
             guard let pair = scanner.nextIdentifierPair() else {
                 return nil

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateExtraction.swift
@@ -300,6 +300,11 @@ package enum IndexCandidateExtraction {
         splitTopLevel(unwrapOuterParens(clause), on: " AND ").map(unwrapOuterParens)
     }
 
+    /// Splits `text` on `separator` wherever it occurs at paren depth 0.
+    /// Unbalanced parentheses (depth going negative mid-scan, or never
+    /// returning to zero) never guess at a split — per this extractor's
+    /// "never guess" contract — and instead fail closed by returning `text`
+    /// unsplit, as a single piece.
     private static func splitTopLevel(_ text: String, on separator: String) -> [String] {
         var depth = 0
         var pieces: [String] = []
@@ -310,6 +315,9 @@ package enum IndexCandidateExtraction {
                 depth += 1
             } else if text[index] == ")" {
                 depth -= 1
+                guard depth >= 0 else {
+                    return [text.trimmingCharacters(in: .whitespaces)]
+                }
             }
             if depth == 0, text[index...].hasPrefix(separator) {
                 pieces.append(current)
@@ -321,6 +329,9 @@ package enum IndexCandidateExtraction {
             index = text.index(after: index)
         }
         pieces.append(current)
+        guard depth == 0 else {
+            return [text.trimmingCharacters(in: .whitespaces)]
+        }
         return pieces.map { $0.trimmingCharacters(in: .whitespaces) }
     }
 

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
@@ -15,10 +15,10 @@ package struct RemediableCandidate: Equatable, Sendable {
 
 
 /// A candidate index: a real table name plus an ordered column list, ready
-/// to render as `CREATE INDEX` DDL. `representativeStatementID`/`Alias`
-/// name one concrete statement this candidate can be verified against (the
-/// first one found); `sourceStatementIDs` keeps every contributing
-/// statement for provenance.
+/// to render as `CREATE INDEX` DDL. `representativeStatementID` and
+/// `representativeAlias` name one concrete statement this candidate can be
+/// verified against (the first one found); `sourceStatementIDs` keeps every
+/// contributing statement for provenance.
 package struct IndexCandidate: Equatable, Sendable {
     package let table: String
     package let columns: [String]

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
@@ -1,0 +1,171 @@
+import Foundation
+import SwiftQLSQLiteEQPVariancePrototype
+import SwiftQLSQLitePlanShapePrototype
+
+
+/// One remediable (statement, table alias) pair before deduplication: a
+/// `full_table_scan` root whose statement yielded a non-empty candidate
+/// column list for that alias.
+package struct RemediableCandidate: Equatable, Sendable {
+    package let table: String
+    package let columns: [String]
+    package let statementID: String
+    package let alias: String
+}
+
+
+/// A candidate index: a real table name plus an ordered column list, ready
+/// to render as `CREATE INDEX` DDL. `representativeStatementID`/`Alias`
+/// name one concrete statement this candidate can be verified against (the
+/// first one found); `sourceStatementIDs` keeps every contributing
+/// statement for provenance.
+package struct IndexCandidate: Equatable, Sendable {
+    package let table: String
+    package let columns: [String]
+    package let sourceStatementIDs: [String]
+    package let representativeStatementID: String
+    package let representativeAlias: String
+
+    package init(
+        table: String,
+        columns: [String],
+        sourceStatementIDs: [String],
+        representativeStatementID: String,
+        representativeAlias: String
+    ) {
+        self.table = table
+        self.columns = columns
+        self.sourceStatementIDs = sourceStatementIDs.sorted()
+        self.representativeStatementID = representativeStatementID
+        self.representativeAlias = representativeAlias
+    }
+
+    package var indexName: String {
+        let sanitizedTable = table.lowercased().map { $0.isLetter || $0.isNumber ? $0 : "_" }
+        let sanitizedColumns = columns.map { column in
+            String(column.lowercased().map { $0.isLetter || $0.isNumber ? $0 : "_" })
+        }
+        return (["ix_advisor"] + [String(sanitizedTable)] + sanitizedColumns).joined(separator: "_")
+    }
+
+    package var ddl: String {
+        let columnList = columns.map { "\"\($0)\"" }.joined(separator: ", ")
+        return "CREATE INDEX \"\(indexName)\" ON \"\(table)\" (\(columnList))"
+    }
+}
+
+
+package enum IndexCandidateGenerator {
+    /// Derives one candidate's column list for `alias` in `sql`, following
+    /// SQLite's own left-to-right composite-index rule: equality-constrained
+    /// columns first (any number of them can narrow a B-tree seek), then at
+    /// most one range-constrained column (a second range column after the
+    /// first cannot narrow the seek any further — SQLite stops using the
+    /// index for narrowing at the first range term), then join-key columns,
+    /// then `ORDER BY` columns (so the index can also satisfy sort order
+    /// without a temp B-tree). Each column is included only once, at its
+    /// highest-precedence position.
+    package static func candidateColumns(for alias: String, in sql: String) -> [String] {
+        let comparisons = IndexCandidateExtraction.whereComparisons(for: alias, in: sql)
+        let equalityColumns = orderedUnique(comparisons.filter { $0.kind == .equality }.map(\.column))
+        let rangeColumns = orderedUnique(comparisons.filter { $0.kind == .range }.map(\.column))
+        let joinColumns = orderedUnique(IndexCandidateExtraction.joinKeys(for: alias, in: sql).map(\.column))
+        let orderColumns = IndexCandidateExtraction.orderByColumns(for: alias, in: sql)
+
+        var columns: [String] = []
+        columns.append(contentsOf: equalityColumns)
+        if let firstRange = rangeColumns.first(where: { !columns.contains($0) }) {
+            columns.append(firstRange)
+        }
+        for column in joinColumns where !columns.contains(column) {
+            columns.append(column)
+        }
+        for column in orderColumns where !columns.contains(column) {
+            columns.append(column)
+        }
+        return columns
+    }
+
+    /// Finds every `full_table_scan` node in a classified plan and, where
+    /// this statement's SQL yields a non-empty candidate column list for
+    /// that node's table alias and the alias resolves to a real table (see
+    /// `IndexCandidateExtraction.tableAliasMap`), produces a remediable
+    /// candidate. A full table scan with no equality/range/join/order-by
+    /// signal, or whose alias can't be confidently resolved, yields nothing
+    /// — never a guess.
+    package static func remediableCandidates(
+        for statement: EQPVarianceStatement,
+        plan: EQPPlan
+    ) -> [RemediableCandidate] {
+        let tableAliases = IndexCandidateExtraction.tableAliasMap(in: statement.renderedSQL)
+        var candidates: [RemediableCandidate] = []
+        for root in plan.roots {
+            guard root.shape == .fullTableScan,
+                  let alias = root.attributes.table,
+                  let table = tableAliases[alias] else {
+                continue
+            }
+            let columns = candidateColumns(for: alias, in: statement.renderedSQL)
+            guard !columns.isEmpty else {
+                continue
+            }
+            candidates.append(RemediableCandidate(
+                table: table,
+                columns: columns,
+                statementID: statement.id,
+                alias: alias
+            ))
+        }
+        return candidates
+    }
+
+    /// Merges remediable candidates for the same `(table, columns)`
+    /// (recording every contributing statement id, and keeping the first
+    /// occurrence as the representative to verify against), then drops any
+    /// candidate whose column list is an exact prefix of another surviving
+    /// candidate on the same table — a wider index already serves every
+    /// query the narrower prefix would have, so keeping both is redundant.
+    package static func deduplicate(_ remediables: [RemediableCandidate]) -> [IndexCandidate] {
+        var merged: [String: IndexCandidate] = [:]
+        for remediable in remediables {
+            let key = "\(remediable.table)\u{0}\(remediable.columns.joined(separator: "\u{0}"))"
+            if let existing = merged[key] {
+                merged[key] = IndexCandidate(
+                    table: existing.table,
+                    columns: existing.columns,
+                    sourceStatementIDs: existing.sourceStatementIDs + [remediable.statementID],
+                    representativeStatementID: existing.representativeStatementID,
+                    representativeAlias: existing.representativeAlias
+                )
+            } else {
+                merged[key] = IndexCandidate(
+                    table: remediable.table,
+                    columns: remediable.columns,
+                    sourceStatementIDs: [remediable.statementID],
+                    representativeStatementID: remediable.statementID,
+                    representativeAlias: remediable.alias
+                )
+            }
+        }
+
+        let all = Array(merged.values)
+        return all.filter { candidate in
+            !all.contains { other in
+                other.table == candidate.table
+                    && other.columns.count > candidate.columns.count
+                    && Array(other.columns.prefix(candidate.columns.count)) == candidate.columns
+            }
+        }.sorted { lhs, rhs in
+            lhs.table != rhs.table ? lhs.table < rhs.table : lhs.columns.lexicographicallyPrecedes(rhs.columns)
+        }
+    }
+
+    private static func orderedUnique(_ values: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        for value in values where seen.insert(value).inserted {
+            result.append(value)
+        }
+        return result
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
@@ -57,14 +57,28 @@ package struct IndexCandidate: Equatable, Sendable {
 
 package enum IndexCandidateGenerator {
     /// Derives one candidate's column list for `alias` in `sql`, following
-    /// SQLite's own left-to-right composite-index rule: equality-constrained
-    /// columns first (any number of them can narrow a B-tree seek), then at
-    /// most one range-constrained column (a second range column after the
-    /// first cannot narrow the seek any further — SQLite stops using the
-    /// index for narrowing at the first range term), then join-key columns,
-    /// then `ORDER BY` columns (so the index can also satisfy sort order
-    /// without a temp B-tree). Each column is included only once, at its
-    /// highest-precedence position.
+    /// SQLite's own left-to-right composite-index rule: every
+    /// equality-constrained column first — **a join key is an equality
+    /// constraint too** (SQLite seeks on it per outer row exactly like a
+    /// `WHERE` equality, it just supplies the bound value at run time
+    /// instead of from the statement text), so `WHERE`-equality and
+    /// join-key columns share this same leading tier — then at most one
+    /// range-constrained column (a second range column after the first
+    /// cannot narrow the seek any further — SQLite stops using the index
+    /// for narrowing at the first range term), then `ORDER BY` columns (so
+    /// the index can also satisfy sort order without a temp B-tree). Each
+    /// column is included only once, at its highest-precedence position.
+    ///
+    /// This ordering is confirmed, not assumed: a candidate with the join
+    /// key before the range column
+    /// (`Products(CategoryID, UnitPrice)`) is the index SQLite actually uses
+    /// for a `LEFT JOIN` looked-up table filtered on both; the reverse
+    /// order (`Products(UnitPrice, CategoryID)`) is silently ignored by the
+    /// planner, which falls back to its own automatic covering index on the
+    /// join key alone. See
+    /// `IndexCandidateGeneratorTests.testJoinKeyMustPrecedeRangeColumnForSQLiteToUseTheIndex`
+    /// and `IndexCandidateVerifierTests` for the same result verified via a
+    /// real scratch-copy re-plan.
     package static func candidateColumns(for alias: String, in sql: String) -> [String] {
         let comparisons = IndexCandidateExtraction.whereComparisons(for: alias, in: sql)
         let equalityColumns = orderedUnique(comparisons.filter { $0.kind == .equality }.map(\.column))
@@ -74,11 +88,11 @@ package enum IndexCandidateGenerator {
 
         var columns: [String] = []
         columns.append(contentsOf: equalityColumns)
-        if let firstRange = rangeColumns.first(where: { !columns.contains($0) }) {
-            columns.append(firstRange)
-        }
         for column in joinColumns where !columns.contains(column) {
             columns.append(column)
+        }
+        if let firstRange = rangeColumns.first(where: { !columns.contains($0) }) {
+            columns.append(firstRange)
         }
         for column in orderColumns where !columns.contains(column) {
             columns.append(column)

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
@@ -119,10 +119,11 @@ package enum IndexCandidateGenerator {
 
     /// Finds every remediable **root** node in a classified plan —
     /// deliberately not a recursive walk into every child node; see this
-    /// issue's write-up ("only the driving table's roots are considered" —
-    /// remediating a nested scan is left as future work) — and, where this
-    /// statement's SQL yields a non-empty candidate column list for that
-    /// node's table alias and the alias resolves to a real table (see
+    /// issue's write-up ("only root nodes are considered" — remediating a
+    /// nested scan, e.g. one inside a subquery, is left as future work) —
+    /// and, where this statement's SQL yields a non-empty candidate column
+    /// list for that node's table alias and the alias resolves to a real
+    /// table (see
     /// `IndexCandidateExtraction.tableAliasMap`), produces a remediable
     /// candidate. A remediable root with no equality/range/join/order-by
     /// signal, or whose alias can't be confidently resolved, yields nothing

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
@@ -100,14 +100,21 @@ package enum IndexCandidateGenerator {
         return columns
     }
 
-    /// Finds every `full_table_scan` **root** node in a classified plan —
+    /// Shapes worth proposing a candidate for: a `full_table_scan` (nothing
+    /// indexes it yet), and SQLite's own `automatic_covering_index` (it
+    /// already built an ephemeral index at query time, which is exactly the
+    /// situation a real, persistent index replaces — see the join-key/
+    /// range-column finding in `SQLiteIndexAdvisor.md`).
+    private static let remediableRootShapes: Set<EQPPlanShapeKind> = [.fullTableScan, .automaticCoveringIndex]
+
+    /// Finds every remediable **root** node in a classified plan —
     /// deliberately not a recursive walk into every child node; see this
     /// issue's write-up ("only the driving table's roots are considered" —
     /// remediating a nested scan is left as future work) — and, where this
     /// statement's SQL yields a non-empty candidate column list for that
     /// node's table alias and the alias resolves to a real table (see
     /// `IndexCandidateExtraction.tableAliasMap`), produces a remediable
-    /// candidate. A full table scan with no equality/range/join/order-by
+    /// candidate. A remediable root with no equality/range/join/order-by
     /// signal, or whose alias can't be confidently resolved, yields nothing
     /// — never a guess.
     package static func remediableCandidates(
@@ -117,7 +124,7 @@ package enum IndexCandidateGenerator {
         let tableAliases = IndexCandidateExtraction.tableAliasMap(in: statement.renderedSQL)
         var candidates: [RemediableCandidate] = []
         for root in plan.roots {
-            guard root.shape == .fullTableScan,
+            guard remediableRootShapes.contains(root.shape),
                   let alias = root.attributes.table,
                   let table = tableAliases[alias] else {
                 continue
@@ -142,6 +149,10 @@ package enum IndexCandidateGenerator {
     /// candidate whose column list is an exact prefix of another surviving
     /// candidate on the same table — a wider index already serves every
     /// query the narrower prefix would have, so keeping both is redundant.
+    /// A dropped prefix candidate's `sourceStatementIDs` are folded into
+    /// every wider candidate it prefixes before being discarded, so the
+    /// statements that only ever produced the narrower prefix are still
+    /// attributed to the index that now serves them.
     package static func deduplicate(_ remediables: [RemediableCandidate]) -> [IndexCandidate] {
         var merged: [String: IndexCandidate] = [:]
         for remediable in remediables {
@@ -166,15 +177,42 @@ package enum IndexCandidateGenerator {
         }
 
         let all = Array(merged.values)
-        return all.filter { candidate in
-            !all.contains { other in
+
+        func widerCandidates(prefixedBy candidate: IndexCandidate) -> [IndexCandidate] {
+            all.filter { other in
                 other.table == candidate.table
                     && other.columns.count > candidate.columns.count
                     && Array(other.columns.prefix(candidate.columns.count)) == candidate.columns
             }
-        }.sorted { lhs, rhs in
-            lhs.table != rhs.table ? lhs.table < rhs.table : lhs.columns.lexicographicallyPrecedes(rhs.columns)
         }
+
+        var additionalSources: [String: [String]] = [:]
+        for candidate in all {
+            let wider = widerCandidates(prefixedBy: candidate)
+            for widerCandidate in wider {
+                let widerKey = "\(widerCandidate.table)\u{0}\(widerCandidate.columns.joined(separator: "\u{0}"))"
+                additionalSources[widerKey, default: []].append(contentsOf: candidate.sourceStatementIDs)
+            }
+        }
+
+        return all
+            .filter { widerCandidates(prefixedBy: $0).isEmpty }
+            .map { survivor -> IndexCandidate in
+                let key = "\(survivor.table)\u{0}\(survivor.columns.joined(separator: "\u{0}"))"
+                guard let extra = additionalSources[key] else {
+                    return survivor
+                }
+                return IndexCandidate(
+                    table: survivor.table,
+                    columns: survivor.columns,
+                    sourceStatementIDs: Array(Set(survivor.sourceStatementIDs + extra)),
+                    representativeStatementID: survivor.representativeStatementID,
+                    representativeAlias: survivor.representativeAlias
+                )
+            }
+            .sorted { lhs, rhs in
+                lhs.table != rhs.table ? lhs.table < rhs.table : lhs.columns.lexicographicallyPrecedes(rhs.columns)
+            }
     }
 
     private static func orderedUnique(_ values: [String]) -> [String] {

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
@@ -86,9 +86,12 @@ package enum IndexCandidateGenerator {
         return columns
     }
 
-    /// Finds every `full_table_scan` node in a classified plan and, where
-    /// this statement's SQL yields a non-empty candidate column list for
-    /// that node's table alias and the alias resolves to a real table (see
+    /// Finds every `full_table_scan` **root** node in a classified plan —
+    /// deliberately not a recursive walk into every child node; see this
+    /// issue's write-up ("only the driving table's roots are considered" —
+    /// remediating a nested scan is left as future work) — and, where this
+    /// statement's SQL yields a non-empty candidate column list for that
+    /// node's table alias and the alias resolves to a real table (see
     /// `IndexCandidateExtraction.tableAliasMap`), produces a remediable
     /// candidate. A full table scan with no equality/range/join/order-by
     /// signal, or whose alias can't be confidently resolved, yields nothing

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateGenerator.swift
@@ -49,8 +49,18 @@ package struct IndexCandidate: Equatable, Sendable {
     }
 
     package var ddl: String {
-        let columnList = columns.map { "\"\($0)\"" }.joined(separator: ", ")
-        return "CREATE INDEX \"\(indexName)\" ON \"\(table)\" (\(columnList))"
+        let columnList = columns.map(Self.quotedIdentifier).joined(separator: ", ")
+        return "CREATE INDEX \(Self.quotedIdentifier(indexName)) ON \(Self.quotedIdentifier(table)) (\(columnList))"
+    }
+
+    /// Quotes a SQL identifier, escaping any embedded `"` as `""` per
+    /// SQLite's quoting rule — `table`/`columns` come from parsing this
+    /// prototype's own SQL corpus, but the CLI can also decode an
+    /// `IndexCandidate` from an arbitrary JSON file and hand its `ddl` to
+    /// `Database.execute(sql:)`, so an unescaped quote in an identifier
+    /// could otherwise break out of the identifier context.
+    private static func quotedIdentifier(_ identifier: String) -> String {
+        "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 }
 

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateVerifier.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateVerifier.swift
@@ -1,0 +1,173 @@
+import Foundation
+import GRDB
+import SwiftQLNorthwindFixtures
+import SwiftQLSQLiteEQPVariancePrototype
+import SwiftQLSQLitePlanShapePrototype
+
+
+/// A candidate's before-plan, DDL, and after-plan, captured as a single
+/// evidence triple, plus whether the stated improvement rule accepted it.
+package struct IndexCandidateEvidence: Codable, Equatable, Sendable {
+    package let table: String
+    package let columns: [String]
+    package let ddl: String
+    package let statementID: String
+    package let beforePlan: EQPPlan
+    package let afterPlan: EQPPlan
+    package let isImprovement: Bool
+    package let improvementReason: String
+
+    package init(
+        table: String,
+        columns: [String],
+        ddl: String,
+        statementID: String,
+        beforePlan: EQPPlan,
+        afterPlan: EQPPlan,
+        isImprovement: Bool,
+        improvementReason: String
+    ) {
+        self.table = table
+        self.columns = columns
+        self.ddl = ddl
+        self.statementID = statementID
+        self.beforePlan = beforePlan
+        self.afterPlan = afterPlan
+        self.isImprovement = isImprovement
+        self.improvementReason = improvementReason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case table
+        case columns
+        case ddl
+        case statementID = "statement_id"
+        case beforePlan = "before_plan"
+        case afterPlan = "after_plan"
+        case isImprovement = "is_improvement"
+        case improvementReason = "improvement_reason"
+    }
+}
+
+
+package enum IndexCandidateVerificationError: Error, Sendable {
+    case statementNotCaptured(String)
+}
+
+
+/// Verifies one index candidate by creating it on a scratch copy of the
+/// pinned Northwind snapshot and re-planning — never against the canonical
+/// file or a long-lived application connection.
+package enum IndexCandidateVerifier {
+    /// `NorthwindFixture.withTemporaryCopy` copies the canonical file to a
+    /// fresh temporary directory, hands this closure a writable pool scoped
+    /// to that copy, and removes the copy afterward on every exit path
+    /// (success, a thrown error from this closure, or a failure creating
+    /// the copy itself) — exactly the "discard on every path including
+    /// failure" this issue requires, reused rather than reimplemented.
+    package static func verify(
+        candidate: IndexCandidate,
+        statement: EQPVarianceStatement
+    ) throws -> IndexCandidateEvidence {
+        try NorthwindFixture.withTemporaryCopy { copy in
+            let beforePlan = try classifiedPlan(for: statement, pool: copy.databasePool, label: "before")
+
+            try copy.databasePool.write { database in
+                try database.execute(sql: candidate.ddl)
+            }
+
+            let afterPlan = try classifiedPlan(for: statement, pool: copy.databasePool, label: "after")
+
+            let (isImprovement, reason) = applyImprovementRule(
+                alias: candidate.representativeAlias,
+                before: beforePlan,
+                after: afterPlan
+            )
+
+            return IndexCandidateEvidence(
+                table: candidate.table,
+                columns: candidate.columns,
+                ddl: candidate.ddl,
+                statementID: statement.id,
+                beforePlan: beforePlan,
+                afterPlan: afterPlan,
+                isImprovement: isImprovement,
+                improvementReason: reason
+            )
+        }
+    }
+
+    private static func classifiedPlan(
+        for statement: EQPVarianceStatement,
+        pool: DatabasePool,
+        label: String
+    ) throws -> EQPPlan {
+        let run = try pool.read { database in
+            try EQPVarianceCapture.capture(from: database, corpus: [statement], label: label)
+        }
+        guard let capture = run.statements.first(where: { $0.statementID == statement.id }) else {
+            throw IndexCandidateVerificationError.statementNotCaptured(statement.id)
+        }
+        return EQPPlanShapeClassifier.classify(rows: capture.rows, statementID: statement.id)
+    }
+
+    /// The improvement rule, stated once here and applied uniformly to every
+    /// candidate: kept only when the plan node for `alias` changes from
+    /// `full_table_scan` to `index_search` or `covering_index_scan`, *and*
+    /// the after-plan node reports at least one constrained column — proving
+    /// the new index is actually narrowing the scan, not merely present and
+    /// unused. No cost estimate or row-count comparison is used: the pinned
+    /// snapshot is deliberately unanalyzed (no `sqlite_stat1`), so a
+    /// structural shape change is the only signal available that isn't
+    /// itself an unfounded guess.
+    private static func applyImprovementRule(
+        alias: String,
+        before: EQPPlan,
+        after: EQPPlan
+    ) -> (Bool, String) {
+        guard let beforeNode = findNode(forTable: alias, in: before) else {
+            return (false, "no before-plan node found for alias \"\(alias)\"")
+        }
+        guard let afterNode = findNode(forTable: alias, in: after) else {
+            return (false, "no after-plan node found for alias \"\(alias)\"")
+        }
+        guard beforeNode.shape == .fullTableScan else {
+            return (false, "before-plan shape was \(beforeNode.shape.rawValue), not full_table_scan")
+        }
+        guard afterNode.shape == .indexSearch || afterNode.shape == .coveringIndexScan else {
+            return (
+                false,
+                "after-plan shape was \(afterNode.shape.rawValue), expected index_search or covering_index_scan"
+            )
+        }
+        guard !afterNode.attributes.constrainedColumns.isEmpty else {
+            return (false, "after-plan node reports no constrained columns; the new index isn't narrowing the scan")
+        }
+        return (
+            true,
+            "shape changed from full_table_scan to \(afterNode.shape.rawValue), "
+                + "constrained by \(afterNode.attributes.constrainedColumns)"
+        )
+    }
+
+    private static func findNode(forTable alias: String, in plan: EQPPlan) -> EQPPlanNode? {
+        for root in plan.roots {
+            if let found = findNode(forTable: alias, in: root) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    private static func findNode(forTable alias: String, in node: EQPPlanNode) -> EQPPlanNode? {
+        if node.attributes.table == alias {
+            return node
+        }
+        for child in node.children {
+            if let found = findNode(forTable: alias, in: child) {
+                return found
+            }
+        }
+        return nil
+    }
+}

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateVerifier.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateVerifier.swift
@@ -113,13 +113,18 @@ package enum IndexCandidateVerifier {
 
     /// The improvement rule, stated once here and applied uniformly to every
     /// candidate: kept only when the plan node for `alias` changes from
-    /// `full_table_scan` to `index_search` or `covering_index_scan`, *and*
-    /// the after-plan node reports at least one constrained column — proving
-    /// the new index is actually narrowing the scan, not merely present and
-    /// unused. No cost estimate or row-count comparison is used: the pinned
-    /// snapshot is deliberately unanalyzed (no `sqlite_stat1`), so a
-    /// structural shape change is the only signal available that isn't
-    /// itself an unfounded guess.
+    /// `full_table_scan` **or `automatic_covering_index`** to `index_search`
+    /// or `covering_index_scan`, *and* the after-plan node reports at least
+    /// one constrained column — proving the new index is actually narrowing
+    /// the scan, not merely present and unused. `automatic_covering_index`
+    /// is included alongside `full_table_scan` as a remediable "before"
+    /// shape because it is SQLite's own ephemeral workaround for exactly
+    /// the situation a real index fixes: ejecting and rebuilding a
+    /// throwaway covering index on every execution instead of reusing a
+    /// persistent one. No cost estimate or row-count comparison is used:
+    /// the pinned snapshot is deliberately unanalyzed (no `sqlite_stat1`),
+    /// so a structural shape change is the only signal available that
+    /// isn't itself an unfounded guess.
     private static func applyImprovementRule(
         alias: String,
         before: EQPPlan,
@@ -131,8 +136,12 @@ package enum IndexCandidateVerifier {
         guard let afterNode = findNode(forTable: alias, in: after) else {
             return (false, "no after-plan node found for alias \"\(alias)\"")
         }
-        guard beforeNode.shape == .fullTableScan else {
-            return (false, "before-plan shape was \(beforeNode.shape.rawValue), not full_table_scan")
+        guard beforeNode.shape == .fullTableScan || beforeNode.shape == .automaticCoveringIndex else {
+            return (
+                false,
+                "before-plan shape was \(beforeNode.shape.rawValue), "
+                    + "not full_table_scan or automatic_covering_index"
+            )
         }
         guard afterNode.shape == .indexSearch || afterNode.shape == .coveringIndexScan else {
             return (
@@ -145,7 +154,7 @@ package enum IndexCandidateVerifier {
         }
         return (
             true,
-            "shape changed from full_table_scan to \(afterNode.shape.rawValue), "
+            "shape changed from \(beforeNode.shape.rawValue) to \(afterNode.shape.rawValue), "
                 + "constrained by \(afterNode.attributes.constrainedColumns)"
         )
     }

--- a/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateVerifier.swift
+++ b/Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteIndexAdvisorPrototype/IndexCandidateVerifier.swift
@@ -159,7 +159,20 @@ package enum IndexCandidateVerifier {
         )
     }
 
-    private static func findNode(forTable alias: String, in plan: EQPPlan) -> EQPPlanNode? {
+    /// Prefers a **root-level** match across every root before considering
+    /// any nested node — a plain per-root depth-first search, tried root by
+    /// root in order, can return a nested match from an earlier root before
+    /// ever reaching a later root that matches at the top level. A real
+    /// capture with exactly this shape exists in the corpus
+    /// (`c390.northwind.subquery.products-above-average`: a root
+    /// `SCAN Products` alongside a sibling `SCALAR SUBQUERY 1` root whose
+    /// own child is a second, nested `SCAN Products`); `representativeAlias`
+    /// always names a root-level table per `IndexCandidateGenerator`, so the
+    /// root-level match is always the intended node.
+    package static func findNode(forTable alias: String, in plan: EQPPlan) -> EQPPlanNode? {
+        if let rootMatch = plan.roots.first(where: { $0.attributes.table == alias }) {
+            return rootMatch
+        }
         for root in plan.roots {
             if let found = findNode(forTable: alias, in: root) {
                 return found

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/candidates.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/candidates.json
@@ -19,7 +19,25 @@
     "representative_alias" : "t0",
     "representative_statement_id" : "c191.v1.select.j-left.w-injection-binding",
     "source_statement_ids" : [
-      "c191.v1.select.j-left.w-injection-binding"
+      "c191.v1.select.j-cross.o-collated",
+      "c191.v1.select.j-cross.w-injection-binding",
+      "c191.v1.select.j-inner.o-collated",
+      "c191.v1.select.j-inner.w-empty-in",
+      "c191.v1.select.j-inner.w-injection-binding",
+      "c191.v1.select.j-inner.w-null-comparison",
+      "c191.v1.select.j-inner.w-precedence",
+      "c191.v1.select.j-left.w-injection-binding",
+      "c191.v1.select.p-aggregate-count.o-collated",
+      "c191.v1.select.p-aggregate-count.w-injection-binding",
+      "c191.v1.select.p-nullable-region.j-inner",
+      "c191.v1.select.p-nullable-region.w-injection-binding",
+      "c191.v1.select.s-table-alias.j-inner",
+      "c191.v1.select.s-table-alias.w-injection-binding",
+      "c191.v1.select.w-empty-in.o-collated",
+      "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one",
+      "c191.v1.select.w-injection-binding.l-five.x-two",
+      "c191.v1.select.w-injection-binding.o-collated",
+      "c191.v1.select.w-precedence.o-collated"
     ],
     "table" : "Orders"
   },
@@ -31,9 +49,27 @@
     "representative_alias" : "t0",
     "representative_statement_id" : "c191.v1.select.j-inner.o-ascending",
     "source_statement_ids" : [
+      "c191.v1.select.j-cross.o-collated",
+      "c191.v1.select.j-cross.w-injection-binding",
       "c191.v1.select.j-inner.o-ascending",
+      "c191.v1.select.j-inner.o-collated",
+      "c191.v1.select.j-inner.w-empty-in",
+      "c191.v1.select.j-inner.w-injection-binding",
+      "c191.v1.select.j-inner.w-null-comparison",
+      "c191.v1.select.j-inner.w-precedence",
+      "c191.v1.select.p-aggregate-count.o-collated",
+      "c191.v1.select.p-aggregate-count.w-injection-binding",
+      "c191.v1.select.p-nullable-region.j-inner",
+      "c191.v1.select.p-nullable-region.w-injection-binding",
+      "c191.v1.select.s-table-alias.j-inner",
+      "c191.v1.select.s-table-alias.w-injection-binding",
+      "c191.v1.select.w-empty-in.o-collated",
+      "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one",
+      "c191.v1.select.w-injection-binding.l-five.x-two",
       "c191.v1.select.w-injection-binding.o-ascending",
-      "c191.v1.select.w-injection-binding.o-descending"
+      "c191.v1.select.w-injection-binding.o-collated",
+      "c191.v1.select.w-injection-binding.o-descending",
+      "c191.v1.select.w-precedence.o-collated"
     ],
     "table" : "Orders"
   },
@@ -45,7 +81,14 @@
     "representative_alias" : "orders_case",
     "representative_statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two",
     "source_statement_ids" : [
+      "c191.v1.select.j-cross.w-repeated-binding",
+      "c191.v1.select.j-left.w-empty-in",
+      "c191.v1.select.j-left.w-precedence",
+      "c191.v1.select.j-left.w-repeated-binding",
+      "c191.v1.select.p-aggregate-count.j-left",
       "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two",
+      "c191.v1.select.p-nullable-region.w-repeated-binding",
+      "c191.v1.select.s-table-alias.w-repeated-binding",
       "c191.v1.select.w-repeated-binding.o-collated"
     ],
     "table" : "Orders"
@@ -58,8 +101,15 @@
     "representative_alias" : "t0",
     "representative_statement_id" : "c191.v1.select.j-left.o-ascending",
     "source_statement_ids" : [
+      "c191.v1.select.j-cross.w-repeated-binding",
       "c191.v1.select.j-left.o-ascending",
       "c191.v1.select.j-left.o-descending",
+      "c191.v1.select.j-left.w-empty-in",
+      "c191.v1.select.j-left.w-precedence",
+      "c191.v1.select.j-left.w-repeated-binding",
+      "c191.v1.select.p-aggregate-count.j-left",
+      "c191.v1.select.p-nullable-region.w-repeated-binding",
+      "c191.v1.select.s-table-alias.w-repeated-binding",
       "c191.v1.select.w-repeated-binding.o-ascending"
     ],
     "table" : "Orders"

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/candidates.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/candidates.json
@@ -1,0 +1,92 @@
+[
+  {
+    "columns" : [
+      "ReportsTo",
+      "EmployeeID"
+    ],
+    "representative_alias" : "e",
+    "representative_statement_id" : "c390.northwind.join.left-null-manager",
+    "source_statement_ids" : [
+      "c390.northwind.join.left-null-manager"
+    ],
+    "table" : "Employees"
+  },
+  {
+    "columns" : [
+      "customerID",
+      "employeeID"
+    ],
+    "representative_alias" : "t0",
+    "representative_statement_id" : "c191.v1.select.j-left.w-injection-binding",
+    "source_statement_ids" : [
+      "c191.v1.select.j-left.w-injection-binding"
+    ],
+    "table" : "Orders"
+  },
+  {
+    "columns" : [
+      "customerID",
+      "orderID"
+    ],
+    "representative_alias" : "t0",
+    "representative_statement_id" : "c191.v1.select.j-inner.o-ascending",
+    "source_statement_ids" : [
+      "c191.v1.select.j-inner.o-ascending",
+      "c191.v1.select.w-injection-binding.o-ascending",
+      "c191.v1.select.w-injection-binding.o-descending"
+    ],
+    "table" : "Orders"
+  },
+  {
+    "columns" : [
+      "employeeID",
+      "customerID"
+    ],
+    "representative_alias" : "orders_case",
+    "representative_statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two",
+    "source_statement_ids" : [
+      "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two",
+      "c191.v1.select.w-repeated-binding.o-collated"
+    ],
+    "table" : "Orders"
+  },
+  {
+    "columns" : [
+      "employeeID",
+      "orderID"
+    ],
+    "representative_alias" : "t0",
+    "representative_statement_id" : "c191.v1.select.j-left.o-ascending",
+    "source_statement_ids" : [
+      "c191.v1.select.j-left.o-ascending",
+      "c191.v1.select.j-left.o-descending",
+      "c191.v1.select.w-repeated-binding.o-ascending"
+    ],
+    "table" : "Orders"
+  },
+  {
+    "columns" : [
+      "orderID"
+    ],
+    "representative_alias" : "t0",
+    "representative_statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending",
+    "source_statement_ids" : [
+      "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending",
+      "c191.v1.select.j-cross.o-ascending",
+      "c191.v1.select.j-cross.o-descending",
+      "c191.v1.select.p-aggregate-count.o-ascending",
+      "c191.v1.select.p-nullable-region.o-ascending",
+      "c191.v1.select.p-nullable-region.o-descending",
+      "c191.v1.select.s-table-alias.o-ascending",
+      "c191.v1.select.s-table-alias.o-descending",
+      "c191.v1.select.w-empty-in.o-ascending",
+      "c191.v1.select.w-empty-in.o-descending",
+      "c191.v1.select.w-null-comparison.o-ascending",
+      "c191.v1.select.w-null-comparison.o-descending",
+      "c191.v1.select.w-precedence.o-ascending",
+      "c191.v1.select.w-precedence.o-descending",
+      "c288.v1.subquery.in-query-functional-nonempty"
+    ],
+    "table" : "Orders"
+  }
+]

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/capture_apple-system-3.51.0.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/capture_apple-system-3.51.0.json
@@ -1,0 +1,5115 @@
+{
+  "capture_method" : "grdb-in-process",
+  "label" : "apple-system-3.51.0",
+  "runtime_metadata" : {
+    "collations" : [
+      "BINARY",
+      "NOCASE",
+      "RTRIM",
+      "swiftCaseInsensitiveCompare",
+      "swiftCompare",
+      "swiftLocalizedCaseInsensitiveCompare",
+      "swiftLocalizedCompare",
+      "swiftLocalizedStandardCompare"
+    ],
+    "compile_options" : [
+      "ATOMIC_INTRINSICS=1",
+      "BUG_COMPATIBLE_20160819",
+      "CCCRYPT256",
+      "CODEC=see-cccrypt",
+      "COMPILER=clang-21.0.0",
+      "DEFAULT_AUTOVACUUM",
+      "DEFAULT_CACHE_SIZE=2000",
+      "DEFAULT_CKPTFULLFSYNC",
+      "DEFAULT_FILE_FORMAT=4",
+      "DEFAULT_JOURNAL_SIZE_LIMIT=32768",
+      "DEFAULT_LOOKASIDE=1200,102",
+      "DEFAULT_MEMSTATUS=0",
+      "DEFAULT_MMAP_SIZE=0",
+      "DEFAULT_PAGE_SIZE=4096",
+      "DEFAULT_PCACHE_INITSZ=20",
+      "DEFAULT_RECURSIVE_TRIGGERS",
+      "DEFAULT_SECTOR_SIZE=4096",
+      "DEFAULT_SYNCHRONOUS=2",
+      "DEFAULT_WAL_AUTOCHECKPOINT=1000",
+      "DEFAULT_WAL_SYNCHRONOUS=1",
+      "DEFAULT_WORKER_THREADS=0",
+      "DIRECT_OVERFLOW_READ",
+      "DQS=3",
+      "ENABLE_API_ARMOR",
+      "ENABLE_BYTECODE_VTAB",
+      "ENABLE_COLUMN_METADATA",
+      "ENABLE_DBSTAT_VTAB",
+      "ENABLE_FTS3",
+      "ENABLE_FTS3_PARENTHESIS",
+      "ENABLE_FTS3_TOKENIZER",
+      "ENABLE_FTS4",
+      "ENABLE_FTS5",
+      "ENABLE_LOCKING_STYLE=1",
+      "ENABLE_MATH_FUNCTIONS",
+      "ENABLE_NORMALIZE",
+      "ENABLE_PREUPDATE_HOOK",
+      "ENABLE_RTREE",
+      "ENABLE_SESSION",
+      "ENABLE_SETLK_TIMEOUT",
+      "ENABLE_SNAPSHOT",
+      "ENABLE_SQLLOG",
+      "ENABLE_STMT_SCANSTATUS",
+      "ENABLE_UNKNOWN_SQL_FUNCTION",
+      "ENABLE_UPDATE_DELETE_LIMIT",
+      "HAS_CODEC_RESTRICTED",
+      "HAVE_ISNAN",
+      "MALLOC_SOFT_LIMIT=1024",
+      "MAX_ATTACHED=10",
+      "MAX_COLUMN=2000",
+      "MAX_COMPOUND_SELECT=500",
+      "MAX_DEFAULT_PAGE_SIZE=8192",
+      "MAX_EXPR_DEPTH=1000",
+      "MAX_FUNCTION_ARG=127",
+      "MAX_LENGTH=2147483645",
+      "MAX_LIKE_PATTERN_LENGTH=50000",
+      "MAX_MMAP_SIZE=1073741824",
+      "MAX_PAGE_COUNT=1073741823",
+      "MAX_PAGE_SIZE=65536",
+      "MAX_SQL_LENGTH=1000000000",
+      "MAX_TRIGGER_DEPTH=1000",
+      "MAX_VARIABLE_NUMBER=500000",
+      "MAX_VDBE_OP=250000000",
+      "MAX_WORKER_THREADS=8",
+      "MUTEX_UNFAIR",
+      "OMIT_AUTORESET",
+      "OMIT_LOAD_EXTENSION",
+      "STMTJRNL_SPILL=131072",
+      "SYSTEM_MALLOC",
+      "TEMP_STORE=1",
+      "THREADSAFE=2",
+      "USE_URI"
+    ],
+    "extension_names" : [
+
+    ],
+    "functions" : [
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "->"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "->>"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "abs"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "acos"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "acosh"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "asin"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "asinh"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "atan"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "atan2"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "atanh"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "avg"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "bm25"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ceil"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ceiling"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "changes"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "char"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "coalesce"
+      },
+      {
+        "argument_count" : -3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "concat"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "concat_ws"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "cos"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "cosh"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "count"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "count"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "cume_dist"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "current_date"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "current_time"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "current_timestamp"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "date"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "datetime"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "degrees"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "dense_rank"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "exp"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "first_value"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "floor"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "format"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 524288,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts3_tokenizer"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 524288,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts3_tokenizer"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_get_locale"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_insttoken"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 3145728,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_locale"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "fts5_source_id"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "glob"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "group_concat"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "group_concat"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "hex"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "highlight"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_exponent"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_from_blob"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_inc"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_mantissa"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "ieee754_to_blob"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "if"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ifnull"
+      },
+      {
+        "argument_count" : -4,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "iif"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "instr"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_array"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_array_length"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_array_length"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_error_position"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_extract"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "json_group_array"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "json_group_object"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_insert"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_object"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_patch"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_pretty"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_pretty"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_quote"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_remove"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_replace"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_set"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_type"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_type"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_valid"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "json_valid"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_array"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_extract"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "jsonb_group_array"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "jsonb_group_object"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_insert"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_object"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_patch"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_remove"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_replace"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "jsonb_set"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "julianday"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lag"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lag"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lag"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "last_insert_rowid"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "last_value"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lead"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lead"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "lead"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "length"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "like"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "like"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "likelihood"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "likely"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ln"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log10"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "log2"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "lower"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ltrim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "ltrim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "match"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "matchinfo"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "matchinfo"
+      },
+      {
+        "argument_count" : -3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "max"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "max"
+      },
+      {
+        "argument_count" : -3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "min"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "min"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "mod"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "nth_value"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "ntile"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "nullif"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "octet_length"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "offsets"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "optimize"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "percent_rank"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "pi"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "pow"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "power"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "printf"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "quote"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "radians"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "random"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "randomblob"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "rank"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "replace"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "round"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "round"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "row_number"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "rtreecheck"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "rtreedepth"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "rtreenode"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "rtrim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "rtrim"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sign"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sin"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sinh"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 0,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "snippet"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_compileoption_get"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_compileoption_used"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_log"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_source_id"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqlite_version"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "sqrt"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "strftime"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "string_agg"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substr"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substr"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substring"
+      },
+      {
+        "argument_count" : 3,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "substring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 3147776,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "subtype"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "sum"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftcapitalizedstring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlocalizedcapitalizedstring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlocalizedlowercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlocalizeduppercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftlowercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2048,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "swiftuppercasestring"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "tan"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "tanh"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "time"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "timediff"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "w",
+        "name" : "total"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "total_changes"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "trim"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "trim"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "trunc"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "typeof"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unhex"
+      },
+      {
+        "argument_count" : 2,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unhex"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unicode"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unistr"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unistr_quote"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unixepoch"
+      },
+      {
+        "argument_count" : -1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unknown"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "unlikely"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "upper"
+      },
+      {
+        "argument_count" : 0,
+        "encoding" : "utf8",
+        "flags" : 2097152,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "uuid"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "uuid_blob"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : false,
+        "kind" : "s",
+        "name" : "uuid_str"
+      },
+      {
+        "argument_count" : 1,
+        "encoding" : "utf8",
+        "flags" : 2099200,
+        "is_built_in" : true,
+        "kind" : "s",
+        "name" : "zeroblob"
+      }
+    ],
+    "module_names" : [
+      "bytecode",
+      "dbstat",
+      "fts3",
+      "fts3tokenize",
+      "fts4",
+      "fts4aux",
+      "fts5",
+      "fts5vocab",
+      "json_each",
+      "json_tree",
+      "rtree",
+      "rtree_i32",
+      "tables_used"
+    ],
+    "schema_fnv1a_64" : "e2c8fadbd38c2313",
+    "schema_row_count" : 37,
+    "sqlite_source_id" : "2025-06-12 13:14:41 f0ca7bba1c5e232e5d279fad6338121ab55af0c8c68c84cdfb18ba5114dcaapl",
+    "sqlite_version" : "3.51.0"
+  },
+  "statements" : [
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "EXCEPT USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.except"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "INTERSECT USING TEMP B-TREE",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 18
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.intersect"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.union"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE nullable_seed",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN nullable_rows",
+          "id" : 9,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION ALL",
+          "id" : 15,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 15
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-nullable.union-all"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "EXCEPT USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.except"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "INTERSECT USING TEMP B-TREE",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 18
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.intersect"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 6,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 10,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION USING TEMP B-TREE",
+          "id" : 17,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 18,
+          "notused" : 0,
+          "parent" : 17
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.union"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE required_seed",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN required_rows",
+          "id" : 9,
+          "notused" : 16,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION ALL",
+          "id" : 15,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 15
+        }
+      ],
+      "statement_id" : "c191.v1.cte.ordinary-required.union-all"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 8
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 20,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 21,
+          "notused" : 216,
+          "parent" : 20
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 31,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "EXCEPT USING TEMP B-TREE",
+          "id" : 38,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 39,
+          "notused" : 0,
+          "parent" : 38
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.except"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 8
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 20,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 21,
+          "notused" : 216,
+          "parent" : 20
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 31,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "INTERSECT USING TEMP B-TREE",
+          "id" : 39,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 40,
+          "notused" : 0,
+          "parent" : 39
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.intersect"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 5,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 8
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 20,
+          "notused" : 0,
+          "parent" : 5
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 21,
+          "notused" : 216,
+          "parent" : 20
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 31,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION USING TEMP B-TREE",
+          "id" : 38,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 39,
+          "notused" : 0,
+          "parent" : 38
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.union"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "COMPOUND QUERY",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT-MOST SUBQUERY",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "CO-ROUTINE integer_sequence",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SETUP",
+          "id" : 7,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 7
+        },
+        {
+          "detail" : "RECURSIVE STEP",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 20,
+          "notused" : 216,
+          "parent" : 19
+        },
+        {
+          "detail" : "SCAN recursive_rows",
+          "id" : 30,
+          "notused" : 215,
+          "parent" : 2
+        },
+        {
+          "detail" : "UNION ALL",
+          "id" : 36,
+          "notused" : 0,
+          "parent" : 1
+        },
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 37,
+          "notused" : 0,
+          "parent" : 36
+        }
+      ],
+      "statement_id" : "c191.v1.cte.recursive-required.union-all"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.cast-text-blob"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.cast-text-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.comparable-min"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.date-unixepoch"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.indexed-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.json-array-length"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.json-valid"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.numeric-abs"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.numeric-floor"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.numeric-round"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.operator-arithmetic-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.operator-glob"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.expression.string-printf"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "MERGE (UNION)",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 4
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "RIGHT",
+          "id" : 28,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN t1",
+          "id" : 31,
+          "notused" : 216,
+          "parent" : 28
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 40,
+          "notused" : 0,
+          "parent" : 28
+        }
+      ],
+      "statement_id" : "c191.v1.northwind.compound-customer-supplier-cities"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "CO-ROUTINE cte0",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id" : 9,
+          "notused" : 62,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 52,
+          "notused" : 82,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.northwind.cte-order-subtotals"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 46,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 9,
+          "notused" : 209,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 11,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 9,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 14,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 22,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 7,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 7,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 11,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 9,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-cross.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 22,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 3,
+          "notused" : 44,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 9,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 6,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 5,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 7,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 11,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 45,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 6,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id" : 6,
+          "notused" : 45,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.j-left"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 12,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 18,
+          "notused" : 44,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 23,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 66,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.s-subquery-alias.j-inner.w-repeated-binding.g-customer-id.h-count-greater-than-one.o-descending.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.s-table-alias"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-aggregate-count.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 5,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.j-inner"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.s-subquery-alias"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 12,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id" : 16,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 21,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 69,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.j-left"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 10,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH source_orders USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-null-comparison"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN source_orders",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-subquery-alias.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN customers_cross USING COVERING INDEX sqlite_autoindex_Customers_1",
+          "id" : 5,
+          "notused" : 209,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.j-cross"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 5,
+          "notused" : 44,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.j-inner"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-empty-in"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-in-list"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-injection-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 2,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-literal"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH orders_case USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 2,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-named-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-precedence"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN orders_case",
+          "id" : 2,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.s-table-alias.w-repeated-binding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 11,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-empty-in.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 25,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 27,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 61,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-in-list.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 12,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-injection-binding.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 6,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 3,
+          "notused" : 33,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-literal.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 6,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 11,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 13,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 51,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.g-customer-id.o-ascending.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 10,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid>?)",
+          "id" : 3,
+          "notused" : 196,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-named-binding.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-null-comparison.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-null-comparison.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 14,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.g-customer-id.h-count-greater-than-one"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.l-five"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 6,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.l-five.x-two"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-precedence.o-descending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-repeated-binding.o-ascending"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 14,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c191.v1.select.w-repeated-binding.o-collated"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR avg(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-average-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR count(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-count-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR group_concat(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-group-concat-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR max(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-max-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR min(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-min-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "USE TEMP B-TREE FOR sum(DISTINCT)",
+          "id" : 3,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN t0",
+          "id" : 5,
+          "notused" : 216,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.aggregate-sum-distinct"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-blob-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-bool-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-integer-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-integer-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-blob-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-bool-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-integer-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-integer-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-real-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-real-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-text-blob"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-text-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-optional-text-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-real-integer"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-real-text"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.cast-text-real"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.comparable-max"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.json-array-length-path"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.numeric-round-no-places"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.numeric-round-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c286.v1.expression.string-printf-array"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.boolean-and-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.boolean-not-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.boolean-or-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.coalesce-storage-classes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.coalescing-operator"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-both-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-left-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.comparison-right-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.equality-optional-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.equality-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.inequality-optional-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-both-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-left-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-arithmetic-right-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.integer-division-boundaries"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.optional-predicates"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-both-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-left-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-required"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-arithmetic-right-optional"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.real-division-boundaries"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-concatenation-null"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-concatenation-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-glob-case-sensitivity"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-glob-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-glob-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-like-ascii-case-folding"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-like-null-propagation"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.text-like-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.unary-nesting"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN CONSTANT ROW",
+          "id" : 1,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c287.v1.expression.unary-shapes"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 1",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-query-builder-empty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 1",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-query-builder-nonempty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 1",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t1 USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 12,
+          "notused" : 39,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 22,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-query-functional-nonempty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 2",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-table-empty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN t0",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "LIST SUBQUERY 2",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH t0 USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 12,
+          "notused" : 33,
+          "parent" : 9
+        },
+        {
+          "detail" : "CREATE BLOOM FILTER",
+          "id" : 19,
+          "notused" : 0,
+          "parent" : 9
+        }
+      ],
+      "statement_id" : "c288.v1.subquery.in-table-nonempty"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN Orders",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "id" : 9,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 47,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.aggregate.grouped-having"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "MERGE (UNION)",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "LEFT",
+          "id" : 4,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN Customers",
+          "id" : 7,
+          "notused" : 216,
+          "parent" : 4
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 16,
+          "notused" : 0,
+          "parent" : 4
+        },
+        {
+          "detail" : "RIGHT",
+          "id" : 28,
+          "notused" : 0,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN Suppliers",
+          "id" : 31,
+          "notused" : 216,
+          "parent" : 28
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 40,
+          "notused" : 0,
+          "parent" : 28
+        }
+      ],
+      "statement_id" : "c390.northwind.compound.customer-supplier-cities"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "CO-ROUTINE order_subtotals",
+          "id" : 2,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH Order Details USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id" : 9,
+          "notused" : 62,
+          "parent" : 2
+        },
+        {
+          "detail" : "SCAN order_subtotals",
+          "id" : 51,
+          "notused" : 82,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.cte.order-subtotals"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SEARCH o USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 9,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH c USING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "id" : 12,
+          "notused" : 46,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH e USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 18,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH d USING INDEX sqlite_autoindex_Order Details_1 (OrderID=?)",
+          "id" : 21,
+          "notused" : 62,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH p USING INTEGER PRIMARY KEY (rowid=?)",
+          "id" : 27,
+          "notused" : 45,
+          "parent" : 0
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 44,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.join.customer-order-employee-product"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN e",
+          "id" : 4,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "id" : 6,
+          "notused" : 45,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.join.left-null-manager"
+    },
+    {
+      "rows" : [
+        {
+          "detail" : "SCAN Products",
+          "id" : 3,
+          "notused" : 216,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCALAR SUBQUERY 1",
+          "id" : 8,
+          "notused" : 0,
+          "parent" : 0
+        },
+        {
+          "detail" : "SCAN Products",
+          "id" : 13,
+          "notused" : 216,
+          "parent" : 8
+        },
+        {
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "id" : 29,
+          "notused" : 0,
+          "parent" : 0
+        }
+      ],
+      "statement_id" : "c390.northwind.subquery.products-above-average"
+    }
+  ]
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/verification.json
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/verification.json
@@ -1,0 +1,516 @@
+[
+  {
+    "after_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "e"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN e",
+          "shape" : "full_table_scan"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+              "rowid"
+            ],
+            "index_name" : "INTEGER PRIMARY KEY",
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "m"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "shape" : "index_search"
+        }
+      ],
+      "statement_id" : "c390.northwind.join.left-null-manager"
+    },
+    "before_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "e"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN e",
+          "shape" : "full_table_scan"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+              "rowid"
+            ],
+            "index_name" : "INTEGER PRIMARY KEY",
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "m"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "shape" : "index_search"
+        }
+      ],
+      "statement_id" : "c390.northwind.join.left-null-manager"
+    },
+    "columns" : [
+      "ReportsTo",
+      "EmployeeID"
+    ],
+    "ddl" : "CREATE INDEX \"ix_advisor_employees_reportsto_employeeid\" ON \"Employees\" (\"ReportsTo\", \"EmployeeID\")",
+    "improvement_reason" : "after-plan shape was full_table_scan, expected index_search or covering_index_scan",
+    "is_improvement" : false,
+    "statement_id" : "c390.northwind.join.left-null-manager",
+    "table" : "Employees"
+  },
+  {
+    "after_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+              "CustomerID"
+            ],
+            "index_name" : "ix_advisor_orders_customerid_employeeid",
+            "is_automatic" : false,
+            "is_covering" : true,
+            "table" : "t0"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SEARCH t0 USING COVERING INDEX ix_advisor_orders_customerid_employeeid (CustomerID=?)",
+          "shape" : "index_search"
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-injection-binding"
+    },
+    "before_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "t0"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN t0",
+          "shape" : "full_table_scan"
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.w-injection-binding"
+    },
+    "columns" : [
+      "customerID",
+      "employeeID"
+    ],
+    "ddl" : "CREATE INDEX \"ix_advisor_orders_customerid_employeeid\" ON \"Orders\" (\"customerID\", \"employeeID\")",
+    "improvement_reason" : "shape changed from full_table_scan to index_search, constrained by [\"CustomerID\"]",
+    "is_improvement" : true,
+    "statement_id" : "c191.v1.select.j-left.w-injection-binding",
+    "table" : "Orders"
+  },
+  {
+    "after_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "t0"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN t0",
+          "shape" : "full_table_scan"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+              "CustomerID"
+            ],
+            "index_name" : "sqlite_autoindex_Customers_1",
+            "is_automatic" : false,
+            "is_covering" : true,
+            "table" : "customers_join"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "shape" : "index_search"
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.o-ascending"
+    },
+    "before_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "t0"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN t0",
+          "shape" : "full_table_scan"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+              "CustomerID"
+            ],
+            "index_name" : "sqlite_autoindex_Customers_1",
+            "is_automatic" : false,
+            "is_covering" : true,
+            "table" : "customers_join"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SEARCH customers_join USING COVERING INDEX sqlite_autoindex_Customers_1 (CustomerID=?)",
+          "shape" : "index_search"
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-inner.o-ascending"
+    },
+    "columns" : [
+      "customerID",
+      "orderID"
+    ],
+    "ddl" : "CREATE INDEX \"ix_advisor_orders_customerid_orderid\" ON \"Orders\" (\"customerID\", \"orderID\")",
+    "improvement_reason" : "after-plan shape was full_table_scan, expected index_search or covering_index_scan",
+    "is_improvement" : false,
+    "statement_id" : "c191.v1.select.j-inner.o-ascending",
+    "table" : "Orders"
+  },
+  {
+    "after_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "orders_case"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN orders_case",
+          "shape" : "full_table_scan"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+              "rowid"
+            ],
+            "index_name" : "INTEGER PRIMARY KEY",
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "employees_join"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "shape" : "index_search"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false
+          },
+          "children" : [
+
+          ],
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "shape" : "temp_b_tree_for_group_by"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false
+          },
+          "children" : [
+
+          ],
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "shape" : "temp_b_tree_for_order_by"
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+    },
+    "before_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "orders_case"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN orders_case",
+          "shape" : "full_table_scan"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+              "rowid"
+            ],
+            "index_name" : "INTEGER PRIMARY KEY",
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "employees_join"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SEARCH employees_join USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN",
+          "shape" : "index_search"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false
+          },
+          "children" : [
+
+          ],
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "shape" : "temp_b_tree_for_group_by"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false
+          },
+          "children" : [
+
+          ],
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "shape" : "temp_b_tree_for_order_by"
+        }
+      ],
+      "statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two"
+    },
+    "columns" : [
+      "employeeID",
+      "customerID"
+    ],
+    "ddl" : "CREATE INDEX \"ix_advisor_orders_employeeid_customerid\" ON \"Orders\" (\"employeeID\", \"customerID\")",
+    "improvement_reason" : "after-plan shape was full_table_scan, expected index_search or covering_index_scan",
+    "is_improvement" : false,
+    "statement_id" : "c191.v1.select.p-nullable-region.s-table-alias.j-left.w-null-comparison.g-customer-id.h-count-greater-than-one.o-collated.l-five.x-two",
+    "table" : "Orders"
+  },
+  {
+    "after_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "t0"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN t0",
+          "shape" : "full_table_scan"
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.o-ascending"
+    },
+    "before_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "t0"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN t0",
+          "shape" : "full_table_scan"
+        }
+      ],
+      "statement_id" : "c191.v1.select.j-left.o-ascending"
+    },
+    "columns" : [
+      "employeeID",
+      "orderID"
+    ],
+    "ddl" : "CREATE INDEX \"ix_advisor_orders_employeeid_orderid\" ON \"Orders\" (\"employeeID\", \"orderID\")",
+    "improvement_reason" : "after-plan shape was full_table_scan, expected index_search or covering_index_scan",
+    "is_improvement" : false,
+    "statement_id" : "c191.v1.select.j-left.o-ascending",
+    "table" : "Orders"
+  },
+  {
+    "after_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "t0"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN t0",
+          "shape" : "full_table_scan"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false
+          },
+          "children" : [
+
+          ],
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "shape" : "temp_b_tree_for_group_by"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false
+          },
+          "children" : [
+
+          ],
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "shape" : "temp_b_tree_for_order_by"
+        }
+      ],
+      "statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+    },
+    "before_plan" : {
+      "roots" : [
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false,
+            "table" : "t0"
+          },
+          "children" : [
+
+          ],
+          "detail" : "SCAN t0",
+          "shape" : "full_table_scan"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false
+          },
+          "children" : [
+
+          ],
+          "detail" : "USE TEMP B-TREE FOR GROUP BY",
+          "shape" : "temp_b_tree_for_group_by"
+        },
+        {
+          "attributes" : {
+            "constrained_columns" : [
+
+            ],
+            "is_automatic" : false,
+            "is_covering" : false
+          },
+          "children" : [
+
+          ],
+          "detail" : "USE TEMP B-TREE FOR ORDER BY",
+          "shape" : "temp_b_tree_for_order_by"
+        }
+      ],
+      "statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending"
+    },
+    "columns" : [
+      "orderID"
+    ],
+    "ddl" : "CREATE INDEX \"ix_advisor_orders_orderid\" ON \"Orders\" (\"orderID\")",
+    "improvement_reason" : "after-plan shape was full_table_scan, expected index_search or covering_index_scan",
+    "is_improvement" : false,
+    "statement_id" : "c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending",
+    "table" : "Orders"
+  }
+]

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateExtractionTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateExtractionTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+import SwiftQLSQLiteEQPVariancePrototype
+@testable import SwiftQLSQLiteIndexAdvisorPrototype
+
+
+final class IndexCandidateExtractionTests: XCTestCase {
+    // MARK: - Real corpus statements (Tests/SwiftQLSQLiteCombinatorialSupport / #390 anchors)
+
+    func testEqualityComparisonOnPrimaryAlias() {
+        let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" CROSS JOIN "Customers" AS "customers_cross" WHERE ("t0"."orderID" == 10248)"#
+        let comparisons = IndexCandidateExtraction.whereComparisons(for: "t0", in: sql)
+        XCTAssertEqual(comparisons, [WhereComparison(alias: "t0", column: "orderID", kind: .equality)])
+    }
+
+    func testRangeComparisonWithNamedBinding() {
+        let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" CROSS JOIN "Customers" AS "customers_cross" WHERE ("t0"."orderID" >= :minimum_order_id)"#
+        let comparisons = IndexCandidateExtraction.whereComparisons(for: "t0", in: sql)
+        XCTAssertEqual(comparisons, [WhereComparison(alias: "t0", column: "orderID", kind: .range)])
+    }
+
+    func testRepeatedRangeBindingProducesTwoRangeComparisons() {
+        let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" CROSS JOIN "Customers" AS "customers_cross" WHERE (("t0"."employeeID" >= :repeated_employee_id) AND ("t0"."employeeID" <= :repeated_employee_id))"#
+        let comparisons = IndexCandidateExtraction.whereComparisons(for: "t0", in: sql)
+        XCTAssertEqual(comparisons, [
+            WhereComparison(alias: "t0", column: "employeeID", kind: .range),
+            WhereComparison(alias: "t0", column: "employeeID", kind: .range),
+        ])
+    }
+
+    /// A top-level OR is exactly the case this extractor deliberately
+    /// refuses to interpret rather than guess at.
+    func testTopLevelOrYieldsNoComparisons() {
+        let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" CROSS JOIN "Customers" AS "customers_cross" WHERE ((("t0"."orderID" > 10248) AND ("t0"."employeeID" == 1)) OR ("t0"."customerID" == 'VINET'))"#
+        XCTAssertEqual(IndexCandidateExtraction.whereComparisons(for: "t0", in: sql), [])
+    }
+
+    func testINComparisonIsNotRecognisedAndYieldsNoComparisonForThatConjunct() {
+        let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" CROSS JOIN "Customers" AS "customers_cross" WHERE ("t0"."orderID" IN (10248, 10249, 10250))"#
+        XCTAssertEqual(IndexCandidateExtraction.whereComparisons(for: "t0", in: sql), [])
+    }
+
+    func testJoinKeysFromInnerJoin() {
+        let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" INNER JOIN "Customers" AS "customers_join" ON ("t0"."customerID" == "customers_join"."customerID") WHERE ("t0"."orderID" == 10248)"#
+        XCTAssertEqual(
+            IndexCandidateExtraction.joinKeys(for: "t0", in: sql),
+            [JoinKey(alias: "t0", column: "customerID")]
+        )
+        XCTAssertEqual(
+            IndexCandidateExtraction.joinKeys(for: "customers_join", in: sql),
+            [JoinKey(alias: "customers_join", column: "customerID")]
+        )
+    }
+
+    func testJoinKeysFromLeftJoinUsesIS() {
+        let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" LEFT JOIN "Employees" AS "employees_join" ON ("t0"."employeeID" IS "employees_join"."employeeID") WHERE ("t0"."orderID" == 10248)"#
+        XCTAssertEqual(
+            IndexCandidateExtraction.joinKeys(for: "t0", in: sql),
+            [JoinKey(alias: "t0", column: "employeeID")]
+        )
+    }
+
+    func testOrderByColumnsIgnoringCollateAndDirection() {
+        let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" WHERE ("t0"."orderID" >= :minimum_order_id) ORDER BY ("t0"."customerID" COLLATE NOCASE) ASC"#
+        XCTAssertEqual(IndexCandidateExtraction.orderByColumns(for: "t0", in: sql), ["customerID"])
+    }
+
+    func testOrderByMultipleColumns() {
+        let sql = #"SELECT "customerID" FROM "Orders" AS "t0" GROUP BY "t0"."customerID" HAVING COUNT("t0"."orderID") >= 10 ORDER BY "orderCount" DESC, "t0"."customerID" ASC"#
+        // Only the second term is qualified by "t0"; the first ("orderCount")
+        // is an unqualified result-column alias this extractor deliberately
+        // does not resolve.
+        XCTAssertEqual(IndexCandidateExtraction.orderByColumns(for: "t0", in: sql), ["customerID"])
+    }
+
+    // MARK: - Real five-table join anchor from #390
+
+    func testFiveTableJoinRealAnchorStatement() throws {
+        let corpus = try EQPVarianceCorpus.assemble()
+        let statement = try XCTUnwrap(
+            corpus.first { $0.id == "c390.northwind.join.customer-order-employee-product" }
+        )
+        let comparisons = IndexCandidateExtraction.whereComparisons(for: "o", in: statement.renderedSQL)
+        XCTAssertEqual(comparisons, [WhereComparison(alias: "o", column: "OrderID", kind: .equality)])
+
+        XCTAssertEqual(
+            IndexCandidateExtraction.joinKeys(for: "c", in: statement.renderedSQL),
+            [JoinKey(alias: "c", column: "CustomerID")]
+        )
+        // "d" (Order Details) is joined twice: to Orders via OrderID and to
+        // Products via ProductID — both are genuine join keys for "d".
+        XCTAssertEqual(
+            IndexCandidateExtraction.joinKeys(for: "d", in: statement.renderedSQL),
+            [JoinKey(alias: "d", column: "OrderID"), JoinKey(alias: "d", column: "ProductID")]
+        )
+        XCTAssertEqual(
+            IndexCandidateExtraction.orderByColumns(for: "p", in: statement.renderedSQL),
+            ["ProductID"]
+        )
+
+        let tableAliases = IndexCandidateExtraction.tableAliasMap(in: statement.renderedSQL)
+        XCTAssertEqual(tableAliases, [
+            "o": "Orders",
+            "c": "Customers",
+            "e": "Employees",
+            "d": "Order Details",
+            "p": "Products",
+        ])
+    }
+
+    func testTableAliasMapQuotedStyle() {
+        let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" INNER JOIN "Customers" AS "customers_join" ON ("t0"."customerID" == "customers_join"."customerID")"#
+        XCTAssertEqual(
+            IndexCandidateExtraction.tableAliasMap(in: sql),
+            ["t0": "Orders", "customers_join": "Customers"]
+        )
+    }
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateExtractionTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateExtractionTests.swift
@@ -107,6 +107,26 @@ final class IndexCandidateExtractionTests: XCTestCase {
         ])
     }
 
+    /// Copilot review: `splitTopLevel` tracked paren depth but didn't guard
+    /// against it going negative on an unmatched closing paren. Before the
+    /// fix, that stray `)` threw off the running depth count enough that a
+    /// later `(` coincidentally brought it back to exactly 0 — making the
+    /// comma *inside* that second, genuinely nested group look top-level and
+    /// get split on. This clause has one extra `)` right after `"t0"."a"`,
+    /// then a second, unrelated group `("t0"."b", "t0"."c")`: pre-fix, that
+    /// group's own comma would wrongly split it into two terms, spuriously
+    /// contributing `"c"` in addition to `"a"`. Per this extractor's "never
+    /// guess" contract, an unbalanced clause now fails closed — treated as
+    /// one undivided term — so only the term's leading identifier (`"a"`)
+    /// is read, not a second column pulled from a wrongly-split fragment.
+    func testUnbalancedParenthesesFailClosedRatherThanMisparse() {
+        let sql = #"""
+            SELECT "t0"."x" FROM "T" AS "t0"
+            ORDER BY "t0"."a"), ("t0"."b", "t0"."c")
+            """#
+        XCTAssertEqual(IndexCandidateExtraction.orderByColumns(for: "t0", in: sql), ["a"])
+    }
+
     func testTableAliasMapQuotedStyle() {
         let sql = #"SELECT "t0"."orderID" FROM "Orders" AS "t0" INNER JOIN "Customers" AS "customers_join" ON ("t0"."customerID" == "customers_join"."customerID")"#
         XCTAssertEqual(

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
@@ -135,6 +135,21 @@ final class IndexCandidateGeneratorTests: XCTestCase {
         )
     }
 
+    /// Copilot review: `table`/`columns` come from parsing this prototype's
+    /// own SQL corpus, but the CLI can also decode an `IndexCandidate` from
+    /// an arbitrary JSON file and hand its `ddl` straight to
+    /// `Database.execute(sql:)` — an unescaped `"` in an identifier could
+    /// break out of the quoted-identifier context and inject arbitrary SQL.
+    /// `indexName` is already sanitized to `[a-z0-9_]`, so this only matters
+    /// for `table`/`columns` as they appear verbatim in the DDL.
+    func testDDLEscapesEmbeddedQuoteInTableAndColumnNames() {
+        let candidate = candidate(table: #"Weird"Table"#, columns: [#"co"l"#])
+        XCTAssertEqual(
+            candidate.ddl,
+            #"CREATE INDEX "ix_advisor_weird_table_co_l" ON "Weird""Table" ("co""l")"#
+        )
+    }
+
     // MARK: - Finding remediable statements
 
     /// The improvement rule accepts `automatic_covering_index` as a

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
@@ -7,7 +7,7 @@ import SwiftQLSQLitePlanShapePrototype
 final class IndexCandidateGeneratorTests: XCTestCase {
     // MARK: - Precedence rule
 
-    func testPrecedenceEqualityThenRangeThenJoinThenOrderBy() {
+    func testPrecedenceEqualityAndJoinThenRangeThenOrderBy() {
         let sql = #"""
             SELECT "t0"."x" FROM "T" AS "t0"
             JOIN "U" AS "u" ON ("t0"."joinCol" == "u"."id")
@@ -16,8 +16,39 @@ final class IndexCandidateGeneratorTests: XCTestCase {
             """#
         XCTAssertEqual(
             IndexCandidateGenerator.candidateColumns(for: "t0", in: sql),
-            ["eq", "rangeA", "joinCol", "sortCol"],
-            "only the FIRST range column is included; the second range column (rangeB) narrows no further"
+            ["eq", "joinCol", "rangeA", "sortCol"],
+            "join keys share the equality tier (both before any range column); "
+                + "only the FIRST range column is included since the second (rangeB) narrows no further"
+        )
+    }
+
+    /// Real, confirmed evidence for the precedence rule, not an assumption:
+    /// `Categories LEFT JOIN Products ON p.CategoryID = c.CategoryID WHERE
+    /// p.UnitPrice > 20 OR p.ProductID IS NULL` puts `Products` on the
+    /// looked-up side of the join, with both a join key (`CategoryID`) and a
+    /// range predicate (`UnitPrice`) on it and no existing index to compete
+    /// with. `CREATE INDEX ON Products(CategoryID, UnitPrice)` (join key
+    /// first) is the index SQLite actually uses, replacing its own
+    /// automatic covering index; `CREATE INDEX ON Products(UnitPrice,
+    /// CategoryID)` (range first) is silently ignored — SQLite falls back
+    /// to the same automatic covering index as if the candidate didn't
+    /// exist. See `IndexCandidateVerifierTests` for the same result
+    /// verified end to end via a real scratch-copy re-plan.
+    func testJoinKeyMustPrecedeRangeColumnForSQLiteToUseTheIndex() {
+        // This is the precedence-logic unit test; IndexCandidateVerifierTests
+        // proves the same ordering against real SQLite via a scratch-copy
+        // re-plan, using an `OR`-qualified WHERE clause there to keep the
+        // LEFT JOIN from being flattened by the planner (this extractor
+        // deliberately doesn't parse `OR` clauses at all, so this simpler
+        // form is what exercises `candidateColumns` directly).
+        let sql = #"""
+            SELECT p.ProductID FROM Categories AS c
+            LEFT JOIN Products AS p ON p.CategoryID = c.CategoryID
+            WHERE p.UnitPrice > 20
+            """#
+        XCTAssertEqual(
+            IndexCandidateGenerator.candidateColumns(for: "p", in: sql),
+            ["CategoryID", "UnitPrice"]
         )
     }
 

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+import SwiftQLSQLiteEQPVariancePrototype
+import SwiftQLSQLitePlanShapePrototype
+@testable import SwiftQLSQLiteIndexAdvisorPrototype
+
+
+final class IndexCandidateGeneratorTests: XCTestCase {
+    // MARK: - Precedence rule
+
+    func testPrecedenceEqualityThenRangeThenJoinThenOrderBy() {
+        let sql = #"""
+            SELECT "t0"."x" FROM "T" AS "t0"
+            JOIN "U" AS "u" ON ("t0"."joinCol" == "u"."id")
+            WHERE (("t0"."eq" == 1) AND ("t0"."rangeA" > 2) AND ("t0"."rangeB" < 3))
+            ORDER BY "t0"."sortCol" ASC
+            """#
+        XCTAssertEqual(
+            IndexCandidateGenerator.candidateColumns(for: "t0", in: sql),
+            ["eq", "rangeA", "joinCol", "sortCol"],
+            "only the FIRST range column is included; the second range column (rangeB) narrows no further"
+        )
+    }
+
+    func testColumnAlreadyIncludedAtHigherPrecedenceIsNotDuplicated() {
+        // The same column appears as both an equality predicate and the
+        // ORDER BY term — it must appear once, at its equality position.
+        let sql = #"""
+            SELECT "t0"."x" FROM "T" AS "t0"
+            WHERE ("t0"."col" == 1)
+            ORDER BY "t0"."col" ASC
+            """#
+        XCTAssertEqual(IndexCandidateGenerator.candidateColumns(for: "t0", in: sql), ["col"])
+    }
+
+    func testNoSignalYieldsEmptyColumnList() {
+        let sql = #"SELECT "t0"."x" FROM "T" AS "t0""#
+        XCTAssertEqual(IndexCandidateGenerator.candidateColumns(for: "t0", in: sql), [])
+    }
+
+    // MARK: - Deduplication
+
+    private func candidate(
+        table: String,
+        columns: [String],
+        statementIDs: [String] = ["s1"]
+    ) -> IndexCandidate {
+        IndexCandidate(
+            table: table,
+            columns: columns,
+            sourceStatementIDs: statementIDs,
+            representativeStatementID: statementIDs[0],
+            representativeAlias: "t0"
+        )
+    }
+
+    func testDeduplicateMergesIdenticalCandidatesRecordingAllSources() {
+        let remediables = [
+            RemediableCandidate(table: "Orders", columns: ["CustomerID"], statementID: "s1", alias: "t0"),
+            RemediableCandidate(table: "Orders", columns: ["CustomerID"], statementID: "s2", alias: "o"),
+        ]
+        let deduped = IndexCandidateGenerator.deduplicate(remediables)
+        XCTAssertEqual(deduped.count, 1)
+        XCTAssertEqual(deduped[0].sourceStatementIDs, ["s1", "s2"])
+        XCTAssertEqual(deduped[0].representativeStatementID, "s1", "keeps the FIRST occurrence as the verification target")
+    }
+
+    func testDeduplicateDropsExactPrefixInFavorOfWiderIndex() {
+        let remediables = [
+            RemediableCandidate(table: "Orders", columns: ["CustomerID"], statementID: "s1", alias: "t0"),
+            RemediableCandidate(table: "Orders", columns: ["CustomerID", "OrderDate"], statementID: "s2", alias: "t0"),
+        ]
+        let deduped = IndexCandidateGenerator.deduplicate(remediables)
+        XCTAssertEqual(deduped.map(\.columns), [["CustomerID", "OrderDate"]])
+    }
+
+    func testDeduplicateKeepsNonPrefixCandidatesOnTheSameTable() {
+        let remediables = [
+            RemediableCandidate(table: "Orders", columns: ["CustomerID"], statementID: "s1", alias: "t0"),
+            RemediableCandidate(table: "Orders", columns: ["EmployeeID"], statementID: "s2", alias: "t0"),
+        ]
+        let deduped = IndexCandidateGenerator.deduplicate(remediables)
+        XCTAssertEqual(Set(deduped.map(\.columns)), [["CustomerID"], ["EmployeeID"]])
+    }
+
+    func testDDLRendersQuotedTableAndColumns() {
+        let candidate = candidate(table: "Order Details", columns: ["OrderID", "ProductID"])
+        XCTAssertEqual(
+            candidate.ddl,
+            #"CREATE INDEX "ix_advisor_order_details_orderid_productid" ON "Order Details" ("OrderID", "ProductID")"#
+        )
+    }
+
+    // MARK: - Real corpus, real #390/#391 evidence
+
+    func testRealCorpusCandidatesMatchCheckedInEvidence() throws {
+        let candidates = try realGeneratedCandidates()
+        let pinned = try loadCandidates("candidates.json")
+        XCTAssertEqual(codable(candidates), pinned, "candidates.json is stale relative to a fresh generate run")
+    }
+
+    func testCandidateGenerationIsDeterministicAcrossRepeatedRuns() throws {
+        let first = try realGeneratedCandidates()
+        let second = try realGeneratedCandidates()
+        XCTAssertEqual(codable(first), codable(second))
+    }
+
+    /// Reconciles with real evidence: the driving/outer table of a join
+    /// (e.g. `Employees AS e` in the self left-join, or `Orders AS t0` in a
+    /// join with no `WHERE` filter) legitimately produces a candidate from
+    /// its join key, but that candidate provides no improvement — see
+    /// `IndexCandidateVerifierTests`. This test only pins that the real
+    /// corpus does produce exactly the 6 deduplicated candidates evidenced
+    /// in `candidates.json`, not that all 6 are good advice.
+    func testRealCorpusProducesExactlySixDeduplicatedCandidates() throws {
+        let candidates = try realGeneratedCandidates()
+        XCTAssertEqual(candidates.count, 6)
+    }
+
+    private func realGeneratedCandidates() throws -> [IndexCandidate] {
+        let corpus = try EQPVarianceCorpus.assemble()
+        let corpusByID = Dictionary(uniqueKeysWithValues: corpus.map { ($0.id, $0) })
+        let run = try loadCapture("capture_apple-system-3.51.0.json")
+
+        var remediables: [RemediableCandidate] = []
+        for capture in run.statements {
+            guard let statement = corpusByID[capture.statementID] else {
+                continue
+            }
+            let plan = EQPPlanShapeClassifier.classify(rows: capture.rows, statementID: statement.id)
+            remediables.append(contentsOf: IndexCandidateGenerator.remediableCandidates(for: statement, plan: plan))
+        }
+        return IndexCandidateGenerator.deduplicate(remediables)
+    }
+}
+
+
+// MARK: - Shared fixture loading (also used by IndexCandidateVerifierTests)
+
+struct CodableIndexCandidateFixture: Codable, Equatable {
+    let table: String
+    let columns: [String]
+    let sourceStatementIDs: [String]
+    let representativeStatementID: String
+    let representativeAlias: String
+
+    private enum CodingKeys: String, CodingKey {
+        case table
+        case columns
+        case sourceStatementIDs = "source_statement_ids"
+        case representativeStatementID = "representative_statement_id"
+        case representativeAlias = "representative_alias"
+    }
+}
+
+
+func codable(_ candidates: [IndexCandidate]) -> [CodableIndexCandidateFixture] {
+    candidates.map {
+        CodableIndexCandidateFixture(
+            table: $0.table,
+            columns: $0.columns,
+            sourceStatementIDs: $0.sourceStatementIDs,
+            representativeStatementID: $0.representativeStatementID,
+            representativeAlias: $0.representativeAlias
+        )
+    }
+}
+
+
+func pinnedEvidenceURL(named name: String) throws -> URL {
+    guard let url = Bundle.module.url(forResource: name, withExtension: nil, subdirectory: "Evidence") else {
+        throw IndexAdvisorFixtureError.missingResource(name)
+    }
+    return url
+}
+
+
+func loadCapture(_ name: String) throws -> EQPCaptureRun {
+    try JSONDecoder().decode(EQPCaptureRun.self, from: Data(contentsOf: pinnedEvidenceURL(named: name)))
+}
+
+
+func loadCandidates(_ name: String) throws -> [CodableIndexCandidateFixture] {
+    try JSONDecoder().decode([CodableIndexCandidateFixture].self, from: Data(contentsOf: pinnedEvidenceURL(named: name)))
+}
+
+
+enum IndexAdvisorFixtureError: Error {
+    case missingResource(String)
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
@@ -104,6 +104,20 @@ final class IndexCandidateGeneratorTests: XCTestCase {
         XCTAssertEqual(deduped.map(\.columns), [["CustomerID", "OrderDate"]])
     }
 
+    /// A dropped prefix candidate's provenance must not be lost: `s1`
+    /// contributed only `(CustomerID)`, which never survives on its own,
+    /// but `s1` is still attributed to the wider `(CustomerID, OrderDate)`
+    /// index that now serves it.
+    func testDeduplicatePreservesPrefixCandidateSourceStatementIDs() {
+        let remediables = [
+            RemediableCandidate(table: "Orders", columns: ["CustomerID"], statementID: "s1", alias: "t0"),
+            RemediableCandidate(table: "Orders", columns: ["CustomerID", "OrderDate"], statementID: "s2", alias: "t0"),
+        ]
+        let deduped = IndexCandidateGenerator.deduplicate(remediables)
+        XCTAssertEqual(deduped.count, 1)
+        XCTAssertEqual(deduped[0].sourceStatementIDs, ["s1", "s2"])
+    }
+
     func testDeduplicateKeepsNonPrefixCandidatesOnTheSameTable() {
         let remediables = [
             RemediableCandidate(table: "Orders", columns: ["CustomerID"], statementID: "s1", alias: "t0"),
@@ -119,6 +133,50 @@ final class IndexCandidateGeneratorTests: XCTestCase {
             candidate.ddl,
             #"CREATE INDEX "ix_advisor_order_details_orderid_productid" ON "Order Details" ("OrderID", "ProductID")"#
         )
+    }
+
+    // MARK: - Finding remediable statements
+
+    /// The improvement rule accepts `automatic_covering_index` as a
+    /// remediable "before" shape (see `IndexCandidateVerifierTests`), but
+    /// that's only reachable end to end if `remediableCandidates` actually
+    /// looks for that root shape too, not only `full_table_scan`. These are
+    /// the same three real EQP rows from the Products/Categories scratch-copy
+    /// finding, hand-built here so this is a pure unit test of the
+    /// generator's root-shape scan, independent of a live database.
+    ///
+    /// `Categories AS c` (the driving side of the `LEFT JOIN`, a genuine
+    /// `full_table_scan` root) also yields a candidate here, same as the
+    /// driving-side false positive in
+    /// `IndexCandidateVerifierTests.testRealFalsePositiveFromDrivingSideJoinKeyIsRejected`
+    /// — `remediableCandidates` surfaces every remediable root regardless of
+    /// whether verification will later confirm it as an improvement.
+    func testRemediableCandidatesIncludesAutomaticCoveringIndexRoots() {
+        let rows = [
+            EQPRow(id: 1, parent: 0, notused: 0, detail: "SCAN c"),
+            EQPRow(id: 2, parent: 0, notused: 0, detail: "BLOOM FILTER ON p (CategoryID=?)"),
+            EQPRow(
+                id: 3,
+                parent: 0,
+                notused: 0,
+                detail: "SEARCH p USING AUTOMATIC COVERING INDEX (CategoryID=?) LEFT-JOIN"
+            ),
+        ]
+        let statement = EQPVarianceStatement(
+            id: "test.remediable.automatic-covering-index",
+            source: .northwindAnchor,
+            renderedSQL: """
+                SELECT p.ProductID FROM Categories AS c
+                LEFT JOIN Products AS p ON p.CategoryID = c.CategoryID
+                WHERE p.UnitPrice > 20
+                """,
+            northwindAnchorCaseIDs: [],
+            bindings: []
+        )
+        let plan = EQPPlanShapeClassifier.classify(rows: rows, statementID: statement.id)
+        let candidates = IndexCandidateGenerator.remediableCandidates(for: statement, plan: plan)
+        XCTAssertEqual(candidates.map(\.table), ["Categories", "Products"])
+        XCTAssertEqual(candidates.map(\.columns), [["CategoryID"], ["CategoryID", "UnitPrice"]])
     }
 
     // MARK: - Real corpus, real #390/#391 evidence

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateGeneratorTests.swift
@@ -140,8 +140,10 @@ final class IndexCandidateGeneratorTests: XCTestCase {
     /// an arbitrary JSON file and hand its `ddl` straight to
     /// `Database.execute(sql:)` — an unescaped `"` in an identifier could
     /// break out of the quoted-identifier context and inject arbitrary SQL.
-    /// `indexName` is already sanitized to `[a-z0-9_]`, so this only matters
-    /// for `table`/`columns` as they appear verbatim in the DDL.
+    /// `indexName` is already sanitized (lowercased, with every character
+    /// that isn't a letter or number replaced by `_` — Unicode-aware via
+    /// `Character.isLetter`/`isNumber`, not limited to ASCII), so this only
+    /// matters for `table`/`columns` as they appear verbatim in the DDL.
     func testDDLEscapesEmbeddedQuoteInTableAndColumnNames() {
         let candidate = candidate(table: #"Weird"Table"#, columns: [#"co"l"#])
         XCTAssertEqual(

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateVerifierTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateVerifierTests.swift
@@ -43,6 +43,59 @@ final class IndexCandidateVerifierTests: XCTestCase {
         XCTAssertFalse(evidence.isImprovement)
     }
 
+    /// Settles the #396 candidate-column precedence question (join key vs.
+    /// range column) with a real scratch-copy re-plan, not just the unit
+    /// test in `IndexCandidateGeneratorTests`. `Products` is the looked-up
+    /// side of a `LEFT JOIN` on `CategoryID`, filtered by `UnitPrice > 20`,
+    /// with no existing index on either column — SQLite's baseline plan is
+    /// its own ephemeral `automatic_covering_index` on `CategoryID` alone
+    /// (verified below). `CREATE INDEX ON Products(CategoryID, UnitPrice)`
+    /// (join key first) is the index SQLite actually adopts, replacing that
+    /// ephemeral index; `CREATE INDEX ON Products(UnitPrice, CategoryID)`
+    /// (range first) is completely ignored — the after-plan is byte-for-byte
+    /// identical to the before-plan, as if the candidate didn't exist.
+    func testJoinKeyPrecedesRangeColumnConfirmedByRealScratchCopyReplan() throws {
+        let statement = EQPVarianceStatement(
+            id: "test.precedence.products-category-unitprice",
+            source: .northwindAnchor,
+            renderedSQL: """
+                SELECT p.ProductID FROM Categories AS c
+                LEFT JOIN Products AS p ON p.CategoryID = c.CategoryID
+                WHERE p.UnitPrice > 20 OR p.ProductID IS NULL
+                """,
+            northwindAnchorCaseIDs: [],
+            bindings: []
+        )
+
+        let joinKeyFirst = IndexCandidate(
+            table: "Products",
+            columns: ["CategoryID", "UnitPrice"],
+            sourceStatementIDs: [statement.id],
+            representativeStatementID: statement.id,
+            representativeAlias: "p"
+        )
+        let rangeFirst = IndexCandidate(
+            table: "Products",
+            columns: ["UnitPrice", "CategoryID"],
+            sourceStatementIDs: [statement.id],
+            representativeStatementID: statement.id,
+            representativeAlias: "p"
+        )
+
+        let joinKeyFirstEvidence = try IndexCandidateVerifier.verify(candidate: joinKeyFirst, statement: statement)
+        XCTAssertTrue(joinKeyFirstEvidence.isImprovement, joinKeyFirstEvidence.improvementReason)
+        XCTAssertTrue(joinKeyFirstEvidence.improvementReason.contains("automatic_covering_index"))
+        XCTAssertTrue(joinKeyFirstEvidence.improvementReason.contains("CategoryID"))
+
+        let rangeFirstEvidence = try IndexCandidateVerifier.verify(candidate: rangeFirst, statement: statement)
+        XCTAssertFalse(rangeFirstEvidence.isImprovement)
+        XCTAssertEqual(
+            rangeFirstEvidence.beforePlan,
+            rangeFirstEvidence.afterPlan,
+            "the wrongly-ordered index is completely ignored by SQLite; the plan is unchanged"
+        )
+    }
+
     func testVerificationNeverMutatesThePinnedNorthwindSnapshot() throws {
         let before = try NorthwindFixture.validateCanonical()
         _ = try verify(candidateWithColumns: ["customerID", "employeeID"], table: "Orders")

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateVerifierTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateVerifierTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import SwiftQLNorthwindFixtures
-import SwiftQLSQLiteBuildValidationPrototype
 import SwiftQLSQLiteEQPVariancePrototype
 import SwiftQLSQLitePlanShapePrototype
 @testable import SwiftQLSQLiteIndexAdvisorPrototype
@@ -96,6 +95,42 @@ final class IndexCandidateVerifierTests: XCTestCase {
         )
     }
 
+    /// Copilot review: `findNode(forTable:in:)` did a plain per-root
+    /// depth-first search, tried root by root in array order — so a nested
+    /// match under an *earlier* root could be returned before a *later*
+    /// root's own direct match was ever considered. Modeled on a real shape
+    /// from the corpus (`c390.northwind.subquery.products-above-average`
+    /// has a root `SCAN Products` and a sibling `SCALAR SUBQUERY 1` root
+    /// whose own child is a second, nested `SCAN Products`), but with the
+    /// non-matching root placed *first* — the real capture's root order
+    /// happens to already put the matching root first, so it wouldn't have
+    /// exercised the bug; this ordering reliably does. Pre-fix this would
+    /// return the nested node (found while recursing into the first root);
+    /// post-fix it returns the second root's own direct match.
+    func testFindNodePrefersRootLevelMatchOverEarlierNestedMatch() {
+        let nestedMatch = EQPPlanNode(
+            detail: "SCAN Products (nested, under the subquery)",
+            shape: .fullTableScan,
+            attributes: EQPPlanShapeAttributes(table: "Products"),
+            children: []
+        )
+        let subqueryRoot = EQPPlanNode(
+            detail: "SCALAR SUBQUERY 1",
+            shape: .scalarSubquery,
+            attributes: .none,
+            children: [nestedMatch]
+        )
+        let rootMatch = EQPPlanNode(
+            detail: "SCAN Products (root, the intended node)",
+            shape: .fullTableScan,
+            attributes: EQPPlanShapeAttributes(table: "Products"),
+            children: []
+        )
+        let plan = EQPPlan(statementID: "test.find-node.root-preferred", roots: [subqueryRoot, rootMatch])
+
+        XCTAssertEqual(IndexCandidateVerifier.findNode(forTable: "Products", in: plan), rootMatch)
+    }
+
     func testVerificationNeverMutatesThePinnedNorthwindSnapshot() throws {
         let before = try NorthwindFixture.validateCanonical()
         _ = try verify(candidateWithColumns: ["customerID", "employeeID"], table: "Orders")
@@ -145,13 +180,12 @@ final class IndexCandidateVerifierTests: XCTestCase {
         return try IndexCandidateVerifier.verify(candidate: candidate.asIndexCandidate, statement: statement)
     }
 
+    /// `validateCanonical()` reads the canonical snapshot through a
+    /// read-only pool — no scratch copy needed just to read
+    /// `sqlite_version()`/`sqlite_source_id()`, unlike `withTemporaryCopy`.
     private func currentSQLiteRuntimeDescription() throws -> String {
-        try NorthwindFixture.withTemporaryCopy { copy in
-            let metadata = try copy.databasePool.read { database in
-                try SQLiteBuildValidationRuntime.capture(from: database)
-            }
-            return "sqlite_version=\(metadata.sqliteVersion) sqlite_source_id=\(metadata.sqliteSourceID)"
-        }
+        let validation = try NorthwindFixture.validateCanonical()
+        return "sqlite_version=\(validation.sqliteVersion) sqlite_source_id=\(validation.sqliteSourceID)"
     }
 }
 

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateVerifierTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateVerifierTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+import SwiftQLNorthwindFixtures
+import SwiftQLSQLiteEQPVariancePrototype
+import SwiftQLSQLitePlanShapePrototype
+@testable import SwiftQLSQLiteIndexAdvisorPrototype
+
+
+final class IndexCandidateVerifierTests: XCTestCase {
+    // MARK: - Real evidence: one genuine improvement, several honest false positives
+
+    /// `Orders(CustomerID, EmployeeID)` for
+    /// `c191.v1.select.j-left.w-injection-binding` — a real `WHERE
+    /// t0.customerID == :customer_input` equality filter on the driving
+    /// table of a `LEFT JOIN`. This is the one real improvement in the
+    /// checked-in evidence: the plan genuinely changes from a full table
+    /// scan to an index search constrained by `CustomerID`.
+    func testRealImprovingCandidateIsConfirmed() throws {
+        let evidence = try verify(candidateWithColumns: ["customerID", "employeeID"], table: "Orders")
+        XCTAssertTrue(evidence.isImprovement)
+        XCTAssertTrue(evidence.improvementReason.contains("CustomerID"))
+    }
+
+    /// `Orders(OrderID)` — derived from an `ORDER BY orderID` term with no
+    /// `WHERE` filter at all. `OrderID` is already the table's
+    /// `INTEGER PRIMARY KEY`/rowid, so a full scan already visits rows in
+    /// that order for free; the candidate index is never chosen. A false
+    /// positive this prototype's own verification catches, not one it
+    /// asserts around.
+    func testRealFalsePositiveOnPrimaryKeyColumnIsRejected() throws {
+        let evidence = try verify(candidateWithColumns: ["orderID"], table: "Orders")
+        XCTAssertFalse(evidence.isImprovement)
+        XCTAssertEqual(evidence.beforePlan, evidence.afterPlan, "the redundant index changes nothing about the chosen plan")
+    }
+
+    /// `Employees(ReportsTo, EmployeeID)` — derived from the self left-join
+    /// anchor. `ReportsTo` is a join key, but for the *driving* side of the
+    /// join (`Employees AS e`), not a `WHERE` filter on it; SQLite must scan
+    /// every row of `e` regardless of any index on `ReportsTo`. Same false-
+    /// positive class as the join-key-only `Orders` candidates.
+    func testRealFalsePositiveFromDrivingSideJoinKeyIsRejected() throws {
+        let evidence = try verify(candidateWithColumns: ["ReportsTo", "EmployeeID"], table: "Employees")
+        XCTAssertFalse(evidence.isImprovement)
+    }
+
+    func testVerificationNeverMutatesThePinnedNorthwindSnapshot() throws {
+        let before = try NorthwindFixture.validateCanonical()
+        _ = try verify(candidateWithColumns: ["customerID", "employeeID"], table: "Orders")
+        let after = try NorthwindFixture.validateCanonical()
+        XCTAssertEqual(before.databaseSHA256, after.databaseSHA256)
+    }
+
+    /// Guards the checked-in verification evidence against silent drift.
+    /// Unlike #390's runtime-provenance-embedding evidence, `EQPPlan` (and
+    /// therefore `IndexCandidateEvidence`) carries no SQLite version field,
+    /// so this comparison has no version-skew caveat — a fresh verify run
+    /// against this same pinned snapshot must reproduce the checked-in
+    /// evidence exactly, on any host.
+    func testCheckedInVerificationEvidenceMatchesFreshRun() throws {
+        let pinnedCandidates = try loadCandidates("candidates.json")
+        let pinnedEvidence = try loadEvidence("verification.json")
+        let corpus = try EQPVarianceCorpus.assemble()
+        let corpusByID = Dictionary(uniqueKeysWithValues: corpus.map { ($0.id, $0) })
+
+        var fresh: [IndexCandidateEvidence] = []
+        for candidate in pinnedCandidates {
+            let statement = try XCTUnwrap(corpusByID[candidate.representativeStatementID])
+            fresh.append(try IndexCandidateVerifier.verify(
+                candidate: candidate.asIndexCandidate,
+                statement: statement
+            ))
+        }
+        XCTAssertEqual(fresh, pinnedEvidence)
+    }
+
+    // MARK: - Helpers
+
+    private func verify(candidateWithColumns columns: [String], table: String) throws -> IndexCandidateEvidence {
+        let pinnedCandidates = try loadCandidates("candidates.json")
+        let candidate = try XCTUnwrap(pinnedCandidates.first { $0.table == table && $0.columns == columns })
+        let corpus = try EQPVarianceCorpus.assemble()
+        let statement = try XCTUnwrap(corpus.first { $0.id == candidate.representativeStatementID })
+        return try IndexCandidateVerifier.verify(candidate: candidate.asIndexCandidate, statement: statement)
+    }
+}
+
+
+private extension CodableIndexCandidateFixture {
+    var asIndexCandidate: IndexCandidate {
+        IndexCandidate(
+            table: table,
+            columns: columns,
+            sourceStatementIDs: sourceStatementIDs,
+            representativeStatementID: representativeStatementID,
+            representativeAlias: representativeAlias
+        )
+    }
+}
+
+
+private func loadEvidence(_ name: String) throws -> [IndexCandidateEvidence] {
+    try JSONDecoder().decode([IndexCandidateEvidence].self, from: Data(contentsOf: pinnedEvidenceURL(named: name)))
+}

--- a/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateVerifierTests.swift
+++ b/Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/IndexCandidateVerifierTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftQLNorthwindFixtures
+import SwiftQLSQLiteBuildValidationPrototype
 import SwiftQLSQLiteEQPVariancePrototype
 import SwiftQLSQLitePlanShapePrototype
 @testable import SwiftQLSQLiteIndexAdvisorPrototype
@@ -50,11 +51,18 @@ final class IndexCandidateVerifierTests: XCTestCase {
     }
 
     /// Guards the checked-in verification evidence against silent drift.
-    /// Unlike #390's runtime-provenance-embedding evidence, `EQPPlan` (and
-    /// therefore `IndexCandidateEvidence`) carries no SQLite version field,
-    /// so this comparison has no version-skew caveat — a fresh verify run
-    /// against this same pinned snapshot must reproduce the checked-in
-    /// evidence exactly, on any host.
+    /// Neither `EQPPlan` nor `IndexCandidateEvidence` embeds an SQLite
+    /// version field, so this assertion is unconditional rather than
+    /// runtime-gated like #390's equivalent check — but that is *not* a
+    /// proof these specific index-search/full-scan decisions are stable
+    /// across every SQLite build, only that #390 observed them stable
+    /// between the two real builds it measured (3.51.0/3.53.2). EQP choices
+    /// remain SQLite-version-dependent in principle (#390's own premise); a
+    /// future SQLite could in principle plan even these simple cases
+    /// differently. If this test ever fails on a host whose SQLite the
+    /// pinned evidence was never verified against, the failure message
+    /// prints that host's `sqlite_version()`/`sqlite_source_id()` so the
+    /// difference is diagnosable rather than a bare JSON diff.
     func testCheckedInVerificationEvidenceMatchesFreshRun() throws {
         let pinnedCandidates = try loadCandidates("candidates.json")
         let pinnedEvidence = try loadEvidence("verification.json")
@@ -69,7 +77,9 @@ final class IndexCandidateVerifierTests: XCTestCase {
                 statement: statement
             ))
         }
-        XCTAssertEqual(fresh, pinnedEvidence)
+
+        let runtime = try currentSQLiteRuntimeDescription()
+        XCTAssertEqual(fresh, pinnedEvidence, "mismatch on \(runtime); if this host's SQLite build genuinely plans one of these statements differently, that's real evidence for this write-up, not just a broken test")
     }
 
     // MARK: - Helpers
@@ -80,6 +90,15 @@ final class IndexCandidateVerifierTests: XCTestCase {
         let corpus = try EQPVarianceCorpus.assemble()
         let statement = try XCTUnwrap(corpus.first { $0.id == candidate.representativeStatementID })
         return try IndexCandidateVerifier.verify(candidate: candidate.asIndexCandidate, statement: statement)
+    }
+
+    private func currentSQLiteRuntimeDescription() throws -> String {
+        try NorthwindFixture.withTemporaryCopy { copy in
+            let metadata = try copy.databasePool.read { database in
+                try SQLiteBuildValidationRuntime.capture(from: database)
+            }
+            return "sqlite_version=\(metadata.sqliteVersion) sqlite_source_id=\(metadata.sqliteSourceID)"
+        }
     }
 }
 


### PR DESCRIPTION
Closes #392.

**Stacked on #422** (this issue depends on #391's shape classifier, which depends on #390's capture pipeline — neither has merged into `experiment/query-plan-index-advice` yet). This PR's base should be retargeted to `experiment/query-plan-index-advice` once #422 (and #412 beneath it) merge — only the last commit (`7d328e5d`) is this issue's actual diff.

## Summary

- Adds a package-private research target, `SwiftQLSQLiteIndexAdvisorPrototype`, that derives index candidates from a statement's `WHERE` predicates, `JOIN` keys, and `ORDER BY` terms — equality > range > join > order-by, SQLite's own left-to-right composite-index precedence — via a narrow pattern-based extractor (not a SQL parser; documented limitations, never a guess).
- Verifies each candidate by creating it on a scratch copy of the pinned Northwind snapshot (`NorthwindFixture.withTemporaryCopy`, already used by #390/#391's own tests — cleans up on every exit path including failure) and re-planning with #390/#391's existing capture + classification pipeline.
- The improvement rule is stated once, applied uniformly: kept only when the target alias's plan node changes from `full_table_scan` to `index_search`/`covering_index_scan` with at least one constrained column. No cost estimate — the pinned snapshot is deliberately unanalyzed (no `sqlite_stat1`).
- Deduplicates candidates across statements and drops an exact-prefix candidate in favor of a wider one on the same table.

## Evidence

Generating + verifying candidates from #390's real 214-statement capture produced exactly **6 deduplicated candidates**:

- **1 genuine improvement**: `Orders(CustomerID, EmployeeID)` — a real `WHERE` equality filter on the driving table of a `LEFT JOIN`; plan changes from `full_table_scan` to `index_search`, constrained by `CustomerID`.
- **5 honest false positives**, all caught by verification itself, not a special case:
  - 4 from a join-key column on a join's *driving/outer* side (must be scanned in full regardless of any index — the generator doesn't currently distinguish driving vs. looked-up side; documented limitation).
  - 1 from indexing `OrderID`, which is already the table's `INTEGER PRIMARY KEY` — a plain scan already visits rows in that order for free, so the redundant index is never chosen (`beforePlan == afterPlan` exactly).

Full write-up, evidence table, and both false-positive explanations: [`Documentation/Architecture/SQLiteIndexAdvisor.md`](../blob/claude/issue-392-index-candidates/Documentation/Architecture/SQLiteIndexAdvisor.md).

Partial and expression indices are explicitly **not implemented** — noted as future candidate-space extensions per this issue's requirement.

## Test plan

- [x] `swift build` — full package builds clean.
- [x] `swift test` — full suite (863 tests) passes, including 26 new tests: extraction correctness (including two real bugs caught and fixed — CTE names and cross-scope alias reuse resolving to the wrong table), precedence/dedup logic, and real end-to-end verification of both the improvement and all 5 false positives.
- [x] Verified the pinned Northwind snapshot's SHA-256 is unchanged after every verification run (also asserted by `testVerificationNeverMutatesThePinnedNorthwindSnapshot`).
- [x] Confirmed determinism: candidate generation and verification are byte-identical across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
