### PR TITLE
Allow SQLRowMacro/SQLRowResult as uninstrumented on the Swift 6.0 coverage cell

### DIFF
--- a/scripts/ci/source-coverage-config.json
+++ b/scripts/ci/source-coverage-config.json
@@ -12,6 +12,8 @@
       "allowed_uninstrumented_sources": [
         "Sources/SwiftQL/GRDBOpenCombineValuePublisher.swift",
         "Sources/SwiftQL/SQL.swift",
+        "Sources/SwiftQL/SQLRowMacro.swift",
+        "Sources/SwiftQL/SQLRowResult.swift",
         "Sources/SwiftQL/SQLScalarResult.swift",
         "Sources/SwiftQL/SwiftQLCore.swift"
       ]


### PR DESCRIPTION
Fixes the one real failure on `main`'s post-merge CI run for v1.5.4 (#443): `Swift 6.0 / first-party source coverage` failed with

```
error: source coverage report: SwiftQL sources disappeared from LLVM coverage without an allowance: Sources/SwiftQL/SQLRowMacro.swift, Sources/SwiftQL/SQLRowResult.swift
```

#443 moved `#row`'s two-to-six column shapes from `compiler(>=6.0)` to `compiler(>=6.1)` after finding the same IRGen crash on the pinned Swift 6.0 cell (Xcode 16.2) that #408 already documented for Swift 5.9.2. That correctly excludes these two files from compilation on the `Swift 6.0 / first-party source coverage` job (pinned to `swift_series == '6.0'`), so they now legitimately disappear from that job's LLVM coverage export and need an explicit allowance — the same mechanism `scripts/ci/source-coverage-config.json` already uses for `SQLScalarResult.swift`/`SQL.swift`.

## Test plan

- [x] Reviewed `scripts/ci/source-coverage-report.py`'s allowance mechanism and confirmed the two added entries match its schema and validation rules
- [x] CI: will confirm `Swift 6.0 / first-party source coverage` passes on this branch
