### PR TITLE
Add XLResultSet: a lazy, single-pass typed result set (#249)

### DIFF
--- a/Sources/SwiftQL/GRDBDatabaseDriver.swift
+++ b/Sources/SwiftQL/GRDBDatabaseDriver.swift
@@ -340,6 +340,36 @@ struct GRDBInvocationExecutor: Sendable {
         )
     }
 
+    ///
+    /// Prepares and binds one statement for `packet`, then lends a
+    /// value-level row stepper scoped to the connection access that owns it.
+    ///
+    /// `operation` runs synchronously inside the same read (or, when
+    /// `requiresWriteConnection` is `true`, write/transaction) connection
+    /// access that creates the stepper, so the GRDB cursor the stepper
+    /// closes over never escapes its owning database access -- the stepper
+    /// closure is only valid for the duration of `operation`. `XLResultSet`
+    /// is built directly on top of this seam.
+    ///
+    func withValuesStepper<Result>(
+        packet: XLInvocationBindings<XLSQLiteValue>,
+        requiresWriteConnection: Bool,
+        _ operation: (@escaping () throws -> [XLSQLiteValue]?) throws -> Result
+    ) throws -> Result {
+        var driver = driver
+        let accessor: (inout GRDBDatabaseDriverConnection) throws -> Result = { connection in
+            let statement = try self.boundStatement(packet: packet, in: &connection)
+            let stepper = try connection.makeValuesStepper(statement)
+            return try operation(stepper)
+        }
+        if requiresWriteConnection {
+            return try driver.withTransaction(accessor)
+        }
+        else {
+            return try driver.withReadConnection(accessor)
+        }
+    }
+
     func fetchOne(
         bindings: any XLInvocationBindingPacket
     ) throws -> [XLSQLiteValue]? {
@@ -655,6 +685,49 @@ struct GRDBDatabaseDriverConnection:
             if try body(values) == .stop {
                 return
             }
+        }
+    }
+
+    ///
+    /// Implements ``XLStreamingDatabaseDriverConnection/makeValuesStepper(_:)``
+    /// for GRDB: prepares one physical statement and returns a value-level
+    /// stepper that performs at most one additional SQLite step and
+    /// value-normalization per call, returning `nil` once the underlying
+    /// cursor is exhausted.
+    ///
+    /// This is the pull-based counterpart to `forEachRow(_:_:)`'s push-based
+    /// callback: `XLResultSet.next()` needs to step exactly one row per call
+    /// from outside code that already ran and returned, which a callback
+    /// invoked once per row cannot express. The returned closure remains
+    /// valid only for the lifetime of this connection's database access: it
+    /// captures a GRDB row cursor bound to `database`, which must not survive
+    /// the access that produced this connection. The caller must stop
+    /// invoking the closure -- and release every reference to it -- no later
+    /// than when that access returns.
+    ///
+    mutating func makeValuesStepper(
+        _ statement: GRDBPhysicalStatement
+    ) throws -> () throws -> [XLSQLiteValue]? {
+        try validateOwnership(of: statement)
+        let cursor = try Row.fetchCursor(
+            statement.statement,
+            arguments: statementArguments(statement)
+        )
+        // Same reusable normalization buffer as forEachRow(_:_:) above, for
+        // the same reason: the streaming contract requires the caller to
+        // consume (decode or copy) each row's values before requesting the
+        // next one.
+        var values: [XLSQLiteValue] = []
+        return {
+            guard let row = try cursor.next() else {
+                return nil
+            }
+            values.removeAll(keepingCapacity: true)
+            values.reserveCapacity(row.count)
+            for databaseValue in row.databaseValues {
+                values.append(databaseValue.sqliteDialectValue)
+            }
+            return values
         }
     }
 

--- a/Sources/SwiftQL/GRDBDatabaseDriver.swift
+++ b/Sources/SwiftQL/GRDBDatabaseDriver.swift
@@ -718,8 +718,25 @@ struct GRDBDatabaseDriverConnection:
         // consume (decode or copy) each row's values before requesting the
         // next one.
         var values: [XLSQLiteValue] = []
