### PR TITLE
Add driver-adapter and SQLite-provenance research for v2/v2.1

### DIFF
--- a/Research/AsyncDriverContractFeasibility.md
+++ b/Research/AsyncDriverContractFeasibility.md
@@ -1,0 +1,429 @@
+# Feasibility: an asynchronous database driver contract for SwiftQL
+
+**Verdict: GO, in a reduced form — "async scope, synchronous cursor."** Make the
+three *scope* methods on `XLDatabaseDriver` (`withReadConnection`,
+`withWriteConnection`, `withTransaction`) async. Leave
+`XLDatabaseDriverConnection` — `preparePhysical`, `bind`, `fetchAll`,
+`fetchOne`, `execute`, and `forEachRow` — entirely synchronous, preserving the
+non-`Sendable` `PhysicalStatement` invariant exactly as it stands today. Land it
+in **v2**, after the GRDB adapter boundary ([#113]) and Swift 6 mode ([#133]),
+before the native SQLite adapter ([#136]).
+
+A fully asynchronous connection contract is **NO-GO**: it buys nothing an
+embedded SQLite library can spend, and it costs the one invariant
+([SQLDatabaseDriver.swift:62-70](../Sources/SwiftQLCore/SQLDatabaseDriver.swift#L62))
+that currently makes cursor escape unrepresentable.
+
+Analysis performed against the working tree at `5eb28fc`, GRDB **6.29.3**
+(`.build/checkouts/GRDB.swift`, the pinned resolution), and the milestone
+definitions in [ROADMAP.md](../ROADMAP.md). Evidence standard and framing follow
+[SQLiteNIOFeasibility.md](SQLiteNIOFeasibility.md) §3.1, which deferred exactly
+this decision.
+
+---
+
+## 1. Motivation, honestly assessed
+
+Start from the baseline, because it is stark: **SwiftQL contains zero `async`
+and zero `await` today.** Not one occurrence across all six targets in
+`Sources/` (17,756 lines in `SwiftQL`, 3,586 in `SwiftQLCore`). There are no
+actors, no `AsyncSequence`, no `AsyncStream`, no `CheckedContinuation`, and one
+single `Task.isCancelled`
+([GRDBSQLDatabase.swift:1291](../Sources/SwiftQL/GRDBSQLDatabase.swift#L1291)).
+The library is synchronous end to end, and the 182 `Sendable` annotations exist
+to make *values* safe to move, not to make execution concurrent.
+
+### What async does not buy
+
+- **Speed.** SQLite reads are synchronous filesystem work — `sqlite3_step` on a
+  page that is in the OS cache or is not. Wrapping that in a continuation adds
+  a hop and a heap allocation. On the hot path (`forEachRow`, which
+  deliberately reuses one normalization buffer across rows,
+  [GRDBDatabaseDriver.swift:640-655](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L640))
+  async is a pure regression.
+- **Concurrency.** WAL multi-reader concurrency already comes from
+  `DatabasePool`, and the writer is serialized by SQLite regardless. Async
+  changes *how you wait*, not *how many can proceed*.
+- **Cancellation, by itself.** This is worth stating plainly because it is the
+  most commonly overstated benefit. GRDB 6.29.3 contains **no**
+  `withTaskCancellationHandler`, **no** `Task.isCancelled`, and **no**
+  `CancellationError` anywhere in its sources — its async `read` is a bare
+  `withUnsafeThrowingContinuation` over `asyncRead`
+  (`GRDB/Core/DatabaseReader.swift` line 462).
+  Making SwiftQL async over GRDB 6 therefore propagates cancellation *not at
+  all* unless SwiftQL builds it. See §4.
+
+### What async genuinely buys
+
+1. **Not blocking a cooperative-pool thread — the strongest argument, and it
+   is a live hazard today.** A caller who writes `Task { try db.personByID(...) }`
+   blocks a cooperative thread pool thread for the whole duration of the read.
+   The pool is sized to the core count; on a 2-core device, two concurrent
+   SwiftQL reads can starve the pool, and under Swift 6's forward-progress
+   model that is a bug, not a slowdown — the runtime assumes pool threads make
+   progress. This hazard exists *now*, and the ROADMAP already advertises the
+   fix: its target developer experience is spelled
+   `func personByID(id: UUID) async throws -> Person?`
+   ([ROADMAP.md:215](../ROADMAP.md#L215)). SwiftQL is currently unable to honour
+   its own published target API — the `@SQLQuery` macro **rejects** an `async`
+   declaration with a diagnostic today
+   ([SQLQueryMacro.swift:190-198](../Sources/SQLMacros/SQLQueryMacro.swift#L190)).
+2. **Network-backed dialects in v2.2–v2.4.** PostgreSQL, MySQL, and T-SQL are
+   genuinely I/O-bound over a socket. There is no defensible synchronous
+   design for them. If the driver contract is still synchronous when [#137]
+   (PostgreSQL vertical slice) starts, the contract breaks then instead — with
+   a second adapter already written against it.
+3. **Structured cancellation, once built.** Real, but it is work (§4), not a
+   free consequence of the `async` keyword.
+4. **Backpressure — the weakest of the four, and it argues *against* async row
+   iteration.** Backpressure over a SQLite cursor requires holding the cursor
+   while the consumer is slow, which means holding a connection out of the
+   pool for an unbounded period. That is worse than materializing. The repo has
+   already reached this conclusion independently: [#249] mandates a
+   *synchronous* scoped `XLResultSet` and explicitly defers async row iteration
+   because "it needs an explicit backpressure, cancellation, and
+   connection-lifetime contract" ([ROADMAP.md:282](../ROADMAP.md#L282)).
+
+**Net:** (1) and (2) are sufficient on their own and are about the *scope*
+boundary. (4) is a reason not to go further. That asymmetry is the whole
+recommendation.
+
+## 2. Blast radius
+
+### 2a. Full async contract (both protocols) — rejected
+
+| Layer | File | Lines | Character |
+|---|---|---|---|
+| Contract | [SQLDatabaseDriver.swift](../Sources/SwiftQLCore/SQLDatabaseDriver.swift) | 327 | **Redesign.** 9 protocol requirements + 9 extension helpers; the `PhysicalStatement` non-`Sendable` invariant is invalidated (§3) |
+| Driver adapter | [GRDBDatabaseDriver.swift](../Sources/SwiftQL/GRDBDatabaseDriver.swift) | 900 | Mixed. Scope methods redesigned; `GRDBInvocationExecutor` mechanical; reentrancy tracker **redesign** (§4) |
+| Request layer | [GRDBSQLDatabase.swift](../Sources/SwiftQL/GRDBSQLDatabase.swift) | 1,313 | Mostly mechanical, except `publisher(fetch:)` which **cannot** go async (§2c) |
+| Static queries | [GRDBStaticQuery.swift](../Sources/SwiftQL/GRDBStaticQuery.swift) | 748 | Mechanical — 8 public entry points |
+| Public protocols | [SQLDatabase.swift](../Sources/SwiftQL/SQLDatabase.swift) | — | **Source break.** `XLRequest` (5 fetch methods), `XLWriteRequest` (2) |
+| Transaction scope | [SQLTransactionScope.swift](../Sources/SwiftQL/SQLTransactionScope.swift) | — | `XLTransactionalDatabase.withTransaction` + its 3-case error enum |
+| Publishers | [GRDBOpenCombineValuePublisher.swift](../Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift), [GRDBLiveQueryRetryPolicy.swift](../Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift) | 343 | **Blocked** (§2c) |
+| Macros | [SQLQueryMacro.swift](../Sources/SQLMacros/SQLQueryMacro.swift), [SQLQueriesMacro.swift](../Sources/SQLMacros/SQLQueriesMacro.swift) | 3,477 | Small and localized: 1 diagnostic + 4 signature-emission sites + 4 `try`-emission sites |
+
+**Public entry points that change signature: 16.** `XLRequest` ×5,
+`XLWriteRequest` ×2, `GRDBStaticQuery` ×8 (`execute`,
+`fetchExactlyOneValues`, `fetchZeroOrOneValues`, `fetchAllValues`,
+`forEachValueRow`, `fetchExactlyOne`, `fetchZeroOrOne`, `fetchAll`),
+`XLTransactionalDatabase.withTransaction` ×1.
+
+**Test churn: ~771 call sites** across 105 files / 49,120 lines — `fetchAll(`
+197, `fetchOne(` 136, `execute(` 339, `withTransaction` 69, `fetchExactlyOne`
+22, `fetchZeroOrOne` 4, `fetchAllValues` 3, `fetchAtMost(` 1. Nearly all
+mechanical (`try` → `try await`, `func test…` → `func test…() async throws`),
+but it is ~771 edits and every XCTest expectation-based timing test needs
+re-examination. Two contract suites are the real work:
+`SQLDriverContractTests.swift` (790 lines) and `GRDBDriverContractTests.swift`
+(1,004 lines).
+
+Docs: 12 DocC pages carry `try`-prefixed examples (137 occurrences), all of
+which are compiled documentation examples.
+
+### 2b. Reduced form (async scope only) — recommended
+
+The contract diff shrinks to **3 protocol requirements + 1 extension helper**
+(`withValidatedTransaction`). `XLDatabaseDriverConnection` — 6 requirements,
+6 `*Validated` helpers, `collectAllRows`/`collectFirstRow` — is **untouched**,
+and `PhysicalStatement` stays non-`Sendable` with the same guarantee it has
+today.
+
+The public-API and test churn in §2a is *not* avoided by the reduced form
+(§5 explains why, and why that is acceptable). What the reduced form avoids is
+the redesign column: the cursor invariant, the streaming seam, and the
+row-normalization hot path all survive unchanged.
+
+### 2c. The live-query path cannot go async at all — a hard constraint
+
+`GRDBSQLDatabase.publisher(fetch:)` calls
+`ValueObservation.tracking(fetch)` with a closure typed
+`(Database) throws -> T`
+([GRDBSQLDatabase.swift:450-462](../Sources/SwiftQL/GRDBSQLDatabase.swift#L450)).
+`ValueObservation` re-runs that closure itself, on its own scheduler, whenever
+the tracked region changes. **It has no async overload and cannot take one** —
+region tracking works by observing which statements the closure executes during
+a synchronous database access.
+
+So `publish()`, `publishOne()`, and the [#308] `AsyncThrowingStream` work
+planned for v1.5.5 must all keep calling the **synchronous** connection
+contract, forever, regardless of what the scope methods do. Under the full
+async contract this layer would need a duplicate synchronous execution path —
+i.e. the full contract does not eliminate the sync contract, it merely adds to
+it. Under the reduced form this falls out for free, because the connection
+contract that `ValueObservation` needs is the one that never changed.
+
+This also confirms the milestone split is already correct: **[#308] async
+live-query streams do not depend on an async driver contract.** They are async
+at the delivery boundary over a synchronous fetch. v1.5.5 can proceed untouched.
+
+## 3. The cursor-confinement problem
+
+The invariant at stake is stated in the contract itself: `PhysicalStatement` is
+"intentionally connection-owned and is not required to be `Sendable`"
+([SQLDatabaseDriver.swift:62-70](../Sources/SwiftQLCore/SQLDatabaseDriver.swift#L62)),
+and `forEachRow`'s callback is synchronous "so a driver cursor and its owning
+connection cannot escape through this value"
+([SQLDatabaseDriver.swift:98-105](../Sources/SwiftQLCore/SQLDatabaseDriver.swift#L98)).
+An `await` inside the cursor loop breaks this by construction: a value held
+across a suspension point outlives the synchronous access that owned it.
+
+**What GRDB does, and why.** GRDB marks *both* relevant types explicitly
+non-`Sendable`, with a comment giving the reason:
+
+```swift
+// Explicit non-conformance to Sendable: statements must be used from
+// a serialized database access dispatch queue.
+@available(*, unavailable)
+extension Statement: Sendable { }
+```
+(`GRDB/Core/Statement.swift` line 626;
+identical treatment for `Database` at
+`GRDB/Core/Database.swift` line 1737.)
+
+And GRDB's async API is shaped **exactly** like the reduced form recommended
+here — async at the scope, synchronous inside:
+
+```swift
+public func read<T>(_ value: @Sendable @escaping (Database) throws -> T) async throws -> T
+```
+
+Note the closure: `throws`, not `async throws`. GRDB — a mature, heavily
+concurrency-audited library — deliberately declines to let anything be awaited
+while a `Database` is in hand. That is the strongest available evidence for
+option (d).
+
+| Option | Verdict |
+|---|---|
+| **(a) Actor-isolated connection** | **No.** Actors are *reentrant*: another task can interleave on the same actor at every `await`, so a half-stepped cursor is exposed to interleaved access — the precise hazard the current design forbids. Non-`Sendable` `PhysicalStatement` cannot cross the actor boundary anyway, and per-row actor hops would dominate the row cost. |
+| **(b) `~Copyable`/`borrowing` statement** | **No — not expressible.** A `borrowing` binding cannot span a suspension point; the borrow must end before the `await`. Noncopyability prevents *duplication*, which was never the failure mode — escape and interleaving are. It solves the wrong problem, and cannot solve it across `await` in any case. |
+| **(c) `AsyncSequence` row streaming** | **No.** Every `next()` is a suspension point, so the connection is pinned out of the pool for the consumer's lifetime, at the consumer's pace. Unbounded connection occupancy under WAL is a deadlock source, not backpressure. [#249] already rules this out for the synchronous result set on the same grounds. |
+| **(d) Sync iteration inside an async scope** | **Yes.** `withReadConnection` is `async`; the body is synchronous; the cursor provably cannot outlive it because there is no suspension point available to it. Zero change to `forEachRow`, the reused normalization buffer, or `XLRowStreamControl`. This is GRDB's answer. |
+
+## 4. Swift concurrency mechanics
+
+**Sendability.** Dialect values are already fine — `XLSQLiteValue` and the
+binding packets are `Sendable`, which is what the 182 existing annotations buy.
+The `Result` generic on the scope methods gains a `Sendable` requirement (it
+crosses the suspension point). `PhysicalStatement` must **remain**
+non-`Sendable`; under the reduced form it never crosses an isolation boundary,
+so nothing is needed beyond leaving it alone.
+
+**Isolation model: serial executor, not actor-per-connection.** GRDB's
+`asyncRead`/`asyncWrite` already own a serialized dispatch queue per connection
+(`SerializedDatabase`). Layering an actor on top would add a second
+serialization point and, worse, would add *reentrancy* where the dispatch queue
+provides none. The adapter should surface GRDB's existing serialization, not
+replace it. For the [#136] native adapter, the same shape applies: one serial
+executor per `sqlite3*`, connection state confined to it.
+
+**Reentrancy — the concrete must-fix.** SwiftQL guards reentrant transactions
+with `GRDBTransactionScopeTracker`, and it is implemented with
+**`Thread.current.threadDictionary`**
+([GRDBDatabaseDriver.swift:895-899](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L895)).
+Its own documentation states the assumption it rests on: *"Scoped
+per-`Thread` rather than per-pool: `body` runs synchronously to completion, so a
+call nested inside it is necessarily on the same thread as the active scope"*
+([GRDBDatabaseDriver.swift:844-847](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L844)).
+
+Async invalidates that premise in both directions. A task that suspends inside
+an async `body` may resume on a different thread — so a genuinely reentrant call
+is **missed** (unsound); and an unrelated task scheduled onto a thread whose
+dictionary was not cleaned up is **falsely rejected** (incomplete). This is not
+a tolerable degradation, because the thing it guards is not recoverable: GRDB's
+reentrant-write guard is an unconditional `fatalError("Database methods are not
+reentrant.")` that fires before any SwiftQL code runs. A missed guard is a
+crash, not a thrown `XLTransactionScopeError`.
+
+The fix is a `@TaskLocal` marker rather than a thread dictionary. It is small
+(one type, ~40 lines) but it is a genuine redesign with its own test matrix, and
+async makes the failure it prevents *easier* to reach — `try await
+db.withTransaction { ... try await somethingElse() ... }` is a natural thing to
+write and an invitation to nest. It should be treated as a first-class
+deliverable of this work, not a follow-up.
+
+**Cancellation propagation.** Today: one pre-flight `Task.isCancelled` check
+before opening a transaction
+([GRDBSQLDatabase.swift:1291](../Sources/SwiftQL/GRDBSQLDatabase.swift#L1291)),
+honestly documented as having "no later cooperative cancellation point."
+Async does not improve this for free — as established in §1, GRDB 6.29.3 has no
+cancellation handling whatsoever. Building it means:
+
+- `withTaskCancellationHandler` around the scope, calling `interrupt()`;
+- but GRDB exposes `interrupt()` only on the **pool**
+  (`GRDB/Core/DatabasePool.swift` line 299),
+  which calls `sqlite3_interrupt` on every connection
+  (`GRDB/Core/Database.swift` line 1079).
+  Cancelling one task would abort **unrelated in-flight reads** on other
+  connections. Per-statement interruption is not reachable through GRDB 6's
+  public API.
+
+So: usable cancellation is a **[#136] native-adapter capability**, not a v2 GRDB
+one. The v2 GRDB adapter should ship the async scope with cancellation checked
+at scope entry and at each `XLRowStreamControl` decision point — cheap, sound,
+and honest — and document that mid-statement interruption arrives with the
+native adapter. (SwiftQL calls neither `sqlite3_interrupt` nor
+`sqlite3_progress_handler` anywhere today; both are net-new.)
+
+**Priority inversion.** GRDB's async `read` is
+`withUnsafeThrowingContinuation` over a dispatch queue at a fixed QoS. Swift
+priority donation does not cross that boundary: a `.userInitiated` task awaiting
+behind a `.utility` write gets no escalation. Not fixable inside SwiftQL against
+GRDB 6 — it is fixable in the [#136] adapter by owning the executor. Worth
+documenting as a known v2 limitation rather than hidden.
+
+## 5. Migration and source compatibility
+
+**The toolchain floor is not the obstacle — say this plainly.** `async`/`await`
+requires Swift 5.5 and, on Apple platforms, iOS 13 / macOS 10.15. SwiftQL pins
+`swift-tools-version: 5.9` with `platforms: [.iOS(.v16), .macOS(.v13)]`
+([Package.swift:1,9](../Package.swift#L9)), and CI verifies exact Swift 5.9.2 on
+Ubuntu 22.04 ([COMPATIBILITY.md](../COMPATIBILITY.md)). Every one of those
+floors is comfortably above what async needs. **An async contract does not
+require raising the 5.9 floor.** The thing that raises the floor is Swift 6
+*language mode* ([#133]), which is a separate, already-planned v2 decision.
+Async could technically ship in 1.x; the argument against is API-break scope
+(below), not toolchain.
+
+**Can both contracts coexist? Yes — but only in the reduced form.** This is the
+decisive structural argument:
+
+- **Sync facade over async: unsafe. Never do this.** It requires blocking on a
+  semaphore to await a continuation, which is precisely the cooperative-pool
+  forward-progress hazard from §1, deliberately reintroduced. It also deadlocks
+  if the awaited work needs the calling thread.
+- **Async facade over sync: safe, and genuinely non-blocking here** — because
+  GRDB's `asyncRead` enqueues and returns rather than blocking, so a SwiftQL
+  `async fetchAll()` layered on it really does free the cooperative thread. This
+  is not a fake async wrapper.
+- **Both, side by side: the actual recommendation.** Because the *connection*
+  contract stays synchronous in both, duplication is confined to the scope
+  layer: `XLDatabaseDriver` grows from 3 methods to 6 (3 sync + 3 async), and
+  `XLRequest` from 5 fetch methods to 10. The connection protocol, the
+  streaming seam, the row-normalization hot path, and every `*Validated` helper
+  are shared verbatim. Under a *full* async contract this sharing is impossible
+  and you maintain two complete execution stacks — which, per §2c, you would be
+  forced into anyway by `ValueObservation`.
+
+**What breaks for downstream clients.** In the coexistence design: nothing, at
+first. Existing sync call sites keep compiling; async is additive. That makes it
+shippable inside v2 alongside the other breaks rather than as a v3 event. The
+sync surface should be deprecated on the same schedule as the [#113] adapter
+boundary and removed no earlier than v3. Third-party `XLDatabaseDriver`
+conformers do break — but that population is small and [#113] is already
+reshaping that protocol in the same milestone, which is the ordering argument in
+§6.
+
+**Macro source stability: yes, and it is close to free.** The macro reads the
+user's declared signature and today *rejects* effect specifiers outright
+([SQLQueryMacro.swift:190-198](../Sources/SQLMacros/SQLQueryMacro.swift#L190)).
+Replacing that rejection with a branch — declare `throws`, get the sync
+executor; declare `async throws`, get `try await` — makes the *user's own
+declaration* select the path, so existing declarations stay source-stable while
+new ones opt in. The emission sites are hardcoded string builders
+([SQLQueryMacro.swift:684](../Sources/SQLMacros/SQLQueryMacro.swift#L684),
+[SQLQueriesMacro.swift:171,210,260](../Sources/SQLMacros/SQLQueriesMacro.swift#L171)):
+4 signature sites, 4 `try` sites, 1 diagnostic. This is also what finally lets
+SwiftQL deliver the `async throws` spelling its own ROADMAP has been publishing
+since v1.
+
+## 6. Milestone placement
+
+**v2**, sequenced **after [#113] and [#133], before [#136].**
+
+- **After [#113] (GRDB adapter boundary).** [#113] is the issue that re-cuts the
+  adapter contract — it already lists "cancellation" and "concurrency/isolation
+  behavior" in its scope. Changing the same protocol twice in one milestone is
+  pure waste, and doing async *first* means [#113] re-does it.
+- **After [#133] (Swift 6 mode).** Strict concurrency is what makes the
+  sendability and isolation obligations in §4 *compiler-checked* rather than
+  reviewed by hand. Writing an isolation model in Swift 5 mode and validating it
+  later is the expensive ordering. [#133] is already a P2 v2 release gate.
+- **Before [#136] (v2.1 native SQLite adapter).** [#136] is a from-scratch
+  adapter. It must be written once, against the final contract. Writing it
+  synchronously and converting it in v2.2 doubles the most expensive single
+  piece of work on the roadmap — and §4 shows [#136] is also where real
+  cancellation and executor control actually become implementable.
+- **Well before v2.2 ([#137], PostgreSQL).** A network dialect has no
+  synchronous design worth shipping. If the contract is still sync then, it
+  breaks then, with two adapters already built on it.
+- **Not in v1.5.5.** [#308]/[#309] are async at the *delivery* boundary over a
+  synchronous `ValueObservation` fetch (§2c) and have no dependency on this
+  work. [#249] is deliberately synchronous. v1.5.5 proceeds unchanged; this
+  analysis reinforces that split rather than disturbing it.
+
+Suggested decomposition (one issue each, in order): async scope methods on the
+contract + `withValidatedTransaction`; `@TaskLocal` reentrancy tracker
+replacing the thread-dictionary one; GRDB adapter async scope implementation;
+additive async `XLRequest`/`XLWriteRequest`/`XLTransactionalDatabase` surface;
+macro effect-specifier passthrough; async contract test suite. The reentrancy
+tracker is the only item that is not mechanical, and it is the one that must
+not be deferred.
+
+## 7. Recommendation
+
+**Do it, in the reduced form: async scope, synchronous cursor. Land it in v2
+between [#113]/[#133] and [#136].**
+
+Concretely — `withReadConnection`, `withWriteConnection`, `withTransaction`
+become `async`; `XLDatabaseDriverConnection` and `XLRowStreamControl` do not
+change at all; the sync scope methods remain alongside for one major version;
+`GRDBTransactionScopeTracker` moves to `@TaskLocal`; the macro passes the user's
+effect specifiers through; and mid-statement cancellation is documented as
+arriving with [#136], not v2.
+
+The case rests on two things and not on performance: SwiftQL currently blocks
+cooperative-pool threads and cannot express the `async throws` API its own
+ROADMAP advertises; and v2.2's PostgreSQL adapter has no synchronous design, so
+the contract breaks in v2.2 if it does not break in v2 — by which point two
+adapters are built on it.
+
+### The strongest counterargument, addressed
+
+*"If the connection contract stays synchronous, you have not really gone async.
+A network dialect needs to await per row, per packet — so the reduced form
+solves the on-device problem and then fails exactly where you claim its main
+justification lies (v2.2 PostgreSQL)."*
+
+This is the real objection, and it is partly right. The response has three
+parts, the last of which is a concession:
+
+1. **The common case is genuinely covered.** A non-cursor PostgreSQL query is
+   one round trip: send `Parse`/`Bind`/`Execute`, await, receive the complete
+   `DataRow` set. An async `withReadConnection` gives the adapter exactly the
+   suspension point it needs to do that I/O, and rows are then handed to
+   `forEachRow` synchronously from a local buffer. This is how most client
+   drivers behave by default, and it is a correct, complete implementation of
+   the contract.
+2. **Where it does not cover — server-side cursors, `DECLARE`/`FETCH`, streamed
+   `COPY` — the alternative is not better.** Awaiting per row means holding a
+   server-side cursor and a pooled connection at the consumer's pace, which is
+   the same unbounded-occupancy failure §3(c) rejects for SQLite, with network
+   timeouts added. A row-batching design (await per *chunk*, iterate the chunk
+   synchronously) fits the reduced contract unchanged and is what a competent
+   PostgreSQL adapter should do regardless.
+3. **The concession: this is not fully settled, and should not be settled
+   now.** True streaming for a network dialect may want a third seam — an async
+   *batch* provider beneath the synchronous row callback. Whether it does is a
+   question that needs a real dialect in hand, not speculation from an
+   SQLite-only codebase. That is precisely what [#137]'s "vertical slice" framing
+   exists to answer. The reduced form is chosen partly *because* it leaves that
+   door open: adding an async batch seam later is additive, whereas having
+   already made `forEachRow` async would have destroyed the cursor invariant
+   for every adapter to buy a capability only one of them needed.
+
+The symmetric counterargument — *"async buys an embedded library nothing, so do
+nothing"* — is answered by §1: the cooperative-pool blocking hazard is real
+today, is a correctness issue under Swift 6 rather than a performance one, and
+the ROADMAP has been publishing the async spelling as the target API since v1.
+Doing nothing is the option that requires the retraction.
+
+---
+
+[#113]: https://github.com/lukevanin/swiftql/issues/113
+[#133]: https://github.com/lukevanin/swiftql/issues/133
+[#136]: https://github.com/lukevanin/swiftql/issues/136
+[#137]: https://github.com/lukevanin/swiftql/issues/137
+[#249]: https://github.com/lukevanin/swiftql/issues/249
+[#308]: https://github.com/lukevanin/swiftql/issues/308
+[#309]: https://github.com/lukevanin/swiftql/issues/309

--- a/Research/BundledDriverAPIAnalysis.md
+++ b/Research/BundledDriverAPIAnalysis.md
@@ -1,0 +1,434 @@
+# Should SwiftQL's driver contract adopt a bundled, sqlite-nio-shaped API?
+
+**Verdict: REJECT as a replacement. ADOPT a narrow hybrid** — keep the
+multi-step contract as the protocol requirement, and add a *bundled convenience
+extension* (`executeBundled`/`forEachBundledRow`) that is derived from the
+existing primitives rather than replacing them. The bundled shape's real
+benefits are almost entirely obtainable without bundling; its central cost —
+forfeiting prepared-statement reuse — is measurable in the repo's own baselines
+at **+11% to +120% per call**, and it is not recoverable behind the seam for
+every backend SwiftQL has committed to.
+
+Analysis performed against the worktree at `5eb28fcf`, comparing
+`XLDatabaseDriverConnection`
+([SQLDatabaseDriver.swift](../Sources/SwiftQLCore/SQLDatabaseDriver.swift)) with
+the shape documented in
+[SQLiteNIOFeasibility.md](SQLiteNIOFeasibility.md) §1. Performance claims are
+computed from the three committed runs in
+[`Benchmarks/Baselines/`](../Benchmarks/Baselines/), not from new measurements.
+
+This is **not** the question of whether to depend on `sqlite-nio` — that was
+assessed and answered NO-GO. It is whether its one-method API shape is a better
+contract for SwiftQL's own drivers.
+
+> **Note:** references to `SQLiteNIOFeasibility.md` point at the companion
+> analysis, which is currently uncommitted on branch
+> `claude/sqlite-nio-feasibility-cbbc40`. Those links resolve once both documents
+> land in `Research/`.
+
+---
+
+## 0. The shapes, stated precisely
+
+Today, per execution (`XLDatabaseDriverConnection`,
+[SQLDatabaseDriver.swift:66-95](../Sources/SwiftQLCore/SQLDatabaseDriver.swift#L66)):
+
+```swift
+mutating func preparePhysical(_: XLValidatedLogicalPreparedStatement) throws -> PhysicalStatement
+mutating func bind(_: Dialect.Value, to: XLBindingKey, in: PhysicalStatement) throws -> PhysicalStatement
+mutating func fetchAll(_: PhysicalStatement) throws -> [[Dialect.Value]]
+mutating func fetchOne(_: PhysicalStatement) throws -> [Dialect.Value]?
+mutating func execute(_: PhysicalStatement) throws
+```
+
+plus the package-internal refinement
+([SQLDatabaseDriver.swift:115-122](../Sources/SwiftQLCore/SQLDatabaseDriver.swift#L115)):
+
+```swift
+mutating func forEachRow(_: PhysicalStatement, _ body: ([Dialect.Value]) throws -> XLRowStreamControl) throws
+```
+
+The bundled counterpart would be a single requirement, roughly:
+
+```swift
+mutating func run(
+    _ statement: XLValidatedLogicalPreparedStatement,
+    _ bindings: XLInvocationBindings<Dialect.Value>,
+    _ onRow: ([Dialect.Value]) throws -> XLRowStreamControl
+) throws
+```
+
+## 1. What the bundled shape genuinely buys — assessed against the real code
+
+### 1.1 "No escaping statement handle, so no cursor-confinement problem" — *already solved, and not by the contract*
+
+This is the headline argument, and against this codebase it is the weakest.
+`GRDBPhysicalStatement`
+([GRDBDatabaseDriver.swift:771-780](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L771))
+is a struct of four stored properties, and **it is not a cursor**. It holds the
+logical statement, a `connectionIdentifier: UUID`, GRDB's `Statement` (a
+prepared handle, not an open cursor), and `bindings: [XLBindingKey: XLSQLiteValue]`.
+
+The actual cursor is created and destroyed entirely inside one call
+([GRDBDatabaseDriver.swift:627-659](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L627)):
+`Row.fetchCursor` is called at line 632 and the cursor never outlives
+`forEachRow`. So the "cursor cannot escape" property that the doc comment
+attributes to non-`Sendable` `PhysicalStatement` is in fact enforced by
+`forEachRow`'s scoped body, which is *already* bundled in the only sense that
+matters. Bundling `prepare` into that call adds nothing to confinement.
+
+The confinement that `PhysicalStatement` *does* provide is cross-connection
+ownership, enforced dynamically by `validateOwnership`
+([GRDBDatabaseDriver.swift:683-690](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L683)),
+and it is exercised by tests
+([SQLDriverContractTests.swift:119](../Tests/SwiftQLCoreTests/SQLDriverContractTests.swift#L119)).
+Bundling would make that check unnecessary — a genuine but small win, worth one
+UUID field and one guard.
+
+**Verdict: overstated.** Real benefit ≈ deleting `validateOwnership` and one
+stored property.
+
+### 1.2 "No partially-bound or half-finalized intermediate states" — *the premise is already false here*
+
+`bind` does not touch SQLite. It is a pure value operation: copy the struct, set
+a dictionary entry, return
+([GRDBDatabaseDriver.swift:576-603](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L576),
+especially lines 600-602). The physical bind happens once, atomically, at
+execution, when `statementArguments` materialises the whole positional table and
+hands it to GRDB
+([GRDBDatabaseDriver.swift:692-739](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L692)).
+
+So SwiftQL's multi-step contract is already *value-accumulating*, not
+*incremental-mutation*. There is no half-bound `sqlite3_stmt` to observe, and
+`validateBindings`
+([GRDBDatabaseDriver.swift:608-613](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L608))
+rejects an incomplete packet before any execution. The "intermediate states"
+hazard is a hazard of a *different* multi-step design than the one SwiftQL has.
+
+**Verdict: not a real benefit against this code.**
+
+### 1.3 "Drastically smaller contract for adapter authors" — *real, but ~3→1, not 5→1, and mostly obtainable for free*
+
+Counting substantive work for a new adapter today: `preparePhysical`, `bind`,
+`forEachRow`. `fetchAll`, `fetchOne`, and `execute` are already one-line
+forwards to the streaming extension's `collectAllRows`/`collectFirstRow`
+([GRDBDatabaseDriver.swift:615-625](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L615);
+same pattern in the test double at
+[SQLDriverContractTests.swift:680-686](../Tests/SwiftQLCoreTests/SQLDriverContractTests.swift#L680)).
+`execute` is the only one with genuinely separate behaviour.
+
+That 3→1 reduction is real. But **most of it is available without bundling**:
+promoting `fetchAll`/`fetchOne` to defaulted requirements for streaming
+conformers is a pure-win cleanup that removes the boilerplate every adapter
+currently duplicates, and it changes no shape. Bundling buys the remaining
+step — merging `preparePhysical` and `bind` into the call — which is the
+step that costs caching (§2).
+
+**Verdict: real but modest, and largely severable from the bundling decision.**
+
+### 1.4 "The natural protocol wire for v2.2–v2.4 *is* one round trip" — *this is backwards*
+
+This is the load-bearing claim for the adapter-authoring argument, and it does
+not survive contact with the wire protocols. ROADMAP explicitly specifies
+"database-bound prepared handles" for all three
+([ROADMAP.md:711, 719, 726](../ROADMAP.md#L707)) — the multi-step shape is a
+stated v2.2–v2.4 requirement, not an accident of the SQLite adapter.
+
+| Backend | Parameterised execution on the wire | Fits bundled? |
+|---|---|---|
+| **PostgreSQL** | Extended query only: `Parse`/`Bind`/`Describe`/`Execute`/`Sync`. The *simple* `Q` protocol carries **no parameters at all** — bundling onto it would mean interpolating literals. | Pipelining Parse+Bind+Execute+Sync is one round trip, but only with the **unnamed** statement, which is destroyed by the next `Parse`. Bundled ⇒ no server-side plan reuse, by construction. |
+| **MySQL** | `COM_STMT_PREPARE` → (read statement id) → `COM_STMT_EXECUTE` → `COM_STMT_CLOSE`. The id is only known from the prepare response. | **Cannot** be one round trip. A bundled call costs *two* round trips where a cached prepared handle costs one. Bundling is strictly worse. |
+| **SQL Server** | `sp_prepare`/`sp_execute`/`sp_unprepare`, or `sp_executesql` (bundled, ad-hoc). | Bundled form exists, but leans on plan-cache text matching instead of an owned handle. |
+| **SQLite** | `prepare_v3`/`bind`/`step`/`finalize`. | Natural fit, at the cost of re-preparing. |
+
+The protocols that actually motivated this question are the ones that fit the
+bundled shape *worst*. For MySQL it is a round-trip regression; for PostgreSQL
+it forecloses named prepared statements. The one backend where bundling is
+natural is SQLite — the backend that already has a working multi-step adapter.
+
+**Verdict: the argument inverts. Multi-step is the better wire match for
+v2.2–v2.4.**
+
+### 1.5 "Trivially async-compatible" — *true, and the strongest genuine point*
+
+This one holds. A bundled `run(...)` has exactly one suspension point and no
+value that must survive across an `await`, so `async` promotion is mechanical.
+The multi-step form makes the connection-owned, non-`Sendable`
+`PhysicalStatement` live across `await` boundaries in the caller — the precise
+difficulty flagged in [SQLiteNIOFeasibility.md](SQLiteNIOFeasibility.md) §3.1.
+
+Two qualifications:
+
+- `forEachRow`'s callback is **synchronous by design**
+  ([SQLDatabaseDriver.swift:98-105](../Sources/SwiftQLCore/SQLDatabaseDriver.swift#L98)),
+  so a bundled call is only async at its boundary, not throughout. That is fine,
+  and it is what you want.
+- The property comes from *scoping*, not from *bundling*. A multi-step contract
+  whose statement is only reachable inside a `withPrepared { … }` scope has the
+  same property. Bundling is one way to get scoping; it is not the only way.
+
+**Verdict: genuine, and it is the one argument that should carry weight — but it
+argues for scoped statement access, not specifically for bundling.**
+
+## 2. What it costs
+
+### 2.1 Statement caching — it *can* live behind a bundled call, but only for SQLite
+
+The mechanism works: key a per-connection `[String: Statement]` cache by SQL
+text inside the bundled call, and `reset`+`clear_bindings`+rebind on reuse. That
+is exactly what GRDB's `cachedStatement(sql:)`
+([GRDBDatabaseDriver.swift:571](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L571))
+already does, and nothing in the bundled signature prevents an adapter from
+calling it. So **bundling does not mechanically foreclose caching for SQLite.**
+
+It forecloses three things that ROADMAP v2.1 asks for by name:
+
+1. **Caller-controlled cache lifetime.** With the handle hidden, "prepare this
+   once and reuse it across N calls" is no longer expressible in the contract;
+   it becomes an adapter-private heuristic. ROADMAP v2.1 requires "per-connection
+   statement preparation and caching" and "preparation **warm-up** and metrics"
+   ([ROADMAP.md:697, 704](../ROADMAP.md#L692)). Warm-up is precisely
+   *prepare without executing* — unrepresentable in a bundled-only contract (§2.3).
+2. **Schema-version invalidation and safe reprepare** ([ROADMAP.md:701](../ROADMAP.md#L701))
+   becomes unobservable from the core. The core can no longer tell whether a
+   given execution hit or missed the cache, so the metrics requirement has no
+   seam to attach to.
+3. **Cross-backend caching.** For MySQL the cache must hold a server-side
+   statement id whose lifetime is explicitly managed by `COM_STMT_CLOSE`; for
+   PostgreSQL a named statement. A bundled call can hide that, but the *only*
+   correctness-preserving policy it can implement without caller input is
+   LRU-with-eviction, and eviction on a server-side handle is a network
+   operation with failure modes the core cannot see.
+
+**Verdict: caching survives bundling for SQLite; the *contractual* caching,
+warm-up, and metrics requirements of v2.1 do not.**
+
+### 2.2 Prepare-once/execute-many for batch inserts
+
+Today `boundStatement`
+([GRDBDatabaseDriver.swift:442-476](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L442))
+calls `connection.prepare` per invocation, so SwiftQL does **not currently
+exploit** prepare-once/execute-many — the win is deferred to the GRDB cache. So
+bundling costs nothing *today*, but it removes the seam where the optimisation
+would naturally land. Given the measured per-prepare surcharge for
+`bounded_write` is ~3.7 µs (§4), a 10 000-row batch insert leaves ~37 ms on the
+table. That is the single clearest future cost.
+
+### 2.3 Prepare-without-execute — the stated dependency is *not* real today, but the forward-looking one is
+
+The task premise is that `Sources/SwiftQLSQLiteBuildValidationValidator/`
+(#292/#293) depends on a prepare-without-execute step in the driver contract. It
+does not. The validator drives `sqlite3_prepare_v3` directly
+([SQLitePrepareV3Probe.swift:158](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift#L158))
+and finalises without stepping; it imports `SwiftQLCore` only for
+`XLSQLiteDialect` identity and capability checks
+([SQLiteBuildValidator.swift:280, 312](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift#L280))
+and never touches `XLDatabaseDriverConnection`. **Bundling the driver contract
+would not break build validation.**
+
+The forward-looking cost is real, though. Extending build validation to
+v2.2–v2.4 means validating SQL against a live server without side effects, and
+the only safe primitives for that are PostgreSQL `Parse`+`Describe` (no
+`Execute`) and MySQL `COM_STMT_PREPARE` (no `COM_STMT_EXECUTE`). A bundled-only
+contract cannot express either, so cross-dialect build validation would need its
+own out-of-contract probe per backend — replicating for three servers the
+duplication SQLite already lives with.
+
+### 2.4 The static-query path
+
+Minimal impact, and this is the part that argues *for* bundling. `GRDBStaticQuery`
+never touches `PhysicalStatement`: it builds an `XLInvocationBindings` packet
+([GRDBStaticQuery.swift:326](../Sources/SwiftQL/GRDBStaticQuery.swift#L326)) and
+hands it to `GRDBPreparedInvocation.fetchAllValues` / `forEachValueRow` /
+`execute`
+([GRDBDatabaseDriver.swift:501-529](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L501)).
+Those methods already take *SQL-plus-a-binding-packet and deliver rows* —
+`GRDBPreparedInvocation` **is** a bundled API, one layer above the driver seam.
+The bundled shape is therefore already SwiftQL's public execution surface; the
+open question is only whether it should also be the *driver* seam.
+
+## 3. Row delivery and early termination
+
+sqlite-nio's `Void`-returning `onRow` is not a property of bundling — it is a
+defect of that particular signature, and one SwiftQL must not inherit.
+
+A bundled call keeps early stop iff its callback returns `XLRowStreamControl`
+and the driver honours `.stop` by abandoning the cursor
+([GRDBDatabaseDriver.swift:655-657](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L655)).
+With that signature, bundling is neutral on streaming.
+
+Early stop is load-bearing beyond `fetchOne`:
+
+- `collectFirstRow` returns `.stop` after row 1
+  ([SQLDatabaseDriver.swift:139-149](../Sources/SwiftQLCore/SQLDatabaseDriver.swift#L139));
+- `fetchAtMost(limit)` stops at the limit *while decoding*
+  ([GRDBSQLDatabase.swift:311-345](../Sources/SwiftQL/GRDBSQLDatabase.swift#L311)) —
+  a `LIMIT`-less early stop that a `Void` callback would turn into a full scan;
+- the reusable normalisation buffer at
+  [GRDBDatabaseDriver.swift:648-651](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L648)
+  makes the typed decode path materialise no intermediate matrix. sqlite-nio's
+  eagerly-materialised `SQLiteRow` forfeits exactly this.
+
+**Required signature:** `([Dialect.Value]) throws -> XLRowStreamControl`,
+synchronous, non-escaping, with values valid only until the callback returns.
+Any bundled proposal that weakens this is a regression, not a refactor.
+
+## 4. Binding model — bundling is *easy* here, because the work is already done
+
+`XLInvocationBindings<Value>`
+([SQLInvocationBindings.swift:450-458](../Sources/SwiftQLCore/SQLInvocationBindings.swift#L450))
+already carries `layout: XLParameterLayout` plus an ordered
+`[XLInvocationBinding<Value>]`, each binding pairing an `XLParameterSlot` (which
+owns the `XLBindingKey`, type identifier, nullability, and codec identity) with
+its value. It is `Sendable`, immutable, and validated by `validatingComplete()`.
+**This is already the bundled binding packet**; a bundled call would take it
+verbatim.
+
+Named binds survive without difficulty. Normalisation from `XLBindingKey` to
+SQLite's positional table already exists at
+[GRDBDatabaseDriver.swift:703-738](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L703),
+and it is derived *entirely* from `parameterLayout` — core-owned data — plus two
+SQLite rules (named placeholders take the next free index; `.indexed(n)` maps to
+`n+1`, gaps preserved as NULL).
+
+Should that move up into the core? **No, and this is the one place where the
+current split is exactly right.** The rules are dialect-specific: SQLite's
+"named takes the next free slot" is a SQLite rule, PostgreSQL is `$1`-positional
+with no named form on the wire, MySQL is `?`-only. Hoisting normalisation into
+core would bake SQLite's numbering into every dialect. Bundling neither forces
+nor forbids the move — the packet is already the right currency either way.
+
+**Verdict: neutral. The binding model is bundling-ready today and needs no
+change under either design.**
+
+## 5. Hybrid designs
+
+| Design | Shape | Assessment |
+|---|---|---|
+| **A. Bundled-only** | One requirement replaces five. | Rejected. Forecloses v2.1 warm-up/metrics (§2.1), regresses MySQL to two round trips (§1.4), and removes the only seam for cross-dialect build validation (§2.3). |
+| **B. Bundled requirement + multi-step optional refinement** (mirroring `XLStreamingDatabaseDriverConnection`) | Every adapter implements `run`; cache-capable adapters additionally conform to a refinement exposing `prepare`/`bind`. | **The trap.** The refinement pattern works for streaming because the *general* form (`fetchAll`) is derivable from the *specific* one (`forEachRow`) — see `collectAllRows`, [SQLDatabaseDriver.swift:128](../Sources/SwiftQLCore/SQLDatabaseDriver.swift#L128). Here the derivation runs the wrong way: you cannot synthesise a bundled `run` from nothing, so every adapter writes `run` *and* the cache-capable ones write the multi-step form too — strictly more work than today, with two paths to keep behaviourally identical. |
+| **C. Multi-step requirement + bundled convenience extension** | Keep today's requirements; add `executeBundled`/`forEachBundledRow` as a protocol *extension* composing `prepare` → bind-loop → `forEachRow`. | **Recommended.** Derivation runs the right way (bundled is a strict composition of the primitives), so it costs adapter authors nothing and can never diverge. It is, almost exactly, `boundStatement` + `forEachRow` promoted from `GRDBInvocationExecutor` into the contract. |
+| **D. Scoped multi-step** | Replace the returned handle with `withPreparedStatement(_:) { stmt in … }`. | Worth doing **later, with the async decision**, not now. Captures the §1.5 async benefit (no handle across `await`) and the §1.1 confinement benefit without losing caching. Source-breaking for direct driver clients, so it belongs in the same change as the async break, not before it. |
+
+**Composition with the async question.** This is the decisive tiebreaker.
+[SQLiteNIOFeasibility.md](SQLiteNIOFeasibility.md) §7.4 says to treat sync→async
+as its own deliberate decision. Option C is the only one that stays neutral: the
+bundled extension is trivially async-promotable *and* the multi-step primitives
+remain available, so the async decision can still choose between D (scoped) and
+a fully bundled async form when it is actually made. Option A pre-commits the
+contract to a shape chosen for a backend SwiftQL rejected, and does so *before*
+the decision that should drive it.
+
+## 6. Benchmark implications
+
+**The instrument already exists and no new benchmark is needed to bound the
+cost.** `BenchmarkPhase`
+([BenchmarkTypes.swift:3-10](../Benchmarks/Sources/SwiftQLBenchmarks/BenchmarkTypes.swift#L3))
+separates `coldStatementPreparation` from `cachedStatementLookup`, measured
+independently at
+[SwiftQLBenchmarkRunner.swift:586-623](../Benchmarks/Sources/SwiftQLBenchmarks/SwiftQLBenchmarkRunner.swift#L586).
+A bundled-without-caching design pays `cold_statement_preparation` where the
+current design pays `cached_statement_lookup`, so the surcharge is a subtraction
+over data already committed.
+
+From the three runs in [`Benchmarks/Baselines/`](../Benchmarks/Baselines/)
+(2026-07-17, mac16-8), median nanoseconds:
+
+| Case | cold prep | cached lookup | surcharge | sum of other phases | **relative cost** |
+|---|---|---|---|---|---|
+| `simple_parameterized_lookup` | 14 062 | 250 | +13 812 | 11 459 | **+120%** |
+| `deterministic_row_decode` | 10 375 | 208 | +10 167 | 13 249 | **+77%** |
+| `bounded_write` | 3 792 | 83 | +3 709 | 22 625 | **+16%** |
+| `representative_multi_join_read` | 20 000 | 291 | +19 709 | 182 854 | **+11%** |
+
+The memory note that this machine is noisy and sub-10% deltas are unreliable is
+respected and does not blunt the finding — these are **11%–120%**, and the
+underlying `cold_statement_preparation` medians reproduce across the three runs
+to within 2% (14 062 / 14 209 / 14 167 ns for `simple_parameterized_lookup`).
+The signal is far above the noise floor because it is a large, structural cost,
+not a micro-delta. The cost is worst precisely for small, frequent queries — the
+shape an embedded app runs in a scroll loop.
+
+**On allocation counts.** The preferred anchor is only half-available. A
+deterministic `malloc_logger`-based allocation probe exists
+([ConstructionProfile.swift](../Benchmarks/Sources/SwiftQLConstructionProfile/ConstructionProfile.swift),
+issue #166), but it is scoped to construction and rendering, and
+`BenchmarkMeasurement`
+([BenchmarkTypes.swift:73-78](../Benchmarks/Sources/SwiftQLBenchmarks/BenchmarkTypes.swift#L73))
+records nanoseconds only — there is no allocation field in the report schema. If
+this question is ever re-opened, the correct first move is to extend that probe
+across the driver phases; `sqlite3_prepare_v3` allocates the VDBE program, so
+the allocation delta would be large, deterministic, and immune to machine noise.
+Until then the wall-clock numbers above stand on reproducibility across runs
+rather than on a single run's precision.
+
+## 7. Recommendation
+
+**Reject the bundled shape as a replacement for the driver contract. Adopt
+hybrid C — multi-step requirements, bundled convenience extension.**
+
+Concretely:
+
+1. **Keep** `preparePhysical`/`bind`/`forEachRow` as the requirements.
+2. **Add** a protocol extension on `XLStreamingDatabaseDriverConnection`
+   providing `forEachBundledRow(_ statement:_ bindings:_ body:)` and
+   `executeBundled(_:_:)`, composing the primitives. This is `boundStatement`
+   ([GRDBDatabaseDriver.swift:442](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L442))
+   generalised out of the GRDB executor. Adapter authors get the small surface
+   for free; the two paths cannot diverge because one is defined by the other.
+3. **Separately** (a pure win, independent of this decision) default
+   `fetchAll`/`fetchOne` for streaming conformers, deleting the identical
+   forwards at
+   [GRDBDatabaseDriver.swift:615-625](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L615)
+   and [SQLDriverContractTests.swift:680-686](../Tests/SwiftQLCoreTests/SQLDriverContractTests.swift#L680).
+   This captures most of the §1.3 ergonomics win with none of the cost.
+4. **Defer** option D (scoped `withPreparedStatement`) to the async-contract
+   decision, where it belongs.
+5. **Do not** adopt a `Void`-returning row callback under any design (§3).
+
+### The strongest counterargument to this position
+
+*"You are optimising for a caching win SwiftQL doesn't currently take. Since
+`boundStatement` re-`prepare`s on every invocation
+([GRDBDatabaseDriver.swift:448](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L448)),
+the multi-step contract is already paying bundling's per-call cost. And the
++120% figure assumes bundling without caching — but §2.1 concedes a SQL-keyed
+cache fits behind a bundled call, which is precisely what GRDB does internally.
+So the honest comparison is bundled-with-cache versus multi-step-with-cache,
+where the surcharge is ~zero and the smaller contract wins outright."*
+
+This is the right objection and it is half correct. The performance comparison
+does collapse for SQLite: a bundled call that internally calls
+`cachedStatement(sql:)` costs the same 250 ns lookup, and the §6 table then
+measures only the naive implementation. If SQLite were the only backend, the
+argument would carry.
+
+It fails on three counts:
+
+- **It doesn't generalise.** For MySQL the bundled call is two round trips
+  unless the adapter caches a server-side statement id — but a hidden cache
+  cannot be told when to `COM_STMT_CLOSE`, and getting that wrong leaks
+  server-side statements. The contract would be pushing a lifetime problem into
+  a place with no interface to solve it (§1.4, §2.1).
+- **It concedes v2.1's stated requirements.** "Preparation warm-up and metrics"
+  ([ROADMAP.md:704](../ROADMAP.md#L704)) is prepare-without-execute plus
+  cache-hit observability. Both are expressible only if the prepare step has
+  contractual existence. A cache that works but that the core cannot observe or
+  warm satisfies the letter of "caching" and none of the requirement.
+- **The ergonomics win is available without the trade.** Hybrid C delivers the
+  same one-call surface to adapter authors. Since the small surface can be had
+  as a derived extension, paying for it by deleting the primitives is buying
+  something already free.
+
+The counterargument's real force is against option A being *catastrophic* — it
+is not, for SQLite. It is against A being *worth it*, and there the answer is
+that hybrid C dominates: same ergonomics, no forfeited capability, and it leaves
+the async decision genuinely open.
+
+### When to revisit
+
+Revisit if SwiftQL commits to an async driver contract *and* PostgreSQL/MySQL
+adapter prototypes show that per-connection prepared-handle caching is not worth
+its complexity on those wires. At that point the choice is between bundled-async
+and scoped-async (option D), and the evidence base will be adapter prototypes
+rather than SQLite baselines.

--- a/Research/SQLiteCFeasibility.md
+++ b/Research/SQLiteCFeasibility.md
@@ -1,0 +1,869 @@
+# Feasibility: a direct SQLite C adapter for SwiftQL v2.1
+
+**Verdict: GO, with conditions.** Every v2.1 requirement in
+[ROADMAP.md:696-705](../ROADMAP.md) is reachable directly against the SQLite C
+API, and SwiftQL's driver contract is unusually well shaped for it — the seam is
+synchronous, `PhysicalStatement` is deliberately connection-owned and not
+`Sendable`, and the streaming seam already forbids a cursor from escaping its
+connection access. The cost is not distributed evenly: roughly 80% of the
+requirement list is small, mechanical, and provable in the first two weeks, and
+one requirement — observation — is larger than everything else combined.
+
+The four conditions are stated in §7. The load-bearing ones are that observation
+ships as its own slice with an explicit reduced-fidelity fallback, and that the
+SQLite provenance decision is made *before* the adapter is written, not after.
+
+This report is the follow-on to
+[SQLiteNIOFeasibility.md](SQLiteNIOFeasibility.md), whose §7.1 asserted that
+"the prove-out already exists in-repo." §5.1 below tests that claim and finds it
+half true.
+
+Analysis performed against the worktree at `5eb28fc` (SwiftQL v1.5.2), GRDB
+6.29.3 as resolved in `.build/checkouts/GRDB.swift`, and SQLite as shipped in
+the macOS 26.5 SDK (`SQLITE_VERSION "3.51.0"`,
+`SQLITE_SOURCE_ID "2025-06-12 …f0ca7bba…apl"`).
+
+---
+
+## 0. What was actually checked
+
+Claims in this report come from one of four places, and are marked accordingly:
+
+- **in-repo** — a file:line in this worktree or in the resolved GRDB checkout;
+- **header** — the SDK's `sqlite3.h` at
+  `$(xcrun --show-sdk-path)/usr/include/sqlite3.h`;
+- **measured** — a command run on this machine, with the command shown;
+- **upstream** — sqlite.org documentation, quoted.
+
+Two findings below correct or update existing repository documents. They are
+flagged inline: §1.4 (the `SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION` characterisation
+in the sqlite-nio report is narrower than stated) and §1.2
+([COMPATIBILITY.md:146](../COMPATIBILITY.md) is stale about
+`SQLITE_ENABLE_SNAPSHOT`).
+
+---
+
+## 1. SQLite provenance
+
+### 1.1 What is linked today, and why it already fails a v2.1 requirement
+
+SwiftQL already contains direct-C SQLite code. It reaches `sqlite3_prepare_v3`
+through GRDB:
+
+```swift
+// Package.swift:157-165
+.target(
+    name: "SwiftQLSQLiteBuildValidationValidator",
+    dependencies: [
+        …
+        .product(name: "GRDB", package: "GRDB.swift"),
+        .product(name: "CSQLite", package: "GRDB.swift"),
+    ]
+),
+```
+
+`CSQLite` is GRDB's target, not SwiftQL's, and it is a **system library**:
+
+```swift
+// .build/checkouts/GRDB.swift/Package.swift:49-51
+.systemLibrary(
+    name: "CSQLite",
+    providers: [.apt(["libsqlite3-dev"])]),
+```
+
+```
+// .build/checkouts/GRDB.swift/Sources/CSQLite/module.modulemap
+module CSQLite [system] {
+    header "shim.h"
+    link "sqlite3"
+    export *
+}
+```
+
+Two consequences follow immediately, and both are independent of which
+provenance option is chosen:
+
+1. **SwiftQL must own its own C module target regardless.** ROADMAP.md:705
+   requires "no GRDB dependency for clients selecting the native adapter."
+   Today the only route to `sqlite3_*` symbols is a GRDB product. A
+   `CSwiftQLSQLite` target is a prerequisite for *every* other slice, and it is
+   the cheapest thing on the list.
+
+2. **That target must include a C shim, not just a module map.** GRDB's
+   `shim.h` exists because two SQLite entry points are variadic and therefore
+   uncallable from Swift:
+
+   ```c
+   // .build/checkouts/GRDB.swift/Sources/CSQLite/shim.h
+   static inline void _registerErrorLogCallback(_errorLogCallback callback) {
+       sqlite3_config(SQLITE_CONFIG_LOG, callback, 0);
+   }
+   static inline void _disableDoubleQuotedStringLiterals(sqlite3 *db) {
+       sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 0, (void *)0);
+       sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 0, (void *)0);
+   }
+   ```
+
+   `sqlite3_config` and `sqlite3_db_config` are the only way to reach
+   `SQLITE_DBCONFIG_DQS_*`, `SQLITE_DBCONFIG_DEFENSIVE`,
+   `SQLITE_DBCONFIG_ENABLE_FKEY`, and the error-log callback. A native adapter
+   that skips the shim silently forfeits all of them. §1.5 explains why DQS in
+   particular is not optional.
+
+### 1.2 Option A — system `libsqlite3` via a `CSwiftQLSQLite` module map
+
+This is what GRDB does and what SwiftQL therefore already ships on. The version
+question is where it gets uncomfortable.
+
+**Apple platforms.** The SDK header pins `SQLITE_VERSION "3.51.0"` with source
+ID ending `…apl` — Apple's patched build, not an upstream SQLite.org source ID.
+The compile options are not what an upstream build produces
+(measured, `sqlite3 :memory: "pragma compile_options;"` on macOS 26.5):
+
+```
+CODEC=see-cccrypt            DQS=3                    ENABLE_API_ARMOR
+ENABLE_COLUMN_METADATA       ENABLE_FTS3/4/5          ENABLE_MATH_FUNCTIONS
+ENABLE_PREUPDATE_HOOK        ENABLE_SNAPSHOT          ENABLE_STMT_SCANSTATUS
+ENABLE_UNKNOWN_SQL_FUNCTION  MAX_VARIABLE_NUMBER=500000
+OMIT_LOAD_EXTENSION          THREADSAFE=2             MUTEX_UNFAIR
+```
+
+Three of these matter for SwiftQL and are discussed below: `DQS=3` (§1.5),
+`MAX_VARIABLE_NUMBER=500000` (§1.5), and `ENABLE_UNKNOWN_SQL_FUNCTION` (§1.4).
+The version is tied to the OS release and is not selectable by the application —
+an iOS 16 device and an iOS 18 device link different SQLite libraries from the
+same app binary.
+
+**Linux.** The repository has already hit the floor problem and documented it:
+
+> Ubuntu 22.04's system SQLite 3.37 predates `UNIXEPOCH`, which is a required
+> capability in SwiftQL's real-SQLite conformance corpus.
+> — [COMPATIBILITY.md:129-131](../COMPATIBILITY.md)
+
+CI's response was to stop using the system library and build the amalgamation —
+i.e. **the project already rejected pure Option A on one of its two pinned
+support points.**
+
+**Version spread today.** Conformance evidence is captured against SQLite 3.51.0
+([COMPATIBILITY.md:69-71](../COMPATIBILITY.md)); Linux CI runs 3.53.3
+([COMPATIBILITY.md:112](../COMPATIBILITY.md)). Under Option A a shipped iOS app
+adds a third, fourth, and fifth version that no CI cell ever exercised.
+
+> **Documentation drift found.** [COMPATIBILITY.md:145-148](../COMPATIBILITY.md)
+> states that "the pinned amalgamation intentionally leaves that optional
+> [snapshot] API disabled." The workflow contradicts this: it compiles with
+> `-DSQLITE_ENABLE_SNAPSHOT`
+> ([.github/workflows/swift.yml:512](../.github/workflows/swift.yml)), asserts
+> `sqlite3_snapshot_get` is an exported symbol
+> ([swift.yml:520](../.github/workflows/swift.yml)), and passes
+> `-DSQLITE_ENABLE_SNAPSHOT` to `swiftc`
+> ([swift.yml:541](../.github/workflows/swift.yml)). This is not a cosmetic
+> discrepancy — snapshot availability is the pivot in §4.3 between
+> snapshot-consistent and writer-serialized observation.
+
+### 1.3 Option B — vendor the amalgamation in-repo
+
+Also partly pre-proven. CI already downloads a SHA3-256-verified amalgamation
+and compiles it with a SwiftQL-chosen option set
+([swift.yml:494-516](../.github/workflows/swift.yml)):
+
+```sh
+cc -O2 -fPIC \
+  -DSQLITE_THREADSAFE=1 \
+  -DSQLITE_ENABLE_COLUMN_METADATA \
+  -DSQLITE_ENABLE_FTS5 \
+  -DSQLITE_ENABLE_MATH_FUNCTIONS \
+  -DSQLITE_ENABLE_SNAPSHOT \
+  -shared "$sqlite_source/sqlite3.c" -o …/libsqlite3.so
+```
+
+Moving this from workflow shell into a SwiftPM `.target` with `cSettings:
+[.define(…)]` is straightforward. `.define` is not an unsafe flag, so a
+downstream package can still depend on SwiftQL — this is the constraint that
+would bite if the build needed `.unsafeFlags`, and it does not.
+
+Two costs are specific to vendoring and neither is theoretical.
+
+**Binary size.** Upstream figures, `-Os`, no optional features:
+
+| Platform | Compiler | Size |
+|---|---|---|
+| MacOS M1 | clang 14.0.0 | 750 KB |
+| Ubuntu 20.04.5 x64 | gcc 9.4.0 | 650 KB |
+
+— [sqlite.org/footprint.html](https://www.sqlite.org/footprint.html), as of
+2023-07-04; larger with FTS5 and RTREE. Against system `libsqlite3`, which lives
+in the dyld shared cache on Apple platforms, the marginal app cost is
+effectively zero. Roughly 0.75–1 MB is the honest sticker price of determinism.
+
+**Symbol collision — the sharp edge of Option B.** During v2.1 both adapters
+ship, so one binary can link the GRDB adapter (which resolves `sqlite3_*`
+dynamically against system `libsqlite3`) *and* a statically-linked amalgamation
+defining the same symbols. Static definitions satisfy undefined symbols before
+the dylib is consulted, so GRDB would silently start executing against the
+vendored library — a different version, different options, and a different
+`sqlite3_source_id()` than the one CI reports. `vapor/sqlite-nio` solves exactly
+this by prefixing every symbol (`sqlite_nio_sqlite3_*`). **If Option B is
+chosen, symbol prefixing is mandatory, not optional**, and proving it is a
+day-one task (§6, S0). It is the single most likely source of a
+"works-in-CI, wrong-in-app" failure in this whole plan.
+
+**App Store.** No App Store rule prohibits either option. System `libsqlite3` is
+a public SDK library (`libsqlite3.tbd`); vendoring adds the bytes above to the
+app download. Neither triggers review issues. This is a size and determinism
+decision, not a policy one.
+
+### 1.4 The `SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION` trap — narrower than reported
+
+[SQLiteNIOFeasibility.md §4](SQLiteNIOFeasibility.md) states that with this
+option enabled, "`sqlite3_prepare_v3` *accepts* statements calling functions that
+do not exist," and that build validation against such a SQLite "would silently
+stop catching misspelled or unregistered function names." The effect is real but
+scoped more narrowly than that, and the correction changes the risk assessment.
+
+Upstream, verbatim:
+
+> When the SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION compile-time option is activated,
+> SQLite will suppress "unknown function" errors when running an EXPLAIN or
+> EXPLAIN QUERY PLAN. Instead of throwing an error, SQLite will insert a
+> substitute no-op function named "unknown()". The substitution of "unknown()"
+> in place of unrecognized functions only occurs on EXPLAIN and EXPLAIN QUERY
+> PLAN, not on ordinary statements.
+> — [sqlite.org/compile.html](https://www.sqlite.org/compile.html)
+
+Measured on Apple's SQLite 3.51.0, which **has the option enabled** (§1.2):
+
+| Statement | `sqlite3_prepare` |
+|---|---|
+| `SELECT no_such_fn(1);` | **FAIL** — `no such function` |
+| `SELECT lenght('a');` (misspelled builtin) | **FAIL** |
+| `CREATE TABLE t(a); SELECT no_such_fn(a) FROM t;` | **FAIL** |
+| `EXPLAIN SELECT no_such_function_xyz(1);` | **OK** — accepted |
+| `EXPLAIN QUERY PLAN SELECT no_such_fn(1);` | **OK** — accepted |
+
+Three conclusions:
+
+1. **The #293 validator is not currently defeated.**
+   [`SQLitePrepareV3Probe.prepare`](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift#L158-L165)
+   passes the manifest SQL to `sqlite3_prepare_v3` verbatim with `prepFlags: 0` —
+   no `EXPLAIN` wrapper. Unknown-function detection works today on Apple's
+   build despite the option being on.
+
+2. **The trap is a latent one, and it is pointed at a plausible future change.**
+   Wrapping validation in `EXPLAIN` is an obvious-looking optimisation ("we only
+   want the plan, not the statement"). Doing so would silently disable
+   unknown-function detection on every Apple platform — where the option is
+   already enabled and outside SwiftQL's control. This belongs in the
+   validator's own test suite as a negative control, not in a design document.
+
+3. **For a vendored build the rule is still "do not enable it,"** but the
+   binding constraint is the stronger one: *never prepare validation statements
+   under `EXPLAIN`*, on any provenance. The second rule subsumes the first.
+
+### 1.5 Recommended `SQLITE_*` option set
+
+The governing principle: **the vendored option set must not create capabilities
+that do not exist on the system path.** v2.1 requires the shared corpus to pass
+on both adapters ([ROADMAP.md:702-703](../ROADMAP.md)); if a vendored build
+enables something Apple's build omits, the corpus splits and the conformance
+inventory stops meaning one thing.
+
+| Option | Setting | Justification |
+|---|---|---|
+| `SQLITE_THREADSAFE` | `=1` | Matches [swift.yml:508](../.github/workflows/swift.yml). Serialized *default*, but per-connection `SQLITE_OPEN_NOMUTEX` downgrades individual connections — upstream: "The SQLITE_OPEN_NOMUTEX and SQLITE_OPEN_FULLMUTEX flags … can also be used to adjust the threading mode of individual database connections at run-time." `=2` would foreclose ever opting a connection back into FULLMUTEX. See §3.1. |
+| `SQLITE_DQS` | `=0` | **Non-negotiable.** Upstream: "The recommended setting is 0 … the default setting is 3 for maximum compatibility with legacy applications." Apple ships `DQS=3` (§1.2). With DQS on, a misspelled quoted identifier silently degrades into a string literal, which SwiftQL's renderer cannot catch and the #293 validator cannot see. On the *system* path this must be set per-connection via the shim's `sqlite3_db_config(SQLITE_DBCONFIG_DQS_DDL/DML, 0)` — exactly as GRDB does. |
+| `SQLITE_ENABLE_FTS5` | on | Already required: GRDB defines it (`GRDB.swift/Package.swift:8` in the resolved checkout), CI builds it ([swift.yml:510](../.github/workflows/swift.yml)), Apple ships it. |
+| `SQLITE_ENABLE_MATH_FUNCTIONS` | on | Same three-way agreement ([swift.yml:511](../.github/workflows/swift.yml)). |
+| `SQLITE_ENABLE_COLUMN_METADATA` | on | Same ([swift.yml:509](../.github/workflows/swift.yml)). Also supplies `sqlite3_column_table_name`/`_origin_name`, which is the cheapest route to mapping result columns back to source tables for observation region inference (§4.2). |
+| `SQLITE_ENABLE_SNAPSHOT` | on | Already enabled and symbol-asserted in CI ([swift.yml:512, 520](../.github/workflows/swift.yml)) and present in Apple's build. This is the pivot for §4.3 — without it, observation must fall back to writer-serialized re-fetch. |
+| `SQLITE_USE_URI` | `=1` | Required for `file:name?mode=memory&cache=shared`, i.e. for an in-memory *pool* rather than a single in-memory connection. Apple ships it. |
+| `SQLITE_MAX_VARIABLE_NUMBER` | `=32766` (upstream default) | Deliberately the **lower** of the two paths. Apple ships 500000; a stock amalgamation defaults to 32766. Pinning the vendored build to the floor means any query that passes conformance passes everywhere. Pinning it to 500000 would let a query pass on the vendored path and fail on stock Linux. |
+| `SQLITE_OMIT_LOAD_EXTENSION` | on | Apple's build omits extension loading (§1.2). Enabling it on the vendored path would create a capability that cannot exist on iOS, violating the governing principle above, and widens attack surface for no v2.1 requirement. |
+| `SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION` | **off** | §1.4. Paired with a validator rule forbidding `EXPLAIN`-wrapped preparation. |
+| `SQLITE_OMIT_PROGRESS_CALLBACK` | **never** | `sqlite3_progress_handler` is the cooperative-interrupt mechanism for cancellation (§2, row 7). Omitting it is what makes cancellation impossible in `sqlite-nio`. |
+| `SQLITE_OMIT_TRACE` | **never** | `sqlite3_trace_v2` with `SQLITE_TRACE_PROFILE` is the per-statement timing source for the metrics requirement ([ROADMAP.md:704](../ROADMAP.md)). |
+| `SQLITE_ENABLE_STMT_SCANSTATUS` | **off** in release | Upstream: "not recommended for production builds because of the added run-time cost even when the performance statistics are not used." Apple enables it; SwiftQL should not, and should not build metrics that depend on it. |
+| `SQLITE_DEFAULT_MEMSTATUS` | `=0` | Removes allocator bookkeeping SwiftQL does not read. Apple sets it. |
+| `SQLITE_ENABLE_API_ARMOR` | on in debug only | Upstream: "intended as an aid for application testing and debugging… Applications should not depend on SQLITE_ENABLE_API_ARMOR for safety." Useful while §5's lifetime discipline is being established; not a release dependency. |
+
+Deliberately left to per-connection PRAGMA/`db_config` rather than compile
+options, matching GRDB's `Configuration` model: `journal_mode=WAL`,
+`foreign_keys=ON`, `busy_timeout`, `synchronous`. These are per-connection
+policy and belong in the `onOpen` hook (§3.4), not baked into the library.
+
+### 1.6 Provenance recommendation
+
+**Support both; default to system; make the vendored target the CI and
+conformance authority.**
+
+| Criterion | System `libsqlite3` | Vendored amalgamation |
+|---|---|---|
+| Version determinism | ✗ — ≥3 versions across macOS/iOS/Linux, plus per-OS-release drift | ✓ — one SHA3-256-pinned source |
+| Source ID provenance | ✗ — Apple's `…apl` ID is not an upstream ID | ✓ |
+| Compile options controllable | ✗ — must be worked around per-connection | ✓ |
+| Binary size | ✓ — ~0 (shared cache) | ✗ — ~0.75–1 MB |
+| App Store | ✓ | ✓ (no rule either way) |
+| CI reproducibility | ✗ — already failed on Ubuntu 22.04 | ✓ — already in use |
+| Coexists with GRDB adapter in one binary | ✓ | ⚠ — requires symbol prefixing (§1.3) |
+| Existing in-repo proof | ✓ (via GRDB's `CSQLite`) | ✓ (CI shell, not SwiftPM) |
+
+The split is deliberate. Clients who want the smallest binary and Apple's
+patched, security-updated SQLite pick system. Clients who want the exact SQLite
+the conformance inventory was measured against pick vendored. Conformance
+evidence is only ever generated on the vendored target, so a claim in
+[Conformance/SQLite/REPORT.md](../Conformance/SQLite/REPORT.md) always names one
+library. The `SQLiteBuildValidationRuntime` capability capture
+([SQLiteBuildValidationRuntime.swift:201-268](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationRuntime.swift))
+already records `compile_options`, `sqlite_version`, and `sqlite_source_id` per
+run, so the machinery to *detect* a provenance mismatch at build-validation time
+exists and needs no new design.
+
+---
+
+## 2. Requirement-by-requirement
+
+Against [ROADMAP.md:696-705](../ROADMAP.md). "Effort" is relative to the whole
+adapter, not absolute.
+
+| v2.1 requirement | Feasible | C primitives | Effort | Notes |
+|---|---|---|---|---|
+| Adapter-contract parity | ✓ | — | M | The contract is *already* the right shape. `XLDatabaseDriverConnection` is synchronous and `mutating` ([SQLDatabaseDriver.swift:66-95](../Sources/SwiftQLCore/SQLDatabaseDriver.swift)); `PhysicalStatement` is documented as connection-owned and not required to be `Sendable` ([:64-65](../Sources/SwiftQLCore/SQLDatabaseDriver.swift)). This is the exact shape a `sqlite3_stmt*` wants. Contrast §3 of the sqlite-nio report, where the mismatch was the decisive blocker. One real design question in §5.4. |
+| Per-connection preparation and caching | ✓ | `sqlite3_prepare_v3` + `SQLITE_PREPARE_PERSISTENT`, `sqlite3_reset`, `sqlite3_clear_bindings`, `sqlite3_finalize` | S | Replaces `database.cachedStatement(sql:)` ([GRDBDatabaseDriver.swift:571](../Sources/SwiftQL/GRDBDatabaseDriver.swift)). A per-connection `[String: OpaquePointer]` keyed on rendered SQL, finalized at connection close. `SQLITE_PREPARE_PERSISTENT` (header, `sqlite3.h:4389-4392`) is the documented hint for exactly this. Ownership is enforced by the existing `connectionIdentifier` check ([:683-690](../Sources/SwiftQL/GRDBDatabaseDriver.swift)), portable verbatim. |
+| Named + positional binding | ✓ | `sqlite3_bind_parameter_index`, `sqlite3_bind_parameter_count`, `sqlite3_bind_parameter_name` | S | `XLBindingKey` has `.named(String)` and `.indexed(Int)` ([SQLDialect.swift:173-176](../Sources/SwiftQLCore/SQLDialect.swift)). Direct C is *better* here than GRDB: `GRDBDatabaseDriverConnection.statementArguments` currently reconstructs the whole physical parameter table positionally to dodge two GRDB normalization hazards it documents at [GRDBDatabaseDriver.swift:718-726](../Sources/SwiftQL/GRDBDatabaseDriver.swift) — a named placeholder shifting `?NNN`, and `:3`/`?3` collapsing after prefix-stripping. Neither hazard exists when calling `sqlite3_bind_parameter_index` directly. **This code gets simpler, not harder.** |
+| Decoding | ✓ | `sqlite3_column_type/_int64/_double/_text/_blob/_bytes` | S | `XLSQLiteValue` has exactly SQLite's five storage classes ([SQLiteDialect.swift:24](../Sources/SwiftQLCore/SQLiteDialect.swift)). The `DatabaseValue → XLSQLiteValue` bridge at [GRDBDatabaseDriver.swift:783-799](../Sources/SwiftQL/GRDBDatabaseDriver.swift) becomes a direct switch on `sqlite3_column_type`, removing one representation hop. Codec policy stays in `SwiftQLCore` — adapters do not own it (release gate, [ROADMAP.md](../ROADMAP.md)). |
+| Transactions | ✓ | `BEGIN`/`COMMIT`/`ROLLBACK`, `sqlite3_get_autocommit` | M | `withTransaction` already has fully-specified semantics: pinned connection, reentrancy rejection, `CancellationError` on an already-cancelled task, rollback preserving the original error ([GRDBSQLDatabase.swift:1276-1312](../Sources/SwiftQL/GRDBSQLDatabase.swift)). `GRDBPinnedConnectionBox` ([GRDBDatabaseDriver.swift:217-251](../Sources/SwiftQL/GRDBDatabaseDriver.swift)) and `GRDBTransactionScopeTracker` ([:862-900](../Sources/SwiftQL/GRDBDatabaseDriver.swift)) are adapter-agnostic and port with a type substitution. **Simplification available:** GRDB's non-reentrant writer traps with an uncatchable `fatalError` ([:840-846](../Sources/SwiftQL/GRDBDatabaseDriver.swift)), which is why the tracker must pre-reject. A first-party pool can make reentrancy a plain `throw`. |
+| Savepoints | ✓ | `SAVEPOINT`/`RELEASE`/`ROLLBACK TO` | S | Not supported today — [COMPATIBILITY.md:44-47](../COMPATIBILITY.md) is explicit that a "nested transaction/savepoint API" is not claimed. So this is **net-new surface, not parity**, and needs a public API decision independent of the adapter. |
+| Errors | ✓ | `sqlite3_errmsg`, `sqlite3_extended_errcode`, `SQLITE_OPEN_EXRESCODE` | S | `XLDatabaseContractError` ([SQLDatabaseDriver.swift:5-59](../Sources/SwiftQLCore/SQLDatabaseDriver.swift)) is the target shape; the probe already demonstrates correct error extraction, including copying SQLite-owned strings *before* the next SQLite call can replace them ([SQLitePrepareV3Probe.swift:169-172](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift)). `SQLITE_OPEN_EXRESCODE` is `0x02000000` (header, `sqlite3.h:623`). **Constraint:** `GRDBLiveQueryRetryPolicy.retryBusy` matches on `resultCode == .SQLITE_BUSY` ([GRDBLiveQueryRetryPolicy.swift:38](../Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift)), so the native error type must expose a *primary* result code distinctly from the extended one. |
+| Cancellation | ✓ | `sqlite3_interrupt`, `sqlite3_progress_handler` | S | Two levels. Row-level early stop is already contractual — `XLRowStreamControl.stop` ([SQLDatabaseDriver.swift:102-105](../Sources/SwiftQLCore/SQLDatabaseDriver.swift)) — and maps to simply not calling `sqlite3_step` again, which is *strictly better* than GRDB's cursor and vastly better than `sqlite-nio`'s `Void`-returning `onRow`. Statement-level interrupt of a long-running step needs `sqlite3_progress_handler` polling `Task.isCancelled`, or `sqlite3_interrupt` from another thread (header, `sqlite3.h:2911`; note the documented caveat that it must not race connection close). |
+| Custom functions | ✓ | `sqlite3_create_function_v2` | S | `XLCustomFunctionRegistration` currently carries a `@Sendable () -> DatabaseFunction` thunk ([SQLCustomFunction.swift:64](../Sources/SwiftQL/SQLCustomFunction.swift)) — a GRDB type in what should be an adapter-neutral value. **This needs refactoring before the adapter, not during it:** the registration should vend an adapter-neutral closure, with each adapter supplying its own bridge. The existing implicit-registration semantics (re-register on whatever pooled connection serves the statement, relying on `sqlite3_create_function` replacing same-name/same-arity registrations — [GRDBDatabaseDriver.swift:668-681](../Sources/SwiftQL/GRDBDatabaseDriver.swift)) transfer unchanged. |
+| Collations | ✓ | `sqlite3_create_collation_v2` | XS | `GRDBDatabaseBuilder.addCollation` ([GRDBSQLDatabase.swift:760-767](../Sources/SwiftQL/GRDBSQLDatabase.swift)) is a one-line wrapper over a `prepareDatabase` hook. Direct equivalent. Note SQLite matches collation names ASCII-case-insensitively, which `sqliteASCIIFolded` ([SQLiteBuildValidationRuntime.swift:414](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationRuntime.swift)) already implements. |
+| Observation | ⚠ | `sqlite3_update_hook`, `sqlite3_commit_hook`, `sqlite3_rollback_hook`, `sqlite3_set_authorizer`, `sqlite3_snapshot_*` | **XL** | §4. This is the whole risk. |
+| Schema/version invalidation, safe reprepare | ✓ | `sqlite3_prepare_v3` auto-reprepare, `PRAGMA schema_version`, authorizer schema-change detection | S | Largely free: statements prepared with `_v2`/`_v3` reprepare themselves on schema change and no longer surface `SQLITE_SCHEMA` to the caller. What is *not* free is invalidating SwiftQL's own caches; GRDB tracks this explicitly via `StatementAuthorizer.invalidatesDatabaseSchemaCache` (`GRDB/Core/StatementAuthorizer.swift:22-26`). Since §4.2 installs an authorizer anyway, this comes along for free with it. |
+| Codec / dialect-value parity | ✓ | — | S | Enforced by construction: both adapters produce `XLSQLiteValue`, and codec policy lives in `SwiftQLCore`. |
+| Shared corpus on both adapters | ✓ | — | M | The corpus exists: [`GRDBDriverContractTests`](../Tests/SQLTests/GRDBDriverContractTests.swift) (1,004 lines), the 141-case combinatorial manifest, 18 Northwind scenarios, 12 observation-stress cases ([COMPATIBILITY.md:83-94](../COMPATIBILITY.md)). Cost is generalising the harness over an adapter, not writing tests. Issue #260 owns this. |
+| Warm-up and metrics | ✓ | `sqlite3_prepare_v3` at open, `sqlite3_trace_v2`, `sqlite3_stmt_status` | S | **Net-new, not parity** — `grep -rn "warm\|metric" Sources/` returns nothing. Warm-up = prepare the #292 manifest's statements at connection open, which is the same operation the #293 validator already performs. |
+| No GRDB dependency | ✓ | — | S | Requires the `CSwiftQLSQLite` target (§1.1) and the `XLCustomFunctionRegistration` refactor above. |
+
+**Score: 15 of 16 rows are S or M.** One row is XL.
+
+---
+
+## 3. Connection pooling and concurrency
+
+GRDB supplies `DatabasePool` (893 lines), `SerializedDatabase` (288),
+`SchedulingWatchdog` (68), and `Configuration` (488). Not all of that is needed,
+but it sets the scale: a competent first-party pool is a four-figure line count,
+not a three-figure one.
+
+### 3.1 Threading mode
+
+`SQLITE_OPEN_NOMUTEX` plus SwiftQL's own serialization, matching GRDB, not
+`SQLITE_OPEN_FULLMUTEX`. Upstream is explicit that per-connection flags adjust
+the threading mode at run time when `SQLITE_THREADSAFE != 0`, which is why §1.5
+recommends `SQLITE_THREADSAFE=1` rather than `=2` — it keeps FULLMUTEX
+reachable per connection if a client ever needs it.
+
+`NOMUTEX` means "no two threads may use this connection concurrently," which is
+precisely the invariant `XLDatabaseDriverConnection`'s non-`Sendable`
+`PhysicalStatement` already encodes in the type system (§5.4). The threading
+mode and the contract agree; that is the good news, and it is not an accident —
+it is why this contract is a better fit for direct C than for `sqlite-nio`.
+
+For comparison: `sqlite-nio` forces `SQLITE_OPEN_FULLMUTEX`
+([SQLiteNIOFeasibility.md §5](SQLiteNIOFeasibility.md)), paying the serialized
+mutex on every call.
+
+### 3.2 Reader/writer routing and WAL
+
+The contract already distinguishes them —
+`withReadConnection` / `withWriteConnection` / `withTransaction`
+([SQLDatabaseDriver.swift:281-291](../Sources/SwiftQLCore/SQLDatabaseDriver.swift)) —
+and the GRDB driver maps them onto `pool.read`, `pool.writeWithoutTransaction`,
+and `pool.write` ([GRDBDatabaseDriver.swift:110-164](../Sources/SwiftQL/GRDBDatabaseDriver.swift)).
+The native shape is standard:
+
+- **one** writer connection behind a serial queue;
+- **N** reader connections (GRDB defaults to 5) behind a semaphore-guarded pool;
+- `PRAGMA journal_mode=WAL` once at database open (it is persistent in the file
+  header, but re-asserting per connection is harmless and self-documenting);
+- readers open `SQLITE_OPEN_READONLY`, which makes "a write leaked onto a
+  reader" an `SQLITE_READONLY` error rather than silent corruption.
+
+WAL is what makes multi-reader concurrency real; without it every read
+serializes behind the writer and the pool is decorative.
+
+### 3.3 Busy handling
+
+**Do not install an unbounded busy handler.** This is the mistake `sqlite-nio`
+makes (`{ _, _ in 1 }` — retry forever, no backoff, no override). SwiftQL cannot
+afford it, because `SQLITE_BUSY` is a *signal SwiftQL consumes*:
+`GRDBLiveQueryRetryPolicy.retryBusy` retries only errors whose primary result
+code is `SQLITE_BUSY`, at 0.1/0.2/0.4 s
+([GRDBLiveQueryRetryPolicy.swift:23-43](../Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift)).
+Swallowing BUSY inside the C layer would make that policy dead code and turn
+contention into an unbounded hang.
+
+Recommended: a bounded `sqlite3_busy_timeout` (GRDB's default is ~5 s) that
+surfaces `SQLITE_BUSY` on expiry, leaving the existing retry policy — and its
+existing tests, [`GRDBLiveQueryRetryTests`](../Tests/SQLTests/GRDBLiveQueryRetryTests.swift) —
+in charge of recovery.
+
+### 3.4 The `prepareDatabase` hook
+
+`Configuration.prepareDatabase` is load-bearing in two places today: function
+registration ([GRDBSQLDatabase.swift:736-749](../Sources/SwiftQL/GRDBSQLDatabase.swift)),
+collation registration ([:760-767](../Sources/SwiftQL/GRDBSQLDatabase.swift)),
+and the validator's `PRAGMA query_only = ON`
+([SQLiteBuildValidator.swift:55-57](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift)).
+
+A native pool needs the equivalent — `onOpen: (Connection) throws -> Void`, run
+on every connection the pool creates, before that connection serves anything.
+This is where `journal_mode`, `foreign_keys`, `busy_timeout`, `synchronous`,
+DQS disabling (§1.5), functions, and collations all land. It is small, and it
+is a hard prerequisite for functions and collations, so it must land in the
+same slice as the pool.
+
+### 3.5 Reentrancy trapping — already solved, adapter-agnostically
+
+`GRDBTransactionScopeTracker` ([GRDBDatabaseDriver.swift:862-900](../Sources/SwiftQL/GRDBDatabaseDriver.swift))
+detects root-executor re-entry using a per-`Thread` dictionary keyed on
+`XLDatabaseIdentifier`. It touches no GRDB type. It ports as a rename. The
+subtle correctness requirement it documents at [:1294-1300](../Sources/SwiftQL/GRDBSQLDatabase.swift) —
+that `withActive` must be entered *inside* the writer closure, on the thread
+that will run the body — applies identically to a first-party pool, and the
+comment is worth carrying across verbatim.
+
+Note the hazard it guards against is not merely a deadlock: at
+[:170-179](../Sources/SwiftQL/GRDBDatabaseDriver.swift) the code explains that a
+stray read from inside a transaction would *silently lease a different
+connection and return last-committed state*, missing the transaction's own
+writes. That failure mode is a property of any WAL multi-reader pool, so it
+survives the port unchanged and must be tested on the native adapter, not
+assumed.
+
+---
+
+## 4. Observation / live queries
+
+This is the largest single chunk, larger than everything in §2 and §3 combined.
+
+### 4.1 What has to be replaced
+
+Today one call site does all of it:
+
+```swift
+// GRDBSQLDatabase.swift:461-464
+ValueObservation
+    .tracking(fetch)
+    .publisher(in: databasePool)
+    .eraseToAnyPublisher()
+```
+
+Behind those four lines (measured, `wc -l` on the resolved checkout):
+
+| GRDB component | Lines | Role |
+|---|---|---|
+| `ValueObservation/` (whole directory) | 3,124 | Observation API, reducers, schedulers, `ValueConcurrentObserver` (905), `ValueWriteOnlyObserver` (488) |
+| `Core/TransactionObserver.swift` | 1,632 | Observer registry, event dispatch, transaction lifecycle |
+| `Core/DatabasePool.swift` | 893 | Pool + observation integration |
+| `Core/DatabaseRegion.swift` | 471 | (table × columns × rowIds) regions and intersection |
+| `Core/SerializedDatabase.swift` | 288 | Writer serialization |
+| `Core/StatementAuthorizer.swift` | 244 | Region inference at prepare time |
+| `Core/DatabaseSnapshotPool.swift` | 382 | Snapshot-isolated reads |
+| `Core/WALSnapshot{,Transaction}.swift` | 188 | WAL snapshot capture/restore |
+| **Total** | **~7,200** | |
+
+A first-party replacement does not need all of that — SwiftQL has one reducer
+shape, not GRDB's full operator set — but the honest estimate for a
+region-tracking, snapshot-consistent, busy-retrying observer is **1,500–2,500
+lines of new, concurrency-sensitive code**, and it is the code most likely to
+produce flaky tests.
+
+### 4.2 Region inference via `sqlite3_set_authorizer`
+
+This is the mechanism GRDB uses and there is no alternative. The authorizer is
+installed on the connection, reset before each preparation, and accumulates
+what the statement reads:
+
+```swift
+// StatementAuthorizer.swift:18-26
+/// What a statement reads.
+var selectedRegion = DatabaseRegion()
+/// What a statement writes.
+var databaseEventKinds: [DatabaseEventKind] = []
+/// True if a statement alters the schema in a way that requires
+/// invalidation of the schema cache.
+var invalidatesDatabaseSchemaCache = false
+```
+
+registered via `sqlite3_set_authorizer` with an `Unmanaged` self pointer
+(`GRDB/Core/StatementAuthorizer.swift:39-51`).
+
+Two constraints follow, and both are easy to miss:
+
+**Single-slot.** Upstream (header, `sqlite3.h:3412`): "Each call to
+sqlite3_set_authorizer overrides the [previous one]." Same for
+`sqlite3_update_hook`, `sqlite3_commit_hook`, `sqlite3_rollback_hook`. If
+SwiftQL owns the connection it owns all four slots, which is exactly why this
+cannot be built on top of GRDB today — GRDB holds them. It is also why the
+multiplexing pattern in §4.5 matters: SwiftQL will have many concurrent live
+queries and only one hook slot each.
+
+**The truncate optimization.** GRDB's authorizer exists partly to *suppress a
+SQLite optimization*:
+
+> `StatementAuthorizer` provides information about compiled database
+> statements, and prevents the truncate optimization when row deletions are
+> observed by transaction observers.
+> — `GRDB/Core/StatementAuthorizer.swift:9-14`
+
+Confirmed upstream (header, near `sqlite3_update_hook`): the update hook "is
+not invoked when rows are deleted using the truncate optimization." So a bare
+`DELETE FROM t` with no `WHERE` fires **no** update-hook callbacks and a naive
+observer misses the entire deletion. This is a real, silent correctness bug that
+a first implementation will almost certainly ship, and it belongs in the
+observation slice's test plan on day one.
+
+### 4.3 Change detection and re-fetch
+
+`sqlite3_update_hook` yields `(op, dbName, tableName, rowid)` — enough to
+intersect against a `(table × columns × rowIds)` region, which is exactly the
+granularity `DatabaseRegion.isModified(by:)`
+(`GRDB/Core/DatabaseRegion.swift:218`)
+operates at. `sqlite3_commit_hook` and `sqlite3_rollback_hook` provide the
+transaction boundary: buffer events, decide at commit, discard at rollback.
+
+**Documented fidelity limits of the hook itself** (header, `sqlite3_update_hook`
+doc comment) — these are SQLite's, not GRDB's, so *GRDB has them too* and they
+are not regressions:
+
+- not invoked for `WITHOUT ROWID` tables;
+- not invoked for internal system tables;
+- not invoked when conflicting rows are deleted by `ON CONFLICT REPLACE`;
+- not invoked under the truncate optimization (§4.2).
+
+**Snapshot-consistent re-fetch** is the genuinely hard part.
+`ValueConcurrentObserver` (905 lines) exists to fetch *concurrently* on a reader
+while remaining consistent with the transaction that triggered it, which
+requires `sqlite3_snapshot_get`/`_open` — hence §1.5's
+`SQLITE_ENABLE_SNAPSHOT`, which CI already enables
+([swift.yml:512, 520](../.github/workflows/swift.yml)) and Apple already ships.
+Where snapshots are unavailable, GRDB degrades to `ValueWriteOnlyObserver` (488
+lines), which re-fetches on the writer connection — correct, but it serializes
+every live query behind the writer.
+
+**A first-party v2.1 observer should ship the writer-serialized model first and
+treat the concurrent/snapshot model as a later optimization.** It is roughly a
+third of the code, it is far easier to test deterministically, and it is
+strictly correct — it trades throughput, not consistency. The 12
+observation-stress cases from #255 ([COMPATIBILITY.md:92-94](../COMPATIBILITY.md))
+are the acceptance gate for whether that trade is acceptable.
+
+### 4.4 Realistic fidelity loss
+
+| Property | Achievable in v2.1? |
+|---|---|
+| Table-level invalidation | ✓ trivially |
+| Column-level region narrowing | ✓ — authorizer `SQLITE_READ` gives (table, column) |
+| RowID-level narrowing | ✓ — update hook gives the rowid |
+| Correct behaviour on `WITHOUT ROWID` / truncate / REPLACE-conflict | ⚠ — requires the authorizer counter-measures of §4.2; GRDB has the same substrate limits |
+| Snapshot-consistent concurrent re-fetch | ✗ initially — writer-serialized instead (§4.3) |
+| Busy retry on observation | ✓ — `GRDBLiveQueryRetryPolicy` is adapter-agnostic once the error type exposes a primary result code (§2) |
+| Positive-demand startup, independent subscriber state, cancellation | ✓ — [`GRDBOpenCombineValuePublisher`](../Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift) (154 lines) is the model, and its only GRDB coupling is `AnyDatabaseCancellable`; a first-party cancellable makes it fully portable |
+| Initial-value delivery without a redundant second fetch | ⚠ — this is precisely what `SQLITE_ENABLE_SNAPSHOT` buys ([swift.yml:530-533](../.github/workflows/swift.yml)) |
+
+### 4.5 On borrowing `sqlite-nio`'s `SQLiteConnection+Hooks.swift`
+
+[SQLiteNIOFeasibility.md §6](SQLiteNIOFeasibility.md) flags this 871-line file
+(MIT) as the strongest thing in that package and recommends taking the pattern.
+Concurring, with one correction of emphasis: the sqlite-nio report frames the
+value as solving "GRDB owns that slot." That framing dissolves once SwiftQL owns
+the connection — SwiftQL will own all four hook slots outright.
+
+The value is the *other* problem the file solves: fanning one physical hook out
+to many logical observers, with scoped/pinned token lifetimes, validator-vs-
+observer separation, and teardown on close. SwiftQL will have N concurrent live
+queries per pool and exactly one `sqlite3_update_hook` slot per connection, so a
+registry with correct lifetime semantics is required regardless. That design is
+worth studying and adapting under MIT — with the attribution the release gates
+require ("adopted third-party behavior has pinned source and license
+provenance", [ROADMAP.md](../ROADMAP.md)) — and not worth reinventing.
+
+---
+
+## 5. Memory safety and lifetime discipline
+
+### 5.1 Is the existing direct-C code a genuine seed? Partly.
+
+[SQLiteNIOFeasibility.md §7.1](SQLiteNIOFeasibility.md) claims "the prove-out
+already exists in-repo." Assessed honestly:
+
+**Genuinely reusable — the discipline, and it is excellent:**
+
+- Finalize-on-every-path, with an explicit rationale for checking the finalize
+  result *before* the inspection result so a lifecycle failure is never masked
+  ([SQLitePrepareV3Probe.swift:218-245](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift)).
+- Finalizing on the *error* path too, including when `prepare_v3` fails but
+  still wrote a statement pointer ([:173-175, 186-188](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift)).
+- Copying every SQLite-owned string before the next SQLite call can invalidate
+  it ([:169-172, 318-322](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift)).
+- Exact byte counts rather than NUL-terminated lengths, with an explicit
+  embedded-NUL rejection and an `Int32.max` guard ([:124-148](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift)).
+- Tail-pointer validation that rejects a non-advancing or out-of-range tail
+  ([:183-193](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift)).
+- The "no handle escapes" contract, stated as a contract, at [:110-118](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift).
+
+**Not reusable — the shape, and the gap is larger than it looks:**
+
+- It is a **single-purpose probe.** It only prepares and inspects. There is no
+  `sqlite3_bind_*`, no `sqlite3_step`, no `sqlite3_reset`, no
+  `sqlite3_column_*` anywhere in the target. Roughly the first 15% of a driver.
+- Its lifetime model is the **opposite** of the adapter's. The probe's entire
+  safety argument is *finalize immediately, always*. A caching adapter must
+  **not** finalize — it must `sqlite3_reset` + `sqlite3_clear_bindings` and
+  finalize only at connection close. Every invariant that makes the probe
+  obviously correct has to be re-argued for a statement that outlives its use.
+- It does not own its connection. It borrows GRDB's
+  (`database.sqliteConnection`, [:127](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift))
+  and depends on GRDB for the connection, the configuration, and the module map
+  (§1.1). It has never opened a `sqlite3*`.
+- Its concurrency model is a serialized read-only `DatabaseQueue`
+  ([SQLiteBuildValidator.swift:52-63](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift)),
+  not a multi-connection WAL pool.
+
+**Verdict: a genuine seed for the *coding standard*, not for the *code*.** Its
+real value is that it proves the team can write this class of code to a high
+standard and that the review culture demands it — which is a better predictor of
+success than a partial implementation would be. But the sqlite-nio report's
+phrasing overstates the head start; the honest figure is that S0+S1 (§6) start
+close to zero lines of transferable implementation.
+
+### 5.2 `SQLITE_TRANSIENT` vs `SQLITE_STATIC`
+
+Both are macros containing casts (header, `sqlite3.h:6354-6355`):
+
+```c
+#define SQLITE_STATIC      ((sqlite3_destructor_type)0)
+#define SQLITE_TRANSIENT   ((sqlite3_destructor_type)-1)
+```
+
+Swift's C importer does not import either. They must be re-declared:
+
+```swift
+let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+```
+
+This is a well-known step, and getting it wrong is not a compile error — it is a
+use-after-free.
+
+**Recommendation: `SQLITE_TRANSIENT` everywhere, unconditionally, in v1 of the
+adapter.** The reasoning is specific rather than generic caution:
+
+- Swift `String` has no stably-addressable UTF-8 storage. The pointer from
+  `withUTF8`/`withCString` is valid only inside the closure. `SQLITE_STATIC`
+  there is a use-after-free the moment the closure returns — and the bug is
+  timing-dependent, so it survives testing.
+- `Data`'s `withUnsafeBytes` has the same property.
+- `SQLITE_STATIC` is only sound if the adapter owns a byte buffer that provably
+  outlives every `sqlite3_step` on that statement — i.e. until `sqlite3_reset`
+  or the next `sqlite3_bind_*` on that parameter. With a *cached* statement
+  (§2), "until reset" is a much longer and much less obvious window than with
+  the probe's prepare-and-finalize model.
+- The upside is one `memcpy` per bound string/blob. That is not worth the class
+  of bug. Revisit only with a profile showing it matters, and only behind an
+  explicitly-owned buffer type.
+
+Integers and doubles are passed by value; the question does not arise.
+
+### 5.3 Cursor confinement — already contractual
+
+The streaming seam is exactly right for `sqlite3_step`:
+
+```swift
+// SQLDatabaseDriver.swift:99-105
+/// Package-scoped control returned by one streamed-row callback.
+///
+/// The callback is synchronous so a driver cursor and its owning connection
+/// cannot escape through this value.
+package enum XLRowStreamControl: Sendable { case advance; case stop }
+```
+
+and the implementation requirement is spelled out at
+[:108-114](../Sources/SwiftQLCore/SQLDatabaseDriver.swift): keep the physical
+cursor inside the current connection access, copy or normalize every value
+before advancing, stop immediately when requested, release cursor resources on
+return **or throw**.
+
+Mapped onto C, that is: `sqlite3_step` in a loop; per row, read every column
+into `XLSQLiteValue` (which copies — `.text(String)` and `.blob(Data)` are
+owning); call `body`; on `.stop`, `defer`ed `sqlite3_reset` and return. The
+reusable-normalization-buffer trick at
+[GRDBDatabaseDriver.swift:636-658](../Sources/SwiftQL/GRDBDatabaseDriver.swift),
+including its copy-on-write reasoning, transfers unchanged.
+
+Critically, `sqlite3_reset` must run on the throwing path too, or a cached
+statement is left mid-cursor and the *next* use of it fails confusingly. A
+`defer` inside `forEachRow` is the whole fix, and it is the single most
+important line in the adapter.
+
+### 5.4 What the non-`Sendable` `PhysicalStatement` helps with — and constrains
+
+**Helps, decisively.** `PhysicalStatement` is an associated type with no
+`Sendable` requirement and a documented connection-ownership rule
+([SQLDatabaseDriver.swift:64-70](../Sources/SwiftQLCore/SQLDatabaseDriver.swift)).
+That is what makes it legal to put an `OpaquePointer` to a `sqlite3_stmt` in it
+at all. Under Swift 6 strict concurrency a `Sendable` requirement here would
+force either an actor hop per statement or an `@unchecked Sendable` escape
+hatch. The contract as written needs neither. Combined with `NOMUTEX` (§3.1),
+type-level confinement and SQLite's threading requirement are the same
+invariant — which is the strongest single argument that this contract was
+designed for this adapter even though it was written for GRDB.
+
+**Constrains, in one specific and important way.** `bind` returns a
+`PhysicalStatement`:
+
+```swift
+// SQLDatabaseDriver.swift:84-88
+mutating func bind(
+    _ value: Dialect.Value,
+    to key: XLBindingKey,
+    in statement: PhysicalStatement
+) throws -> PhysicalStatement
+```
+
+This is value semantics. GRDB satisfies it by accumulating into a dictionary and
+returning a modified copy ([GRDBDatabaseDriver.swift:600-602, 779](../Sources/SwiftQL/GRDBDatabaseDriver.swift)).
+A native adapter's *natural* implementation would call `sqlite3_bind_*`
+immediately — but then the returned "copy" aliases the same `sqlite3_stmt*`, and
+value semantics become a lie. Two callers holding what look like independent
+statements would stomp each other's bindings, silently.
+
+Two options:
+
+- **(a) Deferred bindings** — keep `[XLBindingKey: XLSQLiteValue]` in the
+  struct, apply all binds immediately before `step`. Preserves honest value
+  semantics, mirrors GRDB exactly, keeps the contract unchanged, and costs one
+  dictionary per execution.
+- **(b) Reference-backed handle** — a final class with an ownership token,
+  `bind` returning `self`. Faster, but `PhysicalStatement` stops behaving like a
+  value and every existing test that assumes copy independence has to be
+  re-audited.
+
+**Recommend (a).** It is the only option that satisfies the published contract
+without changing it, and if profiling later justifies (b), that is a contained
+optimization behind the same seam. This decision should be made explicitly in
+slice S1, not discovered in S2.
+
+The `connectionIdentifier` ownership check
+([GRDBDatabaseDriver.swift:683-690](../Sources/SwiftQL/GRDBDatabaseDriver.swift))
+becomes *more* important with raw pointers than it is with GRDB's `Statement`
+class, and should be kept and tested first, not last.
+
+---
+
+## 6. Effort, risk, and staging
+
+### 6.1 Slices
+
+| # | Slice | Size | Depends on | Proves |
+|---|---|---|---|---|
+| S0 | `CSwiftQLSQLite` target: system-library module map + `shim.h` (variadic `db_config`/`config` wrappers, §1.1). If vendoring: amalgamation target + **symbol-prefix proof** (§1.3). | XS–S | — | GRDB-free access to `sqlite3_*` on macOS and Linux; that both adapters can coexist in one binary |
+| S1 | Connection: `open_v2` (NOMUTEX/EXRESCODE), prepare/bind/step/reset/finalize, `XLSQLiteValue` round-trip, `XLDatabaseDriverConnection` + `XLStreamingDatabaseDriverConnection` conformance. Single connection, no pool, no cache. Settle §5.4(a) here. | M | S0 | **The go/no-go signal.** Contract parity without touching the contract |
+| S2 | Statement cache (`SQLITE_PREPARE_PERSISTENT`, reset+clear_bindings, finalize at close) + schema-change invalidation | S | S1 | Caching requirement; no leaks under churn |
+| S3 | Pool: serial writer + N readonly readers, WAL, bounded `busy_timeout` surfacing `SQLITE_BUSY`, `onOpen` hook, reentrancy tracker port | L | S1 | Concurrency requirement; §3.5's stale-read hazard is actually caught |
+| S4 | Transactions + savepoints; error taxonomy mapped to `XLDatabaseContractError` with primary/extended codes | M | S3 | `XLTransactionScopeError` semantics preserved verbatim |
+| S5 | Custom functions + collations. Includes the `XLCustomFunctionRegistration` de-GRDB-ing (§2) | S | S3 | Existing `SQLCustomFunction`/`SQLCustomCollation` tests pass unchanged |
+| S6 | Cancellation: row-level stop (free from S1) + `progress_handler`/`interrupt` | S | S1 | Long statements are interruptible |
+| S7 | **Observation**: authorizer region inference, hook multiplexing, commit/rollback buffering, truncate-optimization counter-measure, writer-serialized re-fetch, retry-policy integration | **XL** | S3, S4 | The 12 #255 observation-stress cases |
+| S8 | Warm-up (prepare #292 manifest at open) + metrics (`trace_v2` PROFILE) | S | S2 | Net-new v2.1 surface |
+| S9 | Shared-corpus parity harness (#260): generalise `GRDBDriverContractTests`, combinatorial manifest, Northwind, observation stress over both adapters | M | S7 | [ROADMAP.md:702-703](../ROADMAP.md) |
+
+S7 alone is plausibly 40% of the total. S0–S6 are the comfortable part.
+
+### 6.2 What can be proven early, and cheaply
+
+- **Day 1 (S0):** a `CSwiftQLSQLite` target compiles and links on macOS and
+  Linux with no GRDB dependency, and `sqlite3_libversion()` returns the expected
+  string on both. If vendoring: `nm` proves the prefixed symbols do not collide
+  with system `libsqlite3` in a binary that also links GRDB.
+- **Week 1 (S1):** retarget
+  [`GRDBDriverContractTests`](../Tests/SQLTests/GRDBDriverContractTests.swift)
+  (1,004 lines) at the native connection. **This is the single best early
+  signal in the whole plan** — it is an existing, comprehensive, adapter-shaped
+  test suite, and it exercises exactly the seam most likely to reveal a
+  contract mismatch. If S1 passes it without modifying
+  `Sources/SwiftQLCore/SQLDatabaseDriver.swift`, the central architectural bet
+  is proven.
+- **Week 2 (S1):** `XLSQLiteValue` round-trips through bind→step→column for all
+  five storage classes, including empty text, empty blob, and NUL-containing
+  blobs — plus a deliberate `SQLITE_STATIC` misuse test to confirm §5.2's
+  reasoning under ASan.
+- **Week 3 (S2/S3):** run the 141-case combinatorial manifest against the
+  native connection. Rendering is shared, so any divergence is a driver bug and
+  nothing else.
+
+### 6.3 Failure modes that would justify abandoning
+
+| Failure mode | Signal | Response |
+|---|---|---|
+| Contract parity needs contract changes — especially `bind`'s value semantics (§5.4) | S1 cannot pass `GRDBDriverContractTests` without editing `SQLDatabaseDriver.swift` | **Stop.** The sync contract itself is the problem, and that is a v3 decision (matching [SQLiteNIOFeasibility.md §7.4](SQLiteNIOFeasibility.md)), not something to settle inside an adapter |
+| Symbol collision unresolvable under vendoring | S0 `nm` proof fails, or GRDB observably runs on the vendored library | Fall back to system-only provenance; determinism is then a CI property, not a shipping one |
+| Observation cannot reach #255 fidelity | S7 stress cases flake or fail | **Ship the native adapter without live queries.** Clients needing observation keep the GRDB adapter. This is a legitimate reduced-scope v2.1, and it should be pre-agreed as acceptable rather than discovered under deadline |
+| Pool concurrency bugs that only appear under load | Intermittent S3/S7 failures; note the machine is already known-noisy for concurrent suites | Timebox. If a WAL/pool race resists diagnosis for more than a slice, adopt writer-serialized reads (correct, slower) and revisit |
+| Effort overruns S7 | S7 exceeds its estimate by >2× | Split: ship S0–S6 + S8 + S9 as "native adapter, non-observing" in v2.1; observation moves to v2.1.1 |
+
+Note that three of five responses are *reduced scope*, not abandonment. That is
+the real argument for this approach: it degrades gracefully. The sqlite-nio path
+did not — its blockers were structural and all-or-nothing.
+
+---
+
+## 7. Recommendation
+
+**GO, with four conditions.**
+
+The requirement list is reachable, the contract is already the right shape, and
+15 of 16 requirement rows are small or medium. Direct C is also, in three
+specific places, *simpler* than what exists today: named binding loses two
+documented GRDB normalization hazards (§2), early row-stop becomes trivial
+(§2), and reentrancy can throw instead of pre-empting an uncatchable
+`fatalError` (§2). The one large risk — observation — is isolated in a single
+slice that can be deferred without invalidating the rest.
+
+The conditions:
+
+1. **Decide provenance before writing the adapter.** §1.6 recommends supporting
+   both with system as the default and the vendored target as the conformance
+   authority. If vendoring is chosen, symbol prefixing is mandatory and must be
+   proven in S0 (§1.3) — this is the highest-probability
+   "works-in-CI, wrong-in-app" failure in the plan.
+
+2. **Pre-agree that observation may ship reduced or deferred.** S7 is ~40% of
+   the effort and the entire risk. A v2.1 that ships a native adapter for
+   execution while live queries continue to require the GRDB adapter is a good
+   outcome, and deciding that *now* is much cheaper than deciding it in month
+   four. Snapshot-consistent concurrent re-fetch should be explicitly
+   out of scope for the first version (§4.3).
+
+3. **Make S1 the go/no-go gate, judged by an unmodified contract.** If
+   `GRDBDriverContractTests` passes against the native connection without
+   editing `Sources/SwiftQLCore/SQLDatabaseDriver.swift`, proceed. If it does
+   not, the finding is about the contract, not the adapter, and belongs with the
+   v3 sync/async decision.
+
+4. **Fix three things that are prerequisites, not adapter work.**
+   `XLCustomFunctionRegistration` currently carries a GRDB `DatabaseFunction`
+   thunk in what should be an adapter-neutral value (§2) and must be refactored
+   first. `SQLiteBuildValidationValidator` must move off GRDB's `CSQLite`
+   product onto `CSwiftQLSQLite` (§1.1). And the validator needs a negative-
+   control test asserting it never prepares under `EXPLAIN` (§1.4) — cheap now,
+   and the only thing standing between Apple's already-enabled
+   `SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION` and a silently blind #293 validator.
+
+Two documentation corrections fall out of this analysis and should be made
+regardless of the go/no-go:
+[COMPATIBILITY.md:145-148](../COMPATIBILITY.md) is stale about
+`SQLITE_ENABLE_SNAPSHOT` (§1.2), and
+[SQLiteNIOFeasibility.md §4](SQLiteNIOFeasibility.md)'s characterisation of
+`SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION` is broader than SQLite's documented and
+measured behaviour (§1.4).

--- a/Research/SQLiteNIOFeasibility.md
+++ b/Research/SQLiteNIOFeasibility.md
@@ -1,0 +1,191 @@
+# Feasibility: `vapor/sqlite-nio` as SwiftQL's native SQLite adapter
+
+**Verdict: NO-GO.** `sqlite-nio` cannot satisfy the v2.1 native-adapter
+requirements without being substantially rewritten, and adopting it would
+impose swift-nio on every SwiftQL client while *removing* capabilities SwiftQL
+already relies on.
+
+Analysis performed against `vapor/sqlite-nio` `main` @ `Modernize for Swift 6.1
+(#109)` (2026-07-28) and released tags up to **1.13.0**, compared against
+SwiftQL's `XLDatabaseDriver`/`XLDatabaseDriverConnection` contract
+([SQLDatabaseDriver.swift](../Sources/SwiftQLCore/SQLDatabaseDriver.swift)) and
+the [ROADMAP](../ROADMAP.md) v2.1 requirement list.
+
+---
+
+## 1. What sqlite-nio actually exposes
+
+The entire public execution surface is one method, in two spellings:
+
+```swift
+func query(_ query: String, _ binds: [SQLiteData], _ onRow: @escaping @Sendable (SQLiteRow) -> Void) async throws
+func query(_ query: String, _ binds: [SQLiteData], logger: Logger, _ onRow: @escaping @Sendable (SQLiteRow) -> Void) -> EventLoopFuture<Void>
+```
+
+Its implementation (`SQLiteConnection.query`) is, per call:
+`sqlite3_prepare_v3` → `column_count` loop → bind → `step` to exhaustion →
+`finalize`. `SQLiteStatement` is `internal`; there is no public prepared
+statement, no cursor, and no statement handle of any kind. The source carries a
+literal `// TODO:` about someday passing `SQLITE_PREPARE_PERSISTENT`.
+
+Supporting surface: `SQLiteData` (5 cases, BLOB as NIO `ByteBuffer`),
+`SQLiteRow` (eagerly materialised `[SQLiteData]` + name→offset table),
+`SQLiteError`, `SQLiteCustomFunction`, and a well-built multiplexed hook
+registry (`SQLiteConnection+Hooks.swift`).
+
+## 2. Requirement-by-requirement
+
+| v2.1 requirement (ROADMAP §v2.1) | sqlite-nio | Notes |
+|---|---|---|
+| Adapter-contract parity | ❌ | SwiftQL's contract is **synchronous** (`withReadConnection`, `fetchAll`, `bind` are all `mutating func … throws`). sqlite-nio is `EventLoopFuture`/`async` end to end, executing on an `NIOThreadPool`. |
+| Per-connection statement preparation and caching | ❌ | No public statement type. Every execution re-prepares and finalises. SwiftQL today calls GRDB `database.cachedStatement(sql:)` ([GRDBDatabaseDriver.swift:571](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L571)). |
+| Binding | ⚠️ | Positional only — `binds[i]` → index `i+1`. `XLBindingKey` has a `.named(String)` case ([SQLDialect.swift:173](../Sources/SwiftQLCore/SQLDialect.swift#L173)); no `sqlite3_bind_parameter_index` is exposed. |
+| Decoding | ⚠️ | Works, but every row is fully materialised before delivery, and BLOBs arrive as `ByteBuffer`, adding a conversion at every codec boundary. |
+| Transactions | ❌ | No API at all. `BEGIN`/`COMMIT`/`ROLLBACK` as text strings; no savepoints, no nesting/reentrancy guard. SwiftQL's `withTransaction` + `XLTransactionScopeError` semantics would be hand-rolled. |
+| Errors | ✅ | `SQLiteError` is good; connections open with `SQLITE_OPEN_EXRESCODE`, so extended result codes are available. |
+| Cancellation | ❌ | `onRow` returns `Void` — there is no early stop, so `XLRowStreamControl.stop` and `fetchOne` cannot avoid stepping the whole result set. Compounded by `SQLITE_OMIT_PROGRESS_CALLBACK` in the vendored build: no `sqlite3_progress_handler`, so long statements cannot be interrupted cooperatively. |
+| Functions | ✅ | `SQLiteCustomFunction` with per-connection install/uninstall. |
+| Collations | ❌ | No `sqlite3_create_collation` wrapper. |
+| Observation | ⚠️ | Raw hooks only (see §5). No region tracking, no snapshot-consistent re-fetch, no busy retry — i.e. none of what `ValueObservation` gives SwiftQL's live queries today ([GRDBSQLDatabase.swift:461](../Sources/SwiftQL/GRDBSQLDatabase.swift#L461)). |
+| Schema/version invalidation, safe reprepare | ➖ | Vacuously "safe" because nothing is cached — which is the same as failing the caching requirement. |
+| Warm-up and metrics | ❌ | Nothing to warm up; `SQLITE_OMIT_TRACE` removes `sqlite3_trace_v2`, so no statement-level timing or SQL logging either. |
+| No GRDB dependency | ✅ | Trades GRDB (zero dependencies) for swift-nio + swift-log. |
+
+## 3. Structural blockers
+
+**3.1 Sync/async impedance mismatch.** This is the decisive one. SwiftQL's
+driver seam is synchronous by design — `PhysicalStatement` is explicitly
+connection-owned and deliberately *not* `Sendable`, precisely so a cursor cannot
+escape its connection access. sqlite-nio requires hopping to an `NIOThreadPool`
+and awaiting a future for every operation. The three ways out are all bad:
+
+- Block on `future.wait()` inside the driver — deadlocks if called from an
+  event loop or from the thread pool itself, and serialises everything anyway.
+- Make `XLDatabaseDriver`/`XLDatabaseDriverConnection` async — a breaking change
+  that propagates through the executor, the static-query path, the macro-generated
+  call sites, and the live-query publishers. That is a v3-scale API break, and it
+  is work you would owe regardless of which SQLite backend you picked.
+- Use only sqlite-nio's C target — **impossible**: `products:` exposes
+  `SQLiteNIO` only, so `VaporCSQLite` is not reachable from another package.
+
+**3.2 Toolchain floor.** SwiftQL 1.x pins `swift-tools-version: 5.9` and CI
+verifies exact Swift 5.9.2 on Ubuntu 22.04 ([COMPATIBILITY.md](../COMPATIBILITY.md)).
+sqlite-nio's tools-version history:
+
+| sqlite-nio | tools-version | swift-nio floor |
+|---|---|---|
+| 1.7.0 | 5.7 | 2.42.0 |
+| 1.8.8 | 5.7 | 2.58.0 |
+| 1.9.0 | 5.8 | 2.65.0 |
+| **1.13.0 (latest)** | **6.1** | **2.101.3** |
+
+The latest release is unresolvable by a 5.9 toolchain. Pinning back to the last
+5.8-era release (1.9.0) forfeits the hook API, which is the one part worth
+having. For v2.1 — post-Swift-6-mode (#133) — a 6.1 floor is tolerable, but it
+still hard-forecloses back-porting the adapter to the 1.x line.
+
+**3.3 Dependency surface.** swift-nio 2.101.3 drags in NIOCore, NIOPosix,
+NIOEmbedded, NIOFoundationCompat/NIOFoundationEssentialsCompat, plus
+swift-atomics / swift-collections / swift-system, and swift-log. For a library
+whose current runtime deps are GRDB (no dependencies) and OpenCombine, that is a
+material regression in graph size, binary size, and audit surface for every
+downstream iOS client — in exchange for a thinner SQLite API than the one being
+replaced.
+
+## 4. Vendored-SQLite build options: a mixed bag with one sharp edge
+
+`VaporCSQLite` compiles amalgamation **3.53.0** with prefixed symbols
+(`sqlite_nio_sqlite3_*`). Determinism is a genuine plus over linking system
+libsqlite3, but the option set diverges meaningfully from what SwiftQL's
+conformance census and COMPATIBILITY matrix are calibrated against (SQLite
+3.53.3 via GRDB):
+
+Enabled and useful: `FTS3/4/5`, `RTREE`, `SESSION`, `COLUMN_METADATA`,
+`DBSTAT_VTAB`, `UNLOCK_NOTIFY`, `MAX_VARIABLE_NUMBER=250000`, `DQS=0`.
+
+Also enabled: `SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION`, which is worth a note
+because it interacts with the #293 build validator — though **more narrowly than
+the first draft of this report claimed.** Per
+[sqlite.org/compile.html](https://www.sqlite.org/compile.html), the option
+suppresses "unknown function" errors *only* under `EXPLAIN` and
+`EXPLAIN QUERY PLAN`, substituting a no-op `unknown()`; ordinary statements still
+fail to prepare. Since
+[`SQLitePrepareV3Probe.prepare`](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLitePrepareV3Probe.swift)
+passes manifest SQL verbatim with no `EXPLAIN` wrapper, the validator is *not*
+defeated by this option. The residual risk is latent rather than active: wrapping
+validation in `EXPLAIN` would look like a harmless optimisation and would
+silently disable unknown-function detection. See
+[SQLiteCFeasibility.md §1.4](SQLiteCFeasibility.md) for the measured behaviour on
+Apple's SQLite (which enables this option) and for the resulting rule — never
+prepare validation statements under `EXPLAIN`, on any provenance.
+
+Omitted, and each one costs something:
+
+- `SQLITE_OMIT_LOAD_EXTENSION` — no runtime extension loading, at all.
+- `SQLITE_OMIT_PROGRESS_CALLBACK` — no cooperative interrupt (§2, cancellation).
+- `SQLITE_OMIT_TRACE` — no `sqlite3_trace_v2`; no SQL logging or per-statement metrics.
+- `SQLITE_OMIT_DESERIALIZE` — no `sqlite3_serialize`/`deserialize`.
+- `SQLITE_OMIT_SHARED_CACHE` — multiple connections to one in-memory database
+  are impossible, so an in-memory *pool* cannot exist. Low impact for SwiftQL
+  today (in-memory usage is via single-connection `DatabaseQueue()`), but it
+  removes an option.
+
+## 5. Concurrency and contention
+
+- **No pool.** One `SQLiteConnection` = one `sqlite3*`. SwiftQL's driver
+  distinguishes read from write connections and leans on `DatabasePool`'s WAL
+  multi-reader concurrency ([GRDBDatabaseDriver.swift:116-148](../Sources/SwiftQL/GRDBDatabaseDriver.swift#L116)).
+  You would build pooling, WAL setup, and reader/writer routing yourself. The
+  package's own docs concede the `SQLiteDatabase` protocol intended for pooling
+  "has become clear that it was poorly designed."
+- **Forced `SQLITE_OPEN_FULLMUTEX`.** Every call takes SQLite's serialized-mode
+  mutex. GRDB opts for `NOMUTEX` plus its own serialization, which is cheaper.
+- **Unconfigurable busy handler: `{ _, _ in 1 }`** — retry forever, no backoff,
+  no timeout, no way to override. Under WAL contention this spins instead of
+  surfacing `SQLITE_BUSY`, which is exactly the signal
+  [GRDBLiveQueryRetryPolicy](../Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift)
+  `.retryBusy` is built on.
+- **No `Configuration.prepareDatabase` equivalent.** `journal_mode`,
+  `foreign_keys`, `busy_timeout` etc. are text PRAGMAs you issue by hand;
+  function registration must be re-run per connection with no hook to do it.
+- Minor: the future-based `query` allocates one `eventLoop.submit` future *per
+  result row* and `andAllSucceed`s them. A 100k-row result creates 100k
+  event-loop tasks. The `async` overload does not have this problem.
+
+## 6. What *is* worth taking
+
+`SQLiteConnection+Hooks.swift` (871 lines) is the strongest thing in the
+package: it multiplexes SQLite's single-slot update/commit/rollback/authorizer
+hooks across many Swift observers, with scoped/pinned token lifetimes,
+validator-vs-observer separation, and teardown on close. SwiftQL cannot register
+an update hook today because GRDB owns that slot — so this design is directly
+relevant to a first-party adapter's observation layer. **Take the pattern, under
+its MIT licence; do not take the dependency.**
+
+## 7. Recommendation
+
+Build the v2.1 adapter directly against the SQLite C API, as originally planned.
+
+1. **The prove-out already exists in-repo.** `SQLitePrepareV3Probe` +
+   `SQLiteBuildValidationRuntime` already drive `sqlite3_prepare_v3`, own a
+   dedicated connection, and return only copied Swift values — with a strict
+   no-handle-escapes discipline that matches `XLDatabaseDriverConnection`'s
+   design intent. That is the seed of the adapter, and it is synchronous.
+2. **Decide the SQLite provenance question separately from the driver
+   question.** If a pinned, vendored amalgamation is wanted over system
+   libsqlite3, vendor a C-only target in-repo with SwiftQL's own `SQLITE_*`
+   options — keeping `PROGRESS_CALLBACK` and `TRACE`, which Vapor omits —
+   rather than inheriting Vapor's option set. This also cleanly decouples the
+   validator from GRDB's `CSQLite`. For the full recommended option set, and for
+   why the binding validator rule is "never prepare under `EXPLAIN`" rather than
+   any particular compile flag, see
+   [SQLiteCFeasibility.md §1.4–1.5](SQLiteCFeasibility.md).
+3. **Adopt sqlite-nio's hook-multiplexing design** for the observation layer.
+4. **Treat the sync→async driver-contract question as its own decision.** If
+   SwiftQL is going async at v2/v3, do it deliberately in the core contract —
+   not as a side effect of picking a backend that happens to be NIO-shaped.
+
+Revisit only if sqlite-nio publicly exposes prepared statements with caching,
+named binds, an early-stop row callback, and transaction/collation APIs. As of
+1.13.0 none of those are on offer, and its stated direction is toward being a
+Fluent/Vapor server driver, not an embedded-app storage engine.

--- a/Research/SQLiteProvenanceAdversarial.md
+++ b/Research/SQLiteProvenanceAdversarial.md
@@ -1,0 +1,278 @@
+# Adversarial review: dual SQLite provenance (system compatibility mode + vendored build)
+
+**Proposal under review.** SwiftQL supports two SQLite provenances: a
+*compatibility mode* linking system `libsqlite3`, for environments where a
+vendored build is technically or contractually impossible; and a *vendored*
+amalgamation with SwiftQL-chosen compile options "to enable specific
+capabilities and/or improve performance."
+
+**Verdict: the dual-provenance split is right, but the stated rationale for
+the vendored build is wrong, and adopting it as stated would break SwiftQL's
+conformance claim.** Vendoring should be justified by *determinism and
+operational access*, not by capabilities or speed. With that substitution the
+proposal is sound and mostly pre-built. Without it, §1 is fatal.
+
+This is a deliberately adversarial reading of
+[SQLiteCFeasibility.md §1](SQLiteCFeasibility.md), which recommended "support
+both; default to system; make the vendored target the CI and conformance
+authority." Two of its conclusions do not survive contact with the proposal as
+framed, and one unexamined precondition turns out to be load-bearing.
+
+---
+
+## 1. The central contradiction: capabilities vs. one conformance claim
+
+The proposal wants the vendored build to *enable specific capabilities*.
+[SQLiteCFeasibility §1.5](SQLiteCFeasibility.md) states the opposing principle:
+
+> The vendored option set **must not create capabilities that do not exist on
+> the system path.** v2.1 requires the shared corpus to pass on both adapters
+> ([ROADMAP.md:702-703](../ROADMAP.md)); if a vendored build enables something
+> Apple's build omits, the corpus splits and the conformance inventory stops
+> meaning one thing.
+
+These cannot both hold. The choice is binary and it should be made explicitly:
+
+- **(a) One conformance claim.** The vendored option set is pinned to the
+  *intersection* of what every supported system SQLite provides. SwiftQL's
+  documented SQL surface is identical on both paths. Vendoring buys determinism,
+  not surface.
+- **(b) Vendored-exclusive capabilities.** SwiftQL's SQL surface becomes
+  provenance-dependent. The conformance inventory needs one environment record
+  per provenance, `Conformance/SQLite/REPORT.md` needs per-provenance claims,
+  the combinatorial corpus needs provenance tagging, and every capability-gated
+  construct needs a compile-time or runtime gate that does not exist today (§3).
+
+Option (b) is not unreasonable — but it is a *much* larger project than the
+proposal implies, and it is the thing that multiplies the support matrix. The
+recommendation in §6 is (a), with an explicit escape hatch for later.
+
+**Note what this costs the proposal.** Under (a), the honest answer to "what
+does vendoring enable?" is: `SQLITE_DQS=0` at compile time rather than per
+connection, `sqlite3_progress_handler` and `sqlite3_trace_v2` guaranteed present
+rather than merely usually present, and a pinned `sqlite3_source_id()`. That is a
+real and sufficient justification. It is not "specific capabilities."
+
+## 2. "Improve performance" is the weakest leg and should be dropped
+
+Compile options that plausibly affect throughput — `SQLITE_DEFAULT_MEMSTATUS=0`,
+various `OMIT_*`, threading-mode selection — produce low-single-digit effects for
+SwiftQL-shaped workloads. Three problems:
+
+1. **SwiftQL cannot currently measure it.** The benchmark machine is contended
+   enough that sub-10% deltas are not trustworthy; allocation counts are the
+   reliable signal, and compile options do not move allocation counts.
+2. **The largest real lever is not a compile option.** It is threading mode, and
+   that is a per-connection `SQLITE_OPEN_NOMUTEX` decision available on *both*
+   provenances ([SQLiteCFeasibility §1.5](SQLiteCFeasibility.md), §3.1).
+3. **Apple's build is already tuned.** It ships `DEFAULT_MEMSTATUS=0` and
+   `MUTEX_UNFAIR`. A naive vendored build is as likely to be slower.
+
+Keeping "performance" in the rationale invites a benchmark obligation SwiftQL
+cannot discharge. Drop it; the determinism argument is strong enough alone.
+
+## 3. The precondition nobody has costed: version gating is unwired and fail-closed
+
+This is the finding that most changes the plan. Compatibility mode is a promise
+that SwiftQL behaves correctly on a SQLite it did not choose. The machinery to
+keep that promise exists in the type system, is **fail-closed**, and is
+**not connected to anything**.
+
+`XLDialectRequirement.validate`
+([SQLDialect.swift:143-152](../Sources/SwiftQLCore/SQLDialect.swift#L143)):
+
+```swift
+if let minimumVersion {
+    guard let actualVersion = descriptor.version, actualVersion >= minimumVersion else {
+        throw XLDatabaseContractError.versionMismatch(…, actual: descriptor.version)
+    }
+}
+```
+
+A `nil` actual version does not pass — it throws. And the actual version is
+always `nil`, because the only production construction site omits it
+([GRDBSQLDatabase.swift:941-943](../Sources/SwiftQL/GRDBSQLDatabase.swift#L941)):
+
+```swift
+let dialect = XLSQLiteDialect(
+    identifierFormattingOptions: formatter.identifierFormattingOptions
+)   // version: defaults to nil
+```
+
+Three consequences:
+
+1. **No production statement declares a minimum version.** `minimumVersion:` is
+   set in exactly 10 places, all under `Tests/`. If any real construct declared
+   one it would throw on every database SwiftQL opens. The mechanism is dormant,
+   and its dormancy is currently invisible because nothing uses it.
+2. **Nothing probes the runtime SQLite version.** The only `sqlite_version()`
+   call in the entire package is in the build-validation runtime
+   ([SQLiteBuildValidationRuntime.swift:209](../Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidationRuntime.swift#L209)),
+   which runs at *build* time on the *developer's* machine.
+3. **`XLDialectCapabilities` cannot express SQL features.** It has exactly two
+   members, `namedBindings` and `indexedBindings`
+   ([SQLDialect.swift:89-91](../Sources/SwiftQLCore/SQLDialect.swift#L89)). It is
+   a binding-style flag set, not a feature-capability system. Every
+   version-sensitive or option-sensitive SQL construct in SwiftQL is presently
+   ungated on both provenances.
+
+Meanwhile the conformance inventory *already records* per-feature minimum
+versions spanning 3.24.0 → 3.42.0. So SwiftQL knows, as data, that its surface is
+version-sensitive, and enforces none of it in code. Compatibility mode does not
+create this gap — it makes it load-bearing, because a vendored-only world can
+pin the version and ignore the whole problem.
+
+**Cost.** Wiring `descriptor.version` from `sqlite3_libversion()`, extending
+capabilities to model SQL features and compile options, and annotating every
+version-sensitive construct is a cross-cutting change touching the dialect, the
+driver, the descriptor, the macros, and the inventory. It is a prerequisite for
+an honest compatibility mode, and it is not in
+[SQLiteCFeasibility §6](SQLiteCFeasibility.md)'s staging plan.
+
+## 4. You cannot enumerate the set you are promising to support
+
+Compatibility mode's support set is "every system SQLite on every OS SwiftQL
+targets" — iOS 16+ and macOS 13+ ([Package.swift:8](../Package.swift)), plus
+Linux distro libsqlite3. **That set is not publicly documented.** Apple publishes
+no per-OS-release SQLite version table; the community reference everyone cites
+([GRDB's SQLite versions wiki](https://github.com/groue/GRDB.swift/wiki/SQLite-versions))
+was last updated in 2019 and stops at iOS 13. Measured locally, the current SDK
+header pins 3.51.0 for both `iphoneos` and `macosx`, but the SDK header is a
+*build-time* constant — a device running iOS 16 links whatever shipped with iOS 16.
+
+This is not a documentation nuisance; it is a testability blocker. You cannot
+write a matrix cell for a version you cannot name, and you cannot CI-verify a
+device SQLite from a Mac. Compatibility mode is therefore **structurally
+untestable at its edges**, and any claim about it is inference, not evidence —
+which is precisely the standard `Conformance/SQLite/REPORT.md` exists to hold.
+
+The repo has already hit the hard end of this. Ubuntu 22.04's system SQLite 3.37
+predates `UNIXEPOCH`, a required capability in the conformance corpus
+([COMPATIBILITY.md:129-131](../COMPATIBILITY.md)); CI's response was to stop using
+the system library and build the amalgamation. **On one of its two pinned support
+points, the project has already rejected compatibility mode.** That is the
+strongest single piece of evidence in this document, and it cuts against the
+proposal: SwiftQL's own CI could not live with system SQLite.
+
+## 5. The selection mechanism is unsolved on the current toolchain
+
+How does a client *choose*? SwiftPM offers no good answer at
+`swift-tools-version: 5.9`:
+
+| Mechanism | Verdict |
+|---|---|
+| Package traits ([SE-0450](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md)) | The designed answer — `.when(traits:)` gates a dependency edge out of the build plan entirely. **Landed in SwiftPM 6.1**, above SwiftQL 1.x's 5.9 floor. |
+| Two products / duplicated target trees | Two module names, so `import` sites and macro-generated code diverge. Source-incompatible between modes. |
+| Environment variable read in `Package.swift` | Breaks resolution reproducibility and is unreliable under Xcode. |
+| Separate C package behind a shared module name | Impossible; C module identity is fixed at compile time. |
+| `.unsafeFlags` | Poisons downstream resolution — dependent packages cannot depend on SwiftQL at all. |
+
+Ecosystem precedent is discouraging. GRDB — the most mature Swift SQLite library,
+a decade in — implements custom SQLite via cloning the repo, initialising a
+submodule, authoring four config files, embedding an Xcode project, and adding a
+pre-action script, and documents plainly that **"the technique described here is
+not compatible with the Swift Package Manager."** If GRDB has not solved this
+with SwiftPM, SwiftQL should not assume it will fall out cheaply.
+
+**Consequence for sequencing.** A clean provenance selector requires Swift 6.1
+traits, which ties this decision to the same Swift-6 milestone as
+[#133](https://github.com/lukevanin/swiftql/issues/133) and the async-contract
+decision. Attempting dual provenance on the 5.9 line means picking one of the bad
+mechanisms above.
+
+## 6. Two hazards the original report understates
+
+**6.1 Symbol prefixing forecloses handle sharing.**
+[SQLiteCFeasibility §1.3](SQLiteCFeasibility.md) correctly makes prefixing
+mandatory for the vendored build, to stop static definitions from silently
+capturing GRDB's dynamic `sqlite3_*` references. The unstated consequence: a
+prefixed vendored SQLite **cannot share a connection handle with anything else** —
+not GRDB, not Core Data, not SQLCipher, not a system-mode SwiftQL database in the
+same process. Vendored mode is therefore not merely a different build, it is an
+isolation boundary. Any client with a mixed stack is pushed onto compatibility
+mode whether they wanted it or not — which is an argument *for* keeping
+compatibility mode genuinely first-class, and against treating it as a fallback.
+
+**6.2 The regulatory argument runs both directions.** The proposal assumes
+compliance pressure favours system SQLite. Often it favours vendoring: an SBOM
+can state exactly which SQLite ships, and builds are reproducible. What vendoring
+actually transfers is **CVE response**. On the system path an OS update patches
+users; on the vendored path a SQLite CVE obliges SwiftQL to cut a release, and
+every client to adopt it. For a single-maintainer project that is a standing,
+unbounded commitment, and it is the strongest cost of vendoring — stronger than
+binary size. It also argues that vendored should track upstream SQLite on a
+schedule, which is new release-process work.
+
+## 7. What survives — the steelman
+
+The proposal is correct in its core instinct, and more of it is pre-built than
+the objections above suggest:
+
+- **The data model already anticipated dual provenance.** The conformance
+  inventory's `sqlite_environments` is a **list**, and each entry carries
+  `sqlite_version`, `sqlite_source_id`, and `compile-option:*` capability strings.
+  It currently holds one element (`sqlite-3.51.0-macos-arm64`). Adding a second
+  environment is a data change, not a schema redesign — genuinely good
+  foresight in the existing design.
+- **`SQLiteBuildValidationRuntime` already captures provenance identity** —
+  `compile_options`, `sqlite_version`, `sqlite_source_id` per run — so mismatch
+  *detection* needs no new design.
+- **CI already builds the amalgamation** with a SHA3-256-pinned source and a
+  chosen option set ([swift.yml:494-516](../.github/workflows/swift.yml)). Moving
+  that into a SwiftPM target using `.define` is mechanical, and `.define` is not
+  an unsafe flag, so downstream resolution is unaffected.
+- **A conformance claim requires a pinned library.** "Evidence-backed conformance"
+  against whatever SQLite the OS happens to ship is not a claim anyone can audit.
+  This alone justifies a vendored target existing, independent of whether any
+  client ever selects it.
+- **Compatibility mode is genuinely necessary** — §6.1 shows mixed-stack clients
+  are forced onto it regardless of preference.
+
+## 8. Recommendation
+
+**Support both. Invert the report's default. Justify vendoring by determinism,
+not capability. Gate the whole thing on version wiring.**
+
+1. **Vendored is the default for the native adapter, and the conformance
+   authority.** [SQLiteCFeasibility §1.6](SQLiteCFeasibility.md) recommended
+   defaulting to system; that is wrong for the *native* adapter specifically,
+   whose entire purpose is determinism. A native adapter defaulting to an
+   unpinnable, unenumerable library inherits the problem it was built to solve.
+   Binary size (~0.75–1 MB) is the price of the guarantee.
+
+2. **Adopt option (a) from §1: no vendored-exclusive SQL capabilities.** Pin the
+   vendored option set to the intersection, per
+   [SQLiteCFeasibility §1.5](SQLiteCFeasibility.md). Revisit only when a concrete
+   feature request justifies splitting the corpus — and cost that split honestly
+   when it comes.
+
+3. **Compatibility mode ships with a deliberately weaker, separately worded
+   claim.** Not "conformant" — something like *supported, version-probed,
+   best-effort*, with conformance evidence explicitly scoped to the vendored
+   environment. §4 shows the stronger claim cannot be substantiated.
+
+4. **Make version wiring a precondition, not a follow-up (§3).** Populate
+   `descriptor.version` from `sqlite3_libversion()`; extend
+   `XLDialectCapabilities` to model SQL features and compile options; annotate
+   version-sensitive constructs using the minimums the inventory already records.
+   Until this lands, compatibility mode is a promise with no mechanism behind it.
+   This belongs in [SQLiteCFeasibility §6](SQLiteCFeasibility.md)'s staging plan,
+   early.
+
+5. **Defer the selection mechanism to Swift 6.1 traits (§5).** Do not attempt
+   dual provenance on the 5.9 line. Until traits are available, ship the vendored
+   target only, and treat compatibility mode as designed-for but not yet
+   selectable — which is honest, and costs nothing that is not already owed.
+
+6. **Drop "performance" from the rationale (§2).** Keep `PROGRESS_CALLBACK`,
+   `TRACE`, and `DQS=0` — those are operational access, and they are the real win.
+
+### What would change this recommendation
+
+A concrete requirement for a SQL feature Apple's build omits — the plausible
+candidate is runtime extension loading, which Apple omits via
+`SQLITE_OMIT_LOAD_EXTENSION` and which no per-connection setting can restore.
+That would force option (b) and, with it, a genuinely provenance-dependent SQL
+surface. If that requirement is foreseeable, it is much cheaper to design the
+capability system for it now (§3) than to retrofit it after the conformance
+corpus has been published as a single claim.


### PR DESCRIPTION
Five feasibility analyses covering the native SQLite adapter ([#136](https://github.com/lukevanin/swiftql/issues/136)) and the driver-contract and provenance decisions it depends on. **Analysis only — no source, contract, or dependency changes.**

The first report was the original ask; the rest were spun off from questions it raised.

## Reports

| Report | Question | Verdict |
|---|---|---|
| [`SQLiteNIOFeasibility.md`](Research/SQLiteNIOFeasibility.md) | `vapor/sqlite-nio` in place of GRDB | **NO-GO** |
| [`SQLiteCFeasibility.md`](Research/SQLiteCFeasibility.md) | Direct SQLite C for v2.1 | **GO**, with four conditions |
| [`AsyncDriverContractFeasibility.md`](Research/AsyncDriverContractFeasibility.md) | Async driver contract in v2/v3 | **Do it**, in reduced form |
| [`BundledDriverAPIAnalysis.md`](Research/BundledDriverAPIAnalysis.md) | One-call bundled driver API | **Reject**; adopt hybrid C |
| [`SQLiteProvenanceAdversarial.md`](Research/SQLiteProvenanceAdversarial.md) | System compatibility mode + vendored build | **Split is right, rationale isn't** |

### sqlite-nio — NO-GO

Its entire public execution surface is one method, which re-runs `prepare_v3` → bind → step-to-exhaustion → `finalize` on every call. `SQLiteStatement` is `internal`, so there is no public prepared statement, cursor, or handle. That alone fails three v2.1 requirements: statement caching, cancellation, and warm-up/metrics. Also missing: transactions, savepoints, collations, named binds, and any early-stop in the row callback.

Three structural blockers: the `EventLoopFuture` surface against SwiftQL's synchronous contract; a `swift-tools-version: 6.1` floor at 1.13.0 against 1.x's 5.9; and swift-nio + swift-log replacing GRDB's zero dependencies. Its `VaporCSQLite` target is not a package product, so the C layer can't be borrowed either.

Worth taking, not depending on: `SQLiteConnection+Hooks.swift` multiplexes SQLite's single-slot hooks across many observers with scoped/pinned tokens (MIT).

### Direct SQLite C — GO with conditions

15 of 16 requirement rows are small or medium, and direct C is *simpler* than GRDB in three places: named binding sheds two normalization hazards, early row-stop becomes trivial, and reentrancy can throw instead of pre-empting an uncatchable `fatalError`. Observation is the one large risk, isolated in a single deferrable slice (~40% of effort). Conditions: decide provenance up front; pre-agree observation may ship reduced; make the contract-test slice the go/no-go gate.

### Async contract — do it, reduced

`withReadConnection`/`withWriteConnection`/`withTransaction` become `async`; `XLDatabaseDriverConnection` and `XLRowStreamControl` don't change. The case rests on blocking cooperative-pool threads and on v2.2's PostgreSQL adapter having no synchronous design — not on performance. Recommended placement: v2, between [#113](https://github.com/lukevanin/swiftql/issues/113)/[#133](https://github.com/lukevanin/swiftql/issues/133) and [#136](https://github.com/lukevanin/swiftql/issues/136).

### Bundled API — reject, adopt hybrid C

Keep the multi-step requirements; add a bundled convenience extension composed from them, so the two paths can't diverge. A `Void`-returning row callback is rejected under any design.

### SQLite provenance — dual support, but not for the stated reasons

An adversarial review of the proposed *system compatibility mode + vendored build* split. The split is right; two things about it are not.

**The contradiction.** Justifying the vendored build by "enabling capabilities" contradicts [`SQLiteCFeasibility.md` §1.5](Research/SQLiteCFeasibility.md), which requires the vendored option set to create no capability absent from the system path — because [ROADMAP.md:702-703](ROADMAP.md) requires the shared corpus to pass on both adapters. You can have one conformance claim *or* vendored-exclusive capabilities. Determinism, `DQS=0`, `PROGRESS_CALLBACK`, and `TRACE` justify vendoring on their own; "capabilities" and "performance" do not, and the performance case sits below the noise floor the benchmark machine can resolve.

**The uncosted precondition.** Version gating is fail-closed and wired to nothing. `XLDialectRequirement.validate` throws when `minimumVersion` is set and `descriptor.version` is `nil` ([SQLDialect.swift:143](Sources/SwiftQLCore/SQLDialect.swift#L143)), and the only production dialect construction omits the version ([GRDBSQLDatabase.swift:941](Sources/SwiftQL/GRDBSQLDatabase.swift#L941)), so it is always `nil`. `minimumVersion:` is set in ten places, all under `Tests/`. `XLDialectCapabilities` models binding style only — two members — not SQL features. The inventory already records per-feature minimums spanning 3.24.0–3.42.0 and enforces none of them. Compatibility mode cannot be honest until this is wired, and it is not in the SQLite C report's staging plan.

Also recorded: per-OS system SQLite versions are not publicly enumerable (Apple publishes no table; the community reference stops at iOS 13 in 2019), so compatibility mode is structurally untestable at its edges; CI already rejected system SQLite on Ubuntu 22.04 over `UNIXEPOCH`; symbol prefixing forecloses handle sharing with GRDB, Core Data, and SQLCipher; and no good SwiftPM provenance selector exists below Swift 6.1 traits — GRDB documents its own custom-SQLite path as SPM-incompatible.

The recommendation inverts the SQLite C report's default: vendored should be the default *for the native adapter*, whose purpose is determinism.

## Corrections and follow-ups

Two items the research turned up. **Neither is fixed in this PR** — the first is corrected in place, the second is deliberately left alone.

1. **Corrected here.** The first draft of the sqlite-nio report claimed `SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION` makes `prepare_v3` accept unknown functions outright, defeating the [#293](https://github.com/lukevanin/swiftql/issues/293) validator. That was overbroad: the option only suppresses those errors under `EXPLAIN`/`EXPLAIN QUERY PLAN`. Since `SQLitePrepareV3Probe` prepares manifest SQL verbatim with no `EXPLAIN` wrapper, **the validator is not defeated today**, including on Apple's SQLite where the option is already enabled. The risk is latent, and the durable rule is "never prepare validation statements under `EXPLAIN`". §4 and §7 of that report are amended accordingly.

2. **Follow-up, not fixed here.** [`COMPATIBILITY.md:145-148`](COMPATIBILITY.md) states the pinned amalgamation "intentionally leaves that optional API disabled" for `SQLITE_ENABLE_SNAPSHOT`, but [`swift.yml:512`](.github/workflows/swift.yml) and `:541` both pass `-DSQLITE_ENABLE_SNAPSHOT`. The doc contradicts CI. Left for a separate PR because amending the compatibility contract shouldn't ride along in a research change — and it matters beyond documentation, since `SQLITE_ENABLE_SNAPSHOT` is the pivot for whether native observation can do snapshot-consistent re-fetch.

Two further items worth tracking, both raised by the provenance review:

- The validator should get a negative-control test asserting it never prepares under `EXPLAIN`. Cheap, and it's the only thing standing between Apple's enabled option and a silently blind #293 validator.
- Wiring `descriptor.version` from `sqlite3_libversion()` and extending `XLDialectCapabilities` to model SQL features is a prerequisite for compatibility mode, and is currently unscheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)