### PR TITLE
Restructure the documentation hierarchy for onboarding first

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,52 @@ If you know SQLite, you already know the shape of SwiftQL: `Select`, `From`,
 `Join`, `Where`, `GroupBy`, `Having`, and `With` appear in SQL order and retain
 their SQL meaning.
 
+## Get started
+
+### Install
+
+Add the following line to the `dependencies` section in your `Package.swift`
+file:
+
+```text
+.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.5.2")
+```
+
+`1.5.2` is the latest published package. The examples above use APIs retained
+by v1.3; the static-query surface remains available from version 1.2.0. Pin a
+source revision only when intentionally testing later changes from `main`.
+
+In Xcode, follow Apple's [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app#Add-a-package-dependency),
+and specify the package URL `https://github.com/lukevanin/swiftql.git`.
+
+### Read the guide
+
+**[Getting started](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/)**
+walks through defining a table, creating it, inserting, selecting, binding
+values, updating, deleting, and grouping work in a transaction. It is the
+fastest path from an empty file to a working query, and it doubles as a quick
+reference afterwards.
+
+From there:
+
+- [Select queries](https://lukevanin.github.io/swiftql/documentation/swiftql/queries/)
+  for joins, grouping, subqueries, and CTEs.
+- [Declared queries](https://lukevanin.github.io/swiftql/documentation/swiftql/declaredqueries/)
+  to write queries as ordinary Swift functions with `@SQLQuery`.
+- [Advanced usage](https://lukevanin.github.io/swiftql/documentation/swiftql/advancedusage/)
+  for connections, statement preparation, row lifetime, and the full
+  transaction contract.
+- The
+  [full documentation](https://lukevanin.github.io/swiftql/documentation/swiftql/),
+  whose examples are connected to executable test scenarios, so the API shown
+  in the guides stays aligned with the library.
+
+## What's new
+
+[WHATSNEW.md](WHATSNEW.md) describes each release in plain language — what you
+can do that you could not before, and whether it affects code you already
+wrote. [CHANGELOG.md](CHANGELOG.md) remains the exact record.
+
 ## What becomes first-class
 
 - **[Tables](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/)
@@ -152,34 +198,7 @@ SQLite remains the authority for the live schema, runtime constraints,
 coercion rules, and dialect-specific behavior. SwiftQL deliberately grows its
 SQLite coverage without blurring that line.
 
-## Installation
-
-### Swift Package Manager
-
-Add the following line to the `dependencies` section in your `Package.swift`
-file:
-
-```text
-.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.5.2")
-```
-
-`1.5.2` is the latest published package. The examples above use APIs retained
-by v1.3; the static-query surface remains available from version 1.2.0. Pin a
-source revision only when intentionally testing later changes from `main`.
-
-### Xcode
-
-Refer to Apple's documentation [Adding package dependencies to your app](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app#Add-a-package-dependency),
-and specify the package URL `https://github.com/lukevanin/swiftql.git`. 
-
-## Explore SwiftQL
-
-Start with the
-[documentation](https://lukevanin.github.io/swiftql/documentation/swiftql/).
-Its examples are connected to executable test scenarios, so the API shown in
-the guides stays aligned with the library.
-
-For project guarantees and direction:
+## Project guarantees and direction
 
 - [Compiler compatibility](COMPATIBILITY.md) records the supported Swift
   toolchains and reproducible CI matrix.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -82,6 +82,11 @@ matrix, and built the exact commit's validated DocC artifact.
    release-preparation change to `main` and tag the tip. When it is not, put
    the dated heading on the preparation branch instead and follow "Releasing a
    commit that is not at `main`'s tip" below.
+
+   Add the version's plain-language section to [`WHATSNEW.md`](WHATSNEW.md) in
+   that same preparation change. No gate enforces it — it is a reader-facing
+   summary, not release evidence — but it is written from the dated changelog
+   section and goes stale immediately if it is skipped.
 5. In repository settings, enable immutable releases. Verify it out of band
    with an administrator token immediately before tagging; HTTP success alone
    is insufficient because the endpoint also returns 200 while disabled:

--- a/SKILL.md
+++ b/SKILL.md
@@ -138,10 +138,10 @@ layouts rather than reproducing those contracts in consumer comments.
   expose `DatabaseError` or `XLColumnReadError` where its compatibility policy
   requires those concrete errors.
 
-Read [contextual codecs](https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/)
-and [prepared execution boundaries](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/)
+Read [contextual codecs](https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/) and
+[prepared execution boundaries](https://lukevanin.github.io/swiftql/documentation/swiftql/advancedusage/)
 for the exact selection order, structured errors, row lifetime, and driver
-contracts.
+contracts; the everyday API is [getting started](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/).
 
 ## Report v1.3 support from canonical evidence
 

--- a/Sources/SwiftQL/SQLTransactionScope.swift
+++ b/Sources/SwiftQL/SQLTransactionScope.swift
@@ -57,8 +57,9 @@ import Foundation
 /// synchronously to completion and has no cooperative cancellation point
 /// while committed or rolled-back writes are underway.
 ///
-/// See <doc:GettingStarted> for the isolation and lifetime rules, and for
+/// See <doc:AdvancedUsage> for the isolation and lifetime rules, and for
 /// concrete examples of the durable-state guarantees this API makes.
+/// <doc:GettingStarted> introduces the everyday spelling.
 ///
 public protocol XLTransactionalDatabase: XLDatabase {
 

--- a/Sources/SwiftQL/SwiftQL.docc/AdvancedUsage.md
+++ b/Sources/SwiftQL/SwiftQL.docc/AdvancedUsage.md
@@ -1,0 +1,257 @@
+# Advanced usage
+
+Understand how a SwiftQL statement reaches SQLite: preparation, connection
+ownership, row lifetime, binding packets, and transaction boundaries.
+
+## Overview
+
+<doc:GettingStarted> shows what to write. This guide explains what happens
+underneath, and it is where the exact contracts live: which values are bound
+to which connection, when SQLite prepares a statement, how long a result row
+survives, what is safe to share between tasks, and which mistakes are rejected
+rather than tolerated.
+
+None of this is required to write a working query. Read it when you are
+tuning execution, running work across tasks, writing your own database
+adapter, or diagnosing something that only fails under a connection pool.
+
+## Package layout and version boundaries
+
+Adapter packages can depend directly on the `SwiftQLCore` library product. It
+exports the dialect, dialect-value, logical-statement, and driver contracts
+without linking GRDB; the `SwiftQL` product remains the compatibility facade
+that includes the current GRDB-backed SQLite adapter.
+
+SwiftQL v1.3 validates the existing SQLite surface against recorded real-engine,
+Northwind, and stress evidence; it does not introduce a new public syntax or
+validation API. In particular, issue
+[#132](https://github.com/lukevanin/swiftql/issues/132) is a
+research-only schema-snapshot preparation prototype. Applications still own
+their schema lifecycle and perform physical preparation on the runtime
+connection that executes each statement.
+
+## Requests, layouts, and packets
+
+Requests retain the generated SQL and an immutable `XLParameterLayout`. The
+layout is static metadata: it records each logical parameter's deterministic
+index, binding key, value type, nullability, coding context, and selected codec
+identity. Runtime values are separate. Put them in a fresh
+`XLInvocationBindings` packet for each call, then pass that packet to
+`fetchAll(bindings:)`, `fetchOne(bindings:)`, `execute(bindings:)`, or a
+packet-backed publisher. Creating a request translates the SwiftQL statement
+into SQL but does not prepare it immediately. On execution, GRDB obtains a
+cached SQLite statement for that SQL on the connection performing the work.
+
+## Dialect and driver responsibilities
+
+The SQLite dialect defines how SwiftQL renders valid SQLite syntax, including
+identifier quoting, placeholder spelling, value storage classes, and required
+SQLite capabilities. The database driver has a separate job: it leases a
+connection, prepares the rendered SQL, binds SQLite values to its transport,
+executes the statement, and reads SQLite values from the result. GRDB is the
+current SQLite driver, but it does not define the SQLite syntax or the logical
+policy for converting application values.
+
+## Logical and physical preparation
+
+Logical requests and prepared handles are database- or pool-bound. They retain
+the rendered SQL and request metadata, but they do not own one physical
+statement. Physical GRDB statements are connection-bound and must not be shared
+between connections or concurrent executions.
+
+With a connection pool, each execution leases a connection and resolves or
+caches the physical statement separately on that leased connection. Another
+execution may lease a different connection and therefore prepare the same SQL
+again. A single-connection database may reuse its own statement cache, but its
+physical statements still belong only to that connection.
+
+Preparation is therefore an execution-time operation. Successful preparation
+on one connection does not guarantee every later preparation: preparation can
+still fail later on a newly leased connection, for example when its schema,
+registered functions, or available capabilities differ.
+
+## Incremental row lifetime
+
+The GRDB adapter steps result rows through a package-internal, driver-neutral
+callback while the leased connection is active. It copies each row into
+normalized SQLite values before advancing because GRDB reuses cursor-backed row
+storage. The synchronous callback may stop without stepping later rows, and a
+thrown decoding error releases the cursor and connection before it propagates.
+A cursor value is never returned from the database-access closure.
+
+The public v1 behavior remains eager: `fetchAll()` still returns a complete
+typed array, while `fetchOne()` returns an optional first row. Those
+compatibility APIs are layered over the same incremental primitive.
+`fetchAll()` therefore retains its typed output as required but no longer
+retains a complete intermediate array of GRDB rows or normalized SQLite-value
+rows before typed decoding. Future package adapters should implement the same
+callback lifetime rather than exposing their native cursor types.
+
+## Transactions and bindings
+
+Transaction-scoped work pins one connection for the duration of the
+transaction. Code inside that transaction must use the pinned connection and
+must not re-enter the root pool, which could lease another connection and break
+the transaction boundary or deadlock while waiting for itself.
+
+The synchronous v1 driver commits when the transaction body returns and rolls
+back when it throws. `withValidatedTransaction` preserves the exact body error,
+so a dedicated caller error can express explicit rollback intent. The v1
+contract does not expose nested transactions, savepoints, or task-cancellation
+hooks; do not attempt those by re-entering the root pool from a pinned body.
+The current GRDB v1 driver is pool-backed and does not expose a separate
+single-connection transaction capability.
+
+Each invocation packet carries normalized dialect values in logical-index
+order, so every call has fresh bindings. Packet-backed execution does not move
+those values into the logical request or connection-wide statement cache.
+Packets and layouts are value-semantic and `Sendable` when their dialect values
+are. The current `XLRequest` facade itself is not `Sendable` and does not yet
+promise that one request can be shared across tasks; use packets to separate
+values across repeated calls in the request's supported isolation context.
+
+Driver integrations can use the `prepareValidated`, `bindValidated`,
+`fetchAllValidated`, `fetchOneValidated`, `executeValidated`, and
+`withValidatedTransaction` helpers to normalize transport failures into
+`XLDatabaseContractError` categories. The existing GRDB compatibility facade
+keeps raw `DatabaseError` and `XLColumnReadError` values where its retry policy
+and established decoding API need to inspect them; database and dialect
+mismatches are still rejected before physical preparation in both paths.
+
+## Cross-task raw-value execution
+
+For cross-task raw-value execution with GRDB, call
+`GRDBDatabase.prepareInvocation(with:)`. Its `GRDBPreparedInvocation` result is
+`Sendable` and accepts an independent packet in `fetchAllValues`,
+`fetchOneValues`, or `execute`. It deliberately returns normalized SQLite
+values instead of retaining the legacy typed row-reader graph.
+
+<!-- test: XLDocumentationTests.testDocumentationAdvancedUsage -->
+```swift
+let minimumAgeParameter = XLNamedBindingReference<Int>(name: "minimumAge")
+let namedAdultsQuery = sql { schema in
+    let person = schema.table(Person.self)
+    Select(person)
+    From(person)
+    Where(person.age >= minimumAgeParameter)
+}
+let preparedInvocation = database.prepareInvocation(with: namedAdultsQuery)
+
+let minimumAgeSlot = preparedInvocation.parameterLayout
+    .slot(for: .named("minimumAge"))!
+let invocationBindings = try XLInvocationBindings<XLSQLiteValue>(
+    layout: preparedInvocation.parameterLayout,
+    bindings: [
+        try XLInvocationBinding(slot: minimumAgeSlot, value: .integer(21))
+    ]
+).validatingComplete()
+
+let rows: [[XLSQLiteValue]] = try preparedInvocation.fetchAllValues(
+    bindings: invocationBindings
+)
+```
+
+Each row arrives as normalized `XLSQLiteValue` columns in the statement's own
+result order; decoding them into application types is the caller's
+responsibility. For a durable, database-independent SQL and value-layout
+contract, create an `XLStaticQueryDescriptor` and prepare it through the
+overload described in <doc:StaticQueries>.
+
+## Legacy mutable bindings
+
+The mutating `set` methods remain as a migration shim for v1 literal bindings.
+They immediately normalize each value into a compatibility packet stored in
+that request copy. Existing code can continue to copy, set, and execute a
+request, but new code should keep the prepared request immutable and pass an
+explicit packet for each call. The shim cannot override a contextual
+parameter's selected codec. Static descriptors use the same immutable packet
+contract while adding stable identity, result metadata, cardinality, and a
+cross-task prepared handle; see <doc:StaticQueries>.
+
+## Typed multi-statement transaction scopes
+
+`GRDBDatabase.withTransaction(_:)` (issue #284, `XLTransactionalDatabase`) runs
+an ordered sequence of typed requests — reads and writes alike — as one atomic
+unit on a single pinned connection, without ever naming a GRDB type. It is the
+typed counterpart to the driver-level `withTransaction` described above: where
+the driver hands an adapter integration a raw connection, this hands ordinary
+application code another `GRDBDatabase`, so the body is just more
+`makeRequest(with:)` calls (and, inside a `@SQLQueries` extension, more
+`Context` calls — `execute(_:)` is sugar over this same primitive).
+<doc:GettingStarted> shows the everyday spelling; this section states the
+guarantees it rests on.
+
+Ordering, atomicity, and lifetime work exactly as the driver-level contract
+above describes, plus the guarantees a typed, adapter-neutral surface adds:
+
+- **Order and results.** Every request the body issues runs in source order
+  on the one connection `withTransaction(_:)` pinned for this call; an
+  ordinary local variable carries one operation's result to a later one or to
+  the transaction's own return value.
+- **Commit and rollback.** The whole body is one commit unit: it commits only
+  after the body returns normally, and rolls back every write the body
+  performed — on a preparation, binding, execution, decoding, or user-thrown
+  failure alike — before rethrowing the original, unmodified error.
+- **Read-your-writes.** A read issued from the scope observes an earlier,
+  still-uncommitted write from the same body, because both run on the same
+  pinned connection.
+- **No GRDB type in the contract.** The scope handed to the body is another
+  `GRDBDatabase` — the exact same type <doc:GettingStarted> uses — never a
+  GRDB `Database`, `DatabasePool`, or statement handle.
+
+Three cases are rejected before any transaction work happens, each with a
+predictable, catchable `XLTransactionScopeError` rather than a crash or silent
+wrong answer:
+
+- **Nested transactions and savepoints are not supported.** Calling
+  `withTransaction(_:)` again from inside an active body — on the scope it was
+  given, *or* on the original database captured from the enclosing scope —
+  throws `.nestedTransactionUnsupported`. The v1 driver has no savepoint hook,
+  so a nested call cannot prove it would only commit or roll back its own
+  writes; re-entering the connection pool from inside an open transaction can
+  also deadlock or silently lease a different connection that only sees the
+  database's last *committed* state, missing the transaction's own
+  uncommitted writes.
+- **The scope must not escape the body.** A request, write request, or scope
+  value used after `withTransaction(_:)` returns throws `.scopeEscaped`: the
+  pinned connection is invalidated the instant the body returns, so
+  continuing would silently touch a connection GRDB may already be reusing
+  for unrelated work.
+- **Live queries are not supported inside a transaction.** `publish()` /
+  `publishOne()` on a transaction-scoped request throws
+  `.liveQueriesUnsupportedInTransaction`: `ValueObservation` tracks a
+  connection pool across commits over time, and a transaction-scoped
+  connection is invalidated before there is anything to observe.
+
+The nested case is worth seeing written out, because the rejection is a
+catchable error and the outer body's own writes still roll back:
+
+<!-- test: XLDocumentationTests.testDocumentationAdvancedUsage -->
+```swift
+do {
+    try database.withTransaction { scope in
+        let candidate = Person(id: "nested", occupationId: nil, name: "Ida", age: 33)
+        try scope.makeRequest(with: sqlInsert(candidate)).execute()
+        try scope.withTransaction { _ in }
+    }
+} catch let error as XLTransactionScopeError {
+    // .nestedTransactionUnsupported — and the insert above rolled back.
+    print(error)
+}
+```
+
+Cancellation is checked once, at the very start of `withTransaction(_:)`: a
+task that is already cancelled throws `CancellationError` before opening the
+transaction. The body itself runs synchronously to completion once started —
+there is no later cooperative cancellation point, so mid-transaction
+cancellation is not a supported capability of this v1 surface, not a silently
+ignored one.
+
+`withTransaction(_:)` is a non-macro v1 compatibility API: a plain closure
+over `XLTransactionalDatabase`, available on the same Swift 5.9 floor as the
+rest of this article, independent of the `@SQLQuery`/`@SQLQueries` macros
+described in <doc:DeclaredQueries>. Composing with those macros needs no
+separate transaction-aware spelling — a `@SQLQueries` extension's generated
+`execute(_:)` already calls `withTransaction(_:)` internally, so every
+declared query it runs shares the same pinned connection as any
+`makeRequest(with:)` call alongside it in the same body.

--- a/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/DeclaredQueries.md
@@ -116,7 +116,7 @@ let sameMatches = try database.execute { context in
 `execute(_:)` and the generated `Context` type let you run more than one
 declared query in the same scope without repeating a database lookup per
 call. Since issue #284, `execute(_:)` is sugar over the adapter-neutral typed
-transaction scope described in <doc:GettingStarted>'s "Typed multi-statement
+transaction scope described in <doc:AdvancedUsage>'s "Typed multi-statement
 transaction scopes": it commits only after the whole closure returns and
 rolls back everything the closure did on any failure, so
 `context.database.makeRequest(with:)` calls interleaved with declared-query

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -6,7 +6,13 @@ Learn how to define a table and perform basic SQLite operations with SwiftQL.
 
 This guide introduces SwiftQL's essential database operations: creating a
 table, inserting rows, selecting data, binding values, updating rows, and
-deleting rows.
+deleting rows. Read it start to finish once, then come back to it as a quick
+reference.
+
+It stays on the everyday path on purpose. Connection ownership, statement
+preparation, row lifetime, and the exact transaction rules are covered
+separately in <doc:AdvancedUsage>; you do not need them to write your first
+query.
 
 The guide assumes a basic understanding of SQLite SQL. For a more comprehensive
 introduction to SQL, see the
@@ -24,14 +30,6 @@ Version 1.5.2 is the published package. This guide's basic request path remains
 supported in v1.3, and its static-query and contextual-codec APIs remain
 available from version 1.2.0 or later. Pin a source revision only when
 intentionally testing later changes from `main`.
-
-SwiftQL v1.3 validates the existing SQLite surface against recorded real-engine,
-Northwind, and stress evidence; it does not introduce a new public syntax or
-validation API. In particular, issue
-[#132](https://github.com/lukevanin/swiftql/issues/132) is a
-research-only schema-snapshot preparation prototype. Applications still own
-their schema lifecycle and perform physical preparation on the runtime
-connection that executes each statement.
 
 Then add `SwiftQL` to the dependencies of your target and import the module in
 files that use it. The package requires Swift tools 5.9 and targets iOS 16 or
@@ -204,105 +202,8 @@ This guide uses the explicit `schema` name for clarity.
 
 ### Reusing requests
 
-Requests retain the generated SQL and an immutable `XLParameterLayout`. The
-layout is static metadata: it records each logical parameter's deterministic
-index, binding key, value type, nullability, coding context, and selected codec
-identity. Runtime values are separate. Put them in a fresh
-`XLInvocationBindings` packet for each call, then pass that packet to
-`fetchAll(bindings:)`, `fetchOne(bindings:)`, `execute(bindings:)`, or a
-packet-backed publisher. Creating a request translates the SwiftQL statement
-into SQL but does not prepare it immediately. On execution, GRDB obtains a
-cached SQLite statement for that SQL on the connection performing the work.
-
-#### Dialect and driver responsibilities
-
-The SQLite dialect defines how SwiftQL renders valid SQLite syntax, including
-identifier quoting, placeholder spelling, value storage classes, and required
-SQLite capabilities. The database driver has a separate job: it leases a
-connection, prepares the rendered SQL, binds SQLite values to its transport,
-executes the statement, and reads SQLite values from the result. GRDB is the
-current SQLite driver, but it does not define the SQLite syntax or the logical
-policy for converting application values.
-
-Adapter packages can depend directly on the `SwiftQLCore` library product. It
-exports the dialect, dialect-value, logical-statement, and driver contracts
-without linking GRDB; the `SwiftQL` product remains the compatibility facade
-that includes the current GRDB-backed SQLite adapter.
-
-#### Logical and physical preparation
-
-Logical requests and prepared handles are database- or pool-bound. They retain
-the rendered SQL and request metadata, but they do not own one physical
-statement. Physical GRDB statements are connection-bound and must not be shared
-between connections or concurrent executions.
-
-With a connection pool, each execution leases a connection and resolves or
-caches the physical statement separately on that leased connection. Another
-execution may lease a different connection and therefore prepare the same SQL
-again. A single-connection database may reuse its own statement cache, but its
-physical statements still belong only to that connection.
-
-Preparation is therefore an execution-time operation. Successful preparation
-on one connection does not guarantee every later preparation: preparation can
-still fail later on a newly leased connection, for example when its schema,
-registered functions, or available capabilities differ.
-
-#### Incremental row lifetime
-
-The GRDB adapter steps result rows through a package-internal, driver-neutral
-callback while the leased connection is active. It copies each row into
-normalized SQLite values before advancing because GRDB reuses cursor-backed row
-storage. The synchronous callback may stop without stepping later rows, and a
-thrown decoding error releases the cursor and connection before it propagates.
-A cursor value is never returned from the database-access closure.
-
-The public v1 behavior remains eager: `fetchAll()` still returns a complete
-typed array, while `fetchOne()` returns an optional first row. Those
-compatibility APIs are layered over the same incremental primitive.
-`fetchAll()` therefore retains its typed output as required but no longer
-retains a complete intermediate array of GRDB rows or normalized SQLite-value
-rows before typed decoding. Future package adapters should implement the same
-callback lifetime rather than exposing their native cursor types.
-
-#### Transactions and bindings
-
-Transaction-scoped work pins one connection for the duration of the
-transaction. Code inside that transaction must use the pinned connection and
-must not re-enter the root pool, which could lease another connection and break
-the transaction boundary or deadlock while waiting for itself.
-
-The synchronous v1 driver commits when the transaction body returns and rolls
-back when it throws. `withValidatedTransaction` preserves the exact body error,
-so a dedicated caller error can express explicit rollback intent. The v1
-contract does not expose nested transactions, savepoints, or task-cancellation
-hooks; do not attempt those by re-entering the root pool from a pinned body.
-The current GRDB v1 driver is pool-backed and does not expose a separate
-single-connection transaction capability.
-
-Each invocation packet carries normalized dialect values in logical-index
-order, so every call has fresh bindings. Packet-backed execution does not move
-those values into the logical request or connection-wide statement cache.
-Packets and layouts are value-semantic and `Sendable` when their dialect values
-are. The current `XLRequest` facade itself is not `Sendable` and does not yet
-promise that one request can be shared across tasks; use packets to separate
-values across repeated calls in the request's supported isolation context.
-
-For cross-task raw-value execution with GRDB, call
-`GRDBDatabase.prepareInvocation(with:)`. Its `GRDBPreparedInvocation` result is
-`Sendable` and accepts an independent packet in `fetchAllValues`,
-`fetchOneValues`, or `execute`. It deliberately returns normalized SQLite
-values instead of retaining the legacy typed row-reader graph. For a durable,
-database-independent SQL and value-layout contract, create an
-`XLStaticQueryDescriptor` and prepare it through the overload described in
-<doc:StaticQueries>.
-
-Driver integrations can use the `prepareValidated`, `bindValidated`,
-`fetchAllValidated`, `fetchOneValidated`, `executeValidated`, and
-`withValidatedTransaction` helpers to normalize transport failures into
-`XLDatabaseContractError` categories. The existing GRDB compatibility facade
-keeps raw `DatabaseError` and `XLColumnReadError` values where its retry policy
-and established decoding API need to inspect them; database and dialect
-mismatches are still rejected before physical preparation in both paths.
+Creating a request translates a SwiftQL statement into SQL once. Keep the
+request and execute it as many times as you need:
 
 <!-- test: XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings -->
 ```swift
@@ -322,86 +223,14 @@ Execute the request whenever it is needed:
 let workingAgePeople = try workingAgeRequest.fetchAll()
 ```
 
-#### Typed multi-statement transaction scopes
+A request holds the rendered SQL and an immutable description of its
+parameters. It does not hold the values for a particular call — those go in a
+separate bindings packet, described in the next section. That separation is
+what lets one request serve many calls with different values.
 
-`GRDBDatabase.withTransaction(_:)` (issue #284, `XLTransactionalDatabase`) runs
-an ordered sequence of typed requests — reads and writes alike — as one atomic
-unit on a single pinned connection, without ever naming a GRDB type. It is the
-typed counterpart to the driver-level `withTransaction` described above: where
-the driver hands an adapter integration a raw connection, this hands ordinary
-application code another `GRDBDatabase`, so the body is just more
-`makeRequest(with:)` calls (and, inside a `@SQLQueries` extension, more
-`Context` calls — `execute(_:)` is sugar over this same primitive).
-
-<!-- test: XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings -->
-```swift
-let (workingAgeCount, insertedID) = try database.withTransaction { scope in
-    let newHire = Person(id: "txn-scope-a", occupationId: nil, name: "Grace", age: 29)
-    try scope.makeRequest(with: sqlInsert(newHire)).execute()
-    let promoted = Person(id: "txn-scope-b", occupationId: nil, name: "Harold", age: 45)
-    try scope.makeRequest(with: sqlInsert(promoted)).execute()
-    let matches = try scope.makeRequest(with: workingAgeQuery).fetchAll()
-    return (matches.count, newHire.id)
-}
-```
-
-Ordering, atomicity, and lifetime work exactly as the driver-level contract
-above describes, plus the guarantees a typed, adapter-neutral surface adds:
-
-- **Order and results.** Every request the body issues runs in source order
-  on the one connection `withTransaction(_:)` pinned for this call; an
-  ordinary local variable carries one operation's result to a later one or to
-  the transaction's own return value.
-- **Commit and rollback.** The whole body is one commit unit: it commits only
-  after the body returns normally, and rolls back every write the body
-  performed — on a preparation, binding, execution, decoding, or user-thrown
-  failure alike — before rethrowing the original, unmodified error.
-- **Read-your-writes.** A read issued from the scope observes an earlier,
-  still-uncommitted write from the same body, because both run on the same
-  pinned connection.
-- **No GRDB type in the contract.** The scope handed to the body is another
-  `GRDBDatabase` — the exact same type the rest of this article uses — never a
-  GRDB `Database`, `DatabasePool`, or statement handle.
-
-Three cases are rejected before any transaction work happens, each with a
-predictable, catchable `XLTransactionScopeError` rather than a crash or silent
-wrong answer:
-
-- **Nested transactions and savepoints are not supported.** Calling
-  `withTransaction(_:)` again from inside an active body — on the scope it was
-  given, *or* on the original database captured from the enclosing scope —
-  throws `.nestedTransactionUnsupported`. The v1 driver has no savepoint hook,
-  so a nested call cannot prove it would only commit or roll back its own
-  writes; re-entering the connection pool from inside an open transaction can
-  also deadlock or silently lease a different connection that only sees the
-  database's last *committed* state, missing the transaction's own
-  uncommitted writes.
-- **The scope must not escape the body.** A request, write request, or scope
-  value used after `withTransaction(_:)` returns throws `.scopeEscaped`: the
-  pinned connection is invalidated the instant the body returns, so
-  continuing would silently touch a connection GRDB may already be reusing
-  for unrelated work.
-- **Live queries are not supported inside a transaction.** `publish()` /
-  `publishOne()` on a transaction-scoped request throws
-  `.liveQueriesUnsupportedInTransaction`: `ValueObservation` tracks a
-  connection pool across commits over time, and a transaction-scoped
-  connection is invalidated before there is anything to observe.
-
-Cancellation is checked once, at the very start of `withTransaction(_:)`: a
-task that is already cancelled throws `CancellationError` before opening the
-transaction. The body itself runs synchronously to completion once started —
-there is no later cooperative cancellation point, so mid-transaction
-cancellation is not a supported capability of this v1 surface, not a silently
-ignored one.
-
-`withTransaction(_:)` is a non-macro v1 compatibility API: a plain closure
-over `XLTransactionalDatabase`, available on the same Swift 5.9 floor as the
-rest of this article, independent of the `@SQLQuery`/`@SQLQueries` macros
-described in <doc:DeclaredQueries>. Composing with those macros needs no
-separate transaction-aware spelling — a `@SQLQueries` extension's generated
-`execute(_:)` already calls `withTransaction(_:)` internally, so every
-declared query it runs shares the same pinned connection as any
-`makeRequest(with:)` call alongside it in the same body.
+<doc:AdvancedUsage> covers when SQLite actually prepares the statement, how
+that interacts with a connection pool, and which of these types are safe to
+share between tasks.
 
 ## Named bindings
 
@@ -457,15 +286,6 @@ duplicate bindings, and missing parameters before driver execution. Missing is
 not the same as SQL `NULL`: omitting a binding fails completeness validation,
 while `.null` is a present value accepted only by a `.nullable` slot. Repeated
 uses of the same named reference share one logical slot and one value.
-
-The mutating `set` methods remain as a migration shim for v1 literal bindings.
-They immediately normalize each value into a compatibility packet stored in
-that request copy. Existing code can continue to copy, set, and execute a
-request, but new code should keep the prepared request immutable and pass an
-explicit packet for each call. The shim cannot override a contextual
-parameter's selected codec. Static descriptors use the same immutable packet
-contract while adding stable identity, result metadata, cardinality, and a
-cross-task prepared handle; see <doc:StaticQueries>.
 
 ## Update statements
 
@@ -558,5 +378,45 @@ try deletePersonRequest.execute(bindings: deleteBindings)
 
 > Warning: A delete without a `Where` clause removes every row in the table.
 
-Continue with <doc:Queries> for select composition, <doc:Expressions> for
-conditions and operators, or <doc:LiveQueries> to observe changing results.
+## Grouping work in a transaction
+
+When several statements must succeed or fail together, run them inside
+`withTransaction(_:)`. The closure receives a scope that works exactly like the
+database you already have — call `makeRequest(with:)` on it as usual:
+
+<!-- test: XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings -->
+```swift
+let (workingAgeCount, insertedID) = try database.withTransaction { scope in
+    let newHire = Person(id: "txn-scope-a", occupationId: nil, name: "Grace", age: 29)
+    try scope.makeRequest(with: sqlInsert(newHire)).execute()
+    let promoted = Person(id: "txn-scope-b", occupationId: nil, name: "Harold", age: 45)
+    try scope.makeRequest(with: sqlInsert(promoted)).execute()
+    let matches = try scope.makeRequest(with: workingAgeQuery).fetchAll()
+    return (matches.count, newHire.id)
+}
+```
+
+The three rules worth knowing on day one:
+
+- Statements run in the order you write them, on one connection.
+- The transaction commits when the closure returns and rolls back every write
+  if the closure throws — including errors you throw yourself.
+- A read inside the closure sees the writes the closure already made.
+
+Values computed inside the closure come back out as its return value, as
+`workingAgeCount` and `insertedID` do above.
+
+Transactions have boundaries the compiler cannot enforce: nesting them, using
+the scope after the closure returns, and observing live queries inside one are
+all rejected at runtime. <doc:AdvancedUsage> lists each rejection and the
+reason for it.
+
+## Where to go next
+
+- <doc:Queries> — joins, grouping, ordering, subqueries, and CTEs.
+- <doc:Expressions> — conditions, operators, and typed expression composition.
+- <doc:DeclaredQueries> — declare queries as functions with the `@SQLQuery` and
+  `@SQLQueries` macros.
+- <doc:LiveQueries> — observe results that change as the database changes.
+- <doc:AdvancedUsage> — connections, statement preparation, row lifetime, and
+  the full transaction contract.

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -6,8 +6,8 @@ Learn how to define a table and perform basic SQLite operations with SwiftQL.
 
 This guide introduces SwiftQL's essential database operations: creating a
 table, inserting rows, selecting data, binding values, updating rows, and
-deleting rows. Read it start to finish once, then come back to it as a quick
-reference.
+deleting rows. Read it from start to finish once, then come back to it as a
+quick reference.
 
 It stays on the everyday path on purpose. Connection ownership, statement
 preparation, row lifetime, and the exact transaction rules are covered

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -33,6 +33,12 @@ to the style and conventions of the Swift language.
 SwiftQL targets SQLite's SQL dialect. If you already know SQLite syntax, the
 corresponding SwiftQL statements should feel familiar.
 
+New here? Start with <doc:GettingStarted>. Upgrading? The repository's
+[what's new](https://github.com/lukevanin/swiftql/blob/main/WHATSNEW.md)
+summarizes each release in plain language, and the
+[changelog](https://github.com/lukevanin/swiftql/blob/main/CHANGELOG.md)
+records the exact detail.
+
 ## Why SQLite?
 
 SQLite is a commonly used database in many iOS and macOS applications. It has
@@ -69,7 +75,7 @@ application-facing compatibility facade: it adds the macros, typed SQL DSL,
 contextual codecs, and the current GRDB-backed SQLite implementation. Dialects
 own SQL spelling and value storage rules; drivers own connections, physical
 preparation, binding transport, execution, and row transport. See
-<doc:GettingStarted> for connection, transaction, and prepared-statement
+<doc:AdvancedUsage> for connection, transaction, and prepared-statement
 ownership.
 
 Existing v1 requests, named bindings, `XLCustomType` wrappers, and explicit
@@ -138,6 +144,7 @@ replacing SQLite's runtime type rules.
 - <doc:FunctionalSyntax>
 
 ### Advanced topics
+- <doc:AdvancedUsage>
 - <doc:Enums>
 - <doc:CustomFunctions>
 - <doc:CustomTypes>

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -68,6 +68,10 @@ private let documentationTests = [
         XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings
     ),
     DocumentationTestReference(
+        "XLDocumentationTests.testDocumentationAdvancedUsage",
+        XLDocumentationTests.testDocumentationAdvancedUsage
+    ),
+    DocumentationTestReference(
         "XLDocumentationTests.testDocumentationExpressions",
         XLDocumentationTests.testDocumentationExpressions
     ),
@@ -117,6 +121,7 @@ private let documentationTests = [
 final class SQLDocumentationCatalogTests: XCTestCase {
 
     private let expectedMarkerByFile = [
+        "AdvancedUsage.md": "XLDocumentationTests.testDocumentationAdvancedUsage",
         "BuiltinFunctions.md": "XLDocumentationTests.testDocumentationConditionalAndScalarFunctions",
         "CustomFunctions.md": "XLDocumentationTests.testDocumentationCustomFunctionRegistrationAndExecution",
         "CustomTypes.md": "XLDocumentationTests.testDocumentationCustomTypeRoundTrips",
@@ -170,17 +175,23 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         )
     }
 
-    func testGettingStartedDocumentsPreparedStatementOwnershipAndFailureSemantics() throws {
-        let gettingStartedURL = documentationCatalogURL()
-            .appendingPathComponent("GettingStarted.md")
-        let contents = try String(contentsOf: gettingStartedURL, encoding: .utf8)
+    /// The execution-model contract moved out of `GettingStarted.md` so the
+    /// onboarding guide stays an onboarding guide. Every heading and phrase
+    /// this test pinned there is still pinned — on the article that now owns
+    /// it.
+    func testAdvancedUsageDocumentsPreparedStatementOwnershipAndFailureSemantics() throws {
+        let advancedUsageURL = documentationCatalogURL()
+            .appendingPathComponent("AdvancedUsage.md")
+        let contents = try String(contentsOf: advancedUsageURL, encoding: .utf8)
 
         for heading in [
-            "#### Dialect and driver responsibilities",
-            "#### Logical and physical preparation",
-            "#### Transactions and bindings",
+            "## Dialect and driver responsibilities",
+            "## Logical and physical preparation",
+            "## Incremental row lifetime",
+            "## Transactions and bindings",
+            "## Typed multi-statement transaction scopes",
         ] {
-            XCTAssertTrue(contents.contains(heading), "GettingStarted.md is missing \(heading).")
+            XCTAssertTrue(contents.contains(heading), "AdvancedUsage.md is missing \(heading).")
         }
 
         for semanticPhrase in [
@@ -193,14 +204,56 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             "fresh bindings",
             "current `XLRequest` facade itself is not `Sendable`",
             "Its `GRDBPreparedInvocation` result is",
-            "not the same as SQL `NULL`",
             "normalize transport failures",
             "keeps raw `DatabaseError` and `XLColumnReadError`",
             "fail later on a newly leased connection",
         ] {
             XCTAssertTrue(
                 contents.contains(semanticPhrase),
-                "GettingStarted.md is missing prepared-statement guidance for '\(semanticPhrase)'."
+                "AdvancedUsage.md is missing prepared-statement guidance for '\(semanticPhrase)'."
+            )
+        }
+    }
+
+    /// The onboarding guide keeps the everyday contract a first-time reader
+    /// needs, and keeps pointing at the advanced article for the rest.
+    func testGettingStartedStaysAnOnboardingGuide() throws {
+        let gettingStartedURL = documentationCatalogURL()
+            .appendingPathComponent("GettingStarted.md")
+        let contents = try String(contentsOf: gettingStartedURL, encoding: .utf8)
+
+        for heading in [
+            "## Defining tables",
+            "## Executing statements",
+            "## Inserting data",
+            "## Running select queries",
+            "## Named bindings",
+            "## Update statements",
+            "## Delete statements",
+            "## Grouping work in a transaction",
+            "## Where to go next",
+        ] {
+            XCTAssertTrue(contents.contains(heading), "GettingStarted.md is missing \(heading).")
+        }
+
+        for semanticPhrase in [
+            "not the same as SQL `NULL`",
+            "<doc:AdvancedUsage>",
+        ] {
+            XCTAssertTrue(
+                contents.contains(semanticPhrase),
+                "GettingStarted.md is missing onboarding guidance for '\(semanticPhrase)'."
+            )
+        }
+
+        for relocatedPhrase in [
+            "Physical GRDB statements are connection-bound",
+            "must not re-enter the root pool",
+            "normalize transport failures",
+        ] {
+            XCTAssertFalse(
+                contents.contains(relocatedPhrase),
+                "GettingStarted.md regained execution-model depth that belongs in AdvancedUsage.md: '\(relocatedPhrase)'."
             )
         }
     }
@@ -378,6 +431,8 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "Version 1.5.2 is the published package",
                 "This guide's basic request path remains",
                 "from version 1.2.0 or later",
+            ],
+            "Sources/SwiftQL/SwiftQL.docc/AdvancedUsage.md": [
                 "research-only schema-snapshot preparation prototype",
                 "perform physical preparation on the runtime",
             ],
@@ -480,6 +535,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "LICENSE.md",
                 "RELEASING.md",
                 "ROADMAP.md",
+                "WHATSNEW.md",
             ]
         )
         for link in repositoryLinks {

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1355,6 +1355,49 @@ extension XLDocumentationTests {
         )
     }
 
+    func testDocumentationAdvancedUsage() throws {
+        let minimumAgeParameter = XLNamedBindingReference<Int>(name: "minimumAge")
+        let namedAdultsQuery = sql { schema in
+            let person = schema.table(Person.self)
+            Select(person)
+            From(person)
+            Where(person.age >= minimumAgeParameter)
+        }
+        let preparedInvocation = database.prepareInvocation(with: namedAdultsQuery)
+
+        let minimumAgeSlot = try XCTUnwrap(
+            preparedInvocation.parameterLayout.slot(for: .named("minimumAge"))
+        )
+        let invocationBindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: preparedInvocation.parameterLayout,
+            bindings: [
+                try XLInvocationBinding(slot: minimumAgeSlot, value: .integer(21))
+            ]
+        ).validatingComplete()
+
+        let rows: [[XLSQLiteValue]] = try preparedInvocation.fetchAllValues(
+            bindings: invocationBindings
+        )
+        XCTAssertEqual(rows.count, 3)
+
+        var rejection: XLTransactionScopeError?
+        do {
+            try database.withTransaction { scope in
+                let candidate = Person(id: "nested", occupationId: nil, name: "Ida", age: 33)
+                try scope.makeRequest(with: sqlInsert(candidate)).execute()
+                try scope.withTransaction { _ in }
+            }
+        } catch let error as XLTransactionScopeError {
+            rejection = error
+        }
+        XCTAssertEqual(rejection, .nestedTransactionUnsupported)
+        XCTAssertEqual(
+            try preparedInvocation.fetchAllValues(bindings: invocationBindings).count,
+            3,
+            "The outer body's insert must roll back with the rejected transaction."
+        )
+    }
+
     func testDocumentationExpressions() throws {
         try testExample_Coalesce()
         try testExample_IfCaseWhenThenElse()

--- a/Tests/SQLTests/SQLSkillDocumentationTests.swift
+++ b/Tests/SQLTests/SQLSkillDocumentationTests.swift
@@ -226,6 +226,7 @@ final class SQLSkillDocumentationTests: XCTestCase {
             "https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/",
             "https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/",
             "https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/",
+            "https://lukevanin.github.io/swiftql/documentation/swiftql/advancedusage/",
         ] {
             XCTAssertTrue(contents.contains(canonicalURL))
         }

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -8,8 +8,10 @@ For the exact, evidence-backed detail — every API name, constraint, and SQLite
 version requirement — read [CHANGELOG.md](CHANGELOG.md). That file is the
 canonical record; this one is a reading aid.
 
-Every 1.x release so far has been source-compatible: upgrading within 1.x has
-not required changing working code.
+Almost every 1.x release has been purely additive. The one exception so far is
+1.4.3, where `unixEpoch(_:)` changed its return type from `Int` to
+`TimeInterval`. Each entry below ends with whether it affects code you already
+wrote.
 
 ## 1.5.2 — build-time query validation
 

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,0 +1,208 @@
+# What's new in SwiftQL
+
+A plain-language summary of what changed in each release, newest first. It
+answers two questions: *what can I do now that I could not do before*, and
+*does this affect code I already wrote?*
+
+For the exact, evidence-backed detail — every API name, constraint, and SQLite
+version requirement — read [CHANGELOG.md](CHANGELOG.md). That file is the
+canonical record; this one is a reading aid.
+
+Every 1.x release so far has been source-compatible: upgrading within 1.x has
+not required changing working code.
+
+## 1.5.2 — build-time query validation
+
+*Released 27 July 2026.*
+
+Your queries can now be checked while you build, not when your app runs. Three
+pieces fit together:
+
+- A **manifest** describes the static queries in a target — the SQL, its
+  parameters, its result columns, and a snapshot of the schema they expect.
+- A **validator** (`swiftql-build-validate`) opens that schema snapshot, hands
+  every query to the real SQLite parser, and reports whether the SQL parses,
+  the tables and columns exist, and the parameter and result shapes match.
+- A **SwiftPM plugin** runs the validator as part of `swift build`, so a query
+  that no longer matches your schema fails the build with a diagnostic instead
+  of failing in front of a user.
+
+What it does *not* do: it checks that a query is well-formed against the
+schema, not that it returns the right answers. Behavior is still your tests'
+job. Manifests are currently written by hand or generated externally.
+
+**Affects existing code?** No. Everything here is new and opt-in.
+
+## 1.5.1 — declare queries as Swift functions
+
+*Released 26 July 2026.*
+
+The headline is `@SQLQuery` and `@SQLQueries`. Instead of building a statement,
+holding a request, and assembling a bindings packet by hand, you write a
+function that describes the query and let the macro generate the rest:
+
+- Parameters come from the function's own signature.
+- The return type decides how many rows you get — `[Row]` fetches all, `Row?`
+  fetches zero or one, and a bare `Row` insists on exactly one.
+- Each call gets a fresh, immutable set of bindings. You never mutate a shared
+  request, and a value can never be baked into cached SQL by accident — the
+  macro rejects, at compile time, every parameter spelling it cannot safely
+  turn into a placeholder.
+- The SQL for a declaration is rendered once and reused, so repeated calls
+  reuse one prepared SQLite statement.
+
+Also in this release:
+
+- **Typed transactions.** `withTransaction { scope in ... }` runs several
+  typed requests as one atomic unit on one connection, with no GRDB type
+  anywhere in your code. Nesting a transaction, using the scope after it ends,
+  or observing a live query inside one are rejected with catchable errors
+  instead of crashing.
+- **Nested result types.** A property of an `@SQLTable` or `@SQLResult` type
+  can now be another such type, so a joined row can decode into a structured
+  Swift value instead of a flat one.
+
+The `#row` macro was cut from this release: it crashed the pinned Swift 5.9.2
+compiler. It is deferred rather than abandoned.
+
+**Affects existing code?** No. The macros are an addition; hand-built requests
+keep working.
+
+## 1.4.6 — faster construction and decoding
+
+*Released 25 July 2026.*
+
+Internal performance work with no visible API change. Building and rendering a
+query allocates noticeably less memory, and decoding no longer allocates a
+fresh buffer per row. The generated SQL is byte-for-byte identical to before.
+
+**Affects existing code?** No — nothing public changed.
+
+## 1.4.5 — more join shapes and better CTEs
+
+*Released 24 July 2026.*
+
+- `NATURAL JOIN` and `JOIN ... USING (columns)`.
+- `RIGHT JOIN` and `FULL OUTER JOIN` (both need SQLite 3.39 or later), plus
+  complete `CROSS JOIN` coverage in the query builder.
+- `MATERIALIZED` / `NOT MATERIALIZED` hints on common table expressions.
+- A common table expression that produces a single scalar column no longer
+  needs a one-property wrapper type just to carry it.
+- Compound queries (`UNION`, `INTERSECT`, `EXCEPT`) work over plain values like
+  `Int` and `String` without a result wrapper.
+
+**Affects existing code?** No. The one previously broken API, `Join.Outer`,
+stays removed in favor of `Join.Left` and `Join.FullOuter`.
+
+## 1.4.4 — writes that handle conflicts and return rows
+
+*Released 23 July 2026.*
+
+- Conflict handling on inserts: `INSERT OR IGNORE`, `OR REPLACE`, `OR ABORT`,
+  and friends, plus `REPLACE INTO`.
+- Upserts through `INSERT ... ON CONFLICT`, in both the `DO NOTHING` and
+  `DO UPDATE SET ...` forms.
+- `RETURNING` on inserts, updates, and deletes — the changed rows come back as
+  typed results from the same statement (needs SQLite 3.35 or later).
+- Updates driven by a common table expression.
+
+**Affects existing code?** No. The existing insert API is unchanged.
+
+## 1.4.3 — dates and times
+
+*Released 23 July 2026.*
+
+Full SQLite date-and-time support: `date`, `time`, `datetime`, `julianDay`,
+`unixEpoch`, and `strftime`, each taking ordered modifiers that apply in the
+order you write them — `moment.datetime(.months(1), .startOfMonth)` reads the
+way it evaluates. Component accessors (`year`, `month`, `day`, `hour`,
+`dayOfWeek`, …) return `Int`, and optional inputs stay optional throughout.
+
+**Affects existing code?** One narrow change: `unixEpoch(_:)` now returns
+`TimeInterval` instead of `Int`, because a subsecond modifier makes SQLite
+return a fractional value. `toUnixTimestamp()` still returns `Int`.
+
+## 1.4.2 — text matching and nullable predicates
+
+*Released 22 July 2026.*
+
+- `LIKE` with an `ESCAPE` character, so a literal `%` or `_` can be matched.
+- `notIn` in every shape `in` already supported — value lists, subqueries, and
+  common table expressions — with the negation carried by the `IN` node itself
+  so composing a predicate cannot accidentally move it.
+- `in` and `notIn` now accept optional operands and `NULL` candidates.
+- Collations, `REGEXP`, and `MATCH`.
+
+**Affects existing code?** No; all additive.
+
+## 1.4.1 — casts, counts, and ranges
+
+*Released 22 July 2026.*
+
+- A complete, type-checked `cast(to:)` matrix. Unsupported conversions simply
+  do not compile, and optionality is preserved.
+- `all()` for an unqualified `*`, and `count(all())` for an exact `COUNT(*)`.
+- `isBetween(_:_:)` and `isNotBetween(_:_:)`, grouped so SQLite precedence is
+  unambiguous.
+- `total()` and a broader `averageOrNull(distinct:)`.
+
+**Affects existing code?** No; all additive.
+
+## 1.3.0 — evidence, not new syntax
+
+*Released 20 July 2026.*
+
+This release added no syntax. It added proof that the existing syntax works: a
+versioned inventory of what SwiftQL supports, a generated conformance report,
+a bounded corpus of generated query combinations, a realistic Northwind
+correctness suite, and a stress suite for live queries. Each claim is tied to a
+recorded SQLite version and its captured environment, so "supported" means
+something specific rather than aspirational.
+
+**Affects existing code?** No.
+
+## 1.2.0 — separating definitions from execution
+
+*Released 19 July 2026.*
+
+The structural release. A query definition, the values for one call, and the
+database that runs it became three separate things:
+
+- `SwiftQLCore` is a new product holding the dialect, statement, and driver
+  contracts with no GRDB dependency, for anyone writing an adapter.
+- `XLStaticQueryDescriptor` describes a query — SQL, parameters, results,
+  identity, cardinality — before any database exists, and can be prepared
+  against one later.
+- Bindings live in fresh immutable packets per call, so runtime values never
+  leak into a cached statement or a query's identity.
+- Contextual value codecs let one Swift type have more than one SQLite
+  representation, chosen per database, with no process-global registry.
+
+Rows are also decoded incrementally now, so a large fetch no longer builds an
+intermediate copy of every row before decoding.
+
+**Affects existing code?** No. Existing requests, named bindings, custom
+types, and result models all keep compiling. The new contracts are there when
+you need durable identity or cross-task execution — not a required migration.
+
+One boundary worth knowing: values SQLite cannot represent, such as a
+non-finite `Double`, now fail with a clear encoding error rather than emitting
+invalid SQL.
+
+## 1.1.0 — reliability and release infrastructure
+
+*Released 17 July 2026.*
+
+Aggregates gained optional-returning forms (`minOrNull`, `sumOrNull`,
+`groupConcatOrNull`, …) that can express an empty or all-`NULL` result as Swift
+`nil`. The non-optional spellings still work for the rest of 1.x, but the
+canonical APIs will return optionals in SwiftQL 2.
+
+Most of the release went into things you do not call directly: a verified
+tag-release pipeline, documentation that is built and validated in CI, a
+downstream consumer fixture that proves the macros work from another package,
+a reproducible benchmark executable, and warnings-as-errors across every
+supported compiler.
+
+**Affects existing code?** The nonoptional `min`, `max`, `sum`, `average`, and
+`groupConcat` APIs are deprecated but retained for all of 1.x.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -206,5 +206,5 @@ downstream consumer fixture that proves the macros work from another package,
 a reproducible benchmark executable, and warnings-as-errors across every
 supported compiler.
 
-**Affects existing code?** The nonoptional `min`, `max`, `sum`, `average`, and
+**Affects existing code?** The non-optional `min`, `max`, `sum`, `average`, and
 `groupConcat` APIs are deprecated but retained for all of 1.x.

--- a/scripts/ci/check-docc-output.sh
+++ b/scripts/ci/check-docc-output.sh
@@ -25,6 +25,7 @@ main() {
         require_page "$output/data/documentation/swiftql/$slug.json" "$title"
         require_file "$output/documentation/swiftql/$slug/index.html"
     done <<'ARTICLES'
+advancedusage|Advanced usage
 builtinfunctions|Built-in Functions
 customfunctions|Custom Functions
 customtypes|Custom Types


### PR DESCRIPTION
Closes #431.

## What changed

### 1. `GettingStarted` is an onboarding guide again

The article had grown into two articles wearing one title. Roughly a third of
it was driver-level depth — connection leasing, logical versus physical
preparation, cursor lifetime, packet `Sendable` boundaries, the full
`XLTransactionScopeError` rejection matrix, the #132 research boundary — sitting
between a first-time reader and their first query.

`GettingStarted` now keeps the everyday arc only: install → define a table →
create it → open a database → insert → select → reuse a request → named
bindings → update → delete → group work in a transaction → where to go next.
The transaction section keeps the practical example and the three rules that
matter on day one, and points at the advanced article for the rest.

### 2. New `AdvancedUsage` article

Everything removed above was **relocated, not deleted**. The new article
carries package layout and version boundaries, request/layout/packet ownership,
dialect and driver responsibilities, logical and physical preparation,
incremental row lifetime, transactions and bindings, the legacy mutable-binding
shim, and the complete typed transaction-scope contract.

It also gains two compiled examples of its own, covering material that was
previously prose-only: the cross-task `prepareInvocation` handle, and the
nested-transaction rejection (showing that it is catchable and that the outer
body's writes still roll back).

### 3. README leads with getting started

Old order: pitch → what becomes first-class → SQL-shaped, not ORM-shaped →
installation → documentation link (near the bottom).

New order: pitch example → **Get started** (install + guide links) → **What's
new** → what becomes first-class → SQL-shaped, not ORM-shaped → project
guarantees and direction → maintainers → license.

### 4. `WHATSNEW.md`

A plain-language companion to `CHANGELOG.md`: one section per release from
1.1.0 to 1.5.2, each saying what you can do that you could not before and
whether it affects code you already wrote, with the changelog still canonical
for exact detail. `RELEASING.md`'s preparation step now names it so it does not
silently go stale — no gate enforces it, because it is a reader-facing summary
rather than release evidence.

## Documentation contract tests

The doc-contract tests pinned the old structure, so they moved with it rather
than being relaxed:

- `testGettingStartedDocumentsPreparedStatementOwnershipAndFailureSemantics` →
  `testAdvancedUsageDocumentsPreparedStatementOwnershipAndFailureSemantics`.
  Every heading and semantic phrase it asserted is still asserted, on the file
  that now owns it, plus `## Incremental row lifetime` and `## Typed
  multi-statement transaction scopes`.
- New `testGettingStartedStaysAnOnboardingGuide` pins the onboarding shape and
  asserts that three relocated execution-model phrases are **absent** — a guard
  against the depth creeping back.
- The v1.3 boundary phrases follow the paragraphs that carry them:
  `AdvancedUsage.md` gains its own `requiredPhrasesByPath` entry.
- `expectedMarkerByFile` gains `AdvancedUsage.md` →
  `XLDocumentationTests.testDocumentationAdvancedUsage`.
- The README link set gains `WHATSNEW.md`.
- `SKILL.md`'s "prepared execution boundaries" link points at `advancedusage`;
  the getting-started link is retained, and the file stays under its line
  budget.
- `scripts/ci/check-docc-output.sh` gains the `advancedusage` page.

Cross-references that pointed at relocated sections were updated:
`SwiftQL.md`, `DeclaredQueries.md`, and `XLTransactionalDatabase`'s doc comment.
The 1.5.1 changelog entry's mention of `GettingStarted` was deliberately left
alone — released changelog sections are historical record.

## Verification

- `swift test` — 985 tests, 0 failures.
- `./make-docs.sh <dir>` builds warnings-as-errors and
  `scripts/ci/check-docc-output.sh` accepts the output, including the new
  `advancedusage` page.
- No public API, macro, or runtime behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)