+        // Exhaustion and a thrown step error are both terminal: GRDB does not
+        // document `Cursor.next()` as safe to call again after it throws, so
+        // once this closure has returned `nil` or thrown once, every later
+        // call keeps returning `nil` instead of stepping the cursor again.
+        var isTerminal = false
         return {
-            guard let row = try cursor.next() else {
+            guard !isTerminal else {
+                return nil
+            }
+            let row: Row?
+            do {
+                row = try cursor.next()
+            }
+            catch {
+                isTerminal = true
+                throw error
+            }
+            guard let row else {
+                isTerminal = true
                 return nil
             }
             values.removeAll(keepingCapacity: true)

--- a/Sources/SwiftQL/GRDBDatabaseDriver.swift
+++ b/Sources/SwiftQL/GRDBDatabaseDriver.swift
@@ -690,9 +690,9 @@ struct GRDBDatabaseDriverConnection:
 
     ///
     /// Implements ``XLStreamingDatabaseDriverConnection/makeValuesStepper(_:)``
-    /// for GRDB: prepares one physical statement and returns a value-level
-    /// stepper that performs at most one additional SQLite step and
-    /// value-normalization per call, returning `nil` once the underlying
+    /// for GRDB: takes one already-prepared physical statement and returns a
+    /// value-level stepper that performs at most one additional SQLite step
+    /// and value-normalization per call, returning `nil` once the underlying
     /// cursor is exhausted.
     ///
     /// This is the pull-based counterpart to `forEachRow(_:_:)`'s push-based

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -412,6 +412,76 @@ struct GRDBRequest<Row>: XLRequest {
         return try GRDBRowDecoder(reader: reader).decode(values: values)
     }
 
+    func withResultSet<Result>(
+        _ operation: (XLResultSet<Row>) throws -> Result
+    ) throws -> Result {
+        try withResultSet(bindings: try compatibilityPacket(), operation)
+    }
+
+    ///
+    /// True-streaming override of the ``XLRequest`` default: lends an
+    /// `XLResultSet` backed directly by `GRDBInvocationExecutor`'s
+    /// value-level cursor stepper, so `next()` performs one real SQLite step
+    /// and one real typed decode -- nothing is prefetched, and nothing is
+    /// buffered beyond the one row currently being decoded.
+    ///
+    /// A `RETURNING` request (`requiresWriteConnection`) is the one
+    /// exception: `RETURNING` rows are produced as SQLite steps through the
+    /// data-changing statement itself, so stepping only part of the cursor
+    /// would commit a write that only partially ran. Decoding lazily could
+    /// silently apply an incomplete `UPDATE`/`DELETE`/`INSERT` if the caller
+    /// stopped calling `next()` early. To keep that impossible, a
+    /// `RETURNING` request decodes every row eagerly inside its transaction
+    /// -- exactly like `fetchAll(bindings:)` -- before handing the
+    /// already-decoded rows to the caller through the same lazy `next()`
+    /// surface. Non-`RETURNING` requests are unaffected and stream lazily.
+    ///
+    func withResultSet<Result>(
+        bindings: any XLInvocationBindingPacket,
+        _ operation: (XLResultSet<Row>) throws -> Result
+    ) throws -> Result {
+        let packet = try executor.sqlitePacket(bindings)
+        logger?.debug(
+            "withResultSet: <<<\(executor.logicalStatement.sql)>>> parameters: <<<\(packet.bindings)>>>")
+
+        if requiresWriteConnection {
+            var driver = executor.driver
+            var items: [Row] = []
+            try driver.withTransaction { connection in
+                items = try decodeRows(packet: packet, in: &connection)
+            }
+            return try withEagerResultSet(items, operation)
+        }
+
+        let rowDecoder = GRDBRowDecoder(reader: reader)
+        return try executor.withValuesStepper(
+            packet: packet,
+            requiresWriteConnection: false
+        ) { valuesStepper in
+            let resultSet = XLResultSet<Row>(stepper: {
+                guard let values = try valuesStepper() else {
+                    return nil
+                }
+                return try rowDecoder.decode(values: values)
+            })
+            defer { resultSet.close() }
+            return try operation(resultSet)
+        }
+    }
+
+    /// Mirrors `XLRequest`'s eager compatibility fallback (see
+    /// `SQLDatabase.swift`), used only for the `RETURNING` path above where
+    /// rows must already be fully decoded before `operation` runs.
+    private func withEagerResultSet<Result>(
+        _ rows: [Row],
+        _ operation: (XLResultSet<Row>) throws -> Result
+    ) throws -> Result {
+        var iterator = rows.makeIterator()
+        let resultSet = XLResultSet<Row>(stepper: { iterator.next() })
+        defer { resultSet.close() }
+        return try operation(resultSet)
+    }
+
     func publish() -> AnyPublisher<[Row], Error> {
         if requiresWriteConnection {
             return Fail(error: XLReturningRequestError.observationUnsupported)

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -174,7 +174,33 @@ public protocol XLRequest<Row> {
 
     /// Fetches the first row with one immutable per-invocation binding packet.
     func fetchOne(bindings: any XLInvocationBindingPacket) throws -> Row?
-    
+
+    ///
+    /// Executes `operation` with a lazy, single-pass ``XLResultSet`` built
+    /// from zero bindings, decoding at most one additional row per `next()`
+    /// call instead of every matching row up front.
+    ///
+    /// Unlike ``fetchAll()``, no row is fetched or decoded before `operation`
+    /// calls `next()` for it, and stopping early means later rows are never
+    /// stepped or decoded. See ``XLResultSet`` for its single-pass reference
+    /// semantics, throwing iteration, non-`Sendable` isolation, scope
+    /// lifetime, connection occupancy, and partial-progress behavior.
+    ///
+    /// - Throws: The original query-execution error, or whatever `operation` throws.
+    ///
+    func withResultSet<Result>(
+        _ operation: (XLResultSet<Row>) throws -> Result
+    ) throws -> Result
+
+    ///
+    /// Executes `operation` with a lazy, single-pass ``XLResultSet`` for one
+    /// immutable per-invocation binding packet. See ``withResultSet(_:)``.
+    ///
+    func withResultSet<Result>(
+        bindings: any XLInvocationBindingPacket,
+        _ operation: (XLResultSet<Row>) throws -> Result
+    ) throws -> Result
+
     ///
     /// Creates a Combine Publisher that observes and emits all rows from the query.
     ///
@@ -232,6 +258,36 @@ extension XLRequest {
     ) throws -> Row? {
         try validateCompatibilityBindings(bindings)
         return try fetchOne()
+    }
+
+    /// Compatibility default for adapters that predate ``XLResultSet``: eagerly fetches every row
+    /// with ``fetchAll()``, then serves the already-decoded rows one at a time through the same
+    /// `next()` surface a true streaming adapter exposes. External conformers written before this
+    /// requirement existed keep compiling and behaving correctly; only the memory and latency
+    /// benefit of true row-at-a-time streaming requires an adapter override (see
+    /// `GRDBRequest.withResultSet(bindings:_:)` for the true-streaming GRDB implementation).
+    public func withResultSet<Result>(
+        _ operation: (XLResultSet<Row>) throws -> Result
+    ) throws -> Result {
+        try withEagerResultSet(fetchAll(), operation)
+    }
+
+    /// Compatibility default for adapters that predate ``XLResultSet``. See ``withResultSet(_:)``.
+    public func withResultSet<Result>(
+        bindings: any XLInvocationBindingPacket,
+        _ operation: (XLResultSet<Row>) throws -> Result
+    ) throws -> Result {
+        try withEagerResultSet(fetchAll(bindings: bindings), operation)
+    }
+
+    private func withEagerResultSet<Result>(
+        _ rows: [Row],
+        _ operation: (XLResultSet<Row>) throws -> Result
+    ) throws -> Result {
+        var iterator = rows.makeIterator()
+        let resultSet = XLResultSet<Row>(stepper: { iterator.next() })
+        defer { resultSet.close() }
+        return try operation(resultSet)
     }
 
     /// Compatibility default for adapters that do not implement early-stopping decode: fetches every

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -176,15 +176,19 @@ public protocol XLRequest<Row> {
     func fetchOne(bindings: any XLInvocationBindingPacket) throws -> Row?
 
     ///
-    /// Executes `operation` with a lazy, single-pass ``XLResultSet`` built
-    /// from zero bindings, decoding at most one additional row per `next()`
-    /// call instead of every matching row up front.
+    /// Executes `operation` with a single-pass ``XLResultSet`` built from
+    /// zero bindings, exposing at most one additional row per `next()` call
+    /// instead of every matching row up front.
     ///
-    /// Unlike ``fetchAll()``, no row is fetched or decoded before `operation`
-    /// calls `next()` for it, and stopping early means later rows are never
-    /// stepped or decoded. See ``XLResultSet`` for its single-pass reference
-    /// semantics, throwing iteration, non-`Sendable` isolation, scope
-    /// lifetime, connection occupancy, and partial-progress behavior.
+    /// This protocol requirement does not itself guarantee lazy stepping --
+    /// see ``XLResultSet`` for which implementations are truly streaming
+    /// (decoding at most one row per `next()`, with no row fetched or decoded
+    /// before `operation` calls `next()` for it) versus eager (this
+    /// protocol's own compatibility default, which calls ``fetchAll()``
+    /// under the hood, and `GRDBRequest`'s `RETURNING` exception) -- both
+    /// still honor `XLResultSet`'s single-pass reference semantics, throwing
+    /// iteration, non-`Sendable` isolation, scope lifetime, and
+    /// partial-progress behavior, just not the streaming cost profile.
     ///
     /// - Throws: The original query-execution error, or whatever `operation` throws.
     ///

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -203,19 +203,24 @@ try database.makeRequest(with: peopleNamedFredQuery).withResultSet { results in
 
 `withResultSet(_:)` hands `operation` an `XLResultSet<Row>`: a reference type
 whose `next()` performs at most one additional row step and typed decode, and
-returns `nil` once the query is exhausted. No row is fetched or decoded before
-`operation` calls `next()` for it, and stopping early means later rows are
-never stepped or decoded. Unlike `fetchAll()`, a decode or SQLite error only
-ends iteration from that point forward -- rows already returned by earlier
-`next()` calls remain valid, independent values; `fetchAll()` instead fails
-atomically and returns nothing.
+returns `nil` once the query is exhausted. For a true streaming
+implementation (the ordinary, non-`RETURNING` case), no row is fetched or
+decoded before `operation` calls `next()` for it, and stopping early means
+later rows are never stepped or decoded. Unlike `fetchAll()`, a decode or
+SQLite error only ends iteration from that point forward -- rows already
+returned by earlier `next()` calls remain valid, independent values;
+`fetchAll()` instead fails atomically and returns nothing.
 
 `XLResultSet` is not a `Sequence` or `Collection`: it has no replayable value
 semantics, cannot be iterated with `for row in results`, and is not
 `Sendable`. It is valid only for the duration of the `withResultSet(_:)`
-callback, which owns the underlying database read connection or snapshot for
-that entire callback -- avoid slow, unrelated work between `next()` calls, and
-never let the result set escape the callback. A reference retained past the
+callback. For a true streaming implementation, that callback owns the
+underlying database read connection or snapshot for its entire duration --
+avoid slow, unrelated work between `next()` calls. (A `RETURNING` statement
+is the one exception: its write must complete atomically regardless of how
+many rows the caller consumes, so it decodes eagerly before `operation` runs
+and does not hold the write connection open across `next()` calls.) Never let
+the result set escape the callback. A reference retained past the
 callback's return throws `XLResultSetError.closed` from every later `next()`
 call -- and so does a reference explicitly closed with `close()`, whether
 `close()` is called before or after the callback returns. That is different

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -216,9 +216,14 @@ semantics, cannot be iterated with `for row in results`, and is not
 callback, which owns the underlying database read connection or snapshot for
 that entire callback -- avoid slow, unrelated work between `next()` calls, and
 never let the result set escape the callback. A reference retained past the
-callback's return throws `XLResultSetError.closed` from `next()`; closing
-explicitly, or letting the query exhaust naturally, is otherwise idempotent
-and does not throw.
+callback's return throws `XLResultSetError.closed` from every later `next()`
+call -- and so does a reference explicitly closed with `close()`, whether
+`close()` is called before or after the callback returns. That is different
+from natural exhaustion: once a query legitimately runs out of rows, `next()`
+keeps returning `nil` rather than throwing. `close()` itself is idempotent and
+never throws, whether called once, more than once, or after natural
+exhaustion -- but calling it does mean every later `next()` throws `.closed`
+from that point on, rather than continuing to return `nil`.
 
 Prefer `fetchAll()` when every row is needed as a complete, retained array, or
 when the array-processing conveniences (`map`, `filter`, `count`, sorting, ...)

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -185,6 +185,48 @@ let firstPersonNamedFred = try database.makeRequest(with: peopleNamedFredQuery).
 guarantee which matching row is returned. Select syntax is discussed in more
 detail in the <doc:Queries> guide.
 
+### Lazy result sets
+
+`fetchAll()` decodes every matching row up front into a complete array;
+`fetchOne()` decodes at most one row. When a query may match many rows and the
+caller does not need all of them retained at once -- or wants to stop as soon
+as it finds what it is looking for -- use `withResultSet(_:)` instead:
+
+<!-- test: XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings -->
+```swift
+try database.makeRequest(with: peopleNamedFredQuery).withResultSet { results in
+    while let person = try results.next() {
+        print(person.name)
+    }
+}
+```
+
+`withResultSet(_:)` hands `operation` an `XLResultSet<Row>`: a reference type
+whose `next()` performs at most one additional row step and typed decode, and
+returns `nil` once the query is exhausted. No row is fetched or decoded before
+`operation` calls `next()` for it, and stopping early means later rows are
+never stepped or decoded. Unlike `fetchAll()`, a decode or SQLite error only
+ends iteration from that point forward -- rows already returned by earlier
+`next()` calls remain valid, independent values; `fetchAll()` instead fails
+atomically and returns nothing.
+
+`XLResultSet` is not a `Sequence` or `Collection`: it has no replayable value
+semantics, cannot be iterated with `for row in results`, and is not
+`Sendable`. It is valid only for the duration of the `withResultSet(_:)`
+callback, which owns the underlying database read connection or snapshot for
+that entire callback -- avoid slow, unrelated work between `next()` calls, and
+never let the result set escape the callback. A reference retained past the
+callback's return throws `XLResultSetError.closed` from `next()`; closing
+explicitly, or letting the query exhaust naturally, is otherwise idempotent
+and does not throw.
+
+Prefer `fetchAll()` when every row is needed as a complete, retained array, or
+when the array-processing conveniences (`map`, `filter`, `count`, sorting, ...)
+matter more than incremental decoding. Prefer `withResultSet(_:)` when the
+result may be large, the caller may stop before consuming every row, or the
+cost of decoding rows nobody uses should scale with rows actually requested
+rather than total query cardinality.
+
 ### Schema parameter
 
 The previous query uses the `schema` parameter to construct a table reference.

--- a/Sources/SwiftQL/XLResultSet.swift
+++ b/Sources/SwiftQL/XLResultSet.swift
@@ -137,8 +137,10 @@ public enum XLResultSetError: Error, Equatable, Sendable, LocalizedError {
 public final class XLResultSet<Row> {
 
     /// One remaining row step, or `nil` once this result set can no longer
-    /// step or decode a row (explicitly closed, terminated by a SQLite step
-    /// or decode error, or invalidated because its owning scope returned).
+    /// step or decode a row: naturally exhausted, explicitly closed,
+    /// terminated by a SQLite step or decode error, or invalidated because
+    /// its owning scope returned. `stepper == nil` alone does not distinguish
+    /// which of these applies -- that is exactly what ``isExhausted`` is for.
     ///
     /// Distinct from ``isExhausted``: exhaustion is a stable, non-throwing
     /// terminal state reached by the underlying cursor legitimately running

--- a/Sources/SwiftQL/XLResultSet.swift
+++ b/Sources/SwiftQL/XLResultSet.swift
@@ -12,14 +12,17 @@ public enum XLResultSetError: Error, Equatable, Sendable, LocalizedError {
     /// This result set can no longer step or decode a row.
     ///
     /// A fresh call to `next()` after the query legitimately runs out of
-    /// matching rows is **not** this error -- that keeps returning `nil`
-    /// forever, exactly like any other exhausted iteration. This error only
-    /// fires once the result set can no longer safely touch its underlying
-    /// cursor or connection at all: after an explicit ``XLResultSet/close()``,
-    /// after a prior SQLite step or row-decode error already terminated
-    /// iteration, or after the ``XLRequest/withResultSet(_:)`` /
-    /// ``XLRequest/withResultSet(bindings:_:)`` scope that owned this result
-    /// set has already returned.
+    /// matching rows is **not** this error -- that keeps returning `nil`,
+    /// exactly like any other exhausted iteration, for as long as the result
+    /// set remains open. This error only fires once the result set can no
+    /// longer safely touch its underlying cursor or connection at all: after
+    /// an explicit ``XLResultSet/close()``, after a prior SQLite step or
+    /// row-decode error already terminated iteration, or after the
+    /// ``XLRequest/withResultSet(_:)`` / ``XLRequest/withResultSet(bindings:_:)``
+    /// scope that owned this result set has already returned -- including
+    /// when the result set had already reached natural exhaustion before the
+    /// scope exited: a reference retained past that point throws `.closed`
+    /// rather than continuing to return `nil`.
     case closed
 
     public var errorDescription: String? {
@@ -190,6 +193,10 @@ public final class XLResultSet<Row> {
             return row
         }
         catch {
+            // Deliver the original error exactly once, from this call; it is
+            // not retained for later inspection. Every subsequent `next()`
+            // throws `.closed` instead of this error, since `stepper` is now
+            // nil -- see the type-level "Partial progress" documentation.
             self.stepper = nil
             throw error
         }

--- a/Sources/SwiftQL/XLResultSet.swift
+++ b/Sources/SwiftQL/XLResultSet.swift
@@ -1,0 +1,214 @@
+//
+//  XLResultSet.swift
+//
+
+import Foundation
+
+
+/// Failures produced by ``XLResultSet`` iteration itself, distinct from the
+/// original SQLite or decode error that ended a result set's iteration.
+public enum XLResultSetError: Error, Equatable, Sendable, LocalizedError {
+
+    /// This result set can no longer step or decode a row.
+    ///
+    /// A fresh call to `next()` after the query legitimately runs out of
+    /// matching rows is **not** this error -- that keeps returning `nil`
+    /// forever, exactly like any other exhausted iteration. This error only
+    /// fires once the result set can no longer safely touch its underlying
+    /// cursor or connection at all: after an explicit ``XLResultSet/close()``,
+    /// after a prior SQLite step or row-decode error already terminated
+    /// iteration, or after the ``XLRequest/withResultSet(_:)`` /
+    /// ``XLRequest/withResultSet(bindings:_:)`` scope that owned this result
+    /// set has already returned.
+    case closed
+
+    public var errorDescription: String? {
+        switch self {
+        case .closed:
+            return "This XLResultSet is closed. It was either closed explicitly, terminated by an earlier SQLite or decode error, or its withResultSet(_:) scope has already returned; request a fresh result set instead of retaining this one."
+        }
+    }
+}
+
+
+///
+/// A single-pass, connection-scoped, lazily-decoded query result.
+///
+/// `next()` performs at most one additional SQLite step and typed decode per
+/// call. No row is fetched or decoded before the first call to `next()`, and
+/// stopping early -- an early `return`, `break`, or thrown error from the
+/// ``XLRequest/withResultSet(_:)`` callback -- means every later row is never
+/// stepped or decoded. There is no read-ahead and no buffering: the cost of
+/// producing rows scales with rows actually requested, not with the query's
+/// total cardinality.
+///
+/// ### Reference semantics, not a collection
+///
+/// `XLResultSet` is deliberately a `final class`, not a `struct`, and it does
+/// not conform to `Sequence`, `IteratorProtocol`, or `Collection`. Those
+/// abstractions promise replayable, copyable value semantics that a live
+/// SQLite cursor cannot honor -- copying a value that wraps a one-shot cursor
+/// would either alias the same cursor from two places or silently require
+/// buffering rows to fake independent iteration. `next() throws -> Row?` is
+/// deliberately the entire surface instead, so every step can throw the
+/// original SQLite or decode error directly, rather than a
+/// `Sequence`/`IteratorProtocol` conformance swallowing it (`Sequence`'s
+/// `next()` cannot throw).
+///
+/// `XLResultSet` is intentionally **not** `Sendable`. It wraps a cursor bound
+/// to one specific database connection or snapshot; never capture it across
+/// threads, tasks, actors, or database queues, and never use it outside the
+/// callback that received it.
+///
+/// ### Scope lifetime and connection occupancy
+///
+/// An `XLResultSet` is valid only for the dynamic extent of the
+/// ``XLRequest/withResultSet(_:)`` (or ``XLRequest/withResultSet(bindings:_:)``)
+/// callback that receives it. That callback owns the underlying database read
+/// access -- a pooled connection, or the pinned connection of an enclosing
+/// transaction -- for its *entire* duration, not just while a `next()` call is
+/// in flight. Avoid slow, unrelated work between `next()` calls, since it
+/// keeps that connection or snapshot occupied the whole time. The owning
+/// scope closes the result set with `defer` before returning or throwing, so
+/// this happens whether the callback returns normally, returns early, or
+/// throws.
+///
+/// A reference retained past that callback's return no longer has a live
+/// cursor to step: every later `next()` throws ``XLResultSetError/closed``
+/// instead of touching a cursor or connection that may already have been
+/// released back to the pool or reused for unrelated work.
+///
+/// ### Partial progress and early termination
+///
+/// Rows already returned by earlier, successful `next()` calls remain valid,
+/// independent decoded values even if a later row fails to step or decode --
+/// unlike `fetchAll()`, which is atomic and returns either a complete array
+/// or no array at all. Once `next()` throws -- a genuine SQLite step failure
+/// or a row-decode failure -- the result set becomes terminal: it does not
+/// retry, does not skip the failing row, and every subsequent call throws
+/// ``XLResultSetError/closed`` rather than re-throwing the original error or
+/// attempting to step further. That original SQLite or decode error is only
+/// ever delivered once, from the `next()` call that produced it.
+///
+/// Natural exhaustion is different from all of the above: once the query
+/// legitimately runs out of matching rows, `next()` keeps returning `nil`
+/// rather than throwing, so callers may safely call `next()` again after
+/// exhaustion without special-casing "the last call."
+///
+/// ### When to use `fetchAll()` instead
+///
+/// Reach for `fetchAll()` when the caller wants a complete, retained,
+/// randomly-indexable `[Row]` -- to sort, count, `map`, `filter`, encode, or
+/// hand to code that expects an ordinary Swift collection -- and the full
+/// result comfortably fits in memory. `fetchAll()` also gives atomic,
+/// all-or-nothing failure semantics: if any row fails, the caller gets either
+/// the complete array or the error, never a partially populated one.
+///
+/// Reach for `withResultSet(_:)` and `next()` when the result may be large,
+/// when the caller may stop before consuming every row, or when the cost of
+/// decoding rows nobody ends up using should scale with rows actually
+/// requested rather than total query cardinality.
+///
+/// ### Why synchronous, scoped iteration is the v1.5 baseline
+///
+/// This API is deliberately synchronous and scoped to one callback rather
+/// than an `async`/`await` row sequence. Swift 5.9's ownership and
+/// actor-isolation model has no way to let a live SQLite cursor -- tied to
+/// one specific pooled connection, or to one pinned transaction connection --
+/// safely survive an arbitrary `await` suspension point between rows, short
+/// of either unsafely widening its lifetime past the access that owns it, or
+/// silently reintroducing the buffering this API exists to avoid. A
+/// synchronous callback keeps the cursor's lifetime exactly as long as the
+/// database access that owns it, which the compiler can check; an
+/// `async` row sequence's lifetime is not something Swift 5.9 can check the
+/// same way.
+///
+/// Demand-driven async row iteration is real, separate follow-up work,
+/// planned for once the package's minimum Swift version and concurrency
+/// story can support it safely. It is also unrelated to issue #308's
+/// `AsyncThrowingStream` of complete, eagerly-decoded live-query snapshots --
+/// that stream re-emits a fresh `fetchAll()`-equivalent array every time the
+/// observed database region changes; it does not stream the individual rows
+/// of one execution incrementally the way `XLResultSet` does.
+///
+public final class XLResultSet<Row> {
+
+    /// One remaining row step, or `nil` once this result set can no longer
+    /// step or decode a row (explicitly closed, terminated by a SQLite step
+    /// or decode error, or invalidated because its owning scope returned).
+    ///
+    /// Distinct from ``isExhausted``: exhaustion is a stable, non-throwing
+    /// terminal state reached by the underlying cursor legitimately running
+    /// out of rows, not by an error or an explicit close.
+    private var stepper: (() throws -> Row?)?
+
+    /// `true` once the underlying cursor has legitimately run out of rows.
+    /// `next()` keeps returning `nil` in this state instead of throwing,
+    /// distinguishing "no more rows" from "closed."
+    private var isExhausted = false
+
+    /// Creates a result set backed by one row-stepping closure.
+    ///
+    /// - Parameter stepper: Performs at most one SQLite step and typed
+    ///   decode per call, returning `nil` once the underlying cursor is
+    ///   exhausted. Must only be invoked from inside the database access
+    ///   that owns whatever cursor it closes over, and must stop being
+    ///   invoked no later than when that access returns.
+    init(stepper: @escaping () throws -> Row?) {
+        self.stepper = stepper
+    }
+
+    ///
+    /// Fetches and decodes the next row, performing at most one additional
+    /// SQLite step and typed decode.
+    ///
+    /// Returns `nil` once the query is exhausted; further calls after
+    /// exhaustion keep returning `nil`. Throws the original SQLite or decode
+    /// error the instant either fails, and the result set becomes terminal:
+    /// every later call throws ``XLResultSetError/closed`` instead of
+    /// retrying, skipping the failing row, or re-throwing the original error
+    /// again. Throws ``XLResultSetError/closed`` immediately if this result
+    /// set was already closed, already terminated by an earlier error, or
+    /// retained past its owning `withResultSet` scope.
+    ///
+    /// - Throws: The original query-execution or row-decoding error, or
+    ///   ``XLResultSetError/closed``.
+    ///
+    public func next() throws -> Row? {
+        if isExhausted {
+            return nil
+        }
+        guard let stepper else {
+            throw XLResultSetError.closed
+        }
+        do {
+            guard let row = try stepper() else {
+                isExhausted = true
+                self.stepper = nil
+                return nil
+            }
+            return row
+        }
+        catch {
+            self.stepper = nil
+            throw error
+        }
+    }
+
+    ///
+    /// Closes this result set, releasing its row-stepping closure (and
+    /// anything it captures, such as a GRDB cursor) immediately instead of
+    /// waiting for the owning scope to return.
+    ///
+    /// Idempotent: closing an already-closed or already-terminated result
+    /// set has no additional effect. After `close()`, every `next()` throws
+    /// ``XLResultSetError/closed`` -- including when the result set was
+    /// already exhausted, since an explicit close is a stronger, deliberate
+    /// signal that this reference is done, not just that its query ran out
+    /// of rows.
+    ///
+    public func close() {
+        isExhausted = false
+        stepper = nil
+    }
+}

--- a/Sources/SwiftQL/XLResultSet.swift
+++ b/Sources/SwiftQL/XLResultSet.swift
@@ -38,12 +38,20 @@ public enum XLResultSetError: Error, Equatable, Sendable, LocalizedError {
 /// A single-pass, connection-scoped, lazily-decoded query result.
 ///
 /// `next()` performs at most one additional SQLite step and typed decode per
-/// call. No row is fetched or decoded before the first call to `next()`, and
-/// stopping early -- an early `return`, `break`, or thrown error from the
-/// ``XLRequest/withResultSet(_:)`` callback -- means every later row is never
-/// stepped or decoded. There is no read-ahead and no buffering: the cost of
-/// producing rows scales with rows actually requested, not with the query's
-/// total cardinality.
+/// call. For a true streaming implementation (`GRDBRequest`'s override, used
+/// for ordinary non-`RETURNING` statements), no row is fetched or decoded
+/// before the first call to `next()`, and stopping early -- an early
+/// `return`, `break`, or thrown error from the ``XLRequest/withResultSet(_:)``
+/// callback -- means every later row is never stepped or decoded, with no
+/// read-ahead or buffering: the cost of producing rows scales with rows
+/// actually requested, not with the query's total cardinality. Two
+/// implementations decode eagerly instead, while still exposing the same
+/// single-pass `next()` surface: the protocol-extension compatibility
+/// default for `XLRequest` conformers that predate this API (which calls
+/// `fetchAll()` under the hood), and `GRDBRequest`'s own `RETURNING`
+/// exception (see "Scope lifetime and connection occupancy" below) --
+/// callers of `withResultSet(_:)` should not assume lazy stepping unless they
+/// know which implementation backs a given request.
 ///
 /// ### Reference semantics, not a collection
 ///
@@ -67,14 +75,20 @@ public enum XLResultSetError: Error, Equatable, Sendable, LocalizedError {
 ///
 /// An `XLResultSet` is valid only for the dynamic extent of the
 /// ``XLRequest/withResultSet(_:)`` (or ``XLRequest/withResultSet(bindings:_:)``)
-/// callback that receives it. That callback owns the underlying database read
-/// access -- a pooled connection, or the pinned connection of an enclosing
-/// transaction -- for its *entire* duration, not just while a `next()` call is
-/// in flight. Avoid slow, unrelated work between `next()` calls, since it
-/// keeps that connection or snapshot occupied the whole time. The owning
-/// scope closes the result set with `defer` before returning or throwing, so
-/// this happens whether the callback returns normally, returns early, or
-/// throws.
+/// callback that receives it. For a true streaming implementation, that
+/// callback owns the underlying database read access -- a pooled connection,
+/// or the pinned connection of an enclosing transaction -- for its *entire*
+/// duration, not just while a `next()` call is in flight; avoid slow,
+/// unrelated work between `next()` calls, since it keeps that connection or
+/// snapshot occupied the whole time. `GRDBRequest`'s one exception is a
+/// `RETURNING` statement: because the statement's write must complete
+/// atomically regardless of how many rows the caller ends up consuming, the
+/// write transaction runs and fully decodes its rows *before* `operation`
+/// is ever called, so the callback in that case does not hold the write
+/// connection open across `next()` calls -- only the already-decoded rows.
+/// The owning scope closes the result set with `defer` before returning or
+/// throwing, so this happens whether the callback returns normally, returns
+/// early, or throws.
 ///
 /// A reference retained past that callback's return no longer has a live
 /// cursor to step: every later `next()` throws ``XLResultSetError/closed``

--- a/Sources/SwiftQLCore/SQLDatabaseDriver.swift
+++ b/Sources/SwiftQLCore/SQLDatabaseDriver.swift
@@ -126,6 +126,10 @@ package protocol XLStreamingDatabaseDriverConnection:
     /// and value-normalization per call, returning `nil` once the underlying
     /// cursor is exhausted.
     ///
+    /// Both exhaustion and a thrown step error are terminal: once the
+    /// returned closure has returned `nil` or thrown once, every later call
+    /// must keep returning `nil` rather than stepping the cursor again.
+    ///
     /// This is the pull-based counterpart to `forEachRow(_:_:)`: a caller
     /// outside the connection access (``XLResultSet/next()``) needs to step
     /// exactly one row per call from code that already ran and returned,

--- a/Sources/SwiftQLCore/SQLDatabaseDriver.swift
+++ b/Sources/SwiftQLCore/SQLDatabaseDriver.swift
@@ -119,6 +119,25 @@ package protocol XLStreamingDatabaseDriverConnection:
         _ statement: PhysicalStatement,
         _ body: ([Dialect.Value]) throws -> XLRowStreamControl
     ) throws
+
+    ///
+    /// Prepares one physical statement and returns a value-level stepper that
+    /// performs at most one additional SQLite step and value-normalization
+    /// per call, returning `nil` once the underlying cursor is exhausted.
+    ///
+    /// This is the pull-based counterpart to `forEachRow(_:_:)`: a caller
+    /// outside the connection access (``XLResultSet/next()``) needs to step
+    /// exactly one row per call from code that already ran and returned,
+    /// which a callback invoked once per row cannot express. The returned
+    /// closure remains valid only for the lifetime of the connection access
+    /// that produced it; implementations must not let the physical cursor it
+    /// closes over survive that access, and callers must stop invoking the
+    /// closure (and release every reference to it) no later than when that
+    /// access returns.
+    ///
+    mutating func makeValuesStepper(
+        _ statement: PhysicalStatement
+    ) throws -> () throws -> [Dialect.Value]?
 }
 
 

--- a/Sources/SwiftQLCore/SQLDatabaseDriver.swift
+++ b/Sources/SwiftQLCore/SQLDatabaseDriver.swift
@@ -121,9 +121,10 @@ package protocol XLStreamingDatabaseDriverConnection:
     ) throws
 
     ///
-    /// Prepares one physical statement and returns a value-level stepper that
-    /// performs at most one additional SQLite step and value-normalization
-    /// per call, returning `nil` once the underlying cursor is exhausted.
+    /// Takes one already-prepared physical statement and returns a
+    /// value-level stepper that performs at most one additional SQLite step
+    /// and value-normalization per call, returning `nil` once the underlying
+    /// cursor is exhausted.
     ///
     /// This is the pull-based counterpart to `forEachRow(_:_:)`: a caller
     /// outside the connection access (``XLResultSet/next()``) needs to step

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1296,6 +1296,14 @@ extension XLDocumentationTests {
             fredPerson
         )
 
+        var lazilyFetchedNames: [String] = []
+        try database.makeRequest(with: peopleNamedFredQuery).withResultSet { results in
+            while let person = try results.next() {
+                lazilyFetchedNames.append(person.name)
+            }
+        }
+        XCTAssertEqual(lazilyFetchedNames, [fredPerson.name])
+
         let peopleNamedFredShorthandQuery = sql {
             let person = $0.table(Person.self)
             Select(person)

--- a/Tests/SQLTests/XLResultSetTests.swift
+++ b/Tests/SQLTests/XLResultSetTests.swift
@@ -107,7 +107,9 @@ final class XLResultSetTests: XCTestCase {
         databasePool = nil
         database = nil
         probe = nil
-        try? FileManager.default.removeItem(at: databaseDirectoryURL)
+        if let databaseDirectoryURL {
+            try? FileManager.default.removeItem(at: databaseDirectoryURL)
+        }
         databaseDirectoryURL = nil
     }
 

--- a/Tests/SQLTests/XLResultSetTests.swift
+++ b/Tests/SQLTests/XLResultSetTests.swift
@@ -1,0 +1,566 @@
+//
+//  XLResultSetTests.swift
+//
+//  Issue #249: a typed, connection-scoped `XLResultSet` that lazily fetches
+//  and decodes one row at a time over the streaming execution seam delivered
+//  by issue #248 (`XLStreamingDatabaseDriverConnection.forEachRow`).
+//
+//  These tests exercise the real GRDB-backed adapter against a real temporary
+//  SQLite database (no mocks), and use a custom SQLite scalar-function probe
+//  -- the same technique `GRDBDriverContractTests` and
+//  `SQLColumnReadErrorTests` already use -- to prove SQLite itself never
+//  steps rows beyond what `next()` actually requested.
+//
+
+#if canImport(Combine)
+import Combine
+#else
+import OpenCombine
+#endif
+import Foundation
+import GRDB
+import SwiftQL
+import XCTest
+
+
+/// Records one invocation per row SQLite actually evaluates through
+/// `XLResultSetStreamStepProbe.functionName`, independent of anything the
+/// Swift decode path does. A thrown Swift error from `observe(_:)` becomes a
+/// genuine SQLite-level (step) failure, distinct from a row-decode failure
+/// that only happens after a row's values are already in hand.
+private final class XLResultSetStreamStepProbe: @unchecked Sendable {
+
+    static let functionName = "swiftql_result_set_stream_probe"
+
+    /// A row whose raw value equals this sentinel makes `observe(_:)` throw,
+    /// simulating a SQLite step failure (as opposed to a Swift-side decode
+    /// failure) at that row.
+    static let stepFailureSentinel: Int64 = -1
+
+    private let lock = NSLock()
+    private var invocationCountValue = 0
+
+    var invocationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return invocationCountValue
+    }
+
+    func observe(_ value: DatabaseValue) throws -> Int64? {
+        lock.lock()
+        invocationCountValue += 1
+        lock.unlock()
+        let intValue = Int64.fromDatabaseValue(value)
+        if intValue == Self.stepFailureSentinel {
+            throw XLResultSetTestStepFailure.simulated
+        }
+        return intValue
+    }
+}
+
+
+private enum XLResultSetTestStepFailure: Error, Equatable {
+    case simulated
+}
+
+
+final class XLResultSetTests: XCTestCase {
+
+    private var database: GRDBDatabase!
+    private var databasePool: DatabasePool!
+    private var databaseDirectoryURL: URL!
+    private var probe: XLResultSetStreamStepProbe!
+
+    override func setUpWithError() throws {
+        probe = XLResultSetStreamStepProbe()
+        databaseDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: databaseDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        let fileURL = databaseDirectoryURL.appendingPathComponent(
+            "database.sqlite",
+            isDirectory: false
+        )
+        var configuration = Configuration()
+        let probe = try XCTUnwrap(probe)
+        configuration.prepareDatabase { database in
+            database.add(
+                function: DatabaseFunction(
+                    XLResultSetStreamStepProbe.functionName,
+                    argumentCount: 1
+                ) { values in
+                    try probe.observe(values[0])
+                }
+            )
+        }
+        database = try GRDBDatabase(
+            url: fileURL,
+            configuration: configuration,
+            logger: nil
+        )
+        databasePool = database.databasePool
+    }
+
+    override func tearDown() {
+        databasePool = nil
+        database = nil
+        probe = nil
+        try? FileManager.default.removeItem(at: databaseDirectoryURL)
+        databaseDirectoryURL = nil
+    }
+
+    // MARK: - Fixtures
+
+    /// Creates the backing table and a `Test` view whose `value` column
+    /// routes through the step probe, then inserts `rows` in the given
+    /// order. `Test` is the table name `TestTable` (see `Tables/TestTable.swift`)
+    /// is declared against, so `probedTableStatement()` below decodes through
+    /// the ordinary `@SQLTable` machinery.
+    private func createProbedTable(rows: [(id: String, value: Int?)]) throws {
+        try databasePool.write { database in
+            try database.execute(
+                sql: """
+                    CREATE TABLE TestStorage (
+                        id TEXT PRIMARY KEY,
+                        value INTEGER
+                    )
+                    """
+            )
+            for row in rows {
+                try database.execute(
+                    sql: "INSERT INTO TestStorage (id, value) VALUES (?, ?)",
+                    arguments: [row.id, row.value]
+                )
+            }
+            try database.execute(
+                sql: """
+                    CREATE VIEW Test AS
+                    SELECT
+                        id,
+                        \(XLResultSetStreamStepProbe.functionName)(value) AS value
+                    FROM TestStorage
+                    """
+            )
+        }
+    }
+
+    private func probedTableStatement() -> any XLQueryStatement<TestTable> {
+        sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            OrderBy(table.id.ascending())
+        }
+    }
+
+    /// A trivial read used to prove the pool's connections are still usable
+    /// (not leaked, not deadlocked) after a `withResultSet` scope returns.
+    private func assertPoolStillUsable(file: StaticString = #filePath, line: UInt = #line) throws {
+        XCTAssertEqual(
+            try databasePool.read { database in
+                try Int.fetchOne(database, sql: "SELECT 42")
+            },
+            42,
+            "The database pool must remain usable after a withResultSet scope returns.",
+            file: file,
+            line: line
+        )
+    }
+
+    // MARK: - Empty result
+
+    func testEmptyResultSetReturnsNilImmediatelyWithoutStepping() throws {
+        try createProbedTable(rows: [])
+
+        var callCount = 0
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            callCount += 1
+            XCTAssertNil(try results.next())
+            XCTAssertNil(try results.next(), "Repeated next() on an empty result must stay nil.")
+        }
+        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(probe.invocationCount, 0)
+        try assertPoolStillUsable()
+    }
+
+    // MARK: - Lazy stepping and decoding
+
+    func testNoRowIsSteppedOrDecodedBeforeFirstNext() throws {
+        try createProbedTable(rows: [
+            ("1", 1), ("2", 2), ("3", 3),
+        ])
+
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            XCTAssertEqual(self.probe.invocationCount, 0, "No row may be stepped before the first next() call.")
+            _ = try results.next()
+            XCTAssertEqual(self.probe.invocationCount, 1)
+        }
+    }
+
+    func testExactlyOneRowDecodedPerSuccessfulNext() throws {
+        try createProbedTable(rows: [
+            ("1", 1), ("2", 2), ("3", 3),
+        ])
+
+        var decoded: [TestTable] = []
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            for expectedCount in 1 ... 3 {
+                guard let row = try results.next() else {
+                    return XCTFail("Expected a row.")
+                }
+                decoded.append(row)
+                XCTAssertEqual(
+                    self.probe.invocationCount,
+                    expectedCount,
+                    "Each successful next() must step and decode exactly one row."
+                )
+            }
+            // Exhaustion: SQLite must not evaluate a fourth, nonexistent row.
+            XCTAssertNil(try results.next())
+            XCTAssertEqual(self.probe.invocationCount, 3)
+        }
+        XCTAssertEqual(decoded, [
+            TestTable(id: "1", value: 1),
+            TestTable(id: "2", value: 2),
+            TestTable(id: "3", value: 3),
+        ])
+        try assertPoolStillUsable()
+    }
+
+    func testStoppingAfterNRowsDoesNotStepOrDecodeRemainingRows() throws {
+        try createProbedTable(rows: [
+            ("1", 1), ("2", 2), ("3", 3), ("4", 4), ("5", 5),
+        ])
+
+        var decoded: [TestTable] = []
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            decoded.append(try XCTUnwrap(results.next()))
+            decoded.append(try XCTUnwrap(results.next()))
+            // Deliberately stop early: rows 3, 4, 5 must never be evaluated.
+        }
+        XCTAssertEqual(decoded, [
+            TestTable(id: "1", value: 1),
+            TestTable(id: "2", value: 2),
+        ])
+        XCTAssertEqual(
+            probe.invocationCount,
+            2,
+            "Early termination must not step or decode the remaining rows."
+        )
+        try assertPoolStillUsable()
+    }
+
+    func testRepeatedNextAfterNaturalExhaustionReturnsNilStably() throws {
+        try createProbedTable(rows: [("1", 1), ("2", 2)])
+
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            XCTAssertNotNil(try results.next())
+            XCTAssertNotNil(try results.next())
+            XCTAssertNil(try results.next(), "The result set is exhausted after the second row.")
+            XCTAssertNil(try results.next(), "Exhaustion must be stable, not an error.")
+            XCTAssertNil(try results.next(), "Exhaustion must remain stable across repeated calls.")
+        }
+        XCTAssertEqual(probe.invocationCount, 2)
+    }
+
+    // MARK: - close() and scope-exit semantics
+
+    func testCloseIsIdempotentAndNextThrowsClosedAfterExplicitClose() throws {
+        try createProbedTable(rows: [("1", 1), ("2", 2)])
+
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            XCTAssertNotNil(try results.next())
+            results.close()
+            results.close() // Idempotent: must not crash or throw.
+
+            XCTAssertThrowsError(try results.next()) { error in
+                XCTAssertEqual(error as? XLResultSetError, .closed)
+            }
+            results.close() // Still idempotent once terminated.
+            XCTAssertThrowsError(try results.next()) { error in
+                XCTAssertEqual(error as? XLResultSetError, .closed)
+            }
+        }
+        XCTAssertEqual(
+            probe.invocationCount,
+            1,
+            "Closing early must not step the remaining row."
+        )
+        try assertPoolStillUsable()
+    }
+
+    func testRetainedResultSetThrowsClosedAfterScopeExits() throws {
+        try createProbedTable(rows: [("1", 1), ("2", 2), ("3", 3)])
+
+        var escaped: XLResultSet<TestTable>!
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            XCTAssertNotNil(try results.next())
+            escaped = results
+        }
+
+        XCTAssertThrowsError(try escaped.next()) { error in
+            XCTAssertEqual(
+                error as? XLResultSetError,
+                .closed,
+                "A retained XLResultSet must throw .closed once its withResultSet scope has returned."
+            )
+        }
+        // Repeated post-scope access must keep throwing the same error.
+        XCTAssertThrowsError(try escaped.next()) { error in
+            XCTAssertEqual(error as? XLResultSetError, .closed)
+        }
+        XCTAssertEqual(
+            probe.invocationCount,
+            1,
+            "A result set escaping its scope must not be able to step further rows."
+        )
+        try assertPoolStillUsable()
+    }
+
+    func testRetainedResultSetThatWasAlreadyExhaustedStillThrowsClosedAfterScopeExits() throws {
+        try createProbedTable(rows: [("1", 1)])
+
+        var escaped: XLResultSet<TestTable>!
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            XCTAssertNotNil(try results.next())
+            XCTAssertNil(try results.next()) // Naturally exhausted inside the scope.
+            escaped = results
+        }
+
+        // Outside the scope, even an already-exhausted reference must report
+        // the stronger, deterministic "closed" state rather than looking
+        // like it could still be validly re-queried.
+        XCTAssertThrowsError(try escaped.next()) { error in
+            XCTAssertEqual(error as? XLResultSetError, .closed)
+        }
+    }
+
+    // MARK: - Consumer-thrown errors
+
+    private struct ConsumerError: Error, Equatable {}
+
+    func testConsumerThrownErrorPropagatesAndClosesResultSet() throws {
+        try createProbedTable(rows: [("1", 1), ("2", 2), ("3", 3)])
+
+        var escaped: XLResultSet<TestTable>!
+        XCTAssertThrowsError(
+            try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+                _ = try results.next()
+                escaped = results
+                throw ConsumerError()
+            }
+        ) { error in
+            XCTAssertEqual(error as? ConsumerError, ConsumerError())
+        }
+
+        XCTAssertEqual(
+            probe.invocationCount,
+            1,
+            "A consumer-thrown error must not step further rows."
+        )
+        XCTAssertThrowsError(try escaped.next()) { error in
+            XCTAssertEqual(error as? XLResultSetError, .closed)
+        }
+        try assertPoolStillUsable()
+    }
+
+    // MARK: - Decode failure (Swift-side, after a value is already fetched)
+
+    func testDecodeErrorMidStreamPreservesOriginalErrorAndStopsStepping() throws {
+        try createProbedTable(rows: [
+            ("1-valid", 1),
+            ("2-invalid", nil),
+            ("3-must-not-step", 3),
+        ])
+
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            let first = try XCTUnwrap(results.next())
+            XCTAssertEqual(first, TestTable(id: "1-valid", value: 1))
+
+            XCTAssertThrowsError(try results.next()) { error in
+                XCTAssertEqual(
+                    error as? XLColumnReadError,
+                    XLColumnReadError(index: 1, expectedType: "Int", failure: .nullValue)
+                )
+            }
+
+            // The original decode error is delivered exactly once; every
+            // later call is the deterministic terminal error instead.
+            XCTAssertThrowsError(try results.next()) { error in
+                XCTAssertEqual(error as? XLResultSetError, .closed)
+            }
+        }
+        XCTAssertEqual(
+            probe.invocationCount,
+            2,
+            "A decode failure at row 2 must stop before SQLite steps row 3."
+        )
+        try assertPoolStillUsable()
+    }
+
+    // MARK: - SQLite step failure (distinct from a Swift-side decode failure)
+
+    func testSQLiteStepFailurePreservesOriginalErrorAndStopsStepping() throws {
+        try createProbedTable(rows: [
+            ("1-valid", 1),
+            ("2-step-failure", Int(XLResultSetStreamStepProbe.stepFailureSentinel)),
+            ("3-must-not-step", 3),
+        ])
+
+        try database.makeRequest(with: probedTableStatement()).withResultSet { results in
+            let first = try XCTUnwrap(results.next())
+            XCTAssertEqual(first, TestTable(id: "1-valid", value: 1))
+
+            XCTAssertThrowsError(try results.next()) { error in
+                // The probe's thrown Swift error surfaces as a SQLite-level
+                // failure raised while stepping row 2, before any typed
+                // decode of that row's values is attempted.
+                XCTAssertFalse(error is XLColumnReadError)
+                XCTAssertFalse(error is XLResultSetError)
+            }
+
+            XCTAssertThrowsError(try results.next()) { error in
+                XCTAssertEqual(error as? XLResultSetError, .closed)
+            }
+        }
+        XCTAssertEqual(
+            probe.invocationCount,
+            2,
+            "A SQLite step failure at row 2 must stop before SQLite steps row 3."
+        )
+        try assertPoolStillUsable()
+    }
+
+    // MARK: - RETURNING statements decode eagerly to protect write completeness
+
+    /// `RETURNING` rows are produced as SQLite steps through the
+    /// data-changing statement itself, so lazily stopping partway through
+    /// them would leave the underlying `UPDATE` only partially applied.
+    /// `GRDBRequest.withResultSet(bindings:_:)` decodes `RETURNING` results
+    /// eagerly for exactly this reason -- confirm the write is always fully
+    /// applied even when the consumer stops after the first `next()` call.
+    func testReturningStatementCommitsCompleteWriteEvenWhenConsumerStopsEarly() throws {
+        try databasePool.write { database in
+            try database.execute(
+                sql: "CREATE TABLE Test (id TEXT PRIMARY KEY, value INTEGER NOT NULL)"
+            )
+            try database.execute(
+                sql: "INSERT INTO Test (id, value) VALUES ('a', 1), ('b', 2), ('c', 3)"
+            )
+        }
+
+        let schema = XLSchema()
+        let t = schema.into(TestTable.self)
+        let projection = schema.table(TestTable.self)
+        let statement = update(t)
+            .set { row in row.value = 99 }
+            .where(t.id != "does-not-exist")
+            .returning(projection)
+
+        var decoded: [TestTable] = []
+        try database.makeRequest(with: statement).withResultSet { results in
+            // Stop after the first row on purpose.
+            decoded.append(try XCTUnwrap(results.next()))
+        }
+        XCTAssertEqual(decoded, [TestTable(id: "a", value: 99)])
+
+        let allRowsStatement = sql { schema in
+            let table = schema.table(TestTable.self)
+            Select(table)
+            From(table)
+            OrderBy(table.id.ascending())
+        }
+        XCTAssertEqual(
+            try database.makeRequest(with: allRowsStatement).fetchAll(),
+            [
+                TestTable(id: "a", value: 99),
+                TestTable(id: "b", value: 99),
+                TestTable(id: "c", value: 99),
+            ],
+            "Stopping withResultSet early must never leave a RETURNING write partially applied."
+        )
+    }
+
+    // MARK: - Compatibility default (adapters that predate XLResultSet)
+
+    func testCompatibilityDefaultServesEagerlyFetchedRowsThroughNext() throws {
+        let request = XLResultSetLegacyRequest(rows: [10, 20, 30])
+
+        var decoded: [Int] = []
+        try request.withResultSet { results in
+            while let value = try results.next() {
+                decoded.append(value)
+            }
+            XCTAssertNil(try results.next(), "Exhaustion must remain stable for the eager fallback too.")
+        }
+        XCTAssertEqual(decoded, [10, 20, 30])
+        XCTAssertEqual(request.fetchAllCallCount, 1)
+    }
+
+    func testCompatibilityDefaultRetainedResultSetThrowsClosedAfterScopeExits() throws {
+        let request = XLResultSetLegacyRequest(rows: [1])
+
+        var escaped: XLResultSet<Int>!
+        try request.withResultSet { results in
+            escaped = results
+        }
+        XCTAssertThrowsError(try escaped.next()) { error in
+            XCTAssertEqual(error as? XLResultSetError, .closed)
+        }
+    }
+}
+
+
+/// A thread-unsafe call counter is fine here: these tests never call
+/// `fetchAll()` concurrently. A reference type lets a non-mutating
+/// `fetchAll()` (the protocol's exact requirement) still record invocations.
+private final class XLResultSetLegacyRequestCallCounter {
+    private(set) var fetchAllCallCount = 0
+
+    func recordFetchAll() {
+        fetchAllCallCount += 1
+    }
+}
+
+
+/// A minimal `XLRequest` conformer that predates `XLResultSet`, mirroring
+/// `LegacyReadRequest` in `SQLRequestCompatibilityTests.swift`. It implements
+/// none of the `withResultSet` requirements itself, relying entirely on the
+/// protocol's eager compatibility default.
+private struct XLResultSetLegacyRequest: XLRequest {
+
+    let rows: [Int]
+
+    private let callCounter = XLResultSetLegacyRequestCallCounter()
+
+    var fetchAllCallCount: Int { callCounter.fetchAllCallCount }
+
+    mutating func set<T>(
+        parameter reference: XLNamedBindingReference<Optional<T>>,
+        value: T?
+    ) where T: XLBindable {}
+
+    mutating func set<T>(
+        parameter reference: XLNamedBindingReference<T>,
+        value: T
+    ) where T: XLBindable {}
+
+    func fetchAll() throws -> [Int] {
+        callCounter.recordFetchAll()
+        return rows
+    }
+
+    func fetchOne() throws -> Int? {
+        rows.first
+    }
+
+    func publish() -> AnyPublisher<[Int], Error> {
+        Just(rows).setFailureType(to: Error.self).eraseToAnyPublisher()
+    }
+
+    func publishOne() -> AnyPublisher<Int?, Error> {
+        Just(rows.first).setFailureType(to: Error.self).eraseToAnyPublisher()
+    }
+}

