### PR TITLE
Publish the query-plan and index-advice spike go/no-go (#393)

### DIFF
--- a/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
+++ b/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
@@ -159,9 +159,12 @@ apply — nothing is closed.
 
 ## Milestone closure
 
-Milestone 29 ("Spike: SQLite query-plan analysis and index advice") closes
-with this issue. Its three prototype issues (#390, #391, #392) each have a
-merged-when-approved PR and a written architecture doc; this document is
-the fourth and closing piece. Milestone 30 ("v1.8") remains open with its
-six issues as confirmed/revised above, still gated on v1.5.2's build
-validator (#292, #293) landing first.
+Milestone 29's four issues (#390, #391, #392, #393) each have an open PR
+and a written architecture doc — [#412](https://github.com/lukevanin/swiftql/pull/412),
+[#422](https://github.com/lukevanin/swiftql/pull/422),
+[#427](https://github.com/lukevanin/swiftql/pull/427), and this issue's PR,
+stacked in dependency order. Milestone 29 is ready to close once all four
+merge; that merge, and the milestone close itself, is left for the
+maintainer rather than done as part of writing this document. Milestone 30
+("v1.8") remains open with its six issues as confirmed/revised above, still
+gated on v1.5.2's build validator (#292, #293) landing first.

--- a/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
+++ b/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
@@ -150,17 +150,17 @@ apply — nothing is closed.
 
 ## Deferred, with a named future owner
 
-| Item | Why deferred | Future owner |
+| Item | Why deferred | Future owner milestone |
 |---|---|---|
-| Partial indices (`CREATE INDEX … WHERE …`) | Would extend #392's candidate space but no real corpus statement in this pass needed one to resolve a false positive (the join-key false positives are structural, not selectivity-driven) | #396 (index-candidate generation), as a scoped enhancement once the base precedence question above is settled |
-| Expression indices | Same — extends the candidate space, unexercised by this pass's corpus | #396, same as above |
-| Vendored `sqlite3expert.c` | Rejected at scaffolding time (needs a custom SQLite build; the scratch-copy approach #392 validated needs only public API) and re-confirmed here: #392 never needed it | Not planned. A deliberate rejection, not a deferred task. |
-| `sqlite3_stmt_scanstatus` measured costs | Named in this issue's own Required Approach as something to record; **not actually evaluated** by any of #390/#391/#392 — this write-up states that gap honestly rather than retroactively claiming coverage | A new, unscheduled research issue (not yet filed): prototype `sqlite3_stmt_scanstatus` as a way to get *measured* per-operation cost without `ANALYZE`, which could sharpen #392's purely structural improvement rule into a graded one |
+| Partial indices (`CREATE INDEX … WHERE …`) | Would extend #392's candidate space but no real corpus statement in this pass needed one to resolve a false positive (the join-key false positives are structural, not selectivity-driven) | **v1.8** (milestone 30), issue #396, as a scoped enhancement once the base precedence question above is settled |
+| Expression indices | Same — extends the candidate space, unexercised by this pass's corpus | **v1.8** (milestone 30), issue #396, same as above |
+| Vendored `sqlite3expert.c` | Rejected at scaffolding time (needs a custom SQLite build; the scratch-copy approach #392 validated needs only public API) and re-confirmed here: #392 never needed it | **None.** A deliberate rejection, not a deferred task — no milestone owns work that isn't going to happen. |
+| `sqlite3_stmt_scanstatus` measured costs | Named in this issue's own Required Approach as something to record; **not actually evaluated** by any of #390/#391/#392 — this write-up states that gap honestly rather than retroactively claiming coverage | **TBD, no milestone yet.** No issue is filed and no existing milestone (v1.8 or otherwise) scopes this work; it needs triage — likely a v1.8.x follow-up or a v1.9 research spike, once v1.8's structural approach has real usage to compare a graded, measured-cost rule against — before either an issue or a milestone is assigned. |
 
 ## Milestone closure
 
-Milestone 29's four issues (#390, #391, #392, #393) each have an open PR
-and a written architecture doc — [#412](https://github.com/lukevanin/swiftql/pull/412),
+Milestone 29's four issues (#390, #391, #392, #393) were each delivered via
+a PR and a written architecture doc — [#412](https://github.com/lukevanin/swiftql/pull/412),
 [#422](https://github.com/lukevanin/swiftql/pull/422),
 [#427](https://github.com/lukevanin/swiftql/pull/427), and this issue's PR,
 stacked in dependency order. Milestone 29 is ready to close once all four

--- a/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
+++ b/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
@@ -1,0 +1,167 @@
+# Query-plan analysis and index advice: spike go/no-go (issue #393)
+
+Milestone 29, "Spike: SQLite query-plan analysis and index advice." This is
+the closing write-up: a go/no-go on advisory query-plan analysis and index
+advice, backed by the measured evidence from the spike's three prototypes,
+and the confirmed (or revised) split of the provisional v1.8 issues. Per
+this milestone's own charter, **this document — not the v1.8 scaffold — is
+authoritative** on how that work is divided.
+
+Research only: no product code, public API, or build-plugin change ships
+from this issue. The three prototype PRs it synthesizes are
+[#412](https://github.com/lukevanin/swiftql/pull/412) (issue #390),
+[#422](https://github.com/lukevanin/swiftql/pull/422) (issue #391), and
+[#427](https://github.com/lukevanin/swiftql/pull/427) (issue #392).
+
+## Verdict: **GO**, with three scoped corrections to the v1.8 issues
+
+Advisory query-plan analysis and index advice are worth building in v1.8.
+All three legs of the spike produced real, reproducible evidence on the
+pinned Northwind snapshot, not merely a plausible design:
+
+- EQP capture is deterministic and, for the shapes that matter, stable
+  across two real SQLite builds (#390).
+- Plan-shape classification handles 100% of a 214-statement real corpus
+  with zero unclassified nodes, and is provably robust to the one
+  cross-build instability #390 found (`id`/`parent` renumbering) (#391).
+- Index-candidate generation and scratch-copy verification produced one
+  genuine, evidenced improvement and caught its own five false positives
+  structurally — without a single special case (#392).
+
+The GO is **scoped**, not unconditional: §"Confirmed and revised v1.8
+issues" below corrects one real discrepancy the spike surfaced (issue #396's
+assumed candidate-column precedence) and adds an evidence-backed caveat to
+two others (issues #394, #395). Nothing in the milestone is closed — see
+[Hard constraint check](#hard-constraint-check).
+
+**Build-host plans are not device plans.** Every measurement in this spike
+ran on this delivery's build host and one additional local SQLite install.
+Apple ships a different SQLite per OS release (#390), so nothing here
+predicts what a specific customer device's query planner will choose. v1.8
+must carry this caveat to every place it surfaces plan-derived advice —
+issues #395 and #398 already say so; that language is confirmed, not new.
+
+## Evidence behind the verdict
+
+### EQP variance by class (#390)
+
+214 real statements (208 from the #191 combinatorial manifest, 6 hand-authored
+Northwind joins/CTEs), captured against two real, distinct SQLite builds
+(Apple system 3.51.0, Homebrew 3.53.2) on the pinned, checksum-verified
+Northwind snapshot:
+
+| Class | Count | Stable across the two builds? |
+|---|---:|---|
+| Byte-identical | 203 | Yes |
+| `id`/`parent` renumbered, structure identical | 2 | Structurally yes, raw ids no |
+| Materialization strategy changed (compound-query CTEs) | 9 | No |
+
+Full detail: [`SQLiteEQPVariance.md`](SQLiteEQPVariance.md).
+
+### Classifier stability (#391)
+
+The same 214 statements, on both builds, classified through `EQPPlanShapeClassifier`:
+**zero** nodes fell back to `unclassified` on either build. The two
+`id`/`parent`-renumbered statements produced byte-identical *normalised*
+plans on both builds (proving the classifier's `id`/`parent`-blind design
+actually delivers on #390's recommendation, not just states it). The nine
+materialization-strategy statements classified fully and differently on each
+build — the classifier *named* the variance #390 measured, which is its job,
+not a failure.
+
+Full detail: [`SQLiteEQPPlanShapeClassifier.md`](SQLiteEQPPlanShapeClassifier.md).
+
+### Index-advice quality on Northwind (#392)
+
+Generating and verifying candidates from the same 214-statement capture
+produced exactly 6 deduplicated candidates:
+
+- **1 confirmed improvement**: a real `WHERE`-equality filter, verified to
+  change the plan from `full_table_scan` to `index_search`.
+- **5 false positives**, all caught by scratch-copy verification itself:
+  4 from indexing a join key on the *driving* side of a join (which must be
+  scanned in full regardless), 1 from indexing a column that was already the
+  table's `INTEGER PRIMARY KEY`.
+
+That is a 1-in-6 yield on a snapshot deliberately picked for correctness
+coverage, not for having many indexable hot paths — the meaningful result is
+not the yield, it's that **every rejection was structural, not asserted**.
+No case required a hand-written exception.
+
+Full detail: [`SQLiteIndexAdvisor.md`](SQLiteIndexAdvisor.md).
+
+## Decided design questions
+
+Per this issue's Required Approach, each open question the milestone
+scaffold left open is settled here:
+
+1. **Do plan records live in the canonical build-validation report, or a
+   sidecar?** **Sidecar.** #390's Finding 2 (real materialization-strategy
+   variance between two ordinary point releases) means folding raw EQP into
+   the pass/fail report would make report diffs noisy for reasons unrelated
+   to SwiftQL correctness. A sidecar keeps that noise out of the
+   correctness contract #293/#294 own. (#394's body is updated to state
+   this directly rather than "where the spike decides.")
+2. **What is the improvement rule for keeping a candidate?** The rule
+   #392 stated and applied uniformly: kept only when the target alias's
+   plan node changes from `full_table_scan` to `index_search` or
+   `covering_index_scan` *and* the after-plan reports at least one
+   constrained column. No cost estimate — the pinned snapshot is
+   deliberately unanalyzed (see decision 4). This is the "rule version" #397
+   asks to record in its report.
+3. **How are unclassified shapes surfaced?** Never coerced into a named
+   shape. `EQPPlanShapeKind.unclassified`, with the raw `detail` string
+   always retained, so a misclassification is auditable rather than silent.
+   #395's diagnostics must key only on named shapes, per its own hard
+   constraint, and #391 proved a 0%-unclassified rate is achievable on a
+   real corpus without ever needing to fall back to that case.
+4. **Should the pinned snapshot's no-statistics policy change?** **No.**
+   #392's structural improvement rule needed no `sqlite_stat1` to find a
+   real improvement and reject five plausible false positives. Adding
+   statistics now would only serve the deferred `sqlite3_stmt_scanstatus`
+   exploration (see below), which is a separate future prototype, not a
+   reason to change today's pinned-snapshot policy.
+
+## Confirmed and revised v1.8 issues
+
+Milestone 30 ("v1.8", #394–#399). Every issue is **confirmed** as scoped
+except the one correction below; two more carry a new evidence-backed
+caveat. None are closed — the GO verdict means proceed, not "some of this
+was wrong."
+
+| Issue | Disposition | Why |
+|---|---|---|
+| #394 — Capture normalised plans in build validation | **Confirmed**, body updated | Directly matches #390/#391's proven pipeline. Updated to state the sidecar decision explicitly (design question 1) instead of leaving it open. Still blocked on #292/#293 (v1.5.2 build validator), independent of this spike. |
+| #395 — Emit advisory shape diagnostics | **Confirmed**, caveat added | Full table scan, temp B-tree (`ORDER BY`/`GROUP BY`) are backed by real, cross-build-stable evidence (#390/#391). **Correlated scalar subquery is not** — the real corpus contains zero correlated scalar subqueries; #391's classifier distinguishes it from a plain scalar subquery by a parent-shape heuristic validated only against one synthetic fixture. Issue body updated to require a real correlated-subquery fixture (extending the Northwind anchor corpus) as part of this issue's own Done-When, not assumed proven. |
+| #396 — Generate index candidates from static descriptors | **Revised**: precedence question reopened | The issue's provisional body assumed equality → **join** → range → order-by. #392's validated implementation used equality → **range** → join → order-by, and matches the one real improvement found. Neither ordering was validated against a real inner-joined table with *both* a range predicate and a join key competing for the second index column — #392's corpus didn't contain that shape. Issue body updated to require settling this empirically (build both orderings, re-plan, keep the one SQLite actually prefers) rather than assuming either. Every other requirement (dedup, prefix-collapse, decline-on-unclassified, deterministic ordering) is confirmed by #392's implementation and tests. |
+| #397 — Verify candidates by re-planning on a scratch copy | **Confirmed as-is** | This is, almost line for line, what #392 built and evidenced: scratch-copy-per-run, same classifier, explicit improvement rule with a recorded version, reject-with-reason, digest-verified cleanup on every path. The one requirement #392 did not address — "note the interaction between a candidate and the write cost it implies" — remains open for #397's implementation; the spike was read-plan-only. |
+| #398 — Surface advice through the SwiftPM build plugin | **Confirmed as-is** | Out of scope for all three spike PRs by design (no build-plugin changes). A downstream consumer of #394/#395/#397's artifacts; nothing in the spike bears on its own requirements. |
+| #399 — `swiftql-index-advisor` codemod | **Confirmed as-is** | Same as #398: downstream consumer, untouched by spike evidence. The fixit-unreachability rationale in its body stands (SwiftPM build-tool plugins cannot emit fixits; a macro cannot open a database). |
+
+### Hard constraint check
+
+Per this issue's own hard constraints: no product code, public API, or
+build-plugin change ships here (confirmed — this delivery is documentation
+and issue-body edits only); no claim that a build-host plan predicts a
+device plan (confirmed — stated explicitly above and already present in
+#395/#398); and since the verdict is **GO**, not no-go, the "close v1.8
+honestly instead of downgrading to vague follow-ups" constraint doesn't
+apply — nothing is closed.
+
+## Deferred, with a named future owner
+
+| Item | Why deferred | Future owner |
+|---|---|---|
+| Partial indices (`CREATE INDEX … WHERE …`) | Would extend #392's candidate space but no real corpus statement in this pass needed one to resolve a false positive (the join-key false positives are structural, not selectivity-driven) | #396 (index-candidate generation), as a scoped enhancement once the base precedence question above is settled |
+| Expression indices | Same — extends the candidate space, unexercised by this pass's corpus | #396, same as above |
+| Vendored `sqlite3expert.c` | Rejected at scaffolding time (needs a custom SQLite build; the scratch-copy approach #392 validated needs only public API) and re-confirmed here: #392 never needed it | Not planned. A deliberate rejection, not a deferred task. |
+| `sqlite3_stmt_scanstatus` measured costs | Named in this issue's own Required Approach as something to record; **not actually evaluated** by any of #390/#391/#392 — this write-up states that gap honestly rather than retroactively claiming coverage | A new, unscheduled research issue (not yet filed): prototype `sqlite3_stmt_scanstatus` as a way to get *measured* per-operation cost without `ANALYZE`, which could sharpen #392's purely structural improvement rule into a graded one |
+
+## Milestone closure
+
+Milestone 29 ("Spike: SQLite query-plan analysis and index advice") closes
+with this issue. Its three prototype issues (#390, #391, #392) each have a
+merged-when-approved PR and a written architecture doc; this document is
+the fourth and closing piece. Milestone 30 ("v1.8") remains open with its
+six issues as confirmed/revised above, still gated on v1.5.2's build
+validator (#292, #293) landing first.

--- a/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
+++ b/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
@@ -13,7 +13,7 @@ from this issue. The three prototype PRs it synthesizes are
 [#422](https://github.com/lukevanin/swiftql/pull/422) (issue #391), and
 [#427](https://github.com/lukevanin/swiftql/pull/427) (issue #392).
 
-## Verdict: **GO**, with three scoped corrections to the v1.8 issues
+## Verdict: **GO**, with two scoped corrections to the v1.8 issues
 
 Advisory query-plan analysis and index advice are worth building in v1.8.
 All three legs of the spike produced real, reproducible evidence on the
@@ -29,10 +29,11 @@ pinned Northwind snapshot, not merely a plausible design:
   structurally — without a single special case (#392).
 
 The GO is **scoped**, not unconditional: §"Confirmed and revised v1.8
-issues" below corrects one real discrepancy the spike surfaced (issue #396's
-assumed candidate-column precedence) and adds an evidence-backed caveat to
-two others (issues #394, #395). Nothing in the milestone is closed — see
-[Hard constraint check](#hard-constraint-check).
+issues" below corrects one real discrepancy the spike found and then
+settled with a real fixture (issue #396's candidate-column precedence —
+see [the finding](SQLiteIndexAdvisor.md#finding-join-keys-must-precede-range-columns))
+and adds an evidence-backed caveat to one more (issue #395). Nothing in the
+milestone is closed — see [Hard constraint check](#hard-constraint-check).
 
 **Build-host plans are not device plans.** Every measurement in this spike
 ran on this delivery's build host and one additional local SQLite install.
@@ -88,6 +89,16 @@ coverage, not for having many indexable hot paths — the meaningful result is
 not the yield, it's that **every rejection was structural, not asserted**.
 No case required a hand-written exception.
 
+A follow-up fixture (a `Categories LEFT JOIN Products` statement with both a
+join key and a range predicate on the looked-up table, deliberately built
+to test the case the real corpus never contained) additionally **confirmed
+the candidate-column precedence rule and found a real bug in it**: a
+candidate index with the join key before the range column is the one
+SQLite actually adopts; the reverse order is silently ignored. Fixing this
+also required accepting SQLite's own `automatic_covering_index` shape, not
+only `full_table_scan`, as a remediable "before" state. See
+[the finding](SQLiteIndexAdvisor.md#finding-join-keys-must-precede-range-columns).
+
 Full detail: [`SQLiteIndexAdvisor.md`](SQLiteIndexAdvisor.md).
 
 ## Decided design questions
@@ -104,11 +115,11 @@ scaffold left open is settled here:
    this directly rather than "where the spike decides.")
 2. **What is the improvement rule for keeping a candidate?** The rule
    #392 stated and applied uniformly: kept only when the target alias's
-   plan node changes from `full_table_scan` to `index_search` or
-   `covering_index_scan` *and* the after-plan reports at least one
-   constrained column. No cost estimate — the pinned snapshot is
-   deliberately unanalyzed (see decision 4). This is the "rule version" #397
-   asks to record in its report.
+   plan node changes from `full_table_scan` **or `automatic_covering_index`**
+   to `index_search` or `covering_index_scan` *and* the after-plan reports
+   at least one constrained column. No cost estimate — the pinned snapshot
+   is deliberately unanalyzed (see decision 4). This is the "rule version"
+   #397 asks to record in its report.
 3. **How are unclassified shapes surfaced?** Never coerced into a named
    shape. `EQPPlanShapeKind.unclassified`, with the raw `detail` string
    always retained, so a misclassification is auditable rather than silent.
@@ -133,7 +144,7 @@ was wrong."
 |---|---|---|
 | #394 — Capture normalised plans in build validation | **Confirmed**, body updated | Directly matches #390/#391's proven pipeline. Updated to state the sidecar decision explicitly (design question 1) instead of leaving it open. Still blocked on #292/#293 (v1.5.2 build validator), independent of this spike. |
 | #395 — Emit advisory shape diagnostics | **Confirmed**, caveat added | Full table scan, temp B-tree (`ORDER BY`/`GROUP BY`) are backed by real, cross-build-stable evidence (#390/#391). **Correlated scalar subquery is not** — the real corpus contains zero correlated scalar subqueries; #391's classifier distinguishes it from a plain scalar subquery by a parent-shape heuristic validated only against one synthetic fixture. Issue body updated to require a real correlated-subquery fixture (extending the Northwind anchor corpus) as part of this issue's own Done-When, not assumed proven. |
-| #396 — Generate index candidates from static descriptors | **Revised**: precedence question reopened | The issue's provisional body assumed equality → **join** → range → order-by. #392's validated implementation used equality → **range** → join → order-by, and matches the one real improvement found. Neither ordering was validated against a real inner-joined table with *both* a range predicate and a join key competing for the second index column — #392's corpus didn't contain that shape. Issue body updated to require settling this empirically (build both orderings, re-plan, keep the one SQLite actually prefers) rather than assuming either. Every other requirement (dedup, prefix-collapse, decline-on-unclassified, deterministic ordering) is confirmed by #392's implementation and tests. |
+| #396 — Generate index candidates from static descriptors | **Revised**: precedence question settled with a real fixture | The issue's provisional body assumed equality → **join** → range → order-by. #392's originally-validated implementation instead used equality → **range** → join → order-by, matching the one real corpus improvement found — but that statement never exercised a join key competing with a range column, so the ordering wasn't actually proven. A follow-up fixture (`Categories LEFT JOIN Products` with both a join key and a range predicate on the looked-up table) settled it with a real scratch-copy re-plan: the join key **must** precede the range column — `Products(CategoryID, UnitPrice)` is the index SQLite adopts, `Products(UnitPrice, CategoryID)` is silently ignored. `IndexCandidateGenerator.candidateColumns` is corrected to equality-and-join-merged → range → order-by, and the improvement rule now also accepts `automatic_covering_index` as a remediable "before" shape (this fixture's baseline, not a full scan). Issue body updated to state the settled rule directly. Every other requirement (dedup, prefix-collapse, decline-on-unclassified, deterministic ordering) is confirmed by #392's implementation and tests. |
 | #397 — Verify candidates by re-planning on a scratch copy | **Confirmed as-is** | This is, almost line for line, what #392 built and evidenced: scratch-copy-per-run, same classifier, explicit improvement rule with a recorded version, reject-with-reason, digest-verified cleanup on every path. The one requirement #392 did not address — "note the interaction between a candidate and the write cost it implies" — remains open for #397's implementation; the spike was read-plan-only. |
 | #398 — Surface advice through the SwiftPM build plugin | **Confirmed as-is** | Out of scope for all three spike PRs by design (no build-plugin changes). A downstream consumer of #394/#395/#397's artifacts; nothing in the spike bears on its own requirements. |
 | #399 — `swiftql-index-advisor` codemod | **Confirmed as-is** | Same as #398: downstream consumer, untouched by spike evidence. The fixit-unreachability rationale in its body stands (SwiftPM build-tool plugins cannot emit fixits; a macro cannot open a database). |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,6 +55,7 @@ Version numbers express the intended order of work, not release dates.
 | [v1.3](https://github.com/lukevanin/swiftql/milestone/8) | Existing SQLite-surface conformance | Current public syntax proven against real SQLite |
 | [v1.4](https://github.com/lukevanin/swiftql/milestone/9) | Common SQLite feature coverage | A documented, useful SQLite subset |
 | [v1.5](https://github.com/lukevanin/swiftql/milestone/1) | Query declarations, ergonomics, and v2 preview | The future API validated without silently raising the v1 toolchain floor |
+| [v1.8](https://github.com/lukevanin/swiftql/milestone/30) | Query-plan analysis and index advice | Advisory `EXPLAIN QUERY PLAN` diagnostics and verified index recommendations layered onto the v1.5.2 build validator, never affecting build exit status |
 | [v2](https://github.com/lukevanin/swiftql/milestone/10) | Generated database catalogs, Swift 6, and a stable dialect-aware API | Fluent catalog-scoped queries plus intentional naming, package, DDL, and adapter cleanup |
 | [v2.1](https://github.com/lukevanin/swiftql/milestone/2) | Native SQLite adapter | Direct SQLite C execution as an alternative to GRDB |
 | [v2.2](https://github.com/lukevanin/swiftql/milestone/5) | PostgreSQL | Native PostgreSQL syntax and adapter |
@@ -75,6 +76,7 @@ Key planning and foundation issues:
 | v1.3 | [syntax conformance inventory](https://github.com/lukevanin/swiftql/issues/190), [combinatorial conformance cases](https://github.com/lukevanin/swiftql/issues/191), [build-time SQLite validation research](https://github.com/lukevanin/swiftql/issues/132), [Northwind correctness corpus](https://github.com/lukevanin/swiftql/issues/254), [observation stress contracts](https://github.com/lukevanin/swiftql/issues/255) |
 | v1.4 | [SQLite coverage index](https://github.com/lukevanin/swiftql/issues/115), [direct scalar CTE rows](https://github.com/lukevanin/swiftql/issues/43) |
 | v1.5 | [ergonomics index](https://github.com/lukevanin/swiftql/issues/116), [macro index](https://github.com/lukevanin/swiftql/issues/117), [prepared handles](https://github.com/lukevanin/swiftql/issues/18), [lazy typed result set](https://github.com/lukevanin/swiftql/issues/249), [@SQLQuery prototype](https://github.com/lukevanin/swiftql/issues/26), [Date text](https://github.com/lukevanin/swiftql/issues/61) and [numeric codecs](https://github.com/lukevanin/swiftql/issues/62), [UUID codecs](https://github.com/lukevanin/swiftql/issues/192), [interactive DocC tutorial](https://github.com/lukevanin/swiftql/issues/27), [macro regression corpus](https://github.com/lukevanin/swiftql/issues/256), [compile scalability benchmarks](https://github.com/lukevanin/swiftql/issues/257), [runtime workload research](https://github.com/lukevanin/swiftql/issues/259) |
+| v1.8 | [query-plan capture](https://github.com/lukevanin/swiftql/issues/394), [advisory shape diagnostics](https://github.com/lukevanin/swiftql/issues/395), [index-candidate generation](https://github.com/lukevanin/swiftql/issues/396), [scratch-copy verification](https://github.com/lukevanin/swiftql/issues/397), [SwiftPM plugin surface](https://github.com/lukevanin/swiftql/issues/398), [swiftql-index-advisor codemod](https://github.com/lukevanin/swiftql/issues/399), [spike go/no-go](https://github.com/lukevanin/swiftql/issues/393) |
 | v2 | [generated database catalogs and fluent table references](https://github.com/lukevanin/swiftql/issues/217), [Swift 6 mode](https://github.com/lukevanin/swiftql/issues/133), [typed DDL](https://github.com/lukevanin/swiftql/issues/139), [FluentQL and DynamicQL extraction](https://github.com/lukevanin/swiftql/issues/326), [GRDB adapter boundary](https://github.com/lukevanin/swiftql/issues/113), [XL migration](https://github.com/lukevanin/swiftql/issues/33), [catalog stress fixtures](https://github.com/lukevanin/swiftql/issues/258) |
 | v2.1 | [native SQLite adapter](https://github.com/lukevanin/swiftql/issues/136), [Linux CI](https://github.com/lukevanin/swiftql/issues/135), [VDBE research](https://github.com/lukevanin/swiftql/issues/138), [shared-corpus adapter parity](https://github.com/lukevanin/swiftql/issues/260) |
 | v2.2 | [PostgreSQL vertical slice](https://github.com/lukevanin/swiftql/issues/137) |
@@ -410,6 +412,36 @@ remains a research track until benchmarks show material value and a prototype
 demonstrates correctness, portability, invalidation, and a safe fallback.
 SwiftQL must not claim persisted or zero-parse preparation until that evidence
 exists.
+
+### Query-Plan Analysis and Index Advice
+
+Milestone 29 spiked whether `EXPLAIN QUERY PLAN` output can be captured
+deterministically enough to build advisory diagnostics and index
+recommendations on top of the build validator above, and concluded **go**:
+[measured EQP variance](https://github.com/lukevanin/swiftql/pull/412), a
+[normalised plan-shape classifier proven against a real 214-statement
+corpus](https://github.com/lukevanin/swiftql/pull/422), and
+[scratch-copy-verified index candidates that caught their own false
+positives structurally](https://github.com/lukevanin/swiftql/pull/427) are
+checked in as evidence, synthesized in the closing
+[go/no-go write-up](Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md).
+
+Two findings shape everything v1.8 builds on this foundation: SQLite's own
+`id`/`parent` row numbering is not a stable diagnostic key even when a plan
+is otherwise unchanged across versions, and a build-host plan is not a
+device plan — Apple ships a different SQLite per OS release, so plan
+analysis is advisory only and must never affect build exit status. Plan
+records live in a sidecar, not the correctness report this section
+describes, to keep that advisory noise out of the pass/fail contract.
+
+v1.8 ("Query-plan analysis and index advice", tracked
+[here](https://github.com/lukevanin/swiftql/milestone/30)) carries this
+forward once the v1.5.2 build validator above ships: normalised plan
+capture, advisory shape diagnostics, index-candidate generation and
+scratch-copy verification, a SwiftPM plugin surface, and a
+`swiftql-index-advisor` codemod as the fixit-equivalent — build-tool
+plugins cannot emit Swift fixits, and a macro cannot open a database
+without breaking hermetic, incremental builds.
 
 ## Conformance and Documentation Strategy
 


### PR DESCRIPTION
Closes #393.

**Stacked on #427** (the last in the #390→#391→#392 chain). This PR's base should be retargeted to `experiment/query-plan-index-advice` once #412/#422/#427 merge — only the last four commits (`a4a7ee79` onward) are this issue's actual diff.

**Update:** per user request, checked the #396 candidate-column precedence question before merging anything, rather than leaving it open. Built a real fixture (`Categories LEFT JOIN Products` with both a join key and a range predicate on the looked-up table — the case the original #392 corpus never contained) and re-planned it on a scratch copy. Result: **join keys must precede range columns** — `Products(CategoryID, UnitPrice)` is the index SQLite actually adopts; `Products(UnitPrice, CategoryID)` is silently ignored. This was a real bug in #392's shipped precedence rule (fixed on that branch, `cc17d5f3`, with two new tests — one unit-level, one a real scratch-copy re-plan of both orderings) and also surfaced that the improvement rule needed to accept `automatic_covering_index`, not only `full_table_scan`, as a remediable "before" shape.

## Verdict: GO, with two scoped corrections to the v1.8 issues

Full write-up: [`Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md`](../blob/claude/issue-393-spike-go-no-go/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md).

- Synthesizes the measured evidence from all three spike prototypes (#390 EQP variance, #391 classifier stability, #392 index-advice quality) into a single go/no-go.
- Settles the four open design questions the milestone scaffold left open: plan records live in a **sidecar**, not the canonical report; the **improvement rule** is #392's structural shape-change rule (now covering both `full_table_scan` and `automatic_covering_index`); unclassified shapes are **never coerced**; the pinned snapshot's **no-statistics policy is unchanged**.
- Confirms 4 of the 6 v1.8 issues (#394 with the sidecar decision folded in, #397/#398/#399 as-is) and revises 2 with real, evidence-backed corrections:
  - **#395**: confirmed the three shapes with real corpus evidence, but flagged that "correlated scalar subquery" has **zero real corpus coverage** — only a synthetic fixture proves #391's classifying heuristic — and added a Done-When requirement for a real fixture before that specific diagnostic ships.
  - **#396**: the provisional body assumed a candidate-column precedence (equality → join → range → order-by). The spike's real fixture **settles** this (not merely reopens it): equality-and-join-key columns together, then at most one range column, then order-by. Issue body updated with the settled rule and the evidence.
- Records deferred items with named future owners: partial/expression indices → v1.8 issue #396; vendored `sqlite3expert` → permanently rejected, not planned; `sqlite3_stmt_scanstatus` → honestly noted as **never actually evaluated** by this spike despite being named in this issue's own Required Approach, left as an unscheduled future research issue (no milestone yet).
- Updates `ROADMAP.md`: adds v1.8 to the Release Sequence and Key Planning Issues tables, and adds a "Query-Plan Analysis and Index Advice" subsection under "Build-Time SQLite Validation" summarizing the spike's outcome.
- Updates all 6 v1.8 issue bodies (#394–#399) directly on GitHub with the resolutions above, each linking back to this write-up.

Per this issue's hard constraints: no product code, public API, or build-plugin change ships from this issue itself (docs and issue-body edits only) — the precedence-rule code fix lives on and ships with #392/#427, not this PR; the build-host-vs-device version-skew limitation is stated explicitly, not implied. Milestone 29 itself is **not closed** by this PR — that's left for the maintainer once all four spike PRs actually merge, not asserted as done by writing the doc.

## Test plan

- [x] `swift build` / `swift test` — full suite (865 tests) passes.
- [x] All 6 v1.8 issue bodies (#394–#399) verified as updated on GitHub with correct blob links to this branch's docs.
- [x] The precedence fix (on #392/#427) is verified by a real scratch-copy re-plan of both column orderings, plus a unit test — not just reasoned about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
