### PR TITLE
Report skipped schema checks and short-circuit per-query validation on schema mismatch

### DIFF
--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -176,15 +176,61 @@ public enum SQLiteBuildValidator {
                     message: "Observed schema FNV-1a-64 is \(runtimeMetadata.schemaFNV1A64); the manifest's schema snapshot declares \(validatedManifest.schemaSnapshot.schemaFingerprint)."
                 ))
             }
+        } else {
+            // Capture failed above (`runtime.capture`), so these two checks
+            // never ran — report them explicitly rather than letting them
+            // vanish from the diagnostic set.
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .schema,
+                code: "schema.row-count",
+                message: "Schema row count could not be checked because SQLite runtime metadata capture failed."
+            ))
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .schema,
+                code: "schema.fingerprint",
+                message: "Schema fingerprint could not be checked because SQLite runtime metadata capture failed."
+            ))
         }
 
-        let outcomes = validatedManifest.queries.map { query in
-            validate(
-                query: query,
-                in: database,
-                runtimeMetadata: runtimeMetadata,
-                environment: environment
-            )
+        // A schema identity mismatch already fails the report outright
+        // (`SQLiteBuildValidationReport.overallVerdict`), independent of
+        // per-query outcomes. Once one is recorded, running every query
+        // against a snapshot already known not to match the manifest is
+        // pointless — skip preparation and emit one deterministic
+        // `unsupported` outcome per manifest entry instead, so callers can
+        // still see which queries were skipped.
+        let hasSchemaIdentityMismatch = reportDiagnostics.contains {
+            $0.stage == .schema && $0.verdict == .failed
+        }
+        let outcomes: [SQLiteBuildValidationQueryOutcome]
+        if hasSchemaIdentityMismatch {
+            outcomes = validatedManifest.queries.map { query in
+                SQLiteBuildValidationQueryOutcome(
+                    query: query,
+                    placeholderAnalysis: SQLiteBuildValidationValidatorPlaceholderScanner.scan(query.sql),
+                    preparedShape: nil,
+                    diagnostics: [
+                        SQLiteBuildValidationDiagnostic(
+                            verdict: .unsupported,
+                            stage: .schema,
+                            code: "schema.mismatch-skipped",
+                            message: "Query validation was skipped because the database snapshot's schema identity does not match the manifest.",
+                            query: query
+                        ),
+                    ]
+                )
+            }
+        } else {
+            outcomes = validatedManifest.queries.map { query in
+                validate(
+                    query: query,
+                    in: database,
+                    runtimeMetadata: runtimeMetadata,
+                    environment: environment
+                )
+            }
         }
         return SQLiteBuildValidationReport(
             manifest: validatedManifest,


### PR DESCRIPTION
## Summary

Addresses two Copilot review findings originally raised on PR #420 (the v1.5.2 release-prep merge), deliberately deferred there and tracked as a follow-up since the validator code was already-shipped, tested logic and the release PR's only job was merging into `main`:

- When `SQLiteBuildValidationRuntime.capture` fails, the schema row-count and fingerprint checks were silently skipped instead of being reported as `.unsupported`.
- When a schema identity mismatch is already recorded, per-query validation ran anyway against a snapshot already known not to match the manifest.

Neither was a soundness bug — `SQLiteBuildValidationReport.overallVerdict` already resolves to `.failed`/`.unsupported` from the report-level diagnostic alone — but both are worth fixing for diagnostic completeness and to avoid pointless work.

## Changes

- `SQLiteBuildValidator.swift`: emit explicit `.unsupported` diagnostics (`schema.row-count`, `schema.fingerprint`) when runtime metadata capture fails, instead of letting those checks silently vanish from the report.
- Short-circuit per-query preparation once a report-level schema `.failed` diagnostic is already recorded, emitting one deterministic `schema.mismatch-skipped` outcome per manifest entry so callers can still see which queries were skipped.

## Test plan

- [x] Full test suite (983 tests) passes, including `SQLiteBuildValidatorIntegrationTests` (`testSnapshotMismatchesFailClosed`, `testRepeatedValidationsProduceByteIdenticalCanonicalReports`, etc.)
- [ ] CI green
