### PR TITLE
Correct the Linux snapshot-flag description in COMPATIBILITY.md

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -155,11 +155,12 @@ whenever the Swift-side `SQLITE_ENABLE_SNAPSHOT` condition is defined, and
 otherwise only through a fallback that additionally requires both
 `GRDBCUSTOMSQLITE` and `GRDBCIPHER` to be undefined and a compiler-version and
 platform condition to hold. `-DGRDBCUSTOMSQLITE` closes that fallback, so on
-its own it would compile the support out. The override therefore passes `-DSQLITE_ENABLE_SNAPSHOT` to
-`swiftc` alongside it, which satisfies the first condition directly and keeps
-the snapshot path in the build; `DatabasePool` observations use it to avoid an
-unconditional second startup fetch when the database has not changed. The
-override delegates SwiftPM's module-wrapping phase directly to the matching
+its own it would compile the support out. The override therefore passes
+`-DSQLITE_ENABLE_SNAPSHOT` to `swiftc` alongside it, which satisfies the first
+condition directly and keeps the snapshot path in the build; `DatabasePool`
+observations use it to avoid an unconditional second startup fetch when the
+database has not changed. The override delegates SwiftPM's module-wrapping
+phase directly to the matching
 `swift-frontend` and remains next to the selected compiler so SwiftPM loads
 that toolchain's index-store runtime. The exact-version runtime probe,
 capability report, and full tests remain authoritative for the pinned SQLite

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -142,20 +142,21 @@ and the `x86_64-unknown-linux-gnu` target. macOS additionally verifies the exact
 Xcode version, build, and SDK. Toolchain or image drift therefore fails instead
 of silently redefining support.
 
-The Linux cells compile the pinned amalgamation with `SQLITE_ENABLE_SNAPSHOT`
+The Linux cells compile the pinned amalgamation with `-DSQLITE_ENABLE_SNAPSHOT`
 and fail unless `nm -D --defined-only` lists `sqlite3_snapshot_get` among the
 resulting library's exported definitions, so the optional snapshot API is
 enabled rather than disabled. Because the cells link that private build instead
 of the distribution's `libsqlite3-dev` package that GRDB's SwiftPM
 system-library target otherwise expects, they follow GRDB's documented
-custom-SQLite recipe through SwiftPM's compiler override: the override defines
-`GRDBCUSTOMSQLITE` and points compilation and linking at the pinned headers and
-library. GRDB 6.29.3 admits its `WALSnapshot` support when either
-`SQLITE_ENABLE_SNAPSHOT` is defined or no custom-SQLite flag is set, so
-`GRDBCUSTOMSQLITE` alone would compile that support out. The override therefore
-defines `SQLITE_ENABLE_SNAPSHOT` alongside it, which keeps the snapshot path in
-the build; `DatabasePool` observations use it to avoid an unconditional second
-startup fetch when the database has not changed. The override delegates
+custom-SQLite recipe through SwiftPM's compiler override: the override passes
+`-DGRDBCUSTOMSQLITE` to `swiftc` and points compilation and linking at the
+pinned headers and library. GRDB 6.29.3 admits its `WALSnapshot` support when
+either the Swift-side `SQLITE_ENABLE_SNAPSHOT` condition is defined or no
+custom-SQLite flag is set, so `-DGRDBCUSTOMSQLITE` alone would compile that
+support out. The override therefore passes `-DSQLITE_ENABLE_SNAPSHOT` to
+`swiftc` alongside it, which keeps the snapshot path in the build;
+`DatabasePool` observations use it to avoid an unconditional second startup
+fetch when the database has not changed. The override delegates
 SwiftPM's module-wrapping phase directly to the matching `swift-frontend` and
 remains next to the selected compiler so SwiftPM loads that toolchain's
 index-store runtime. The exact-version runtime probe, capability report, and

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -142,13 +142,23 @@ and the `x86_64-unknown-linux-gnu` target. macOS additionally verifies the exact
 Xcode version, build, and SDK. Toolchain or image drift therefore fails instead
 of silently redefining support.
 
