### PR TITLE
Report skipped schema checks and short-circuit per-query validation on schema mismatch

### DIFF
--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -201,8 +201,14 @@ public enum SQLiteBuildValidator {
         // pointless — skip preparation and emit one deterministic
         // `unsupported` outcome per manifest entry instead, so callers can
         // still see which queries were skipped.
+        //
+        // Matched by code, not just `stage == .schema && verdict == .failed`:
+        // a future schema-stage check unrelated to snapshot identity would
+        // otherwise silently trigger this short-circuit too.
         let hasSchemaIdentityMismatch = reportDiagnostics.contains {
-            $0.stage == .schema && $0.verdict == .failed
+            $0.stage == .schema
+                && $0.verdict == .failed
+                && Self.schemaIdentityMismatchCodes.contains($0.code)
         }
         let outcomes: [SQLiteBuildValidationQueryOutcome]
         if hasSchemaIdentityMismatch {
@@ -246,6 +252,19 @@ public enum SQLiteBuildValidator {
 
 
 private extension SQLiteBuildValidator {
+    /// Every diagnostic code that reports the live database snapshot's
+    /// identity not matching the manifest's schema snapshot -- the four
+    /// checks in `validate(manifest:in:...)` above (byte count, SHA-256, row
+    /// count, FNV-1a-64 fingerprint). Used to scope the schema-mismatch
+    /// short-circuit to identity checks specifically, not to every
+    /// `.schema`-stage `.failed` diagnostic a future check might add.
+    static let schemaIdentityMismatchCodes: Set<String> = [
+        "schema.byte-count",
+        "schema.snapshot-sha",
+        "schema.row-count",
+        "schema.fingerprint",
+    ]
+
     static func validate(
         query: SQLiteBuildValidationQueryEntry,
         in database: Database,

--- a/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
+++ b/Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift
@@ -176,15 +176,61 @@ public enum SQLiteBuildValidator {
                     message: "Observed schema FNV-1a-64 is \(runtimeMetadata.schemaFNV1A64); the manifest's schema snapshot declares \(validatedManifest.schemaSnapshot.schemaFingerprint)."
                 ))
             }
+        } else {
+            // Capture failed above (`runtime.capture`), so these two checks
+            // never ran — report them explicitly rather than letting them
+            // vanish from the diagnostic set.
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .schema,
+                code: "schema.row-count",
+                message: "Schema row count could not be checked because SQLite runtime metadata capture failed."
+            ))
+            reportDiagnostics.append(SQLiteBuildValidationDiagnostic(
+                verdict: .unsupported,
+                stage: .schema,
+                code: "schema.fingerprint",
+                message: "Schema fingerprint could not be checked because SQLite runtime metadata capture failed."
+            ))
         }
 
-        let outcomes = validatedManifest.queries.map { query in
-            validate(
-                query: query,
-                in: database,
-                runtimeMetadata: runtimeMetadata,
-                environment: environment
-            )
+        // A schema identity mismatch already fails the report outright
+        // (`SQLiteBuildValidationReport.overallVerdict`), independent of
+        // per-query outcomes. Once one is recorded, running every query
+        // against a snapshot already known not to match the manifest is
+        // pointless — skip preparation and emit one deterministic
+        // `unsupported` outcome per manifest entry instead, so callers can
+        // still see which queries were skipped.
+        let hasSchemaIdentityMismatch = reportDiagnostics.contains {
+            $0.stage == .schema && $0.verdict == .failed
+        }
+        let outcomes: [SQLiteBuildValidationQueryOutcome]
+        if hasSchemaIdentityMismatch {
+            outcomes = validatedManifest.queries.map { query in
+                SQLiteBuildValidationQueryOutcome(
+                    query: query,
+                    placeholderAnalysis: SQLiteBuildValidationValidatorPlaceholderScanner.scan(query.sql),
+                    preparedShape: nil,
+                    diagnostics: [
+                        SQLiteBuildValidationDiagnostic(
+                            verdict: .unsupported,
+                            stage: .schema,
+                            code: "schema.mismatch-skipped",
+                            message: "Query validation was skipped because the database snapshot's schema identity does not match the manifest.",
+                            query: query
+                        ),
+                    ]
+                )
+            }
+        } else {
+            outcomes = validatedManifest.queries.map { query in
+                validate(
+                    query: query,
+                    in: database,
+                    runtimeMetadata: runtimeMetadata,
+                    environment: environment
+                )
+            }
         }
         return SQLiteBuildValidationReport(
             manifest: validatedManifest,

--- a/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
+++ b/Tests/SwiftQLSQLiteBuildValidationValidatorTests/SQLiteBuildValidatorIntegrationTests.swift
@@ -405,4 +405,40 @@ final class SQLiteBuildValidatorIntegrationTests: XCTestCase {
             })
         }
     }