--- a/Tests/SwiftQLCoreTests/SQLDriverContractTests.swift
+++ b/Tests/SwiftQLCoreTests/SQLDriverContractTests.swift
@@ -87,6 +87,77 @@ final class SQLDriverContractTests: XCTestCase {
         XCTAssertEqual(recorder.streamedRows, rows)
     }
 
+    /// The pull-based counterpart to `forEachRow(_:_:)`:
+    /// `makeValuesStepper(_:)` backs ``XLResultSet``'s `next()`. Each call to
+    /// the returned closure must step and record exactly one row, stopping
+    /// permanently once the caller stops calling it, and a thrown error must
+    /// not step further rows.
+    func testDriverNeutralValuesStepperStepsOneRowPerCallAndStopsOnDemand() throws {
+        let recorder = DriverRecorder()
+        let databaseIdentifier = databaseID(11)
+        let rows: [[XLSQLiteValue]] = [
+            [.integer(1), .text("first")],
+            [.integer(2), .text("second")],
+            [.integer(3), .text("third")],
+        ]
+        var connection = FakeConnection(
+            connectionID: 9,
+            databaseIdentifier: databaseIdentifier,
+            recorder: recorder,
+            resultRows: rows
+        )
+        let statement = try connection.prepareValidated(
+            logicalStatement(databaseIdentifier: databaseIdentifier)
+        )
+
+        let stepper = try connection.makeValuesStepper(statement)
+        XCTAssertTrue(recorder.streamedRows.isEmpty, "No row may be stepped before the stepper is invoked.")
+
+        XCTAssertEqual(try stepper(), rows[0])
+        XCTAssertEqual(recorder.streamedRows, [rows[0]])
+        XCTAssertEqual(try stepper(), rows[1])
+        XCTAssertEqual(recorder.streamedRows, Array(rows.prefix(2)))
+
+        // Stopping here (never calling the stepper again) must not step row 3.
+        XCTAssertEqual(recorder.streamedRows, Array(rows.prefix(2)))
+
+        recorder.streamedRows.removeAll()
+        var failingConnection = FakeConnection(
+            connectionID: 9,
+            databaseIdentifier: databaseIdentifier,
+            recorder: recorder,
+            failure: .execute,
+            resultRows: rows
+        )
+        XCTAssertThrowsError(try failingConnection.makeValuesStepper(statement)) { error in
+            XCTAssertEqual(error as? FakeFailure, .execute)
+        }
+        XCTAssertTrue(recorder.streamedRows.isEmpty)
+    }
+
+    /// Exhaustion of the pull-based stepper is stable: once it returns `nil`,
+    /// further calls keep returning `nil` rather than stepping again.
+    func testDriverNeutralValuesStepperExhaustionIsStable() throws {
+        let recorder = DriverRecorder()
+        let databaseIdentifier = databaseID(12)
+        let rows: [[XLSQLiteValue]] = [[.integer(1), .text("only")]]
+        var connection = FakeConnection(
+            connectionID: 10,
+            databaseIdentifier: databaseIdentifier,
+            recorder: recorder,
+            resultRows: rows
+        )
+        let statement = try connection.prepareValidated(
+            logicalStatement(databaseIdentifier: databaseIdentifier)
+        )
+
+        let stepper = try connection.makeValuesStepper(statement)
+        XCTAssertEqual(try stepper(), rows[0])
+        XCTAssertNil(try stepper())
+        XCTAssertNil(try stepper(), "Exhaustion must remain stable across repeated calls.")
+        XCTAssertEqual(recorder.streamedRows, rows)
+    }
+
     func testLogicalStatementCreatesConnectionOwnedPhysicalStatements() throws {
         let recorder = DriverRecorder()
         let databaseIdentifier = databaseID(2)
@@ -702,6 +773,29 @@ private struct FakeConnection:
             if try body(row) == .stop {
                 return
             }
+        }
+    }
+
+    mutating func makeValuesStepper(
+        _ statement: FakePhysicalStatement
+    ) throws -> () throws -> [XLSQLiteValue]? {
+        guard statement.connectionID == connectionID else {
+            throw FakeFailure.execute
+        }
+        if failure == .execute {
+            throw FakeFailure.execute
+        }
+        let rows = resultRows ?? [orderedValues(in: statement)]
+        let recorder = recorder
+        var index = 0
+        return {
+            guard index < rows.count else {
+                return nil
+            }
+            let row = rows[index]
+            index += 1
+            recorder.streamedRows.append(row)
+            return row
         }
     }
 

