### PR TITLE
Define buffering and resumed-demand semantics for live-query streams (#291)

### DIFF
--- a/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
@@ -193,3 +193,230 @@ GRDB-backed observations have these behaviors:
 
 Keep the returned cancellable alive for as long as results are needed, and cancel it when the consumer
 no longer needs updates.
+
+## Buffering and Resumed-Demand Semantics (#291)
+
+This section records the decision required by
+[issue #291](https://github.com/lukevanin/swiftql/issues/291): the buffering, cancellation, and
+snapshot-ownership contract that #308's canonical `AsyncThrowingStream` live-query source and #309's
+demand-aware Combine adapter must both implement. It is a design record, not new public API — #308 and
+#309 implement it.
+
+### Why this needed a decision
+
+[Issue #255](https://github.com/lukevanin/swiftql/issues/255)'s repeated-stress contract
+(`Tests/SQLTests/SQLPublisherTests.swift`, `testIncrementalDemandBoundsDeliveryUntilLaterCommitReachesCurrentState`)
+demonstrated that an observed-table refresh can already be in flight after Combine demand is exhausted.
+If demand is replenished before that refresh reaches the subscription, the intermediate durable snapshot
+consumes the new demand, and a later commit then needs another unit of demand. That is not a bug in the
+current Combine publisher; it is the documented, deliberate behavior described above under "Observation
+Semantics" ("Do not treat a new demand request as a 'fetch latest' operation"). But it also means the
+current Combine publisher retains **zero** buffered state: a value that cannot be delivered because
+demand is exhausted is simply dropped, not held. The pinned GRDB dependency's own async observation API
+(`ValueObservation.values(in:bufferingPolicy:)`) defaults `bufferingPolicy` to `.unbounded` — an
+unreviewed default SwiftQL must not silently inherit for its own canonical stream.
+
+### Decision
+
+**SwiftQL's canonical live-query stream buffers at most one snapshot, and a newly produced snapshot
+always replaces (never queues behind) a snapshot that has not yet been delivered.** This is GRDB's own
+`AsyncThrowingStream.Continuation.BufferingPolicy.bufferingNewest(1)` semantics, applied consistently
+whether the eventual consumer is a `for try await` loop or a Combine subscriber pulling through #309's
+adapter. Concretely:
+
+- A stream never holds more than one undelivered snapshot in memory, regardless of write rate or how
+  long a consumer pauses.
+- A snapshot the consumer has not yet asked for is never lost while there is still a chance to deliver
+  a more current one: if two relevant commits happen while the consumer is paused, the second snapshot
+  replaces the first, and the consumer sees the newer one when it resumes.
+- Resuming iteration (or resuming Combine demand) delivers whatever the bridge has already produced — it
+  does not itself force a brand-new fetch of "the literal latest row," and it does not guarantee the
+  single freshest possible state if a write races the delivery. This preserves, rather than changes, the
+  existing Combine contract's warning against treating "new demand" as "fetch latest."
+- The database-state semantics are identical for async and Combine consumers: both are fed by the same
+  bounded, newest-wins buffer. Only how each adapter turns "a value is available" into delivery (await
+  vs. Combine demand accounting) differs.
+
+#### Alternatives considered and rejected
+
+| Policy | Verdict | Why |
+| --- | --- | --- |
+| Unbounded buffer (GRDB's own `.values` default) | Rejected | Memory grows without bound under a slow/paused consumer plus rapid writes — exactly the risk flagged by the #290 evidence. Turns the stream into a de facto commit log, which the issue explicitly forbids. |
+| No buffering at all (current Combine behavior: drop when no demand, hold nothing) | Rejected as the *sole* policy, kept as an accurate description of today's Combine publisher | Correct and bounded, but wasteful: GRDB already did the fetch work, and a resumed consumer must wait for the *next* write to see state it could have had immediately. Does not optimize for "current-state usefulness" the way the issue asks. |
+| A larger fixed bound (e.g. `bufferingNewest(4)`) | Rejected | Buffered live-query snapshots are *state*, not *events*; delivering several stale intermediate snapshots to a resumed consumer misrepresents a state stream as a commit log and does not serve any consumer need "current-state usefulness" doesn't already cover. Memory scales with the bound for no compensating benefit. |
+| Explicit drop-at-fetch-boundary (only one fetch in flight; further relevant-write notifications while a fetch is running are coalesced independent of consumer demand) | Subsumed | This describes GRDB's *own* internal change-coalescing (verified empirically below — it is not exactly one-fetch-per-write), which SwiftQL does not control and should not try to redefine. `bufferingNewest(1)` is the correctly-scoped SwiftQL-owned policy that sits on top of whatever coalescing granularity GRDB's tracking layer already provides. |
+| `bufferingNewest(1)` (selected) | **Accepted** | Bounded to O(1) regardless of write rate or pause duration; always exposes the newest known state on resume; verified implementable and correctly bounded against real GRDB (see Evidence, below); does not change database-state semantics between async and Combine consumers. |
+
+### Snapshot lifecycle state machine
+
+```text
+                     first next() / first iteration
+                                  |
+                                  v
+  [not started] --------------------------------------> [observing]
+       |                                                    |  |
+       | (stream constructed, never iterated)               |  | onChange(value)
+       | -> deinit, no GRDB work ever performed              |  v
+       |                                                     |  [fetched] --yield--> mailbox holds
+       |                                                     |                        exactly 0 or 1
+       |                                                     |                        undelivered
+       |                                                     |                        snapshot
+       |                                                     |
+       | cancel() / consuming Task cancelled                 | onError(error)
+       v                                                      v
+  [terminated: cancelled]                             [terminated: failed]
+       |                                                      |
+       +--------------------- next() resolves to ----------- +
+                  nil (cancelled)     |      throws original error (failed)
+                                      v
+                           no further onChange/onError is delivered;
+                           the GRDB observation and any pending retry
+                           backoff are torn down exactly once.
+```
+
+Lifecycle points, precisely:
+
+- **Fetched**: GRDB's `ValueObservation` computed a value from a relevant commit (or the initial
+  current-state fetch). This always happens, on every relevant write, independent of consumer demand —
+  SwiftQL does not and cannot pause GRDB's own tracking short of cancelling the whole observation.
+- **Yielded**: the fetched value is handed to the buffer. If nothing is waiting, it becomes the single
+  buffered snapshot, replacing whatever was buffered before.
+- **Buffered**: at most one snapshot, held only until either a consumer takes it or a newer one replaces
+  it.
+- **Requested**: a consumer calls `next()` (directly, via `for try await`, or via #309's demand-mapped
+  pull). This never itself triggers a new GRDB fetch; it only asks for whatever the buffer already has,
+  suspending if nothing is buffered yet.
+- **Delivered**: the buffered snapshot (or a value produced synchronously enough to skip buffering) is
+  returned from `next()`.
+- **Superseded**: a buffered-but-undelivered snapshot is discarded because a newer one replaced it. This
+  is the only form of "dropping" in the new policy, and it only ever discards a snapshot that was never
+  delivered to any consumer.
+- **Cancelled**: the consuming `Task` is cancelled, or the bridge's cancellation is invoked explicitly.
+  `next()` resolves to `nil` (a normal end of iteration), never a thrown `CancellationError` and never a
+  completion failure — this matches how cancelling a Combine subscription today never delivers a
+  `.failure` completion.
+
+### Does resuming trigger a fresh fetch?
+
+**No.** Requesting demand again (Combine) or calling `next()` again (async) only asks for whatever GRDB
+has already produced. It does not force GRDB to re-run the query. The only work that unconditionally
+happens on every relevant commit is GRDB's own tracking/fetch, which runs independent of whether any
+consumer is currently asking for values. This is unchanged from today's Combine contract and is
+deliberately **not** strengthened into "resuming fetches the latest state," per the issue's explicit
+hard constraint.
+
+### Single-consumer behavior and an unused stream
+
+Each `stream()` (and `streamOne()`) call creates one independent observation with its own single-slot
+buffer — exactly like each `publish()` call today creates one independent Combine subscription. Two
+consumers that both want live updates must call `stream()` twice; iterating the same `AsyncThrowingStream`
+value with two concurrent loops is not a supported fan-out (Swift's `AsyncThrowingStream` itself does not
+guarantee fan-out semantics — concurrent iterators race over one shared buffer). Constructing a stream
+value and never iterating it must perform no SQLite work: the GRDB observation starts only inside the
+first `next()` call, mirroring "subscribing with zero demand does not start SQLite work" for Combine.
+
+### Cancellation ownership
+
+Cancellation is owned by **`Task` cancellation reaching the suspended `next()` call**, not by merely
+breaking out of a `for await` loop while other strong references to the stream remain alive (breaking a
+loop, by itself, does not cancel anything — the underlying resources stay live until nothing references
+them). Concretely, for #308's implementation:
+
+- `AsyncThrowingStream<Element, Error>`'s `unfolding:` initializer (the one that produces the literal
+  return type #308's methods must expose) has **no separate `onCancel` parameter** — that parameter only
+  exists on `AsyncStream`. Cancellation-awareness must live inside the `produce` closure itself, by
+  wrapping its suspension point in `withTaskCancellationHandler(operation:onCancel:)`.
+- A plain `withCheckedThrowingContinuation` is **not** automatically cancellation-aware; without an
+  explicit `withTaskCancellationHandler`, a suspended `next()` call would simply never resume, and the
+  underlying GRDB observation would keep running indefinitely.
+- #308's retry integration must reuse `GRDBLiveQueryRetryPolicy.swift`'s existing generation-counter
+  cancellation-ownership design (`GRDBLiveQueryRetryState`), retargeted to feed the stream's buffer
+  instead of a Combine `AnyPublisher`. Cancelling the bridge must both end the buffer (so a suspended or
+  future `next()` resolves to `nil`) and cancel the underlying GRDB `AnyDatabaseCancellable`, so no further
+  fetch, retry backoff, or delivery occurs after cancellation.
+
+### Async-to-Combine demand mapping (for #309)
+
+Combine demand maps onto stream iteration through a small pull loop, not a second buffer:
+
+- **Zero demand**: the adapter's internal consumer task must not call `next()` at all. It must not even
+  start the underlying observation until the first unit of demand arrives — this preserves "subscribing
+  with zero demand does not start SQLite work."
+- **Incremental demand** (`request(.max(n))`): the consumer task calls `next()` exactly `n` times,
+  delivering each result downstream and decrementing remaining demand by one per delivery, exactly like
+  GRDB's own `ValueSubscription.request(_:)` accounting today. It never calls `next()` ahead of
+  outstanding demand.
+- **Unlimited demand**: the consumer task loops calling `next()` as fast as values become available,
+  which in practice means it is rate-limited by the bounded buffer and GRDB's own write-driven fetch
+  cadence — not by an unbounded read-ahead queue.
+- **Demand added from `receive(_:)`**: additional demand returned from the downstream subscriber's
+  `receive(_:)` simply increases the remaining-demand counter, which may resume a stalled pull loop; it
+  does not need its own separate mechanism.
+- **Cancellation**: cancelling the Combine subscription cancels the adapter's consumer `Task`, which — via
+  the cancellation-ownership rule above — tears down the GRDB observation. The subscription must never
+  emit after cancellation and must never turn cancellation into a `.failure` completion.
+
+This reproduces the existing Combine demand contract's shape (a value that arrives with no demand
+outstanding is effectively not delivered) while changing *what "not delivered" means*: today it means
+"permanently dropped, gone"; under the new policy it means "held as the one buffered snapshot, and
+delivered without needing to wait for one more relevant write, once demand resumes." That is the one
+intentional behavior change from the current publisher contract — see Migration, below.
+
+### Evidence
+
+`Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift` contains a throwaway, test-scoped prototype
+(`LazyBufferedGRDBBridge`, `SingleSlotMailbox`, `DemandDrivenPuller` — none of this is production API)
+built directly on GRDB's own `ValueObservation.start(in:scheduling:onError:onChange:)`, the same
+primitive `GRDBLiveQueryRetryPolicy.swift` already uses for the Combine path. It exists only to produce
+deterministic, real-GRDB evidence that this policy is implementable on the pinned Swift 5.9 / GRDB 6.29.3
+toolchain, using bounded polling (not sleeps) for synchronization, matching the existing test suite's
+style. Two properties of `AsyncThrowingStream<Element, Error>(unfolding:)` were verified empirically
+against the pinned Swift toolchain (not assumed) before this design was finalized: constructing it
+performs no work until the first `next()` call, and its `produce` closure is invoked exactly once per
+consumer pull with no internal read-ahead — both required for the literal `AsyncThrowingStream` return
+type to satisfy "observation begins with iteration."
+
+| Edge case | Test oracle |
+| --- | --- |
+| Unused stream | `LiveQueryBufferingSemanticsTests.testUnusedStreamPerformsNoFetch` |
+| Slow/paused async consumer, rapid commits, in-flight fetch, buffer replacement | `LiveQueryBufferingSemanticsTests.testPausedConsumerWithRapidCommitsSeesOnlyTheNewestBoundedSnapshot` |
+| Resumed iteration does not itself trigger a fetch | `LiveQueryBufferingSemanticsTests.testResumingIterationDoesNotItselfStartASecondObservationOrForceAFetch` |
+| Cancellation (explicit) | `LiveQueryBufferingSemanticsTests.testExplicitCancelStopsDeliveryAndTearsDownTheUnderlyingObservation` |
+| Cancellation (consuming `Task`, via the literal `AsyncThrowingStream` type) | `LiveQueryBufferingSemanticsTests.testCancellingTheConsumingTaskCancelsTheUnderlyingObservation` |
+| Terminal error, delivered exactly once | `LiveQueryBufferingSemanticsTests.testTerminalErrorIsForwardedExactlyOnceThroughTheBridge` |
+| Two consumers from separate calls; independent databases/streams | `LiveQueryBufferingSemanticsTests.testTwoIndependentBridgesDoNotShareBufferedStateOrCrossTrigger` |
+| Zero demand, incremental demand | `LiveQueryBufferingSemanticsTests.testDemandDrivenPullerConsumesExactlyDemandedCountWithoutEagerDraining` |
+| Unlimited demand | `LiveQueryBufferingSemanticsTests.testUnlimitedDemandDeliversAsValuesBecomeAvailableWithoutSpinningOrDoubleDelivery` |
+| Cancellation during fetch/backoff, retry, consecutive-equal-snapshot, transaction coalescing, rollback exclusion, immutable-binding capture, cross-database isolation | Already covered by the existing #255 stress contract and are **unchanged** by this decision: `Tests/SQLTests/GRDBLiveQueryRetryTests.swift` (`testCancellationDuringBackoffStartsNoLaterAttemptOrCallback`, `testEachSubscriberOwnsAnIndependentRetryBudget`, `testRealGRDBObservationRecoversFromInjectedBusyAndKeepsObserving`) and `Tests/SQLTests/SQLPublisherTests.swift` (`testMultipleWritesInOneTransactionPublishOnlyDurableState`, `testRolledBackWriteNeverAppearsBeforeCommittedLiveness`, `testDistinctDatabasePoolsDoNotCrossTrigger`, `testIrrelevantTableWriteDoesNotChangeObservedSnapshot`) |
+
+### Migration guidance
+
+Nothing about `publish()`/`publishOne()`'s public signatures, subscription-time behavior, fresh-initial-
+value guarantee, main-queue delivery default, retry policy, transaction coalescing, or cross-database
+isolation changes. The one intentional behavior change, once #309 lands:
+
+- **Before**: a value computed while a Combine subscriber had zero outstanding demand was dropped
+  permanently. The subscriber would not see that state until another *relevant write* happened after
+  demand was replenished.
+- **After**: that value is retained as the single buffered snapshot. Once demand is replenished, the
+  subscriber sees it immediately — without needing to wait for a further write.
+- **Who is affected**: only consumers that relied on the old drop-everything behavior to mean "resuming
+  demand never reveals state that existed before I requested more" — that was never a documented
+  guarantee, and the existing documentation already warns against depending on demand timing to infer
+  freshness. No source changes are required; no client can newly observe *stale* data it could not see
+  before, only *current* data slightly sooner.
+
+### Remaining limitations
+
+- The evidence above validates the bridge design against a raw GRDB `ValueObservation`, not against
+  #308's actual production request/retry/binding-capture pipeline; #308 must still write its own
+  integration tests once the real `stream()` methods exist, following the same bounded-polling style.
+  This document's edge-case coverage should be treated as a checklist for that follow-up test suite, not
+  a replacement for it.
+- GRDB's own change-notification coalescing granularity (how many rapid writes collapse into one
+  `ValueObservation` re-fetch) is not something SwiftQL controls or has committed to a specific number
+  for; `testPausedConsumerWithRapidCommitsSeesOnlyTheNewestBoundedSnapshot` deliberately asserts only that
+  resuming needs *far fewer* `next()` calls than there were writes, not an exact coalescing ratio, since
+  that ratio can vary with scheduling and is not part of this contract.
+- This decision does not address `XLResultSet` row-by-row cursors (#249) or the query-plan/index-advice
+  work (#396) — it is scoped exclusively to whole-snapshot live-query streams.

--- a/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
@@ -367,7 +367,9 @@ intentional behavior change from the current publisher contract — see Migratio
 `Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift` contains a throwaway, test-scoped prototype
 (`LazyBufferedGRDBBridge`, `SingleSlotMailbox`, `DemandDrivenPuller` — none of this is production API)
 built directly on GRDB's own `ValueObservation.start(in:scheduling:onError:onChange:)`, the same
-primitive `GRDBLiveQueryRetryPolicy.swift` already uses for the Combine path. It exists only to produce
+primitive `GRDBSQLDatabase.swift`'s `publisher(fetch:)` already calls for the OpenCombine path -- with
+retry supplied by `GRDBLiveQueryRetryPolicy.swift`'s `makeGRDBLiveQueryRetryPublisher` wrapping that
+source, not by calling `.start` itself. It exists only to produce
 deterministic, real-GRDB evidence that this policy is implementable on the pinned Swift 5.9 / GRDB 6.29.3
 toolchain, using bounded polling (not sleeps) for synchronization, matching the existing test suite's
 style. Two properties of `AsyncThrowingStream<Element, Error>(unfolding:)` were verified empirically

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -126,7 +126,10 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
             return .value(value)
         }
         if isFinished {
-            if let pendingError { return .error(pendingError) }
+            if let pendingError {
+                self.pendingError = nil
+                return .error(pendingError)
+            }
             return .finished
         }
         return .pending
@@ -150,6 +153,7 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
         }
         if isFinished {
             let error = pendingError
+            pendingError = nil
             lock.unlock()
             if let error {
                 continuation.resume(throwing: error)

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -1,9 +1,6 @@
 //
 //  LiveQueryBufferingSemanticsTests.swift
 //
-//
-//  Created by Claude on 2026/07/29.
-//
 
 import Foundation
 import GRDB
@@ -22,8 +19,10 @@ private struct AwaitNextTimeoutError: Error {}
 // pinned Swift 5.9 / GRDB 6.29.3 toolchain, ahead of #308 building the real
 // canonical `AsyncThrowingStream` source. It intentionally reuses GRDB's own
 // low-level `ValueObservation.start(in:scheduling:onError:onChange:)`, the
-// same primitive `GRDBLiveQueryRetryPolicy.swift` already builds retry on top
-// of for the Combine path.
+// same primitive `GRDBSQLDatabase.swift`'s `publisher(fetch:)` already calls
+// for the OpenCombine path -- with retry supplied by
+// `GRDBLiveQueryRetryPolicy.swift`'s `makeGRDBLiveQueryRetryPublisher`
+// wrapping that source, not by calling `.start` itself.
 //
 // Design, empirically verified against the pinned Swift toolchain before
 // writing these tests (see the session's throwaway `probe.swift` /
@@ -176,6 +175,11 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
             }
             return
         }
+        precondition(
+            waiter == nil,
+            "SingleSlotMailbox.next() called concurrently: a second caller "
+                + "would silently overwrite and leak/hang the first waiter."
+        )
         waiter = continuation
         lock.unlock()
     }