+
+    // MARK: - Schema identity mismatch skips every query
+
+    func testSchemaIdentityMismatchSkipsEveryQueryWithNoPreparedShape() throws {
+        let manifest = Support.manifest(
+            schemaSnapshot: Support.schemaSnapshot(schemaRowCount: 999),
+            queries: [
+                Support.query(id: "first", sql: "SELECT 1 AS value"),
+                Support.query(id: "second", sql: "SELECT 2 AS value"),
+                Support.query(id: "third", sql: "SELECT 3 AS value"),
+            ]
+        )
+
+        try Support.withValidatorOwnedNorthwindURL { url in
+            let report = try SQLiteBuildValidator.validate(
+                manifest: manifest,
+                againstDatabaseAt: url
+            )
+            XCTAssertEqual(report.overallVerdict, .failed)
+            XCTAssertEqual(report.outcomes.count, manifest.queries.count)
+            for outcome in report.outcomes {
+                XCTAssertNil(outcome.preparedShape, outcome.queryID)
+                XCTAssertEqual(outcome.diagnostics.count, 1, outcome.queryID)
+                XCTAssertEqual(
+                    outcome.diagnostics.first?.code,
+                    "schema.mismatch-skipped",
+                    outcome.queryID
+                )
+                XCTAssertEqual(
+                    outcome.diagnostics.first?.verdict,
+                    .unsupported,
+                    outcome.queryID
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #440

## Summary

Closes two diagnostic gaps in `SQLiteBuildValidator`, originally raised by Copilot on PR #420 (the v1.5.2 release-prep merge) and deliberately deferred there — the validator code was already-shipped, tested logic and that PR's only job was merging into `main`.

- When `SQLiteBuildValidationRuntime.capture` fails, the schema row-count and fingerprint checks were silently skipped instead of being reported as `.unsupported`.
- When a schema identity mismatch is already recorded, per-query validation ran anyway against a snapshot already known not to match the manifest.

Neither was a soundness bug — `SQLiteBuildValidationReport.overallVerdict` already resolves to `.failed`/`.unsupported` from the report-level diagnostic alone — but both are worth fixing for diagnostic completeness and to avoid pointless work.

## Changes

- `SQLiteBuildValidator.swift`: emit explicit `.unsupported` diagnostics (`schema.row-count`, `schema.fingerprint`) when runtime metadata capture fails, instead of letting those checks silently vanish from the report.
- Short-circuit per-query preparation once a report-level schema `.failed` diagnostic is already recorded, emitting one deterministic `schema.mismatch-skipped` outcome per manifest entry so callers can still see which queries were skipped.

## Supersedes PR #429

This replaces #429, which carried the same commit but targeted `main` directly. Retargeting #429 in place would have dragged 44 unrelated `main` commits into its diff, since `version/1.5.6` branched earlier. Instead the single commit is cherry-picked onto `version/1.5.6`, and #429 is closed.

`Sources/SwiftQLSQLiteBuildValidationValidator/SQLiteBuildValidator.swift` is byte-identical on `main` and `version/1.5.6`, so the cherry-pick applied without conflict and the change is exactly what #429 reviewed.

## Test plan

- [x] `swift test --filter SwiftQLSQLiteBuildValidationValidatorTests` on this branch — 21 tests, 0 failures
- [ ] CI green

Note for CI: `XLPublisherTests.testDistinctDatabasePoolsDoNotCrossTrigger` is a known flake and was the sole failure on #429's otherwise-green run.