-GRDB 6.29.3's Swift 5.9 Linux condition assumes the linked SQLite exports its
-optional snapshot symbols. The pinned amalgamation intentionally leaves that
-optional API disabled, so the Linux cells consistently define GRDB's documented
-`GRDBCUSTOMSQLITE` build path through SwiftPM's compiler override. This removes
-only the unavailable snapshot API branch. The override delegates SwiftPM's
-module-wrapping phase directly to the matching `swift-frontend` and remains next
-to the selected compiler so SwiftPM loads that toolchain's index-store runtime.
+The Linux cells compile the pinned amalgamation with `SQLITE_ENABLE_SNAPSHOT`
+and fail unless `nm -D` reports `sqlite3_snapshot_get` as an exported symbol of
+the resulting library, so the optional snapshot API is enabled rather than
+disabled. Because the cells link that private build instead of the
+distribution's `libsqlite3-dev` package that GRDB's SwiftPM system-library
+target otherwise expects, they follow GRDB's documented custom-SQLite recipe
+through SwiftPM's compiler override: the override defines `GRDBCUSTOMSQLITE`
+and points compilation and linking at the pinned headers and library. GRDB
+6.29.3 admits its `WALSnapshot` support when either `SQLITE_ENABLE_SNAPSHOT` is
+defined or no custom-SQLite flag is set, so `GRDBCUSTOMSQLITE` alone would
+compile that support out. The override therefore defines
+`SQLITE_ENABLE_SNAPSHOT` alongside it, which keeps the snapshot path in the
+build; `DatabasePool` observations use it to avoid an unconditional second
+startup fetch when the database has not changed. The override delegates
+SwiftPM's module-wrapping phase directly to the matching `swift-frontend` and
+remains next to the selected compiler so SwiftPM loads that toolchain's
+index-store runtime.
 The exact-version runtime probe, capability report, and full tests remain
 authoritative for the pinned SQLite surface.
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -150,17 +150,20 @@ of the distribution's `libsqlite3-dev` package that GRDB's SwiftPM
 system-library target otherwise expects, they follow GRDB's documented
 custom-SQLite recipe through SwiftPM's compiler override: the override passes
 `-DGRDBCUSTOMSQLITE` to `swiftc` and points compilation and linking at the
-pinned headers and library. GRDB 6.29.3 admits its `WALSnapshot` support when
-either the Swift-side `SQLITE_ENABLE_SNAPSHOT` condition is defined or no
-custom-SQLite flag is set, so `-DGRDBCUSTOMSQLITE` alone would compile that
+pinned headers and library. GRDB 6.29.3 compiles its `WALSnapshot` support
+whenever the Swift-side `SQLITE_ENABLE_SNAPSHOT` condition is defined, and
+otherwise only through a fallback that additionally requires both custom-SQLite
+flags to be absent and a compiler-version and platform condition to hold.
+`-DGRDBCUSTOMSQLITE` closes that fallback, so on its own it would compile the
 support out. The override therefore passes `-DSQLITE_ENABLE_SNAPSHOT` to
-`swiftc` alongside it, which keeps the snapshot path in the build;
-`DatabasePool` observations use it to avoid an unconditional second startup
-fetch when the database has not changed. The override delegates
-SwiftPM's module-wrapping phase directly to the matching `swift-frontend` and
-remains next to the selected compiler so SwiftPM loads that toolchain's
-index-store runtime. The exact-version runtime probe, capability report, and
-full tests remain authoritative for the pinned SQLite surface.
+`swiftc` alongside it, which satisfies the first condition directly and keeps
+the snapshot path in the build; `DatabasePool` observations use it to avoid an
+unconditional second startup fetch when the database has not changed. The
+override delegates SwiftPM's module-wrapping phase directly to the matching
+`swift-frontend` and remains next to the selected compiler so SwiftPM loads
+that toolchain's index-store runtime. The exact-version runtime probe,
+capability report, and full tests remain authoritative for the pinned SQLite
+surface.
 
 ## Swift 6 series coverage
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -152,10 +152,10 @@ custom-SQLite recipe through SwiftPM's compiler override: the override passes
 `-DGRDBCUSTOMSQLITE` to `swiftc` and points compilation and linking at the
 pinned headers and library. GRDB 6.29.3 compiles its `WALSnapshot` support
 whenever the Swift-side `SQLITE_ENABLE_SNAPSHOT` condition is defined, and
-otherwise only through a fallback that additionally requires both custom-SQLite
-flags to be absent and a compiler-version and platform condition to hold.
-`-DGRDBCUSTOMSQLITE` closes that fallback, so on its own it would compile the
-support out. The override therefore passes `-DSQLITE_ENABLE_SNAPSHOT` to
+otherwise only through a fallback that additionally requires both
+`GRDBCUSTOMSQLITE` and `GRDBCIPHER` to be undefined and a compiler-version and
+platform condition to hold. `-DGRDBCUSTOMSQLITE` closes that fallback, so on
+its own it would compile the support out. The override therefore passes `-DSQLITE_ENABLE_SNAPSHOT` to
 `swiftc` alongside it, which satisfies the first condition directly and keeps
 the snapshot path in the build; `DatabasePool` observations use it to avoid an
 unconditional second startup fetch when the database has not changed. The

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -143,24 +143,23 @@ Xcode version, build, and SDK. Toolchain or image drift therefore fails instead
 of silently redefining support.
 
 The Linux cells compile the pinned amalgamation with `SQLITE_ENABLE_SNAPSHOT`