--- a/Tests/SwiftQLCoreTests/SQLDriverContractTests.swift
+++ b/Tests/SwiftQLCoreTests/SQLDriverContractTests.swift
@@ -158,6 +158,61 @@ final class SQLDriverContractTests: XCTestCase {
         XCTAssertEqual(recorder.streamedRows, rows)
     }
 
+    /// The pull-based stepper's most important failure mode is not a failure
+    /// at creation time (`.execute`, covered above) but a failure *from the
+    /// returned closure itself* after some rows already stepped
+    /// successfully -- what a mid-stream SQLite step error actually looks
+    /// like. Rows already stepped must remain recorded, and no row at or
+    /// after the failing index may ever be stepped.
+    func testDriverNeutralValuesStepperFailsFromTheReturnedClosureNotAtCreation() throws {
+        let recorder = DriverRecorder()
+        let databaseIdentifier = databaseID(13)
+        let rows: [[XLSQLiteValue]] = [
+            [.integer(1), .text("first")],
+            [.integer(2), .text("second")],
+            [.integer(3), .text("third")],
+        ]
+        var connection = FakeConnection(
+            connectionID: 11,
+            databaseIdentifier: databaseIdentifier,
+            recorder: recorder,
+            failure: .step,
+            resultRows: rows,
+            stepFailureAtIndex: 1
+        )
+        let statement = try connection.prepareValidated(
+            logicalStatement(databaseIdentifier: databaseIdentifier)
+        )
+
+        // Creating the stepper must not itself throw or step anything: the
+        // failure belongs to the returned closure, not to
+        // `makeValuesStepper(_:)`.
+        let stepper = try connection.makeValuesStepper(statement)
+        XCTAssertTrue(recorder.streamedRows.isEmpty)
+
+        XCTAssertEqual(try stepper(), rows[0])
+        XCTAssertEqual(recorder.streamedRows, [rows[0]])
+
+        XCTAssertThrowsError(try stepper()) { error in
+            XCTAssertEqual(error as? FakeFailure, .step)
+        }
+        XCTAssertEqual(
+            recorder.streamedRows,
+            [rows[0]],
+            "The failing step must not record a row."
+        )
+
+        XCTAssertNil(
+            try stepper(),
+            "Exhaustion past the failure index, not a repeat of the same error or a later row."
+        )
+        XCTAssertEqual(
+            recorder.streamedRows,
+            [rows[0]],
+            "No row at or after the failing index may ever be stepped."
+        )
+    }
+
     func testLogicalStatementCreatesConnectionOwnedPhysicalStatements() throws {
         let recorder = DriverRecorder()
         let databaseIdentifier = databaseID(2)
@@ -650,6 +705,14 @@ private enum FakeFailure: Error, Equatable, CustomStringConvertible {
     case execute
     case transaction
     case unsupportedValue
+    /// Distinct from `.execute`: `.execute` fails the whole push-based
+    /// `forEachRow(_:_:)` call, or `makeValuesStepper(_:)` itself, before any
+    /// stepping happens. `.step` instead lets `makeValuesStepper(_:)` return
+    /// a working stepper that fails from *inside* the returned closure after
+    /// some rows have already stepped successfully -- the pull-based
+    /// counterpart's most important failure mode, and the one a mid-stream
+    /// SQLite step error actually looks like.
+    case step
 
     var description: String {
         switch self {
@@ -663,6 +726,8 @@ private enum FakeFailure: Error, Equatable, CustomStringConvertible {
             return "transaction"
         case .unsupportedValue:
             return "unsupported value"
+        case .step:
+            return "step"
         }
     }
 }
@@ -680,6 +745,10 @@ private struct FakeConnection:
     let recorder: DriverRecorder
     var failure: FakeFailure?
     let resultRows: [[XLSQLiteValue]]?
+    /// With `failure == .step`, the 0-based row index the stepper closure
+    /// fails on: rows before it step and record normally, this index fails
+    /// without recording a row, and no later index is ever reached.
+    let stepFailureAtIndex: Int?
 
     let driverIdentifier = FakeConnection.driverID
     let dialect = XLSQLiteDialect(
@@ -692,13 +761,15 @@ private struct FakeConnection:
         databaseIdentifier: XLDatabaseIdentifier,
         recorder: DriverRecorder,
         failure: FakeFailure? = nil,
-        resultRows: [[XLSQLiteValue]]? = nil
+        resultRows: [[XLSQLiteValue]]? = nil,
+        stepFailureAtIndex: Int? = nil
     ) {
         self.connectionID = connectionID
         self.databaseIdentifier = databaseIdentifier
         self.recorder = recorder
         self.failure = failure
         self.resultRows = resultRows
+        self.stepFailureAtIndex = stepFailureAtIndex
     }
 
     mutating func preparePhysical(
@@ -787,10 +858,16 @@ private struct FakeConnection:
         }
         let rows = resultRows ?? [orderedValues(in: statement)]
         let recorder = recorder
+        let stepFailureAtIndex = stepFailureAtIndex
         var index = 0
+        var hasFailed = false
         return {
-            guard index < rows.count else {
+            guard !hasFailed, index < rows.count else {
                 return nil
+            }
+            if index == stepFailureAtIndex {
+                hasFailed = true
+                throw FakeFailure.step
             }
             let row = rows[index]
             index += 1


### PR DESCRIPTION
## Summary

- Adds `XLResultSet<Row>`, a connection-scoped `final class` (not `Sequence`/`Collection`/`Sendable`) whose `next() throws -> Row?` steps and decodes exactly one row at a time over a new pull-based streaming seam.
- Adds `withResultSet(_:)` / `withResultSet(bindings:_:)` to `XLRequest`, with an eager compatibility default in the protocol extension and a true-streaming override in `GRDBRequest`.
- Adds `makeValuesStepper(_:)` to the package-internal `XLStreamingDatabaseDriverConnection` protocol (`SwiftQLCore`) as a driver-neutral, pull-based sibling to #248's push-based `forEachRow`, implemented for the GRDB driver and the contract-test fake driver.
- `close()` is idempotent; exhaustion, explicit close, decode error, or SQLite step error are all terminal and make later `next()` calls throw `XLResultSetError.closed` deterministically, while preserving the original terminating error.
- `RETURNING` requests decode eagerly inside the write transaction (like `fetchAll`) before serving rows lazily through the same `next()` surface — documented exception, since the write must complete even if the consumer stops early; covered by a dedicated test.
- `fetchAll()`/`fetchOne()`/existing publisher APIs are unchanged.
- New docs section in `GettingStarted.md`; new tests in `Tests/SQLTests/XLResultSetTests.swift` (15) and `Tests/SwiftQLCoreTests/SQLDriverContractTests.swift` (2), using the existing SQLite-probe technique to verify step/decode counts.

Closes #249.

## Test plan
- [x] `swift build`
- [x] `swift test` — 1127 tests, 0 failures
- [x] Verified: no row stepped/decoded before first `next()`; exactly one decode per `next()`; early stop doesn't step later rows; repeated `next()` after exhaustion is stable; `close()` idempotent; retained reference after scope exit throws `.closed`; consumer-thrown and decode/SQLite errors propagate and close the result set; pooled connections remain usable after every exit path; RETURNING write completeness under early termination.