@@ -311,6 +315,13 @@ private final class DemandDrivenPuller<Value>: @unchecked Sendable {
 
     private var isFinished = false
 
+    /// Set by an explicit `cancel()`, distinct from `isFinished` alone: lets
+    /// an in-flight `pumpNext()` tell "the bridge legitimately completed or
+    /// failed" apart from "this puller was cancelled," so cancellation never
+    /// surfaces through `onFinish` -- mirroring how cancelling a Combine
+    /// subscription never delivers a `.finished`/`.failure` completion.
+    private var wasCancelled = false
+
     private let onValue: (Value) -> Void
 
     private let onFinish: (Error?) -> Void
@@ -352,6 +363,7 @@ private final class DemandDrivenPuller<Value>: @unchecked Sendable {
     func cancel() {
         lock.lock()
         isFinished = true
+        wasCancelled = true
         lock.unlock()
         bridge.cancel()
     }
@@ -360,8 +372,9 @@ private final class DemandDrivenPuller<Value>: @unchecked Sendable {
         Task {
             do {
                 guard let value = try await bridge.next() else {
-                    markFinished()
-                    onFinish(nil)
+                    if markFinished() {
+                        onFinish(nil)
+                    }
                     return
                 }
                 onValue(value)
@@ -370,8 +383,9 @@ private final class DemandDrivenPuller<Value>: @unchecked Sendable {
                 }
             }
             catch {
-                markFinished()
-                onFinish(error)
+                if markFinished() {
+                    onFinish(error)
+                }
             }
         }
     }
@@ -381,11 +395,18 @@ private final class DemandDrivenPuller<Value>: @unchecked Sendable {
     /// unavailable directly inside asynchronous contexts (an error under the
     /// Swift 6 language mode), so every mutation happens in a plain,
     /// non-`async` helper instead.
-    private func markFinished() {
+    ///
+    /// - Returns: `true` if `onFinish` should be delivered for this
+    ///   termination, `false` if an explicit `cancel()` already fired (or
+    ///   raced this call) and the completion must be suppressed.
+    @discardableResult
+    private func markFinished() -> Bool {
         lock.lock()
+        defer { lock.unlock() }
+        let shouldDeliver = !wasCancelled
         isFinished = true
         isPulling = false
-        lock.unlock()
+        return shouldDeliver
     }
 
     private func decrementDemandAndCheckWhetherToContinue() -> Bool {

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -329,6 +329,9 @@ private final class DemandDrivenPuller<Value>: @unchecked Sendable {
     /// stops the instant remaining demand reaches zero rather than reading
     /// ahead into a side buffer.
     func requestDemand(_ amount: Int) {
+        guard amount > 0 else {
+            return
+        }
         lock.lock()
         guard !isFinished else {
             lock.unlock()
@@ -465,7 +468,9 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
 
     override func tearDown() {
         databasePool = nil
-        try? FileManager.default.removeItem(at: databaseDirectoryURL)
+        if let databaseDirectoryURL {
+            try? FileManager.default.removeItem(at: databaseDirectoryURL)
+        }
         databaseDirectoryURL = nil
     }
 
@@ -794,20 +799,6 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
             barrier.fulfill()
         }
         wait(for: [barrier], timeout: 2)
-    }
-
-    private func waitForCounter(_ counter: LockedCounter, toExceed floor: Int) {
-        for attempt in 1 ... 200 {
-            if counter.read() > floor {
-                return
-            }
-            let poll = expectation(description: "counter poll \(attempt)")
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                poll.fulfill()
-            }
-            wait(for: [poll], timeout: 0.2)
-        }
-        XCTFail("Expected counter to exceed \(floor); read \(counter.read()).")
     }
 
     private func waitForCount<Element>(_ array: LockedArray<Element>, atLeast minimumCount: Int) {

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -278,6 +278,7 @@ private final class LazyBufferedGRDBBridge<Value>: @unchecked Sendable {
         lock.lock()
         didStart = true
         let existing = cancellable
+        cancellable = nil
         lock.unlock()
         existing?.cancel()
         mailbox.cancel()

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -87,11 +87,17 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
             return
         }
         isFinished = true
-        // Termination wins over any value already buffered (or about to be
-        // buffered by a `yield` that lost the lock race to this call): a
-        // buffered-but-undelivered snapshot must not surface after the
-        // stream has ended.
-        pendingValue = nil
+        // Deliberately does NOT clear `pendingValue`: a value legitimately
+        // yielded before `finish()` is called (e.g. a source that emits one
+        // final value and completes immediately afterward) must still be
+        // delivered by the next `next()` call before iteration ends -- values
+        // then completion, in that order. Confirmed by #308's production use
+        // of this same policy: a `Just`-backed compatibility publisher's
+        // yield-then-finish happens synchronously within one callback chain,
+        // and discarding the buffered value here silently dropped it.
+        // `yield(_:)`'s own `isFinished` guard already prevents a value that
+        // arrives *after* `finish()`/`cancel()` from ever being buffered,
+        // which is the actual race this type must reject.
         if let waiter {
             self.waiter = nil
             lock.unlock()

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -62,6 +62,14 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
 
     func yield(_ value: Value) {
         lock.lock()
+        // Termination wins over any value that arrives at or after it: once
+        // finished, a mailbox never buffers or delivers a further value, so a
+        // GRDB refresh racing with cancellation/completion cannot resurrect
+        // delivery after the stream has ended.
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
         totalYieldCount += 1
         if let waiter {
             self.waiter = nil
@@ -80,6 +88,11 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
             return
         }
         isFinished = true
+        // Termination wins over any value already buffered (or about to be
+        // buffered by a `yield` that lost the lock race to this call): a
+        // buffered-but-undelivered snapshot must not surface after the
+        // stream has ended.
+        pendingValue = nil
         if let waiter {
             self.waiter = nil
             lock.unlock()
@@ -257,9 +270,13 @@ private final class LazyBufferedGRDBBridge<Value>: @unchecked Sendable {
 
     /// Cancels the underlying GRDB observation and ends the mailbox. Safe to
     /// call more than once, and safe to call whether or not `next()` was
-    /// ever invoked.
+    /// ever invoked. Claims the start slot itself when observation never
+    /// began, so a `next()` call arriving after `cancel()` finds the mailbox
+    /// already finished instead of starting a fresh GRDB observation that
+    /// nothing will ever consume.
     func cancel() {
         lock.lock()
+        didStart = true
         let existing = cancellable
         lock.unlock()
         existing?.cancel()
@@ -788,7 +805,7 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                 poll.fulfill()
             }
-            wait(for: [poll], timeout: 1)
+            wait(for: [poll], timeout: 0.2)
         }
         XCTFail("Expected counter to exceed \(floor); read \(counter.read()).")
     }
@@ -802,7 +819,7 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                 poll.fulfill()
             }
-            wait(for: [poll], timeout: 1)
+            wait(for: [poll], timeout: 0.2)
         }
         XCTFail("Expected at least \(minimumCount) delivered values; received \(array.read().count).")
     }

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -1,0 +1,829 @@
+//
+//  LiveQueryBufferingSemanticsTests.swift
+//
+//
+//  Created by Claude on 2026/07/29.
+//
+
+import Foundation
+import GRDB
+import XCTest
+
+
+private struct AwaitNextTimeoutError: Error {}
+
+
+// MARK: - Evidence-only prototype (see Sources/SwiftQL/SwiftQL.docc/LiveQueries.md,
+// "Buffering and Resumed-Demand Semantics (#291)")
+//
+// `LazyBufferedGRDBBridge` is NOT production SwiftQL API. It exists only to
+// produce deterministic, real-GRDB evidence that the buffering, cancellation,
+// and lazy-start policy selected by issue #291 is implementable on the
+// pinned Swift 5.9 / GRDB 6.29.3 toolchain, ahead of #308 building the real
+// canonical `AsyncThrowingStream` source. It intentionally reuses GRDB's own
+// low-level `ValueObservation.start(in:scheduling:onError:onChange:)`, the
+// same primitive `GRDBLiveQueryRetryPolicy.swift` already builds retry on top
+// of for the Combine path.
+//
+// Design, empirically verified against the pinned Swift toolchain before
+// writing these tests (see the session's throwaway `probe.swift` /
+// `probe2.swift` scripts, not checked into the repository):
+//
+// - `AsyncThrowingStream<Element, Error>(unfolding:)` performs zero work
+//   until the first `next()` call, and calls its `produce` closure exactly
+//   once per consumer pull — it does not pull ahead of consumption or
+//   accumulate a backlog on its own. This is what makes it possible to
+//   return the literal `AsyncThrowingStream<[Row], Error>` type required by
+//   #308 while still deferring GRDB observation start to first iteration.
+// - `AsyncThrowingStream`'s `unfolding:` initializer has no `onCancel`
+//   parameter (unlike `AsyncStream`). Cancellation must be handled inside
+//   the `produce` closure itself, by wrapping the suspension point in
+//   `withTaskCancellationHandler(operation:onCancel:)`.
+private final class SingleSlotMailbox<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    /// The buffering bound selected by #291: at most one snapshot is ever
+    /// held. A newly yielded value replaces (not queues behind) any
+    /// previously buffered, undelivered value.
+    private var pendingValue: Value?
+
+    private var pendingError: Error?
+
+    private var isFinished = false
+
+    private var waiter: CheckedContinuation<Value?, Error>?
+
+    /// Number of values ever placed into the mailbox (delivered immediately
+    /// to a waiter, or buffered and possibly later replaced). Used by tests
+    /// to observe how many times GRDB actually produced a fresh value,
+    /// independent of consumer pacing.
+    private(set) var totalYieldCount = 0
+
+    func yield(_ value: Value) {
+        lock.lock()
+        totalYieldCount += 1
+        if let waiter {
+            self.waiter = nil
+            lock.unlock()
+            waiter.resume(returning: value)
+            return
+        }
+        pendingValue = value
+        lock.unlock()
+    }
+
+    func finish(throwing error: Error?) {
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        isFinished = true
+        if let waiter {
+            self.waiter = nil
+            lock.unlock()
+            if let error {
+                waiter.resume(throwing: error)
+            }
+            else {
+                waiter.resume(returning: nil)
+            }
+            return
+        }
+        pendingError = error
+        lock.unlock()
+    }
+
+    /// Ends the mailbox without an error: a cancelled bridge resolves any
+    /// outstanding or future `next()` call to `nil`, exactly like a normal,
+    /// non-erroring end of iteration. Cancellation is never surfaced to the
+    /// consumer as a thrown `CancellationError` or as a completion failure,
+    /// mirroring how cancelling a Combine subscription today never delivers
+    /// a `.failure` completion.
+    func cancel() {
+        finish(throwing: nil)
+    }
+
+    private enum FastPathOutcome {
+        case value(Value)
+        case error(Error)
+        case finished
+        case pending
+    }
+
+    /// All plain synchronous locked mutation is kept out of `next()`'s
+    /// `async` body: recent Foundation marks `NSLock.lock()`/`unlock()` as
+    /// unavailable directly inside asynchronous contexts (an error under the
+    /// Swift 6 language mode), so both the initial fast-path check and the
+    /// re-check performed once a continuation is available live in plain,
+    /// non-`async` helper methods instead.
+    private func checkFastPath() -> FastPathOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        if let value = pendingValue {
+            pendingValue = nil
+            return .value(value)
+        }
+        if isFinished {
+            if let pendingError { return .error(pendingError) }
+            return .finished
+        }
+        return .pending
+    }
+
+    /// Re-checks and, if still pending, registers the continuation as the
+    /// single outstanding waiter — all inside one locked critical section.
+    /// This must not be split into a separate check-then-register pair of
+    /// locked calls: a value or termination arriving on another thread in
+    /// the gap between them would otherwise be lost (`yield`/`finish` only
+    /// resume a `waiter` that is already registered; anything arriving
+    /// before registration would sit in `pendingValue`/`isFinished` and
+    /// never wake this continuation).
+    private func resolveImmediatelyOrRegister(_ continuation: CheckedContinuation<Value?, Error>) {
+        lock.lock()
+        if let value = pendingValue {
+            pendingValue = nil
+            lock.unlock()
+            continuation.resume(returning: value)
+            return
+        }
+        if isFinished {
+            let error = pendingError
+            lock.unlock()
+            if let error {
+                continuation.resume(throwing: error)
+            }
+            else {
+                continuation.resume(returning: nil)
+            }
+            return
+        }
+        waiter = continuation
+        lock.unlock()
+    }
+
+    func next() async throws -> Value? {
+        switch checkFastPath() {
+        case .value(let value):
+            return value
+        case .error(let error):
+            throw error
+        case .finished:
+            return nil
+        case .pending:
+            return try await withCheckedThrowingContinuation { continuation in
+                resolveImmediatelyOrRegister(continuation)
+            }
+        }
+    }
+}
+
+
+/// Bridges a raw GRDB `ValueObservation` into a lazily-started, single-slot
+/// ("newest wins") buffered `AsyncThrowingStream`. Observation starts only on
+/// the first `next()` call — never merely by constructing the bridge or its
+/// `stream()` value — and a cancelled consuming `Task` tears down the
+/// underlying GRDB `AnyDatabaseCancellable` promptly.
+private final class LazyBufferedGRDBBridge<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var didStart = false
+
+    private var cancellable: AnyDatabaseCancellable?
+
+    private let mailbox = SingleSlotMailbox<Value>()
+
+    private let startObservation: (
+        @escaping (Error) -> Void,
+        @escaping (Value) -> Void
+    ) -> AnyDatabaseCancellable
+
+    /// Number of times this bridge has actually started the underlying GRDB
+    /// observation. Must be 0 for a bridge whose stream is never iterated,
+    /// and at most 1 for the lifetime of one bridge (one `stream()` call is
+    /// one independent, single-consumer observation).
+    private(set) var startCount = 0
+
+    init(
+        start: @escaping (
+            @escaping (Error) -> Void,
+            @escaping (Value) -> Void
+        ) -> AnyDatabaseCancellable
+    ) {
+        self.startObservation = start
+    }
+
+    var totalYieldCount: Int { mailbox.totalYieldCount }
+
+    /// Synchronous locked mutation kept out of `next()`'s `async` body (see
+    /// the equivalent note on `SingleSlotMailbox`). Returns `true` exactly
+    /// once, for the call that must actually start the GRDB observation.
+    private func claimStart() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !didStart else { return false }
+        didStart = true
+        startCount += 1
+        return true
+    }
+
+    private func storeCancellable(_ newCancellable: AnyDatabaseCancellable) {
+        lock.lock()
+        cancellable = newCancellable
+        lock.unlock()
+    }
+
+    func next() async throws -> Value? {
+        if claimStart() {
+            let mailbox = self.mailbox
+            let newCancellable = startObservation(
+                { error in mailbox.finish(throwing: error) },
+                { value in mailbox.yield(value) }
+            )
+            storeCancellable(newCancellable)
+        }
+
+        return try await withTaskCancellationHandler(
+            operation: { try await mailbox.next() },
+            onCancel: { [weak self] in self?.cancel() }
+        )
+    }
+
+    /// Cancels the underlying GRDB observation and ends the mailbox. Safe to
+    /// call more than once, and safe to call whether or not `next()` was
+    /// ever invoked.
+    func cancel() {
+        lock.lock()
+        let existing = cancellable
+        lock.unlock()
+        existing?.cancel()
+        mailbox.cancel()
+    }
+
+    /// The publicly-shaped return type #308 must expose. Constructing this
+    /// value performs no database work: only the first `next()` call (i.e.
+    /// the first iteration attempt, whether via `for try await` or a manual
+    /// `makeAsyncIterator().next()`) starts the GRDB observation.
+    func stream() -> AsyncThrowingStream<Value, Error> {
+        AsyncThrowingStream(unfolding: { [weak self] in
+            try await self?.next()
+        })
+    }
+}
+
+
+/// Minimal demand-aware puller validating the #309 async-to-Combine demand
+/// mapping: pulls from the bridge exactly once per unit of granted demand,
+/// never ahead of demand, and never through a second unbounded queue.
+private final class DemandDrivenPuller<Value>: @unchecked Sendable {
+
+    private let bridge: LazyBufferedGRDBBridge<Value>
+
+    private let lock = NSLock()
+
+    private var remainingDemand = 0
+
+    private var isPulling = false
+
+    private var isFinished = false
+
+    private let onValue: (Value) -> Void
+
+    private let onFinish: (Error?) -> Void
+
+    init(
+        bridge: LazyBufferedGRDBBridge<Value>,
+        onValue: @escaping (Value) -> Void,
+        onFinish: @escaping (Error?) -> Void
+    ) {
+        self.bridge = bridge
+        self.onValue = onValue
+        self.onFinish = onFinish
+    }
+
+    /// Combine's `request(_:)` maps onto this: granting demand only ever
+    /// starts pulling if nothing is currently in flight, and the pull loop
+    /// stops the instant remaining demand reaches zero rather than reading
+    /// ahead into a side buffer.
+    func requestDemand(_ amount: Int) {
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        remainingDemand += amount
+        let shouldStartPulling = !isPulling && remainingDemand > 0
+        if shouldStartPulling {
+            isPulling = true
+        }
+        lock.unlock()
+        if shouldStartPulling {
+            pumpNext()
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        isFinished = true
+        lock.unlock()
+        bridge.cancel()
+    }
+
+    private func pumpNext() {
+        Task {
+            do {
+                guard let value = try await bridge.next() else {
+                    markFinished()
+                    onFinish(nil)
+                    return
+                }
+                onValue(value)
+                if decrementDemandAndCheckWhetherToContinue() {
+                    pumpNext()
+                }
+            }
+            catch {
+                markFinished()
+                onFinish(error)
+            }
+        }
+    }
+
+    /// Synchronous locked mutation extracted out of the `async` `pumpNext`
+    /// body: recent Foundation marks `NSLock.lock()`/`unlock()` as
+    /// unavailable directly inside asynchronous contexts (an error under the
+    /// Swift 6 language mode), so every mutation happens in a plain,
+    /// non-`async` helper instead.
+    private func markFinished() {
+        lock.lock()
+        isFinished = true
+        isPulling = false
+        lock.unlock()
+    }
+
+    private func decrementDemandAndCheckWhetherToContinue() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        remainingDemand -= 1
+        let shouldContinue = remainingDemand > 0 && !isFinished
+        if !shouldContinue {
+            isPulling = false
+        }
+        return shouldContinue
+    }
+}
+
+
+private final class LockedCounter: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var value = 0
+
+    @discardableResult
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+        return value
+    }
+
+    func read() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+
+private final class LockedArray<Element>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var values: [Element] = []
+
+    func append(_ value: Element) {
+        lock.lock()
+        defer { lock.unlock() }
+        values.append(value)
+    }
+
+    func read() -> [Element] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+
+final class LiveQueryBufferingSemanticsTests: XCTestCase {
+
+    private var databaseDirectoryURL: URL!
+    private var databasePool: DatabasePool!
+
+    override func setUpWithError() throws {
+        databaseDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: databaseDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        let fileURL = databaseDirectoryURL.appendingPathComponent(
+            "evidence.sqlite",
+            isDirectory: false
+        )
+        databasePool = try DatabasePool(path: fileURL.path)
+        try databasePool.write { database in
+            try database.execute(
+                sql: "CREATE TABLE Row (id TEXT NOT NULL PRIMARY KEY, value INT NOT NULL)"
+            )
+        }
+    }
+
+    override func tearDown() {
+        databasePool = nil
+        try? FileManager.default.removeItem(at: databaseDirectoryURL)
+        databaseDirectoryURL = nil
+    }
+
+    // MARK: - Unused stream (edge case: unused stream)
+
+    func testUnusedStreamPerformsNoFetch() throws {
+        let fetchCounter = LockedCounter()
+        var bridge: LazyBufferedGRDBBridge<Int>? = makeBridge(fetchProbe: { fetchCounter.increment() })
+        _ = bridge!.stream() // constructed, never iterated
+
+        drainMainQueue()
+        XCTAssertEqual(fetchCounter.read(), 0, "Constructing an unused stream must perform no fetch.")
+        XCTAssertEqual(bridge!.startCount, 0, "Constructing an unused stream must not start an observation.")
+        bridge = nil
+    }
+
+    // MARK: - Slow/paused consumer + rapid commits (edge cases: slow async
+    // consumer, rapid commits, in-flight fetch, buffer replacement)
+
+    func testPausedConsumerWithRapidCommitsSeesOnlyTheNewestBoundedSnapshot() throws {
+        let writeCount = 20
+        let bridge = makeBridge()
+
+        let initialValue = try awaitNext(bridge)
+        XCTAssertEqual(initialValue, 0)
+
+        // Consumer is "paused": twenty relevant commits happen back to back,
+        // synchronously, with no intervening `next()` call. GRDB's own
+        // change-notification scheduling decides how many of these coalesce
+        // into a single re-fetch, so this deliberately does not assume
+        // exactly one re-fetch reflects all twenty writes (it may not:
+        // a concurrent reader-based re-fetch can race ahead of the writer
+        // loop and observe an intermediate row count). What the bounded,
+        // newest-wins mailbox *does* guarantee is that resuming iteration
+        // never needs one `next()` call per write to catch up.
+        for index in 0 ..< writeCount {
+            try insert("row-\(index)", index)
+        }
+
+        var observedValues: [Int] = []
+        for attempt in 1 ... writeCount {
+            guard let value = try awaitNext(bridge) else {
+                XCTFail("Bridge terminated unexpectedly while draining to the final snapshot.")
+                break
+            }
+            observedValues.append(value)
+            if value == writeCount {
+                XCTAssertLessThan(
+                    attempt,
+                    writeCount,
+                    "Bounded buffering must coalesce most of \(writeCount) rapid commits into far "
+                        + "fewer delivered snapshots than one `next()` call per write."
+                )
+                break
+            }
+        }
+        XCTAssertEqual(observedValues.last, writeCount, "Resuming must eventually reach the current state.")
+
+        bridge.cancel()
+    }
+
+    // MARK: - Resumed iteration does not itself trigger a fetch
+
+    func testResumingIterationDoesNotItselfStartASecondObservationOrForceAFetch() throws {
+        let fetchCounter = LockedCounter()
+        let bridge = makeBridge(fetchProbe: { fetchCounter.increment() })
+
+        _ = try awaitNext(bridge)
+        XCTAssertEqual(bridge.startCount, 1)
+        let fetchCountAfterInitial = fetchCounter.read()
+        XCTAssertGreaterThanOrEqual(fetchCountAfterInitial, 1)
+
+        // Resume iteration with no relevant write in between. Starting a
+        // fresh observation increments `startCount` synchronously inside
+        // `next()`, so this check is not a timing race: an already-started
+        // bridge must never touch it again.
+        let secondExpectation = expectation(description: "second next() resolves only after a later write")
+        let secondValue = LockedValueBox<Int?>(nil)
+        Task {
+            secondValue.set(try await bridge.next())
+            secondExpectation.fulfill()
+        }
+        drainMainQueue()
+        XCTAssertEqual(bridge.startCount, 1, "Resuming iteration must not start a second observation.")
+        XCTAssertEqual(fetchCounter.read(), fetchCountAfterInitial, "Resuming iteration must not itself force a fetch.")
+
+        try insert("later", 1)
+        wait(for: [secondExpectation], timeout: 2)
+        XCTAssertEqual(secondValue.get(), 1)
+
+        bridge.cancel()
+    }
+
+    // MARK: - Cancellation ownership (edge cases: cancellation during
+    // fetch/backoff is covered by the existing GRDBLiveQueryRetryTests
+    // suite; this covers cancellation of the buffered bridge itself)
+
+    func testExplicitCancelStopsDeliveryAndTearsDownTheUnderlyingObservation() throws {
+        let fetchCounter = LockedCounter()
+        let bridge = makeBridge(fetchProbe: { fetchCounter.increment() })
+
+        _ = try awaitNext(bridge)
+        let fetchCountBeforeCancel = fetchCounter.read()
+
+        bridge.cancel()
+
+        let afterCancel = try awaitNext(bridge)
+        XCTAssertNil(afterCancel, "A cancelled bridge resolves to nil, never a value or an error.")
+
+        try insert("after-cancel", 1)
+        drainMainQueue()
+        XCTAssertEqual(
+            fetchCounter.read(),
+            fetchCountBeforeCancel,
+            "Cancellation must stop the underlying GRDB observation from fetching again."
+        )
+    }
+
+    func testCancellingTheConsumingTaskCancelsTheUnderlyingObservation() throws {
+        let fetchCounter = LockedCounter()
+        let bridge = makeBridge(fetchProbe: { fetchCounter.increment() })
+        let stream = bridge.stream()
+        let seen = LockedArray<Int>()
+        let loopExpectation = expectation(description: "loop ends after task cancellation")
+
+        let task = Task {
+            do {
+                for try await value in stream {
+                    seen.append(value)
+                }
+            }
+            catch {
+                XCTFail("Unexpected stream error: \(error)")
+            }
+            loopExpectation.fulfill()
+        }
+
+        waitForCount(seen, atLeast: 1)
+        task.cancel()
+        wait(for: [loopExpectation], timeout: 2)
+        XCTAssertEqual(seen.read(), [0])
+
+        let fetchCountAtCancel = fetchCounter.read()
+        try insert("after-task-cancel", 99)
+        drainMainQueue()
+        XCTAssertEqual(
+            fetchCounter.read(),
+            fetchCountAtCancel,
+            "Cancelling the consuming task must cancel the underlying GRDB observation."
+        )
+    }
+
+    // MARK: - Terminal error (edge case: terminal error)
+
+    func testTerminalErrorIsForwardedExactlyOnceThroughTheBridge() throws {
+        struct ProbeError: Error, Equatable {}
+        let bridge = LazyBufferedGRDBBridge<Int> { onError, onChange in
+            ValueObservation
+                .tracking { db -> Int in
+                    _ = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM Row")
+                    throw ProbeError()
+                }
+                .start(in: self.databasePool, onError: onError, onChange: onChange)
+        }
+
+        do {
+            _ = try awaitNext(bridge)
+            XCTFail("Expected the bridge to throw ProbeError")
+        }
+        catch {
+            XCTAssertTrue(error is ProbeError)
+        }
+
+        // Exactly once: a second call after termination resolves to nil, it
+        // does not re-throw, hang, or deliver a second error.
+        let afterTerminal = try awaitNext(bridge)
+        XCTAssertNil(afterTerminal)
+    }
+
+    // MARK: - Independent streams (edge cases: two consumers created from
+    // separate calls, independent databases)
+
+    func testTwoIndependentBridgesDoNotShareBufferedStateOrCrossTrigger() throws {
+        let bridgeA = makeBridge()
+        let bridgeB = makeBridge()
+
+        XCTAssertEqual(try awaitNext(bridgeA), 0)
+        XCTAssertEqual(try awaitNext(bridgeB), 0)
+
+        try insert("shared-write", 1)
+
+        XCTAssertEqual(try awaitNext(bridgeA), 1)
+        XCTAssertEqual(try awaitNext(bridgeB), 1)
+
+        bridgeA.cancel()
+        bridgeB.cancel()
+    }
+
+    // MARK: - Demand mapping (edge cases: zero demand, incremental demand,
+    // unlimited demand, demand added from receive)
+
+    func testDemandDrivenPullerConsumesExactlyDemandedCountWithoutEagerDraining() throws {
+        let bridge = makeBridge()
+        let delivered = LockedArray<Int>()
+        let puller = DemandDrivenPuller(
+            bridge: bridge,
+            onValue: { delivered.append($0) },
+            onFinish: { _ in }
+        )
+
+        // Zero demand: the puller must not touch the bridge at all.
+        drainMainQueue()
+        XCTAssertEqual(bridge.startCount, 0, "Zero demand must not start the observation.")
+        XCTAssertEqual(delivered.read(), [])
+
+        // Grant demand for exactly one value.
+        puller.requestDemand(1)
+        waitForCount(delivered, atLeast: 1)
+        XCTAssertEqual(delivered.read(), [0])
+
+        // Multiple rapid writes while demand is exhausted (zero outstanding):
+        // the puller must not pull ahead of demand. The bridge observes
+        // `COUNT(*)`, so two inserts into this fresh table move the row
+        // count from 0 to 2 (the `value` columns, 1 and 2, are unrelated to
+        // the observed count).
+        try insert("a", 1)
+        try insert("b", 2)
+        drainMainQueue()
+        XCTAssertEqual(
+            delivered.read(),
+            [0],
+            "With no demand outstanding, the puller must not deliver further values."
+        )
+
+        // Resuming demand delivers exactly one more value: the bridge's
+        // single buffered "newest" snapshot, not a backlog of every write
+        // that occurred while paused.
+        puller.requestDemand(1)
+        waitForCount(delivered, atLeast: 2)
+        XCTAssertEqual(delivered.read(), [0, 2])
+
+        puller.cancel()
+    }
+
+    func testUnlimitedDemandDeliversAsValuesBecomeAvailableWithoutSpinningOrDoubleDelivery() throws {
+        let bridge = makeBridge()
+        let delivered = LockedArray<Int>()
+        let finished = LockedValueBox<Error??>(nil)
+        let puller = DemandDrivenPuller(
+            bridge: bridge,
+            onValue: { delivered.append($0) },
+            onFinish: { finished.set($0) }
+        )
+
+        // A very large demand simulates Combine's `.unlimited`.
+        puller.requestDemand(1_000_000)
+        waitForCount(delivered, atLeast: 1)
+        XCTAssertEqual(delivered.read(), [0])
+
+        // The bridge observes `COUNT(*)`, so one insert into this fresh
+        // table moves the row count from 0 to 1 (the inserted row's own
+        // `value` column, 42, is unrelated to the observed count).
+        try insert("x", 42)
+        waitForCount(delivered, atLeast: 2)
+        XCTAssertEqual(delivered.read(), [0, 1])
+
+        // No further writes: the puller must not spin, error, or duplicate
+        // delivery while waiting for the next relevant commit.
+        drainMainQueue()
+        XCTAssertEqual(delivered.read(), [0, 1])
+        XCTAssertNil(finished.get() ?? nil)
+
+        puller.cancel()
+    }
+
+    // MARK: - Helpers
+
+    private func makeBridge(fetchProbe: @escaping () -> Void = {}) -> LazyBufferedGRDBBridge<Int> {
+        let pool = databasePool!
+        return LazyBufferedGRDBBridge<Int> { onError, onChange in
+            ValueObservation
+                .tracking { db -> Int in
+                    fetchProbe()
+                    return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM Row") ?? 0
+                }
+                .start(in: pool, onError: onError, onChange: onChange)
+        }
+    }
+
+    private func insert(_ id: String, _ value: Int) throws {
+        try databasePool.write { database in
+            try database.execute(
+                sql: "INSERT INTO Row (id, value) VALUES (?, ?)",
+                arguments: [id, value]
+            )
+        }
+    }
+
+    /// Awaits one `next()` call from a synchronous (non-`async`) XCTestCase
+    /// test method. `wait(for:timeout:)` pumps the run loop, which is what
+    /// lets GRDB's default main-queue scheduler actually deliver values
+    /// while this method blocks — the same mechanism the existing Combine
+    /// publisher tests rely on via `sink`.
+    private func awaitNext<Value>(_ bridge: LazyBufferedGRDBBridge<Value>) throws -> Value? {
+        let resultBox = LockedValueBox<Result<Value?, Error>?>(nil)
+        let barrier = expectation(description: "awaitNext")
+        Task {
+            do {
+                resultBox.set(.success(try await bridge.next()))
+            }
+            catch {
+                resultBox.set(.failure(error))
+            }
+            barrier.fulfill()
+        }
+        wait(for: [barrier], timeout: 2)
+        guard let result = resultBox.get() else {
+            throw AwaitNextTimeoutError()
+        }
+        return try result.get()
+    }
+
+    private func drainMainQueue() {
+        let barrier = expectation(description: "main-queue barrier")
+        DispatchQueue.main.async {
+            barrier.fulfill()
+        }
+        wait(for: [barrier], timeout: 2)
+    }
+
+    private func waitForCounter(_ counter: LockedCounter, toExceed floor: Int) {
+        for attempt in 1 ... 200 {
+            if counter.read() > floor {
+                return
+            }
+            let poll = expectation(description: "counter poll \(attempt)")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                poll.fulfill()
+            }
+            wait(for: [poll], timeout: 1)
+        }
+        XCTFail("Expected counter to exceed \(floor); read \(counter.read()).")
+    }
+
+    private func waitForCount<Element>(_ array: LockedArray<Element>, atLeast minimumCount: Int) {
+        for attempt in 1 ... 200 {
+            if array.read().count >= minimumCount {
+                return
+            }
+            let poll = expectation(description: "array poll \(attempt)")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                poll.fulfill()
+            }
+            wait(for: [poll], timeout: 1)
+        }
+        XCTFail("Expected at least \(minimumCount) delivered values; received \(array.read().count).")
+    }
+}
+
+
+private final class LockedValueBox<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func set(_ newValue: Value) {
+        lock.lock()
+        defer { lock.unlock() }
+        value = newValue
+    }
+
+    func get() -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -80,6 +80,22 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Ends the mailbox with the upstream source's own normal completion or
+    /// terminal error -- NOT with consumer-initiated cancellation; use
+    /// ``cancel()`` for that instead, which has different, stricter delivery
+    /// semantics (see its documentation).
+    ///
+    /// Deliberately does NOT clear `pendingValue`: a value legitimately
+    /// yielded before `finish()` is called (e.g. a source that emits one
+    /// final value and completes immediately afterward) must still be
+    /// delivered by the next `next()` call before iteration ends -- values
+    /// then completion, in that order. Confirmed by #308's production use of
+    /// this same policy: a `Just`-backed compatibility publisher's
+    /// yield-then-finish happens synchronously within one callback chain, and
+    /// discarding the buffered value here silently dropped it. `yield(_:)`'s
+    /// own `isFinished` guard already prevents a value that arrives *after*
+    /// `finish()`/`cancel()` from ever being buffered, which is the actual
+    /// race this type must reject.
     func finish(throwing error: Error?) {
         lock.lock()
         guard !isFinished else {
@@ -87,17 +103,6 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
             return
         }
         isFinished = true
-        // Deliberately does NOT clear `pendingValue`: a value legitimately
-        // yielded before `finish()` is called (e.g. a source that emits one
-        // final value and completes immediately afterward) must still be
-        // delivered by the next `next()` call before iteration ends -- values
-        // then completion, in that order. Confirmed by #308's production use
-        // of this same policy: a `Just`-backed compatibility publisher's
-        // yield-then-finish happens synchronously within one callback chain,
-        // and discarding the buffered value here silently dropped it.
-        // `yield(_:)`'s own `isFinished` guard already prevents a value that
-        // arrives *after* `finish()`/`cancel()` from ever being buffered,
-        // which is the actual race this type must reject.
         if let waiter {
             self.waiter = nil
             lock.unlock()
@@ -113,14 +118,37 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
         lock.unlock()
     }
 
-    /// Ends the mailbox without an error: a cancelled bridge resolves any
-    /// outstanding or future `next()` call to `nil`, exactly like a normal,
-    /// non-erroring end of iteration. Cancellation is never surfaced to the
-    /// consumer as a thrown `CancellationError` or as a completion failure,
-    /// mirroring how cancelling a Combine subscription today never delivers
-    /// a `.failure` completion.
+    /// Ends the mailbox because the *consumer* cancelled, not because the
+    /// upstream source completed: every outstanding or future `next()` call
+    /// resolves to `nil`, exactly like a normal, non-erroring end of
+    /// iteration, and cancellation is never surfaced as a thrown
+    /// `CancellationError` or a completion failure -- mirroring how
+    /// cancelling a Combine subscription today never delivers a `.failure`
+    /// completion.
+    ///
+    /// Unlike ``finish(throwing:)``, this also discards any value already
+    /// buffered but not yet delivered: once the consumer has said it no
+    /// longer wants delivery, a stale snapshot slipping through afterward
+    /// would be a real cancellation-contract violation, not a legitimate
+    /// "last value before normal completion." This is the distinction that
+    /// makes ``finish(throwing:)`` and `cancel()` different operations rather
+    /// than one delegating to the other.
     func cancel() {
-        finish(throwing: nil)
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        isFinished = true
+        pendingValue = nil
+        pendingError = nil
+        if let waiter {
+            self.waiter = nil
+            lock.unlock()
+            waiter.resume(returning: nil)
+            return
+        }
+        lock.unlock()
     }
 
     private enum FastPathOutcome {
@@ -383,6 +411,13 @@ private final class DemandDrivenPuller<Value>: @unchecked Sendable {
                     }
                     return
                 }
+                // `bridge.next()` can resolve with an already-in-flight value
+                // at almost the same instant `cancel()` runs; re-check right
+                // before delivery so that narrow race cannot hand a value to
+                // a consumer that has already unsubscribed.
+                guard isStillAcceptingDelivery() else {
+                    return
+                }
                 onValue(value)
                 if decrementDemandAndCheckWhetherToContinue() {
                     pumpNext()
@@ -413,6 +448,16 @@ private final class DemandDrivenPuller<Value>: @unchecked Sendable {
         isFinished = true
         isPulling = false
         return shouldDeliver
+    }
+
+    /// Narrows, but cannot fully close, the window between `bridge.next()`
+    /// resolving with a value and `onValue` being called: if `cancel()` won
+    /// that race, this returns `false` so the value is dropped instead of
+    /// reaching a consumer that already unsubscribed.
+    private func isStillAcceptingDelivery() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !wasCancelled
     }
 
     private func decrementDemandAndCheckWhetherToContinue() -> Bool {


### PR DESCRIPTION
## Summary

- Defines the buffering, snapshot-ownership, and cancellation contract for #308's canonical `AsyncThrowingStream` live-query source and #309's Combine adapter: bound-1 "newest wins" buffering, an explicit snapshot lifecycle (not-started → observing → requested → delivered/superseded/terminated), and cancellation wired through `withTaskCancellationHandler` (required because `AsyncThrowingStream`'s `unfolding:` initializer — the one that returns the literal type #308 needs — has no `onCancel` parameter).
- Documents that resuming/replenishing demand never forces a fresh fetch; it only surfaces whatever GRDB already produced.
- Adds `Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift`: 9 deterministic real-GRDB tests (bounded polling, no sleeps/inverted expectations) covering unused stream, paused-consumer/rapid-commits coalescing, resumed iteration not forcing a fetch, explicit cancel, `Task`-cancellation via the literal `AsyncThrowingStream` type, terminal error exactly once, two independent streams, and zero/incremental/unlimited demand.
- Adds a "Buffering and Resumed-Demand Semantics" section to `Sources/SwiftQL/SwiftQL.docc/LiveQueries.md` recording the decision, rejected alternatives (unbounded default, no buffering, larger fixed bound, drop-at-fetch-boundary), and concrete constraints #308/#309 must follow.

Research/semantics task only, per issue #291 — no production `AsyncThrowingStream` API or Combine adapter is implemented here; that's #308 and #309.

Closes #291.

## Test plan
- [x] `swift build`
- [x] `swift test` (1120 tests, 0 failures)
- [x] `LiveQueryBufferingSemanticsTests` repeated 5x for stability