-and fail unless `nm -D` reports `sqlite3_snapshot_get` as an exported symbol of
-the resulting library, so the optional snapshot API is enabled rather than
-disabled. Because the cells link that private build instead of the
-distribution's `libsqlite3-dev` package that GRDB's SwiftPM system-library
-target otherwise expects, they follow GRDB's documented custom-SQLite recipe
-through SwiftPM's compiler override: the override defines `GRDBCUSTOMSQLITE`
-and points compilation and linking at the pinned headers and library. GRDB
-6.29.3 admits its `WALSnapshot` support when either `SQLITE_ENABLE_SNAPSHOT` is
-defined or no custom-SQLite flag is set, so `GRDBCUSTOMSQLITE` alone would
-compile that support out. The override therefore defines
-`SQLITE_ENABLE_SNAPSHOT` alongside it, which keeps the snapshot path in the
-build; `DatabasePool` observations use it to avoid an unconditional second
+and fail unless `nm -D --defined-only` lists `sqlite3_snapshot_get` among the
+resulting library's exported definitions, so the optional snapshot API is
+enabled rather than disabled. Because the cells link that private build instead
+of the distribution's `libsqlite3-dev` package that GRDB's SwiftPM
+system-library target otherwise expects, they follow GRDB's documented
+custom-SQLite recipe through SwiftPM's compiler override: the override defines
+`GRDBCUSTOMSQLITE` and points compilation and linking at the pinned headers and
+library. GRDB 6.29.3 admits its `WALSnapshot` support when either
+`SQLITE_ENABLE_SNAPSHOT` is defined or no custom-SQLite flag is set, so
+`GRDBCUSTOMSQLITE` alone would compile that support out. The override therefore
+defines `SQLITE_ENABLE_SNAPSHOT` alongside it, which keeps the snapshot path in
+the build; `DatabasePool` observations use it to avoid an unconditional second
 startup fetch when the database has not changed. The override delegates
 SwiftPM's module-wrapping phase directly to the matching `swift-frontend` and
 remains next to the selected compiler so SwiftPM loads that toolchain's
-index-store runtime.
-The exact-version runtime probe, capability report, and full tests remain
-authoritative for the pinned SQLite surface.
+index-store runtime. The exact-version runtime probe, capability report, and
+full tests remain authoritative for the pinned SQLite surface.
 
 ## Swift 6 series coverage
 


### PR DESCRIPTION
## Problem

The "Swift 5.9 support" section of `COMPATIBILITY.md` described the pinned Linux SQLite build incorrectly:

> GRDB 6.29.3's Swift 5.9 Linux condition assumes the linked SQLite exports its optional snapshot symbols. The pinned amalgamation intentionally leaves that optional API disabled, so the Linux cells consistently define GRDB's documented `GRDBCUSTOMSQLITE` build path through SwiftPM's compiler override. This removes only the unavailable snapshot API branch.

`.github/workflows/swift.yml` does the opposite:

- Line 512 compiles the 3.53.3 amalgamation with `-DSQLITE_ENABLE_SNAPSHOT`.
- Line 520 fails the job unless `nm -D --defined-only` finds `sqlite3_snapshot_get` exported by the resulting `libsqlite3.so`.
- Line 541 passes `-DSQLITE_ENABLE_SNAPSHOT` to `swiftc` alongside `-DGRDBCUSTOMSQLITE`.
- The comment at lines 529-532 states the snapshot capability *is* exposed, and that `DatabasePool` observations use it "to avoid an unconditional second startup fetch when the database has not changed".

So the snapshot API is enabled, and the reason for the `GRDBCUSTOMSQLITE` override was misstated.

## What the override is actually for

Verified against the GRDB 6.29.3 checkout:

- `GRDB/Core/WALSnapshot.swift:2`, `GRDB/Core/DatabasePool.swift:648`, and `GRDB/ValueObservation/Observers/ValueConcurrentObserver.swift:277` all gate the snapshot support on
  `#if SQLITE_ENABLE_SNAPSHOT || (!GRDBCUSTOMSQLITE && !GRDBCIPHER && (compiler(>=5.7.1) || !(os(macOS) || targetEnvironment(macCatalyst))))`.
  Defining `GRDBCUSTOMSQLITE` on its own therefore compiles that support **out** — pairing it with `SQLITE_ENABLE_SNAPSHOT` keeps it **in**.
- GRDB's own `Documentation/CustomSQLiteBuilds.md` prescribes exactly this pairing for custom builds (`-DSQLITE_ENABLE_SNAPSHOT` in the C flags, `-D SQLITE_ENABLE_SNAPSHOT` in the Swift flags), and recommends the option because it "allows GRDB to optimize ValueObservation when you use a Database Pool".
- GRDB's `CSQLite` target is declared as `.systemLibrary(name: "CSQLite", providers: [.apt(["libsqlite3-dev"])])`. The Linux cells link a private amalgamation instead of that distribution package, which is the arrangement `GRDBCUSTOMSQLITE` is documented to signal. The compiler wrapper also carries `-Xcc -I <include>` and `-L <lib>` so compilation and linking resolve against the pinned 3.53.3 headers and library rather than the runner's system SQLite 3.37.
- `ValueConcurrentObserver.swift:202-227` documents the behavioural payoff: without the flag GRDB "will thus always perform a secondary fetch"; with it GRDB "can detect if the database was not changed at all".

## Change

Rewrites the paragraph to describe the enabled snapshot API, the `nm -D` export assertion, why the custom-SQLite path is taken, and why `GRDBCUSTOMSQLITE` must be paired with `SQLITE_ENABLE_SNAPSHOT`. The following sentences about `-modulewrap` delegation, index-store loading, and the runtime probe were already accurate and are kept (only re-wrapped).

Documentation only — no source, workflow, or test changes. `swift test --filter SQLDocumentationCatalogTests` passes (7 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)