### PR TITLE
Add canonical async live-query streams: stream()/streamOne() (#308)

### DIFF
--- a/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
+++ b/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
@@ -207,7 +207,19 @@ final class GRDBLiveQueryAsyncBridge<Value>: @unchecked Sendable {
     /// Cancels the underlying GRDB observation, any pending retry backoff,
     /// and the buffer. Safe to call more than once, and safe to call whether
     /// or not `next()` was ever invoked.
+    ///
+    /// `retryState.cancel()` runs *first*, before touching `cancellable`/
+    /// `pendingDelayCancellable`: it bumps `retryState`'s generation, which
+    /// is what actually invalidates a `beginAttempt()`/`scheduleRetry()` call
+    /// racing this one. Clearing this class's own stored references before
+    /// that point would leave a window where such a race could obtain a
+    /// still-valid generation, store a fresh observation or delay
+    /// cancellable, and pass its own check-after-store `shouldDeliver` guard
+    /// before `retryState.cancel()` had a chance to invalidate it -- leaking
+    /// an observation or timer with no remaining owner to cancel it.
     func cancel() {
+        retryState.cancel()
+
         lock.lock()
         let existingObservation = cancellable
         let existingDelay = pendingDelayCancellable
@@ -215,7 +227,6 @@ final class GRDBLiveQueryAsyncBridge<Value>: @unchecked Sendable {
         pendingDelayCancellable = nil
         lock.unlock()
 
-        retryState.cancel()
         existingDelay?.cancel()
         existingObservation?.cancel()
         buffer.cancel()

--- a/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
+++ b/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
@@ -1,0 +1,237 @@
+#if canImport(Combine)
+import Combine
+#else
+import OpenCombine
+#endif
+import Foundation
+import GRDB
+
+
+/// Bridges a raw GRDB `ValueObservation` into SwiftQL's canonical,
+/// lazily-started, single-slot ("newest wins") buffered async live-query
+/// source (issue #308), implementing the buffering, cancellation, and
+/// snapshot-ownership contract recorded at
+/// `Sources/SwiftQL/SwiftQL.docc/LiveQueries.md`, "Buffering and
+/// Resumed-Demand Semantics (#291)".
+///
+/// This is the type `GRDBRequest.stream()`/`streamOne()` (and their bindings
+/// variants) build on. It intentionally does not use Combine, `AnyPublisher`,
+/// or `.values` as its observation source — only GRDB's own
+/// `ValueObservation.start(in:scheduling:onError:onChange:)`, the same
+/// primitive ``GRDBLiveQueryRetryPolicy`` already uses for the Combine path.
+///
+/// Retry reuses ``GRDBLiveQueryRetryState`` (the exact generation-counter
+/// cancellation-ownership design the Combine retry attempt runner in
+/// `GRDBLiveQueryRetryPolicy.swift` already uses) and ``GRDBLiveQueryRetryScheduler``
+/// (the exact delay seam that scheduler's deterministic tests already drive),
+/// so this bridge does not fork a second retry engine, and any future adapter
+/// (e.g. #309's Combine adapter) sharing this bridge inherits the identical
+/// retry budget and delay semantics without reimplementing them.
+///
+/// Each bridge owns exactly one independent observation and one single-slot
+/// buffer: constructing a bridge (or calling ``stream()`` on it) performs no
+/// database work. Only the first consumer pull — the first `next()` call
+/// reaching this bridge, whether through a manual iterator or a `for try
+/// await` loop over the returned `AsyncThrowingStream` — starts the
+/// underlying GRDB observation. This is verified explicitly by
+/// `GRDBLiveQueryAsyncStreamTests.testUnusedStreamPerformsNoObservationOrFetch`.
+final class GRDBLiveQueryAsyncBridge<Value>: @unchecked Sendable {
+
+    typealias Start = (
+        @escaping (Error) -> Void,
+        @escaping (Value) -> Void
+    ) -> AnyDatabaseCancellable
+
+    private let lock = NSLock()
+
+    private var didStart = false
+
+    private var cancellable: AnyDatabaseCancellable?
+
+    private var pendingDelayCancellable: AnyCancellable?
+
+    private let buffer = XLSingleSlotAsyncBuffer<Value>()
+
+    private let retryState: GRDBLiveQueryRetryState
+
+    private let scheduler: GRDBLiveQueryRetryScheduler
+
+    private let makeSource: Start
+
+    init(
+        policy: GRDBLiveQueryRetryPolicy,
+        scheduler: GRDBLiveQueryRetryScheduler,
+        makeSource: @escaping Start
+    ) {
+        self.retryState = GRDBLiveQueryRetryState(policy: policy)
+        self.scheduler = scheduler
+        self.makeSource = makeSource
+    }
+
+    /// Synchronous locked mutation kept out of `next()`'s `async` body (see
+    /// the equivalent note on ``XLSingleSlotAsyncBuffer``). Returns `true`
+    /// exactly once, for the call that must actually start the first GRDB
+    /// observation attempt.
+    private func claimStart() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !didStart else { return false }
+        didStart = true
+        return true
+    }
+
+    private func storeCancellable(_ newCancellable: AnyDatabaseCancellable?) {
+        lock.lock()
+        cancellable = newCancellable
+        lock.unlock()
+    }
+
+    private func storePendingDelay(_ newCancellable: AnyCancellable?) {
+        lock.lock()
+        pendingDelayCancellable = newCancellable
+        lock.unlock()
+    }
+
+    func next() async throws -> Value? {
+        if claimStart() {
+            beginAttempt()
+        }
+
+        return try await withTaskCancellationHandler(
+            operation: { try await buffer.next() },
+            onCancel: { [weak self] in self?.cancel() }
+        )
+    }
+
+    /// Starts one fresh, protected GRDB observation attempt under a new
+    /// retry generation. Reentrant via ``scheduleRetry(after:generation:)``
+    /// below: a qualifying BUSY failure schedules another call to this
+    /// method after the policy's backoff. Any callback from a superseded
+    /// generation is dropped by `retryState`, so attempts never overlap.
+    private func beginAttempt() {
+        guard let generation = retryState.beginAttempt() else {
+            // Cancelled before this attempt ever started (e.g. cancellation
+            // raced the very first `next()` call, or arrived during backoff).
+            buffer.cancel()
+            return
+        }
+        let newCancellable = makeSource(
+            { [weak self] error in self?.handleError(error, generation: generation) },
+            { [weak self] value in self?.handleValue(value, generation: generation) }
+        )
+        storeCancellable(newCancellable)
+
+        // `cancel()` may have run concurrently between `beginAttempt()`
+        // succeeding above and `newCancellable` being stored — it would then
+        // have read (and cleared) whatever was stored *before* this attempt,
+        // never learning about this one. Re-checking the generation after
+        // storing closes that race: if this attempt is already stale, cancel
+        // what was just started and stored ourselves, mirroring the same
+        // check-after-start pattern `GRDBOpenCombineValuePublisher.swift`
+        // uses for the identical race on `request(_:)`.
+        guard retryState.shouldDeliver(generation: generation) else {
+            storeCancellable(nil)
+            newCancellable.cancel()
+            return
+        }
+    }
+
+    private func handleValue(_ value: Value, generation: Int) {
+        guard retryState.shouldDeliver(generation: generation) else { return }
+        retryState.didDeliver(generation: generation)
+        buffer.yield(value)
+    }
+
+    private func handleError(_ error: Error, generation: Int) {
+        guard retryState.shouldDeliver(generation: generation) else { return }
+        if let delay = retryState.retryDelay(after: error, generation: generation) {
+            scheduleRetry(after: delay, generation: generation)
+        }
+        else {
+            buffer.finish(throwing: error)
+        }
+    }
+
+    /// Waits `delay` on the shared ``GRDBLiveQueryRetryScheduler`` seam
+    /// before starting the next attempt. Cancelling the pending delay
+    /// (`cancel()` below) stops this wait immediately rather than merely
+    /// letting a fresh attempt no-op once the full delay eventually elapses,
+    /// matching "cancelling during backoff cancels the pending delay and
+    /// starts no new fetch."
+    private func scheduleRetry(after delay: TimeInterval, generation: Int) {
+        var delayCancellable: AnyCancellable?
+        delayCancellable = scheduler.publisher(after: delay).sink(
+            receiveCompletion: { [weak self] _ in
+                self?.storePendingDelay(nil)
+                self?.beginAttempt()
+            },
+            receiveValue: { _ in }
+        )
+        storePendingDelay(delayCancellable)
+
+        // Same check-after-store race as `beginAttempt()`: `cancel()` may
+        // have run between the guard in `handleError` and this store.
+        guard retryState.shouldDeliver(generation: generation) else {
+            storePendingDelay(nil)
+            delayCancellable?.cancel()
+            return
+        }
+    }
+
+    /// Cancels the underlying GRDB observation, any pending retry backoff,
+    /// and the buffer. Safe to call more than once, and safe to call whether
+    /// or not `next()` was ever invoked.
+    func cancel() {
+        lock.lock()
+        let existingObservation = cancellable
+        let existingDelay = pendingDelayCancellable
+        cancellable = nil
+        pendingDelayCancellable = nil
+        lock.unlock()
+
+        retryState.cancel()
+        existingDelay?.cancel()
+        existingObservation?.cancel()
+        buffer.cancel()
+    }
+
+    /// The publicly-shaped return type #308's methods must expose.
+    /// Constructing this value performs no database work: only the first
+    /// `next()` call (i.e. the first iteration attempt) starts the GRDB
+    /// observation. Built with `AsyncThrowingStream`'s `unfolding:`
+    /// initializer rather than its continuation-based
+    /// `init(_:bufferingPolicy:_:)`, because that initializer runs its
+    /// `build` closure eagerly at construction time — which would start GRDB
+    /// observation before iteration begins.
+    ///
+    /// The `unfolding` closure captures `self` strongly, not weakly: this
+    /// bridge is typically constructed and handed straight to `stream()`
+    /// with no other owner (see `GRDBRequest.stream()`), so a weak capture
+    /// would let it deallocate immediately after this call returns, before
+    /// any consumer ever iterates — silently turning every stream into one
+    /// that resolves to `nil` on its very first `next()`. The returned
+    /// `AsyncThrowingStream` becomes this bridge's only owner from here on,
+    /// and the bridge does not hold a reference back to the stream, so this
+    /// creates no retain cycle: the bridge is released once the stream (and
+    /// its iterator) are no longer referenced.
+    func stream() -> AsyncThrowingStream<Value, Error> {
+        AsyncThrowingStream(unfolding: {
+            try await self.next()
+        })
+    }
+}
+
+
+/// Returns an `AsyncThrowingStream` that performs no work until its first
+/// `next()` call, at which point it immediately throws `error` and finishes.
+/// Used when a stream cannot be constructed at all (an invalid invocation
+/// packet, a `RETURNING` request, or a transaction-scoped driver with no
+/// pool to observe) — the error must still be reported lazily, on first
+/// iteration, to preserve "observation begins with iteration, not merely by
+/// constructing an unused stream" for every code path, not only the
+/// successful one.
+func xlFailingAsyncThrowingStream<Value>(_ error: Error) -> AsyncThrowingStream<Value, Error> {
+    AsyncThrowingStream(unfolding: {
+        throw error
+    })
+}

--- a/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
+++ b/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
@@ -231,15 +231,21 @@ final class GRDBLiveQueryAsyncBridge<Value>: @unchecked Sendable {
 
 
 /// Returns an `AsyncThrowingStream` that performs no work until its first
-/// `next()` call, at which point it immediately throws `error` and finishes.
-/// Used when a stream cannot be constructed at all (an invalid invocation
-/// packet, a `RETURNING` request, or a transaction-scoped driver with no
-/// pool to observe) — the error must still be reported lazily, on first
-/// iteration, to preserve "observation begins with iteration, not merely by
-/// constructing an unused stream" for every code path, not only the
-/// successful one.
+/// `next()` call, at which point it immediately throws `error` and finishes
+/// -- unless the consuming `Task` is already cancelled, in which case it
+/// resolves to `nil` instead, per the same cancellation contract every other
+/// canonical stream honors: cancellation ends iteration with `nil`, never a
+/// thrown error, `CancellationError` included. Used when a stream cannot be
+/// constructed at all (an invalid invocation packet, a `RETURNING` request,
+/// or a transaction-scoped driver with no pool to observe) — the
+/// construction error must still be reported lazily, on first iteration, to
+/// preserve "observation begins with iteration, not merely by constructing
+/// an unused stream" for every code path, not only the successful one.
 func xlFailingAsyncThrowingStream<Value>(_ error: Error) -> AsyncThrowingStream<Value, Error> {
     AsyncThrowingStream(unfolding: {
+        guard !Task.isCancelled else {
+            return nil
+        }
         throw error
     })
 }

--- a/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
+++ b/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
@@ -10,8 +10,7 @@ import GRDB
 /// Bridges a raw GRDB `ValueObservation` into SwiftQL's canonical,
 /// lazily-started, single-slot ("newest wins") buffered async live-query
 /// source (issue #308), implementing the buffering, cancellation, and
-/// snapshot-ownership contract recorded at
-/// `Sources/SwiftQL/SwiftQL.docc/LiveQueries.md`, "Buffering and
+/// snapshot-ownership contract recorded at <doc:LiveQueries>, "Buffering and
 /// Resumed-Demand Semantics (#291)".
 ///
 /// This is the type `GRDBRequest.stream()`/`streamOne()` (and their bindings

--- a/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
+++ b/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
@@ -170,12 +170,15 @@ final class GRDBLiveQueryAsyncBridge<Value>: @unchecked Sendable {
         var delayCancellable: AnyCancellable?
         // Triggers on the first emitted *value*, not on completion:
         // `GRDBLiveQueryRetryScheduler.publisher(after:)` is a type-erased
-        // seam with no documented guarantee that it completes after
-        // emitting -- the deterministic manual scheduler used by this
-        // bridge's own retry tests emits from a `PassthroughSubject` that
-        // never sends a completion at all. The Combine retry path already
-        // treats this seam the same way, via `flatMap` reacting to each
-        // emitted value rather than waiting for completion. `.prefix(1)`
+        // seam whose completion behavior is unspecified by contract, even
+        // though every scheduler this package currently ships (including the
+        // deterministic manual schedulers used by this bridge's own retry
+        // tests) happens to complete right after emitting. The Combine retry
+        // path already treats this seam as value-driven, via `flatMap`
+        // reacting to each emitted value rather than waiting for completion
+        // -- matching that here, instead of relying on today's incidental
+        // completion behavior, is what keeps a future scheduler that only
+        // emits (without completing) from deadlocking retries. `.prefix(1)`
         // guarantees this fires at most once even if the scheduler emits
         // more than one value.
         delayCancellable = scheduler.publisher(after: delay)

--- a/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
+++ b/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
@@ -93,12 +93,20 @@ final class GRDBLiveQueryAsyncBridge<Value>: @unchecked Sendable {
     }
 
     func next() async throws -> Value? {
-        if claimStart() {
-            beginAttempt()
-        }
-
+        // The start decision lives *inside* `operation`, not before this
+        // call: if the consuming `Task` is already cancelled at this point,
+        // Swift guarantees `onCancel` runs before `operation` starts
+        // executing, so `cancel()` (and therefore `retryState.cancel()`)
+        // completes first. `beginAttempt()` then correctly sees an already-
+        // cancelled `retryState` and starts no observation at all, instead
+        // of starting one and cancelling it a moment later.
         return try await withTaskCancellationHandler(
-            operation: { try await buffer.next() },
+            operation: {
+                if claimStart() {
+                    beginAttempt()
+                }
+                return try await buffer.next()
+            },
             onCancel: { [weak self] in self?.cancel() }
         )
     }

--- a/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
+++ b/Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift
@@ -168,13 +168,28 @@ final class GRDBLiveQueryAsyncBridge<Value>: @unchecked Sendable {
     /// starts no new fetch."
     private func scheduleRetry(after delay: TimeInterval, generation: Int) {
         var delayCancellable: AnyCancellable?
-        delayCancellable = scheduler.publisher(after: delay).sink(
-            receiveCompletion: { [weak self] _ in
-                self?.storePendingDelay(nil)
-                self?.beginAttempt()
-            },
-            receiveValue: { _ in }
-        )
+        // Triggers on the first emitted *value*, not on completion:
+        // `GRDBLiveQueryRetryScheduler.publisher(after:)` is a type-erased
+        // seam with no documented guarantee that it completes after
+        // emitting -- the deterministic manual scheduler used by this
+        // bridge's own retry tests emits from a `PassthroughSubject` that
+        // never sends a completion at all. The Combine retry path already
+        // treats this seam the same way, via `flatMap` reacting to each
+        // emitted value rather than waiting for completion. `.prefix(1)`
+        // guarantees this fires at most once even if the scheduler emits
+        // more than one value.
+        delayCancellable = scheduler.publisher(after: delay)
+            .prefix(1)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { [weak self] _ in
+                    self?.storePendingDelay(nil)
+                    guard let self, self.retryState.shouldDeliver(generation: generation) else {
+                        return
+                    }
+                    self.beginAttempt()
+                }
+            )
         storePendingDelay(delayCancellable)
 
         // Same check-after-store race as `beginAttempt()`: `cancel()` may

--- a/Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift
+++ b/Sources/SwiftQL/GRDBLiveQueryRetryPolicy.swift
@@ -69,7 +69,13 @@ struct GRDBLiveQueryRetryScheduler: @unchecked Sendable {
 
 
 /// Subscriber-local state for a retrying observation.
-private final class GRDBLiveQueryRetryState: @unchecked Sendable {
+///
+/// Shared by both the Combine retry attempt runner below and
+/// ``GRDBLiveQueryAsyncBridge``'s async-native retry integration (#308), so
+/// the generation-counter cancellation-ownership design is defined exactly
+/// once rather than forked per adapter. `internal` (not `private`) access
+/// deliberately lets `GRDBLiveQueryAsyncStream.swift` reuse this exact type.
+final class GRDBLiveQueryRetryState: @unchecked Sendable {
 
     private let lock = NSLock()
 
@@ -85,6 +91,9 @@ private final class GRDBLiveQueryRetryState: @unchecked Sendable {
         self.policy = policy
     }
 
+    /// Begins a fresh attempt, returning its generation, or `nil` if the
+    /// state has already been cancelled (in which case the caller must start
+    /// no new observation).
     func beginAttempt() -> Int? {
         lock.lock()
         defer { lock.unlock() }

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -478,6 +478,93 @@ struct GRDBRequest<Row>: XLRequest {
         }
     }
     
+    func stream() -> AsyncThrowingStream<[Row], Error> {
+        do {
+            return try stream(bindings: compatibilityPacket())
+        }
+        catch {
+            return xlFailingAsyncThrowingStream(error)
+        }
+    }
+
+    func stream(
+        bindings: any XLInvocationBindingPacket
+    ) -> AsyncThrowingStream<[Row], Error> {
+        if requiresWriteConnection {
+            return xlFailingAsyncThrowingStream(XLReturningRequestError.observationUnsupported)
+        }
+        do {
+            let packet = try executor.sqlitePacket(bindings)
+            guard let bridge = liveQueryStreamBridge(fetch: { database -> [Row] in
+                logger?.debug(
+                    "stream: <<<\(executor.logicalStatement.sql)>>> parameters: <<<\(packet.bindings)>>>")
+                var connection = executor.driver.makeConnection(database)
+                return try decodeRows(packet: packet, in: &connection)
+            }) else {
+                return xlFailingAsyncThrowingStream(XLTransactionScopeError.liveQueriesUnsupportedInTransaction)
+            }
+            return bridge.stream()
+        }
+        catch {
+            return xlFailingAsyncThrowingStream(error)
+        }
+    }
+
+    func streamOne() -> AsyncThrowingStream<Row?, Error> {
+        do {
+            return try streamOne(bindings: compatibilityPacket())
+        }
+        catch {
+            return xlFailingAsyncThrowingStream(error)
+        }
+    }
+
+    func streamOne(
+        bindings: any XLInvocationBindingPacket
+    ) -> AsyncThrowingStream<Row?, Error> {
+        if requiresWriteConnection {
+            return xlFailingAsyncThrowingStream(XLReturningRequestError.observationUnsupported)
+        }
+        do {
+            let packet = try executor.sqlitePacket(bindings)
+            guard let bridge = liveQueryStreamBridge(fetch: { database -> Row? in
+                logger?.debug(
+                    "streamOne: <<<\(executor.logicalStatement.sql)>>> parameters: <<<\(packet.bindings)>>>")
+                var connection = executor.driver.makeConnection(database)
+                guard let values = try executor.fetchOne(packet: packet, in: &connection) else {
+                    return nil
+                }
+                return try GRDBRowDecoder(reader: reader).decode(values: values)
+            }) else {
+                return xlFailingAsyncThrowingStream(XLTransactionScopeError.liveQueriesUnsupportedInTransaction)
+            }
+            return bridge.stream()
+        }
+        catch {
+            return xlFailingAsyncThrowingStream(error)
+        }
+    }
+
+    /// Builds the async-native GRDB observation bridge shared by `stream()`/`streamOne()`. Returns `nil`
+    /// for a transaction-scoped driver (issue #284), which has no pool to track — the same guard
+    /// `publisher(fetch:)` below applies for the Combine path.
+    private func liveQueryStreamBridge<Value>(
+        fetch: @escaping (Database) throws -> Value
+    ) -> GRDBLiveQueryAsyncBridge<Value>? {
+        guard let databasePool = executor.driver.databasePool else {
+            return nil
+        }
+        return GRDBLiveQueryAsyncBridge(
+            policy: liveQueryRetryPolicy,
+            scheduler: liveQueryRetryScheduler,
+            makeSource: { onError, onChange in
+                ValueObservation
+                    .tracking(fetch)
+                    .start(in: databasePool, onError: onError, onChange: onChange)
+            }
+        )
+    }
+
     private func publisher<T>(fetch: @escaping (Database) throws -> T) -> AnyPublisher<T, Error> {
         // A transaction-scoped driver (issue #284) has no pool to track: its
         // connection is invalidated the instant the `withTransaction(_:)`

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -206,6 +206,53 @@ public protocol XLRequest<Row> {
 
     /// Observes the first row using one immutable packet for every retry and refresh.
     func publishOne(bindings: any XLInvocationBindingPacket) -> AnyPublisher<Row?, Error>
+
+    ///
+    /// Returns SwiftQL's canonical async live-query source (issue #308): a complete snapshot of every
+    /// row returned by the query, delivered through Swift structured concurrency instead of Combine.
+    ///
+    /// Observation begins with iteration, not merely by constructing the returned stream: only the
+    /// first `next()` call (directly, or via `for try await`) starts the underlying observation. Each
+    /// call to `stream()` creates one independent, single-consumer observation — exactly like each
+    /// `publish()` call today creates one independent Combine subscription. Two consumers that both
+    /// want live updates must call `stream()` twice; concurrently iterating one returned stream value
+    /// from two places is not a supported fan-out.
+    ///
+    /// The stream buffers at most one undelivered snapshot: a newly produced snapshot always replaces,
+    /// never queues behind, a snapshot the consumer has not yet asked for. Resuming iteration delivers
+    /// whatever has already been produced — it does not itself force a fresh fetch. See
+    /// `Sources/SwiftQL/SwiftQL.docc/LiveQueries.md`, "Buffering and Resumed-Demand Semantics (#291)",
+    /// for the full contract this implements.
+    ///
+    /// Fetching is all-or-nothing, exactly like `fetchAll()`/`publish()`: if the query cannot execute
+    /// or any row cannot be decoded, iteration throws the original error and does not yield a truncated
+    /// result. Cancelling the consuming `Task` ends iteration — `next()` resolves to `nil`, never a
+    /// thrown `CancellationError` — and tears down the underlying observation; it never surfaces as a
+    /// completion failure.
+    ///
+    /// This is a complete live-query snapshot, distinct from ``XLRequest``'s `RETURNING`-based readback
+    /// and from a lazy, single-pass, row-by-row result cursor (issue #249): every delivery here is the
+    /// full matching row set as of one committed transaction, and the same query can deliver many
+    /// snapshots over the stream's lifetime.
+    ///
+    func stream() -> AsyncThrowingStream<[Row], Error>
+
+    /// Observes all rows using one immutable packet for every initial fetch, refresh, and retry — the
+    /// async analog of ``publish(bindings:)``. The packet is captured and validated once; it is never
+    /// re-read from mutable request state.
+    func stream(bindings: any XLInvocationBindingPacket) -> AsyncThrowingStream<[Row], Error>
+
+    ///
+    /// Returns SwiftQL's canonical async live-query source (issue #308) for just the first row: the
+    /// async analog of ``publishOne()``. See ``stream()`` for the full observation, buffering, and
+    /// cancellation contract; `streamOne()` differs only in delivering `Row?` snapshots instead of
+    /// `[Row]` snapshots.
+    ///
+    func streamOne() -> AsyncThrowingStream<Row?, Error>
+
+    /// Observes the first row using one immutable packet for every initial fetch, refresh, and retry —
+    /// the async analog of ``publishOne(bindings:)``.
+    func streamOne(bindings: any XLInvocationBindingPacket) -> AsyncThrowingStream<Row?, Error>
 }
 
 extension XLRequest {
@@ -288,26 +335,157 @@ extension XLRequest {
             )
         }
     }
-    
+
+    ///
+    /// Compatibility default for request adapters that predate #308's async live-query source.
+    ///
+    /// Bridges this conformer's existing `publish()` Combine pipeline into the literal
+    /// `AsyncThrowingStream<[Row], Error>` surface, lazily: the Combine subscription — and any
+    /// database work it triggers — starts only on the returned stream's first `next()` call, so
+    /// "observation begins with iteration" still holds for adapters that only ever implemented the
+    /// Combine surface.
+    ///
+    /// `GRDBRequest` overrides this default with a true async-native GRDB observation source
+    /// (``GRDBLiveQueryAsyncBridge``) that never routes through Combine. This default must never be
+    /// changed to call `stream()` (directly or indirectly) itself — that would recurse indefinitely for
+    /// any conformer that does not override `stream()`; it must always bridge from `publish()` instead.
+    ///
+    public func stream() -> AsyncThrowingStream<[Row], Error> {
+        XLRequestPublisherAsyncBridge(makePublisher: { self.publish() }).stream()
+    }
+
+    /// Compatibility default mirroring ``stream()``, bridging ``publish(bindings:)`` instead. See
+    /// ``stream()`` for why this must never call `stream(bindings:)` itself.
+    public func stream(
+        bindings: any XLInvocationBindingPacket
+    ) -> AsyncThrowingStream<[Row], Error> {
+        XLRequestPublisherAsyncBridge(makePublisher: { self.publish(bindings: bindings) }).stream()
+    }
+
+    /// Compatibility default mirroring ``stream()``, bridging ``publishOne()`` instead. See
+    /// ``stream()`` for why this must never call `streamOne()` itself.
+    public func streamOne() -> AsyncThrowingStream<Row?, Error> {
+        XLRequestPublisherAsyncBridge(makePublisher: { self.publishOne() }).stream()
+    }
+
+    /// Compatibility default mirroring ``stream()``, bridging ``publishOne(bindings:)`` instead. See
+    /// ``stream()`` for why this must never call `streamOne(bindings:)` itself.
+    public func streamOne(
+        bindings: any XLInvocationBindingPacket
+    ) -> AsyncThrowingStream<Row?, Error> {
+        XLRequestPublisherAsyncBridge(makePublisher: { self.publishOne(bindings: bindings) }).stream()
+    }
+
     ///
     /// Convenience method used to set an optional named parameter on the request.
     ///
     public mutating func set<T>(_ parameter: XLNamedBindingReference<Optional<T>>, _ value: T?) where T: XLBindable  {
         set(parameter: parameter, value: value)
     }
-    
+
     ///
     /// Convenience method used to set a named parameter on the request.
     ///
     public mutating func set<T>(_ parameter: XLNamedBindingReference<T>, _ value: T) where T: XLBindable {
         set(parameter: parameter, value: value)
     }
-    
+
     ///
     /// Convenience method used to set the value of a parameter by its literal string name.
     ///
     public mutating func set<T>(_ name: XLName, _ value: T) where T: XLBindable & XLLiteral {
         set(parameter: XLNamedBindingReference(name: name), value: value)
+    }
+}
+
+
+/// Lazily bridges an `XLRequest` compatibility default's `publish()`/`publishOne()` Combine pipeline
+/// into a single-consumer `AsyncThrowingStream`, reusing ``XLSingleSlotAsyncBuffer`` for #291's
+/// bound-1 "newest wins" policy. This is the non-GRDB-aware half of #308: it knows nothing about GRDB
+/// or retry policy, only Combine, because it exists purely so third-party `XLRequest` conformers that
+/// predate `stream()`/`streamOne()` keep compiling with a reasonable, still lazily-started default.
+///
+/// `GRDBRequest` does not use this type: its own `stream()`/`streamOne()` overrides build directly on
+/// ``GRDBLiveQueryAsyncBridge`` instead, per the hard constraint that the canonical GRDB-backed source
+/// must not be implemented in terms of `publish()`/`publishOne()`/`AnyPublisher.values`/any Combine
+/// pipeline.
+final class XLRequestPublisherAsyncBridge<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var didStart = false
+
+    private var cancellable: AnyCancellable?
+
+    private let buffer = XLSingleSlotAsyncBuffer<Value>()
+
+    private let makePublisher: () -> AnyPublisher<Value, Error>
+
+    init(makePublisher: @escaping () -> AnyPublisher<Value, Error>) {
+        self.makePublisher = makePublisher
+    }
+
+    private func claimStart() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !didStart else { return false }
+        didStart = true
+        return true
+    }
+
+    private func storeCancellable(_ newCancellable: AnyCancellable?) {
+        lock.lock()
+        cancellable = newCancellable
+        lock.unlock()
+    }
+
+    func next() async throws -> Value? {
+        if claimStart() {
+            let buffer = self.buffer
+            let subscription = makePublisher().sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        buffer.finish(throwing: nil)
+                    case .failure(let error):
+                        buffer.finish(throwing: error)
+                    }
+                },
+                receiveValue: { value in
+                    buffer.yield(value)
+                }
+            )
+            storeCancellable(subscription)
+        }
+
+        return try await withTaskCancellationHandler(
+            operation: { try await buffer.next() },
+            onCancel: { [weak self] in self?.cancel() }
+        )
+    }
+
+    func cancel() {
+        lock.lock()
+        let existing = cancellable
+        cancellable = nil
+        lock.unlock()
+        existing?.cancel()
+        buffer.cancel()
+    }
+
+    /// The `unfolding` closure captures `self` strongly, not weakly: this
+    /// bridge is constructed and handed straight to `stream()` with no other
+    /// owner (see the `stream()`/`streamOne()` compatibility defaults
+    /// above), so a weak capture would let it deallocate immediately after
+    /// this call returns, before any consumer ever iterates — silently
+    /// turning every stream into one that resolves to `nil` on its very
+    /// first `next()`. The returned `AsyncThrowingStream` becomes this
+    /// bridge's only owner from here on, and the bridge does not hold a
+    /// reference back to the stream, so this creates no retain cycle.
+    func stream() -> AsyncThrowingStream<Value, Error> {
+        AsyncThrowingStream(unfolding: {
+            try await self.next()
+        })
     }
 }
 

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -415,6 +415,8 @@ final class XLRequestPublisherAsyncBridge<Value>: @unchecked Sendable {
 
     private var didStart = false
 
+    private var isCancelled = false
+
     private var cancellable: AnyCancellable?
 
     private let buffer = XLSingleSlotAsyncBuffer<Value>()
@@ -433,10 +435,22 @@ final class XLRequestPublisherAsyncBridge<Value>: @unchecked Sendable {
         return true
     }
 
-    private func storeCancellable(_ newCancellable: AnyCancellable?) {
+    /// Stores `newCancellable`, then reports whether `cancel()` had already
+    /// run by that point. `cancel()` can run concurrently between `sink(...)`
+    /// creating the subscription and this call storing it -- in that window
+    /// `cancel()` finds nothing stored yet to cancel, so without this
+    /// check-after-store re-verification the subscription it just missed
+    /// would keep running forever, leaking whatever resources the wrapped
+    /// publisher holds. Mirrors the identical pattern
+    /// `GRDBLiveQueryAsyncBridge.beginAttempt()` uses for the same race.
+    private func storeCancellableReportingIfAlreadyCancelled(
+        _ newCancellable: AnyCancellable
+    ) -> Bool {
         lock.lock()
+        defer { lock.unlock() }
+        guard !isCancelled else { return true }
         cancellable = newCancellable
-        lock.unlock()
+        return false
     }
 
     func next() async throws -> Value? {
@@ -463,7 +477,12 @@ final class XLRequestPublisherAsyncBridge<Value>: @unchecked Sendable {
                             buffer.yield(value)
                         }
                     )
-                    storeCancellable(subscription)
+                    if storeCancellableReportingIfAlreadyCancelled(subscription) {
+                        // `cancel()` ran between subscribing above and
+                        // storing here, missing this subscription entirely.
+                        // Cancel it ourselves so it doesn't keep running.
+                        subscription.cancel()
+                    }
                 }
                 return try await buffer.next()
             },
@@ -479,6 +498,7 @@ final class XLRequestPublisherAsyncBridge<Value>: @unchecked Sendable {
     func cancel() {
         lock.lock()
         didStart = true
+        isCancelled = true
         let existing = cancellable
         cancellable = nil
         lock.unlock()

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -221,8 +221,8 @@ public protocol XLRequest<Row> {
     /// The stream buffers at most one undelivered snapshot: a newly produced snapshot always replaces,
     /// never queues behind, a snapshot the consumer has not yet asked for. Resuming iteration delivers
     /// whatever has already been produced — it does not itself force a fresh fetch. See
-    /// `Sources/SwiftQL/SwiftQL.docc/LiveQueries.md`, "Buffering and Resumed-Demand Semantics (#291)",
-    /// for the full contract this implements.
+    /// <doc:LiveQueries>, "Buffering and Resumed-Demand Semantics (#291)", for the full contract
+    /// this implements.
     ///
     /// Fetching is all-or-nothing, exactly like `fetchAll()`/`publish()`: if the query cannot execute
     /// or any row cannot be decoded, iteration throws the original error and does not yield a truncated

--- a/Sources/SwiftQL/SQLDatabase.swift
+++ b/Sources/SwiftQL/SQLDatabase.swift
@@ -440,32 +440,45 @@ final class XLRequestPublisherAsyncBridge<Value>: @unchecked Sendable {
     }
 
     func next() async throws -> Value? {
-        if claimStart() {
-            let buffer = self.buffer
-            let subscription = makePublisher().sink(
-                receiveCompletion: { completion in
-                    switch completion {
-                    case .finished:
-                        buffer.finish(throwing: nil)
-                    case .failure(let error):
-                        buffer.finish(throwing: error)
-                    }
-                },
-                receiveValue: { value in
-                    buffer.yield(value)
-                }
-            )
-            storeCancellable(subscription)
-        }
-
+        // The start decision lives *inside* `operation`, not before this
+        // call: if the consuming `Task` is already cancelled at this point,
+        // Swift guarantees `onCancel` runs before `operation` starts
+        // executing, so `cancel()` completes -- and claims the start slot,
+        // see below -- before `claimStart()` ever runs, so an
+        // already-cancelled task subscribes to nothing.
         return try await withTaskCancellationHandler(
-            operation: { try await buffer.next() },
+            operation: {
+                if claimStart() {
+                    let buffer = self.buffer
+                    let subscription = makePublisher().sink(
+                        receiveCompletion: { completion in
+                            switch completion {
+                            case .finished:
+                                buffer.finish(throwing: nil)
+                            case .failure(let error):
+                                buffer.finish(throwing: error)
+                            }
+                        },
+                        receiveValue: { value in
+                            buffer.yield(value)
+                        }
+                    )
+                    storeCancellable(subscription)
+                }
+                return try await buffer.next()
+            },
             onCancel: { [weak self] in self?.cancel() }
         )
     }
 
+    /// Safe to call more than once, and safe to call whether or not `next()`
+    /// was ever invoked: claims the start slot itself so a `next()` call
+    /// arriving after `cancel()` (before a subscription ever began) finds the
+    /// buffer already finished instead of subscribing to a publisher nothing
+    /// will ever consume.
     func cancel() {
         lock.lock()
+        didStart = true
         let existing = cancellable
         cancellable = nil
         lock.unlock()

--- a/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/LiveQueries.md
@@ -4,10 +4,11 @@ Use Combine-compatible publishers to observe query results as a database changes
 
 ## Overview
 
-SwiftQL requests expose `publish()` and `publishOne()` alongside their synchronous fetch methods.
-With the GRDB adapter, each subscriber's first positive demand starts a GRDB value observation and
-begins a fresh database fetch. The observation then tracks the database region that the query
-actually reads.
+SwiftQL requests expose `publish()`/`publishOne()` for Combine and `stream()`/`streamOne()` (issue
+#308) for Swift structured concurrency, alongside their synchronous fetch methods. With the GRDB
+adapter, each subscriber's first positive demand — or each stream's first `next()` call — starts a
+GRDB value observation and begins a fresh database fetch. The observation then tracks the database
+region that the query actually reads.
 
 Apple platforms use Combine. Linux uses OpenCombine 0.14.0 and preserves the
 same demand-driven GRDB observation, error, and cancellation contracts. Import
@@ -97,6 +98,98 @@ cross-triggering or leaking values. A missing binding fails the publisher,
 whereas `.null` is a present value and is accepted only for a nullable slot.
 This packet isolation does not make the current request facade `Sendable` or
 promise that one request can be shared directly across tasks.
+
+### Async live-query streams (#308)
+
+`stream()` and `streamOne()` are the canonical async analogs of `publish()`/`publishOne()`: Swift
+structured concurrency is the single source of truth for SwiftQL live-query snapshots, so a `for try
+await` loop observes the same GRDB lifecycle, retry policy, and immutable-packet-capture contract as
+the Combine publishers above, without routing through Combine. Framework adapters — Combine's own
+demand-mapped adapter (#309) and `@Observable` (#97) — build on this canonical source rather than
+maintaining a parallel observation engine.
+
+Use `stream()` to observe all rows returned by a request:
+
+<!-- test: XLDocumentationTests.testDocumentationLiveQueryPublishers -->
+```swift
+let task = Task {
+    do {
+        for try await results in request.stream() {
+            print("Fetched results: \(results)")
+        }
+    }
+    catch {
+        print("Query failed: \(error)")
+    }
+}
+// Later, when results are no longer needed:
+task.cancel()
+```
+
+Use `streamOne()` to observe just the first result:
+
+<!-- test: XLDocumentationTests.testDocumentationLiveQueryPublishers -->
+```swift
+let task = Task {
+    do {
+        for try await result in request.streamOne() {
+            print("Fetched result: \(String(describing: result))")
+        }
+    }
+    catch {
+        print("Query failed: \(error)")
+    }
+}
+task.cancel()
+```
+
+`stream(bindings:)` and `streamOne(bindings:)` accept the same immutable `XLInvocationBindingPacket`
+as `publish(bindings:)`/`publishOne(bindings:)`: the packet is captured and validated once, and every
+initial fetch, refresh, and retry reuses it:
+
+<!-- test: XLDocumentationTests.testDocumentationLiveQueryPublishers -->
+```swift
+for try await results in request.stream(bindings: idBindings) {
+    print("Fetched results: \(results)")
+}
+```
+
+Fetching remains all-or-nothing: if the query cannot execute or any row cannot be decoded, iteration
+throws the original error and does not yield a truncated result — exactly like `publish()`/
+`publishOne()` finishing with the original error instead of a partial result. Constructing a stream
+performs no database work; only its first `next()` call (directly, or the first loop iteration of a
+`for try await`) starts the underlying GRDB observation. Each `stream()`/`streamOne()` call creates
+one independent, single-consumer observation, exactly like each `publish()` call creates one
+independent Combine subscription — two consumers that both want live updates must call `stream()`
+twice.
+
+Cancellation is owned by `Task` cancellation reaching a suspended `next()` call: cancelling the
+consuming `Task` ends iteration — `next()` resolves to `nil`, never a thrown `CancellationError` —
+and tears down the underlying GRDB observation and any pending retry backoff. This mirrors how
+cancelling a Combine subscription today never delivers a `.failure` completion. Breaking out of a
+`for await` loop while another strong reference to the stream survives does not, by itself, cancel
+anything.
+
+The stream buffers at most one undelivered snapshot: a newly produced snapshot always replaces,
+never queues behind, a snapshot the consumer has not yet asked for, and resuming iteration delivers
+whatever has already been produced rather than forcing a fresh fetch. See "Buffering and
+Resumed-Demand Semantics (#291)" below for the full contract `stream()`/`streamOne()` implement.
+
+Async consumers resume per ordinary Swift concurrency scheduling — there is no async analog of
+Combine's main-queue delivery default. A framework adapter that needs a specific delivery guarantee
+(e.g. main-thread delivery for SwiftUI) implements that guarantee itself on top of this canonical
+source; it is not a property of `stream()`/`streamOne()`.
+
+``XLRequest`` is a public protocol with external conformers. `stream()`/`streamOne()` (and their
+bindings variants) have a source-compatible default implemented in terms of `publish()`/
+`publishOne()`, so an existing third-party conformer that only implements the Combine surface keeps
+compiling and still starts its underlying work lazily. `GRDBRequest` overrides this default with a
+true async-native GRDB observation source that never routes through Combine.
+
+`stream()`/`streamOne()` observe complete live-query snapshots — the entire matching row set (or its
+first row) as of one committed transaction — and are distinct from `XLResultSet`'s row-by-row lazy
+cursor (issue #249): a result set decodes one already-fetched, static result page lazily and once,
+while a live-query stream re-observes the database and can yield many snapshots over its lifetime.
 
 ### SwiftUI
 
@@ -199,8 +292,9 @@ no longer needs updates.
 This section records the decision required by
 [issue #291](https://github.com/lukevanin/swiftql/issues/291): the buffering, cancellation, and
 snapshot-ownership contract that #308's canonical `AsyncThrowingStream` live-query source and #309's
-demand-aware Combine adapter must both implement. It is a design record, not new public API — #308 and
-#309 implement it.
+demand-aware Combine adapter must both implement. It originated as a design record, not new public
+API; #308's `stream()`/`streamOne()` above have since implemented it, and #309 will adapt Combine to
+the same policy.
 
 ### Why this needed a decision
 
@@ -411,10 +505,11 @@ isolation changes. The one intentional behavior change, once #309 lands:
 ### Remaining limitations
 
 - The evidence above validates the bridge design against a raw GRDB `ValueObservation`, not against
-  #308's actual production request/retry/binding-capture pipeline; #308 must still write its own
-  integration tests once the real `stream()` methods exist, following the same bounded-polling style.
-  This document's edge-case coverage should be treated as a checklist for that follow-up test suite, not
-  a replacement for it.
+  #308's actual production request/retry/binding-capture pipeline. `Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift`
+  is that follow-up suite: it drives the real `stream()`/`streamOne()` methods against temporary GRDB
+  databases, using the same bounded-polling style, and covers every edge case in the table above plus
+  the immutable-packet-capture and cross-database-isolation contracts specific to the production
+  request pipeline.
 - GRDB's own change-notification coalescing granularity (how many rapid writes collapse into one
   `ValueObservation` re-fetch) is not something SwiftQL controls or has committed to a specific number
   for; `testPausedConsumerWithRapidCommitsSeesOnlyTheNewestBoundedSnapshot` deliberately asserts only that

--- a/Sources/SwiftQL/XLSingleSlotAsyncBuffer.swift
+++ b/Sources/SwiftQL/XLSingleSlotAsyncBuffer.swift
@@ -91,14 +91,36 @@ final class XLSingleSlotAsyncBuffer<Value>: @unchecked Sendable {
         lock.unlock()
     }
 
-    /// Ends the buffer without an error: a cancelled bridge resolves any
-    /// outstanding or future `next()` call to `nil`, exactly like a normal,
-    /// non-erroring end of iteration. Cancellation is never surfaced to the
-    /// consumer as a thrown `CancellationError` or as a completion failure,
-    /// mirroring how cancelling a Combine subscription today never delivers
-    /// a `.failure` completion.
+    /// Ends the buffer because the *consumer* cancelled, not because the
+    /// upstream source completed: every outstanding or future `next()` call
+    /// resolves to `nil`, exactly like a normal, non-erroring end of
+    /// iteration, and cancellation is never surfaced as a thrown
+    /// `CancellationError` or a completion failure -- mirroring how
+    /// cancelling a Combine subscription today never delivers a `.failure`
+    /// completion.
+    ///
+    /// Unlike ``finish(throwing:)``, this also discards any value already
+    /// buffered but not yet delivered: once the consumer no longer wants
+    /// delivery, a stale snapshot slipping through afterward would violate
+    /// the cancellation contract, not represent a legitimate "last value
+    /// before normal completion." This is why `cancel()` does not simply
+    /// delegate to `finish(throwing: nil)`.
     func cancel() {
-        finish(throwing: nil)
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        isFinished = true
+        pendingValue = nil
+        pendingError = nil
+        if let waiter {
+            self.waiter = nil
+            lock.unlock()
+            waiter.resume(returning: nil)
+            return
+        }
+        lock.unlock()
     }
 
     private enum FastPathOutcome {

--- a/Sources/SwiftQL/XLSingleSlotAsyncBuffer.swift
+++ b/Sources/SwiftQL/XLSingleSlotAsyncBuffer.swift
@@ -1,9 +1,6 @@
 //
 //  XLSingleSlotAsyncBuffer.swift
 //
-//
-//  Created by Claude on 2026/07/29.
-//
 
 import Foundation
 
@@ -69,6 +66,16 @@ final class XLSingleSlotAsyncBuffer<Value>: @unchecked Sendable {
             return
         }
         isFinished = true
+        // Deliberately does NOT clear `pendingValue`: a value legitimately
+        // yielded before `finish()` is called (e.g. a one-shot compatibility
+        // publisher that emits once and completes immediately, delivered
+        // synchronously within the same `sink` callback chain) must still be
+        // delivered by the next `next()` call before iteration ends -- values
+        // then completion, in that order, exactly like the Combine pipeline
+        // being bridged. `yield(_:)`'s own `isFinished` guard already
+        // prevents a value that arrives *after* `finish()`/`cancel()` from
+        // ever being buffered in the first place, which is the actual race
+        // this type must reject.
         if let waiter {
             self.waiter = nil
             lock.unlock()
@@ -115,7 +122,10 @@ final class XLSingleSlotAsyncBuffer<Value>: @unchecked Sendable {
             return .value(value)
         }
         if isFinished {
-            if let pendingError { return .error(pendingError) }
+            if let pendingError {
+                self.pendingError = nil
+                return .error(pendingError)
+            }
             return .finished
         }
         return .pending
@@ -139,6 +149,7 @@ final class XLSingleSlotAsyncBuffer<Value>: @unchecked Sendable {
         }
         if isFinished {
             let error = pendingError
+            pendingError = nil
             lock.unlock()
             if let error {
                 continuation.resume(throwing: error)
@@ -148,6 +159,12 @@ final class XLSingleSlotAsyncBuffer<Value>: @unchecked Sendable {
             }
             return
         }
+        precondition(
+            waiter == nil,
+            "XLSingleSlotAsyncBuffer.next() called concurrently: a second "
+                + "caller would silently overwrite and leak/hang the first "
+                + "waiter. Each canonical stream is single-consumer."
+        )
         waiter = continuation
         lock.unlock()
     }

--- a/Sources/SwiftQL/XLSingleSlotAsyncBuffer.swift
+++ b/Sources/SwiftQL/XLSingleSlotAsyncBuffer.swift
@@ -1,0 +1,176 @@
+//
+//  XLSingleSlotAsyncBuffer.swift
+//
+//
+//  Created by Claude on 2026/07/29.
+//
+
+import Foundation
+
+
+/// Bound-1, "newest wins" async handoff selected by issue #291 for every
+/// SwiftQL canonical live-query stream.
+///
+/// At most one produced value is ever held undelivered. A value that arrives
+/// while nothing is buffered either resumes a waiting `next()` call directly
+/// or becomes the single buffered value; a value that arrives while an
+/// earlier one is still buffered *replaces* it rather than queuing behind it.
+/// This mirrors `AsyncThrowingStream.Continuation.BufferingPolicy
+/// .bufferingNewest(1)` semantics without depending on that GRDB-experimental
+/// buffering-policy API directly, so the exact same type backs both
+/// ``GRDBLiveQueryAsyncBridge`` (the true async-native GRDB source, #308) and
+/// the `XLRequest` protocol-extension compatibility default that bridges an
+/// adapter's existing `publish()`/`publishOne()` Combine pipeline.
+///
+/// `Value` may itself be `Optional` (as `streamOne()`'s `Row?` is): a present
+/// `nil` row is a real delivered snapshot and is buffered like any other
+/// value, distinct from "nothing buffered yet."
+final class XLSingleSlotAsyncBuffer<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    /// The buffering bound selected by #291: at most one snapshot is ever
+    /// held. A newly yielded value replaces (not queues behind) any
+    /// previously buffered, undelivered value.
+    private var pendingValue: Value?
+
+    private var pendingError: Error?
+
+    private var isFinished = false
+
+    private var waiter: CheckedContinuation<Value?, Error>?
+
+    /// Buffers `value`, replacing whatever was previously buffered, or
+    /// resumes an already-suspended `next()` call directly if one is
+    /// waiting. Has no effect after ``finish(throwing:)``/``cancel()``.
+    func yield(_ value: Value) {
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        if let waiter {
+            self.waiter = nil
+            lock.unlock()
+            waiter.resume(returning: value)
+            return
+        }
+        pendingValue = value
+        lock.unlock()
+    }
+
+    /// Ends the buffer, delivering `error` (if any) to the currently
+    /// suspended or next `next()` call exactly once. Safe to call more than
+    /// once; only the first call has an effect.
+    func finish(throwing error: Error?) {
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        isFinished = true
+        if let waiter {
+            self.waiter = nil
+            lock.unlock()
+            if let error {
+                waiter.resume(throwing: error)
+            }
+            else {
+                waiter.resume(returning: nil)
+            }
+            return
+        }
+        pendingError = error
+        lock.unlock()
+    }
+
+    /// Ends the buffer without an error: a cancelled bridge resolves any
+    /// outstanding or future `next()` call to `nil`, exactly like a normal,
+    /// non-erroring end of iteration. Cancellation is never surfaced to the
+    /// consumer as a thrown `CancellationError` or as a completion failure,
+    /// mirroring how cancelling a Combine subscription today never delivers
+    /// a `.failure` completion.
+    func cancel() {
+        finish(throwing: nil)
+    }
+
+    private enum FastPathOutcome {
+        case value(Value)
+        case error(Error)
+        case finished
+        case pending
+    }
+
+    /// All plain synchronous locked mutation is kept out of `next()`'s
+    /// `async` body: recent Foundation marks `NSLock.lock()`/`unlock()` as
+    /// unavailable directly inside asynchronous contexts (an error under the
+    /// Swift 6 language mode), so both the initial fast-path check and the
+    /// re-check performed once a continuation is available live in plain,
+    /// non-`async` helper methods instead.
+    private func checkFastPath() -> FastPathOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        if let value = pendingValue {
+            pendingValue = nil
+            return .value(value)
+        }
+        if isFinished {
+            if let pendingError { return .error(pendingError) }
+            return .finished
+        }
+        return .pending
+    }
+
+    /// Re-checks and, if still pending, registers the continuation as the
+    /// single outstanding waiter — all inside one locked critical section.
+    /// This must not be split into a separate check-then-register pair of
+    /// locked calls: a value or termination arriving on another thread in
+    /// the gap between them would otherwise be lost (`yield`/`finish` only
+    /// resume a `waiter` that is already registered; anything arriving
+    /// before registration would sit in `pendingValue`/`isFinished` and
+    /// never wake this continuation).
+    private func resolveImmediatelyOrRegister(_ continuation: CheckedContinuation<Value?, Error>) {
+        lock.lock()
+        if let value = pendingValue {
+            pendingValue = nil
+            lock.unlock()
+            continuation.resume(returning: value)
+            return
+        }
+        if isFinished {
+            let error = pendingError
+            lock.unlock()
+            if let error {
+                continuation.resume(throwing: error)
+            }
+            else {
+                continuation.resume(returning: nil)
+            }
+            return
+        }
+        waiter = continuation
+        lock.unlock()
+    }
+
+    /// Returns the next buffered value, suspending if nothing is buffered
+    /// yet. Resolves to `nil` once cancelled/finished without an error,
+    /// or throws the original terminal error exactly once.
+    ///
+    /// Calling `next()` never itself triggers new upstream work — it only
+    /// asks for whatever has already been produced, per #291's "resuming
+    /// does not force a fresh fetch" rule.
+    func next() async throws -> Value? {
+        switch checkFastPath() {
+        case .value(let value):
+            return value
+        case .error(let error):
+            throw error
+        case .finished:
+            return nil
+        case .pending:
+            return try await withCheckedThrowingContinuation { continuation in
+                resolveImmediatelyOrRegister(continuation)
+            }
+        }
+    }
+}

--- a/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
+++ b/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
@@ -616,8 +616,13 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
     func testBoundedBufferingUnderRapidCommits() async throws {
         try createRecordTable()
         let writeCount = 20
+        // Ordered by `value` descending, not `id` ascending: the top row only
+        // becomes the *last*-inserted row once every write has committed, so
+        // observing it actually requires reaching the final database state --
+        // unlike ordering by `id`, where "row-0" sorts first as soon as it
+        // exists, regardless of how many later writes have happened.
         let iterator = AsyncStreamIteratorBox(
-            database.makeRequest(with: orderedStatement()).streamOne()
+            database.makeRequest(with: orderedByValueDescendingStatement()).streamOne()
         )
         _ = try await iterator.next() // consumes the initial (nil) snapshot
 
@@ -627,6 +632,7 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
             try insertDirect(AsyncStreamRecord(id: "row-\(index)", value: index))
         }
 
+        let finalValue = writeCount - 1
         var attempts = 0
         while attempts < writeCount {
             attempts += 1
@@ -634,7 +640,7 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
                 XCTFail("Stream terminated unexpectedly while draining to the final snapshot.")
                 break
             }
-            if row?.id == "row-0" {
+            if row?.value == finalValue {
                 // GRDB's own change coalescing decides how many commits collapse into
                 // one re-fetch; the bounded buffer only guarantees resuming does not
                 // need one `next()` per write to reach the final state.
@@ -972,6 +978,19 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
             Select(table)
             From(table)
             OrderBy(table.id.ascending())
+        }
+    }
+
+    /// Orders by the numeric `value` column, descending, so the top row only
+    /// becomes the row with the highest `value` inserted so far -- unlike
+    /// `orderedStatement()`'s lexicographic `id` ordering, where `"row-0"`
+    /// sorts first regardless of how many later rows have committed.
+    private func orderedByValueDescendingStatement() -> any XLQueryStatement<AsyncStreamRecord> {
+        sql { schema in
+            let table = schema.table(AsyncStreamRecord.self)
+            Select(table)
+            From(table)
+            OrderBy(table.value.descending())
         }
     }
 

--- a/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
+++ b/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
@@ -1,0 +1,1106 @@
+//
+//  GRDBLiveQueryAsyncStreamTests.swift
+//
+//
+//  Created by Claude on 2026/07/29.
+//
+
+#if canImport(Combine)
+import Combine
+#else
+import OpenCombine
+import OpenCombineDispatch
+#endif
+import Foundation
+import GRDB
+import XCTest
+@testable import SwiftQL
+
+
+// MARK: - Fixtures
+
+@SQLTable(name: "AsyncStreamRecord")
+private struct AsyncStreamRecord: Equatable, Identifiable {
+    let id: String
+    let value: Int
+}
+
+
+@SQLTable(name: "AsyncStreamNullableRecord")
+private struct AsyncStreamNullableRecord: Equatable, Identifiable {
+    let id: String
+    let value: Int?
+}
+
+
+@SQLTable(name: "AsyncStreamRetryRecord")
+private struct AsyncStreamRetryRecord: Equatable, Identifiable {
+    let id: String
+    let value: Int
+}
+
+
+private struct AsyncStreamInjectedBusyExpression: XLExpression {
+    typealias T = Int
+
+    static let functionName = "swiftql_test_async_stream_injected_busy"
+
+    func makeSQL(context: inout XLBuilder) {
+        context.simpleFunction(name: Self.functionName) { _ in }
+    }
+}
+
+
+private enum AsyncStreamTestError: Error, Equatable {
+    case rollback
+    case permanent
+}
+
+
+// MARK: - Locked helpers
+
+private final class AsyncStreamLockedValue<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    @discardableResult
+    func withValue<Result>(_ body: (inout Value) -> Result) -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&value)
+    }
+
+    func set(_ newValue: Value) {
+        withValue { $0 = newValue }
+    }
+
+    func read() -> Value {
+        withValue { $0 }
+    }
+}
+
+
+private final class AsyncStreamLockedArray<Element>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var values: [Element] = []
+
+    func append(_ value: Element) {
+        lock.lock()
+        defer { lock.unlock() }
+        values.append(value)
+    }
+
+    func read() -> [Element] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+
+private final class AsyncStreamInjectedBusyFunctionState: @unchecked Sendable {
+
+    enum Behavior {
+        case succeed
+        case failOnce
+        case failAlways
+    }
+
+    private let lock = NSLock()
+
+    private let behavior: Behavior
+
+    private var invocationCountValue = 0
+
+    init(behavior: Behavior) {
+        self.behavior = behavior
+    }
+
+    var invocationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return invocationCountValue
+    }
+
+    func invoke() throws -> Int {
+        lock.lock()
+        invocationCountValue += 1
+        let invocationCount = invocationCountValue
+        let failsThisInvocation: Bool
+        switch behavior {
+        case .succeed:
+            failsThisInvocation = false
+        case .failOnce:
+            failsThisInvocation = invocationCount == 1
+        case .failAlways:
+            failsThisInvocation = true
+        }
+        lock.unlock()
+
+        if failsThisInvocation {
+            throw DatabaseError(
+                resultCode: .SQLITE_BUSY_SNAPSHOT,
+                message: "injected busy attempt \(invocationCount)"
+            )
+        }
+        return 1
+    }
+}
+
+
+/// Deterministic stand-in for ``GRDBLiveQueryRetryScheduler``'s real timers: records every
+/// scheduled delay and only fires it when the test calls `runNext()`, mirroring
+/// `GRDBLiveQueryRetryTests.swift`'s `ManualRetryScheduler` but scoped to this file.
+private final class AsyncStreamManualRetryScheduler: @unchecked Sendable {
+
+    private struct PendingDelay {
+        let delay: TimeInterval
+        let subject: PassthroughSubject<Void, Never>
+    }
+
+    private let lock = NSLock()
+
+    private var pending: [PendingDelay] = []
+
+    private var recorded: [TimeInterval] = []
+
+    var scheduler: GRDBLiveQueryRetryScheduler {
+        GRDBLiveQueryRetryScheduler { [weak self] delay in
+            guard let self else {
+                return Empty(completeImmediately: false).eraseToAnyPublisher()
+            }
+            let subject = PassthroughSubject<Void, Never>()
+            self.lock.lock()
+            self.pending.append(PendingDelay(delay: delay, subject: subject))
+            self.recorded.append(delay)
+            self.lock.unlock()
+            return subject.eraseToAnyPublisher()
+        }
+    }
+
+    var pendingDelays: [TimeInterval] {
+        lock.lock()
+        defer { lock.unlock() }
+        return pending.map(\.delay)
+    }
+
+    var recordedDelays: [TimeInterval] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+
+    @discardableResult
+    func runNext() -> Bool {
+        let next: PendingDelay?
+        lock.lock()
+        if pending.isEmpty {
+            next = nil
+        }
+        else {
+            next = pending.removeFirst()
+        }
+        lock.unlock()
+
+        guard let next else { return false }
+        next.subject.send(())
+        next.subject.send(completion: .finished)
+        return true
+    }
+}
+
+
+/// Wraps an `AsyncThrowingStream`'s iterator in a class so it can be driven from a background
+/// `Task` and awaited from a synchronous or `async` test method without capturing a mutable
+/// struct across a concurrency boundary.
+private final class AsyncStreamIteratorBox<Value>: @unchecked Sendable {
+
+    private var iterator: AsyncThrowingStream<Value, Error>.AsyncIterator
+
+    init(_ stream: AsyncThrowingStream<Value, Error>) {
+        iterator = stream.makeAsyncIterator()
+    }
+
+    func next() async throws -> Value? {
+        try await iterator.next()
+    }
+}
+
+
+final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
+
+    private final class RecordingLogger: XLLogger {
+        private let lock = NSLock()
+        private var messages: [String] = []
+
+        func log(level: XLLogLevel, message: String) {
+            lock.lock()
+            messages.append(message)
+            lock.unlock()
+        }
+
+        func count(containing fragment: String) -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return messages.filter { $0.contains(fragment) }.count
+        }
+    }
+
+    private var databaseDirectoryURL: URL!
+    private var databasePool: DatabasePool!
+    private var database: GRDBDatabase!
+    private var logger: RecordingLogger!
+
+    override func setUpWithError() throws {
+        databaseDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: databaseDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        let fileURL = databaseDirectoryURL.appendingPathComponent(
+            "async-stream.sqlite",
+            isDirectory: false
+        )
+        databasePool = try DatabasePool(path: fileURL.path)
+        logger = RecordingLogger()
+        database = try GRDBDatabase(databasePool: databasePool, formatter: XLiteFormatter(), logger: logger)
+    }
+
+    override func tearDown() {
+        database = nil
+        databasePool = nil
+        logger = nil
+        try? FileManager.default.removeItem(at: databaseDirectoryURL)
+        databaseDirectoryURL = nil
+    }
+
+    // MARK: - Lazy start / unused stream
+
+    func testUnusedStreamPerformsNoObservationOrFetch() throws {
+        try createRecordTable()
+        let request = database.makeRequest(with: orderedStatement())
+
+        _ = request.stream() // constructed, never iterated
+        _ = request.streamOne() // constructed, never iterated
+
+        drainMainQueue()
+        XCTAssertEqual(
+            logger.count(containing: "stream:"),
+            0,
+            "Constructing an unused stream() must perform no fetch."
+        )
+        XCTAssertEqual(
+            logger.count(containing: "streamOne:"),
+            0,
+            "Constructing an unused streamOne() must perform no fetch."
+        )
+    }
+
+    // MARK: - Initial delivery + relevant-write refresh
+
+    func testStreamEmitsFreshInitialSnapshotAndRelevantWriteRefresh() async throws {
+        try createRecordTable()
+        try insertDirect(AsyncStreamRecord(id: "written-before-iteration", value: 1))
+
+        let iterator = AsyncStreamIteratorBox(
+            database.makeRequest(with: orderedStatement()).stream()
+        )
+
+        let initial = try await iterator.next()
+        XCTAssertEqual(initial, [AsyncStreamRecord(id: "written-before-iteration", value: 1)])
+
+        try insertDirect(AsyncStreamRecord(id: "relevant", value: 2))
+        let refreshed = try await iterator.next()
+        XCTAssertEqual(
+            refreshed,
+            [
+                AsyncStreamRecord(id: "relevant", value: 2),
+                AsyncStreamRecord(id: "written-before-iteration", value: 1),
+            ]
+        )
+    }
+
+    func testStreamOneEmitsFreshInitialSnapshotAndRelevantWriteRefresh() async throws {
+        try createRecordTable()
+        try insertDirect(AsyncStreamRecord(id: "a", value: 1))
+
+        let iterator = AsyncStreamIteratorBox(
+            database.makeRequest(with: orderedStatement()).streamOne()
+        )
+
+        let initial = try await iterator.next()
+        XCTAssertEqual(initial, AsyncStreamRecord(id: "a", value: 1))
+
+        // "a" sorts after a lexicographically-earlier id, so the observed first row changes.
+        try insertDirect(AsyncStreamRecord(id: "A-earlier", value: 2))
+        let refreshed = try await iterator.next()
+        XCTAssertEqual(refreshed, AsyncStreamRecord(id: "A-earlier", value: 2))
+    }
+
+    // MARK: - Transaction coalescing / rollback exclusion / irrelevant writes (#146/#255)
+
+    func testTransactionCoalescingExposesOnlyDurableState() async throws {
+        try createRecordTable()
+        let iterator = AsyncStreamIteratorBox(
+            database.makeRequest(with: orderedStatement()).stream()
+        )
+
+        let initial = try await iterator.next()
+        XCTAssertEqual(initial, [])
+
+        try await databasePool.write { database in
+            try database.execute(
+                sql: "INSERT INTO AsyncStreamRecord (id, value) VALUES (?, ?)",
+                arguments: ["a", 1]
+            )
+            try database.execute(
+                sql: "INSERT INTO AsyncStreamRecord (id, value) VALUES (?, ?)",
+                arguments: ["b", 2]
+            )
+            try database.execute(
+                sql: "UPDATE AsyncStreamRecord SET value = ? WHERE id = ?",
+                arguments: [3, "a"]
+            )
+        }
+
+        let finalRows = [
+            AsyncStreamRecord(id: "a", value: 3),
+            AsyncStreamRecord(id: "b", value: 2),
+        ]
+        var observed: [[AsyncStreamRecord]] = []
+        while true {
+            guard let rows = try await iterator.next() else {
+                XCTFail("Stream terminated unexpectedly.")
+                break
+            }
+            observed.append(rows)
+            if rows == finalRows { break }
+        }
+        XCTAssertTrue(
+            observed.allSatisfy { $0.isEmpty || $0 == finalRows },
+            "One transaction may coalesce, but no intermediate durable state may escape."
+        )
+    }
+
+    func testRolledBackWriteNeverAppearsBeforeCommittedLiveness() async throws {
+        try createRecordTable()
+        let iterator = AsyncStreamIteratorBox(
+            database.makeRequest(with: orderedStatement()).stream()
+        )
+        let initial = try await iterator.next()
+        XCTAssertEqual(initial, [])
+
+        do {
+            try await databasePool.write { database in
+                try database.execute(
+                    sql: "INSERT INTO AsyncStreamRecord (id, value) VALUES (?, ?)",
+                    arguments: ["rolled-back", 1]
+                )
+                throw AsyncStreamTestError.rollback
+            }
+            XCTFail("Expected the injected rollback.")
+        }
+        catch AsyncStreamTestError.rollback {
+            // Deterministic rollback trigger.
+        }
+
+        try insertDirect(AsyncStreamRecord(id: "committed", value: 2))
+        let committedRows = [AsyncStreamRecord(id: "committed", value: 2)]
+        var observed: [[AsyncStreamRecord]] = []
+        while true {
+            guard let rows = try await iterator.next() else {
+                XCTFail("Stream terminated unexpectedly.")
+                break
+            }
+            observed.append(rows)
+            if rows == committedRows { break }
+        }
+        XCTAssertFalse(observed.flatMap { $0 }.contains { $0.id == "rolled-back" })
+        XCTAssertTrue(observed.allSatisfy { $0.isEmpty || $0 == committedRows })
+    }
+
+    func testIrrelevantTableWriteDoesNotChangeObservedSnapshot() async throws {
+        try createRecordTable()
+        try await databasePool.write { database in
+            try database.execute(sql: "CREATE TABLE AsyncStreamOther (id TEXT NOT NULL PRIMARY KEY)")
+        }
+        let iterator = AsyncStreamIteratorBox(
+            database.makeRequest(with: orderedStatement()).stream()
+        )
+        let initial = try await iterator.next()
+        XCTAssertEqual(initial, [])
+
+        try await databasePool.write { database in
+            try database.execute(sql: "INSERT INTO AsyncStreamOther (id) VALUES ('irrelevant')")
+        }
+        try insertDirect(AsyncStreamRecord(id: "relevant", value: 1))
+
+        let finalRows = [AsyncStreamRecord(id: "relevant", value: 1)]
+        var observed: [[AsyncStreamRecord]] = []
+        while true {
+            guard let rows = try await iterator.next() else {
+                XCTFail("Stream terminated unexpectedly.")
+                break
+            }
+            observed.append(rows)
+            if rows == finalRows { break }
+        }
+        XCTAssertTrue(
+            observed.allSatisfy { $0.isEmpty || $0 == finalRows },
+            "An irrelevant-table commit must not create a different query snapshot."
+        )
+    }
+
+    // MARK: - Immutable packet capture
+
+    func testStreamBindingsCapturesPacketOnceAcrossInitialFetchAndRefresh() async throws {
+        try createRecordTable()
+        try insertDirect(AsyncStreamRecord(id: "per-1", value: 1))
+        try insertDirect(AsyncStreamRecord(id: "per-2", value: 2))
+
+        let request = database.makeRequest(with: byIDStatement())
+        let layout = request.parameterLayout
+        let slot = try XCTUnwrap(layout.slot(for: .named("id")))
+        let bindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: layout,
+            bindings: [try XLInvocationBinding(slot: slot, value: .text("per-1"))]
+        ).validatingComplete()
+
+        let iterator = AsyncStreamIteratorBox(request.stream(bindings: bindings))
+        let initial = try await iterator.next()
+        XCTAssertEqual(initial, [AsyncStreamRecord(id: "per-1", value: 1)])
+
+        // A write to an unrelated row may or may not itself trigger a re-fetch,
+        // depending on how precisely GRDB's own region tracking scopes this
+        // dynamic WHERE clause; either way it must never change what the packet
+        // selects.
+        try insertDirect(AsyncStreamRecord(id: "per-3", value: 3))
+
+        try await databasePool.write { database in
+            try database.execute(
+                sql: "DELETE FROM AsyncStreamRecord WHERE id = ?",
+                arguments: ["per-1"]
+            )
+        }
+
+        let expectedRow = [AsyncStreamRecord(id: "per-1", value: 1)]
+        var observed: [[AsyncStreamRecord]] = []
+        while true {
+            guard let rows = try await iterator.next() else {
+                XCTFail("Stream terminated unexpectedly.")
+                break
+            }
+            observed.append(rows)
+            if rows.isEmpty { break }
+        }
+        XCTAssertTrue(
+            observed.allSatisfy { $0.isEmpty || $0 == expectedRow },
+            "The packet must keep selecting id == 'per-1' on every refresh, never per-2 or per-3."
+        )
+        XCTAssertEqual(observed.last, [], "The packet must keep selecting id == 'per-1' after it is deleted.")
+    }
+
+    func testStreamBindingsRejectsMissingRequiredBindingLazily() async throws {
+        try createRecordTable()
+        let request = database.makeRequest(with: byIDStatement())
+        let layout = request.parameterLayout
+
+        // Deliberately incomplete: the required "id" slot is never bound.
+        let incompletePacket = XLInvocationBindings<XLSQLiteValue>(layout: layout)
+
+        // Constructing the stream must not throw synchronously; the error is only
+        // delivered lazily, on the first `next()` call.
+        let stream = request.stream(bindings: incompletePacket)
+        let iterator = AsyncStreamIteratorBox(stream)
+
+        do {
+            _ = try await iterator.next()
+            XCTFail("Expected an invocation-binding error.")
+        }
+        catch is XLInvocationBindingError {
+            // Expected.
+        }
+    }
+
+    func testStreamAcceptsNullBindingForANullableSlot() async throws {
+        try database.makeRequest(with: sqlCreate(AsyncStreamNullableRecord.self)).execute()
+        try database.makeRequest(
+            with: sqlInsert(AsyncStreamNullableRecord(id: "has-null", value: nil))
+        ).execute()
+        try database.makeRequest(
+            with: sqlInsert(AsyncStreamNullableRecord(id: "has-value", value: 7))
+        ).execute()
+
+        let valueParameter = XLNamedBindingReference<Optional<Int>>(name: "value")
+        let statement: any XLQueryStatement<AsyncStreamNullableRecord> = sql { schema in
+            let table = schema.table(AsyncStreamNullableRecord.self)
+            Select(table)
+            From(table)
+            Where(table.value == valueParameter)
+            OrderBy(table.id.ascending())
+        }
+        let request = database.makeRequest(with: statement)
+        let layout = request.parameterLayout
+        let slot = try XCTUnwrap(layout.slot(for: .named("value")))
+        XCTAssertEqual(slot.nullability, .nullable)
+        let bindings = try XLInvocationBindings<XLSQLiteValue>(
+            layout: layout,
+            bindings: [try XLInvocationBinding(slot: slot, value: .null)]
+        ).validatingComplete()
+
+        let iterator = AsyncStreamIteratorBox(request.stream(bindings: bindings))
+        let rows = try await iterator.next()
+        XCTAssertEqual(rows, [AsyncStreamNullableRecord(id: "has-null", value: nil)])
+    }
+
+    // MARK: - Cancellation
+
+    func testCancellingConsumingTaskTearsDownObservationAndStopsFurtherFetches() async throws {
+        try createRecordTable()
+        let stream = database.makeRequest(with: orderedStatement()).stream()
+        let seen = AsyncStreamLockedArray<[AsyncStreamRecord]>()
+        let loopEnded = AsyncStreamLockedValue(false)
+
+        let task = Task {
+            do {
+                for try await rows in stream {
+                    seen.append(rows)
+                }
+            }
+            catch {
+                XCTFail("Unexpected stream error: \(error)")
+            }
+            loopEnded.set(true)
+        }
+
+        try await waitUntil { !seen.read().isEmpty }
+        task.cancel()
+        try await waitUntil { loopEnded.read() }
+        XCTAssertEqual(seen.read(), [[]])
+
+        let fetchCountAtCancel = logger.count(containing: "stream:")
+        try insertDirect(AsyncStreamRecord(id: "after-cancel", value: 1))
+        drainMainQueue()
+        XCTAssertEqual(
+            logger.count(containing: "stream:"),
+            fetchCountAtCancel,
+            "Cancelling the consuming task must cancel the underlying observation."
+        )
+    }
+
+    func testCancellationBeforeFirstNextPreventsAnyFetch() async throws {
+        try createRecordTable()
+        let stream = database.makeRequest(with: orderedStatement()).stream()
+        let iterator = AsyncStreamIteratorBox(stream)
+
+        let task = Task<[AsyncStreamRecord]?, Error> {
+            try await iterator.next()
+        }
+        task.cancel()
+
+        let result = try await task.value
+        XCTAssertNil(result, "A stream cancelled before delivering a value resolves to nil, not an error.")
+    }
+
+    // MARK: - Bounded buffering under rapid commits (#291)
+
+    func testBoundedBufferingUnderRapidCommits() async throws {
+        try createRecordTable()
+        let writeCount = 20
+        let iterator = AsyncStreamIteratorBox(
+            database.makeRequest(with: orderedStatement()).streamOne()
+        )
+        _ = try await iterator.next() // consumes the initial (nil) snapshot
+
+        // Simulate a "paused" consumer: many relevant commits happen back to back
+        // with no intervening `next()` call.
+        for index in 0 ..< writeCount {
+            try insertDirect(AsyncStreamRecord(id: "row-\(index)", value: index))
+        }
+
+        var attempts = 0
+        while attempts < writeCount {
+            attempts += 1
+            guard let row = try await iterator.next() else {
+                XCTFail("Stream terminated unexpectedly while draining to the final snapshot.")
+                break
+            }
+            if row?.id == "row-0" {
+                // GRDB's own change coalescing decides how many commits collapse into
+                // one re-fetch; the bounded buffer only guarantees resuming does not
+                // need one `next()` per write to reach the final state.
+                XCTAssertLessThan(
+                    attempts,
+                    writeCount,
+                    "Bounded buffering must coalesce most of \(writeCount) rapid commits into far "
+                        + "fewer delivered snapshots than one next() call per write."
+                )
+                break
+            }
+        }
+    }
+
+    // MARK: - Independent consumers / databases
+
+    func testTwoSeparateStreamCallsAreIndependentAndDoNotCrossTrigger() async throws {
+        try createRecordTable()
+        let request = database.makeRequest(with: orderedStatement())
+        let iteratorA = AsyncStreamIteratorBox(request.stream())
+        let iteratorB = AsyncStreamIteratorBox(request.stream())
+
+        let initialA = try await iteratorA.next()
+        XCTAssertEqual(initialA, [])
+        let initialB = try await iteratorB.next()
+        XCTAssertEqual(initialB, [])
+
+        try insertDirect(AsyncStreamRecord(id: "shared", value: 1))
+
+        let expected = [AsyncStreamRecord(id: "shared", value: 1)]
+        let refreshedA = try await iteratorA.next()
+        XCTAssertEqual(refreshedA, expected)
+        let refreshedB = try await iteratorB.next()
+        XCTAssertEqual(refreshedB, expected)
+    }
+
+    func testTwoDatabasesWithIdenticalTableNamesDoNotCrossTrigger() async throws {
+        try createRecordTable()
+
+        let secondDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: secondDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: secondDirectory) }
+        let secondPool = try DatabasePool(
+            path: secondDirectory.appendingPathComponent("second.sqlite").path
+        )
+        let secondDatabase = try GRDBDatabase(
+            databasePool: secondPool,
+            formatter: XLiteFormatter(),
+            logger: nil
+        )
+        try await secondPool.write { database in
+            try database.execute(
+                literal: """
+                    CREATE TABLE AsyncStreamRecord (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        value INT NOT NULL
+                    );
+                """
+            )
+        }
+
+        let iteratorA = AsyncStreamIteratorBox(
+            database.makeRequest(with: orderedStatement()).stream()
+        )
+        let iteratorB = AsyncStreamIteratorBox(
+            secondDatabase.makeRequest(with: orderedStatement()).stream()
+        )
+        let initialA = try await iteratorA.next()
+        XCTAssertEqual(initialA, [])
+        let initialB = try await iteratorB.next()
+        XCTAssertEqual(initialB, [])
+
+        try insertDirect(AsyncStreamRecord(id: "only-in-a", value: 1))
+        let refreshedA = try await iteratorA.next()
+        XCTAssertEqual(refreshedA, [AsyncStreamRecord(id: "only-in-a", value: 1)])
+
+        // The second, identically-named table in the other pool must remain empty.
+        drainMainQueue()
+        let secondRows = try secondDatabase.makeRequest(with: orderedStatement()).fetchAll()
+        XCTAssertEqual(secondRows, [])
+    }
+
+    // MARK: - Retry integration (reuses GRDBLiveQueryRetryPolicy/State/Scheduler)
+
+    func testRealGRDBObservationRecoversFromInjectedBusyAndKeepsObserving() async throws {
+        let fixture = try makeInjectedBusyFixture(policy: .retryBusy, behavior: .failOnce)
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let iterator = AsyncStreamIteratorBox(
+            fixture.database.makeRequest(with: fixture.statement).stream()
+        )
+        let recovered = try await iterator.next()
+        XCTAssertEqual(recovered, [AsyncStreamRetryRecord(id: "initial", value: 1)])
+        XCTAssertGreaterThanOrEqual(fixture.functionState.invocationCount, 2)
+
+        try await fixture.database.databasePool.write { database in
+            try database.execute(
+                sql: "INSERT INTO AsyncStreamRetryRecord (id, value) VALUES (?, ?)",
+                arguments: ["updated", 2]
+            )
+        }
+        let updated = try await iterator.next()
+        XCTAssertEqual(
+            updated,
+            [
+                AsyncStreamRetryRecord(id: "initial", value: 1),
+                AsyncStreamRetryRecord(id: "updated", value: 2),
+            ]
+        )
+    }
+
+    func testRetryExhaustionTerminatesOnceWithLastBusyErrorUsingManualScheduler() async throws {
+        let scheduler = AsyncStreamManualRetryScheduler()
+        let fixture = try makeInjectedBusyFixture(
+            policy: .retryBusy,
+            behavior: .failAlways,
+            retryScheduler: scheduler.scheduler
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let iterator = AsyncStreamIteratorBox(
+            fixture.database.makeRequest(with: fixture.statement).stream()
+        )
+        let consumeTask = Task { () -> Result<[AsyncStreamRetryRecord]?, Error> in
+            do {
+                return .success(try await iterator.next())
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        try await waitUntil { scheduler.pendingDelays == [0.1] }
+        XCTAssertEqual(fixture.functionState.invocationCount, 1)
+        scheduler.runNext()
+        try await waitUntil { scheduler.pendingDelays == [0.2] }
+        XCTAssertEqual(fixture.functionState.invocationCount, 2)
+        scheduler.runNext()
+        try await waitUntil { scheduler.pendingDelays == [0.4] }
+        XCTAssertEqual(fixture.functionState.invocationCount, 3)
+        scheduler.runNext()
+        try await waitUntil { fixture.functionState.invocationCount == 4 }
+
+        switch await consumeTask.value {
+        case .success:
+            XCTFail("An exhausted retry budget must terminate with the last BUSY error.")
+        case .failure(let error):
+            XCTAssertEqual((error as? DatabaseError)?.resultCode, .SQLITE_BUSY)
+        }
+        XCTAssertEqual(scheduler.recordedDelays, [0.1, 0.2, 0.4])
+    }
+
+    func testPermanentFailureTerminatesWithoutSchedulingRetry() async throws {
+        let scheduler = AsyncStreamManualRetryScheduler()
+        let fixture = try makeInjectedBusyFixture(
+            policy: .retryBusy,
+            behavior: .succeed,
+            retryScheduler: scheduler.scheduler
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        // Drop the table so the very first fetch fails permanently (SQL error,
+        // not BUSY), regardless of the injected-busy function's own behavior.
+        try await fixture.database.databasePool.write { database in
+            try database.execute(sql: "DROP TABLE AsyncStreamRetryRecord")
+        }
+
+        let iterator = AsyncStreamIteratorBox(
+            fixture.database.makeRequest(with: fixture.statement).stream()
+        )
+
+        do {
+            _ = try await iterator.next()
+            XCTFail("Expected a permanent (non-BUSY) failure.")
+        }
+        catch is DatabaseError {
+            // Expected: "no such table" is not a BUSY error and must not retry.
+        }
+        XCTAssertTrue(scheduler.recordedDelays.isEmpty)
+    }
+
+    func testCancellationDuringBackoffStartsNoLaterAttempt() async throws {
+        let scheduler = AsyncStreamManualRetryScheduler()
+        let fixture = try makeInjectedBusyFixture(
+            policy: .retryBusy,
+            behavior: .failAlways,
+            retryScheduler: scheduler.scheduler
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let stream = fixture.database.makeRequest(with: fixture.statement).stream()
+        let iterator = AsyncStreamIteratorBox(stream)
+        let task = Task<[AsyncStreamRetryRecord]?, Error> {
+            try await iterator.next()
+        }
+
+        try await waitUntil { scheduler.pendingDelays == [0.1] }
+        XCTAssertEqual(fixture.functionState.invocationCount, 1)
+        task.cancel()
+
+        let result = try await task.value
+        XCTAssertNil(result, "Cancelling during backoff resolves to nil, not an error.")
+
+        // Firing the pending delay after cancellation must not start a new attempt.
+        scheduler.runNext()
+        drainMainQueue()
+        XCTAssertEqual(
+            fixture.functionState.invocationCount,
+            1,
+            "Cancelling during backoff must start no later attempt."
+        )
+    }
+
+    func testDeliveredValueResetsRetryBudget() async throws {
+        let scheduler = AsyncStreamManualRetryScheduler()
+        // Fails once, then succeeds, then (if retried again later) would fail
+        // again — behavior below alternates manually via a custom fixture.
+        let functionState = AsyncStreamInjectedBusyFunctionState(behavior: .failOnce)
+        let fixture = try makeInjectedBusyFixture(
+            policy: .retryBusy,
+            functionState: functionState,
+            retryScheduler: scheduler.scheduler
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let iterator = AsyncStreamIteratorBox(
+            fixture.database.makeRequest(with: fixture.statement).stream()
+        )
+        let consumeTask = Task { () -> [AsyncStreamRetryRecord]? in
+            try await iterator.next()
+        }
+
+        try await waitUntil { scheduler.pendingDelays == [0.1] }
+        scheduler.runNext()
+        let delivered = try await consumeTask.value
+        XCTAssertEqual(delivered, [AsyncStreamRetryRecord(id: "initial", value: 1)])
+        XCTAssertEqual(
+            scheduler.recordedDelays,
+            [0.1],
+            "A delivered value must reset the retry budget; only the first delay was ever needed."
+        )
+    }
+
+    // MARK: - Unsupported observation paths
+
+    func testReturningRequestStreamFailsLazilyWithObservationUnsupported() async throws {
+        try createRecordTable()
+        let schema = XLSchema()
+        let table = schema.table(AsyncStreamRecord.self)
+        let statement = insert(table)
+            .values(AsyncStreamRecord.MetaInsert(AsyncStreamRecord(id: "a", value: 1)))
+            .returning(table)
+        let request = database.makeRequest(with: statement)
+
+        let iterator = AsyncStreamIteratorBox(request.stream())
+        do {
+            _ = try await iterator.next()
+            XCTFail("Expected observationUnsupported.")
+        }
+        catch let error as XLReturningRequestError {
+            XCTAssertEqual(error, .observationUnsupported)
+        }
+
+        // The failed stream must not have executed the insert.
+        let rows = try database.makeRequest(with: orderedStatement()).fetchAll()
+        XCTAssertEqual(rows, [])
+    }
+
+    func testTransactionScopedDriverStreamFailsLazilyWithLiveQueriesUnsupported() async throws {
+        try createRecordTable()
+
+        // The pool-availability check that decides this happens synchronously when
+        // `stream()` is called (while the pinned scope is still valid); only the
+        // *delivery* of the already-determined error is deferred to `next()`. This
+        // lets the stream be constructed inside `withTransaction`'s synchronous
+        // closure and awaited afterward, without needing an async transaction body.
+        let stream = try database.withTransaction { scope in
+            scope.makeRequest(with: self.orderedStatement()).stream()
+        }
+        let iterator = AsyncStreamIteratorBox(stream)
+        do {
+            _ = try await iterator.next()
+            XCTFail("Expected liveQueriesUnsupportedInTransaction.")
+        }
+        catch let error as XLTransactionScopeError {
+            XCTAssertEqual(error, .liveQueriesUnsupportedInTransaction)
+        }
+    }
+
+    // MARK: - Deterministic repeated-stress run
+
+    func testRepeatedStressCoversRapidCommitsCancellationRetryAndBuffering() async throws {
+        try createRecordTable()
+
+        for round in 0 ..< 5 {
+            let request = database.makeRequest(with: orderedStatement())
+            let iterator = AsyncStreamIteratorBox(request.stream())
+
+            // Establish the current baseline before this round's rapid writes.
+            _ = try await iterator.next()
+
+            for burst in 0 ..< 10 {
+                try insertDirect(AsyncStreamRecord(id: "stress-\(round)-\(burst)", value: burst))
+            }
+
+            // Drain to a snapshot containing every row inserted so far, without
+            // requiring one `next()` per write.
+            var lastCount = 0
+            var attempts = 0
+            while attempts < 10 {
+                attempts += 1
+                guard let rows = try await iterator.next() else { break }
+                lastCount = rows.count
+                if rows.count == (round + 1) * 10 { break }
+            }
+            XCTAssertGreaterThan(lastCount, 0)
+
+            // Cancel this round's stream mid-stream and verify no further fetch
+            // happens for it once a subsequent, unrelated write occurs.
+            let task = Task<[AsyncStreamRecord]?, Error> { try await iterator.next() }
+            task.cancel()
+            _ = try await task.value
+        }
+
+        let total = try database.makeRequest(with: orderedStatement()).fetchAll().count
+        XCTAssertEqual(total, 50)
+    }
+
+    // MARK: - Helpers
+
+    private func orderedStatement() -> any XLQueryStatement<AsyncStreamRecord> {
+        sql { schema in
+            let table = schema.table(AsyncStreamRecord.self)
+            Select(table)
+            From(table)
+            OrderBy(table.id.ascending())
+        }
+    }
+
+    private func byIDStatement() -> any XLQueryStatement<AsyncStreamRecord> {
+        let idParameter = XLNamedBindingReference<String>(name: "id")
+        return sql { schema in
+            let table = schema.table(AsyncStreamRecord.self)
+            Select(table)
+            From(table)
+            Where(table.id == idParameter)
+        }
+    }
+
+    private func createRecordTable() throws {
+        try databasePool.write { database in
+            try database.execute(
+                literal: """
+                    CREATE TABLE AsyncStreamRecord (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        value INT NOT NULL
+                    );
+                """
+            )
+        }
+    }
+
+    private func insertDirect(_ row: AsyncStreamRecord) throws {
+        try databasePool.write { database in
+            try database.execute(
+                sql: "INSERT INTO AsyncStreamRecord (id, value) VALUES (?, ?)",
+                arguments: [row.id, row.value]
+            )
+        }
+    }
+
+    private func drainMainQueue() {
+        let barrier = expectation(description: "main-queue barrier")
+        DispatchQueue.main.async {
+            barrier.fulfill()
+        }
+        wait(for: [barrier], timeout: 2)
+    }
+
+    /// Bounded, deterministic polling: sleeps in small increments up to `timeout`, checking
+    /// `condition` each time, rather than proving anything via one blind sleep.
+    private func waitUntil(
+        timeout: TimeInterval = 3,
+        pollInterval: UInt64 = 10_000_000,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: () -> Bool
+    ) async throws {
+        let maxAttempts = max(Int((timeout * 1_000_000_000) / Double(pollInterval)), 1)
+        for _ in 0 ..< maxAttempts {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: pollInterval)
+        }
+        XCTFail("Condition not met within \(timeout)s", file: file, line: line)
+    }
+
+    private struct InjectedBusyFixture {
+        let database: GRDBDatabase
+        let directoryURL: URL
+        let functionState: AsyncStreamInjectedBusyFunctionState
+        let statement: any XLQueryStatement<AsyncStreamRetryRecord>
+    }
+
+    private func makeInjectedBusyFixture(
+        policy: GRDBLiveQueryRetryPolicy,
+        behavior: AsyncStreamInjectedBusyFunctionState.Behavior = .failOnce,
+        functionState: AsyncStreamInjectedBusyFunctionState? = nil,
+        retryScheduler: GRDBLiveQueryRetryScheduler? = nil
+    ) throws -> InjectedBusyFixture {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let databaseURL = directoryURL.appendingPathComponent("retry.sqlite", isDirectory: false)
+        let resolvedFunctionState = functionState ?? AsyncStreamInjectedBusyFunctionState(behavior: behavior)
+
+        var configuration = Configuration()
+        configuration.prepareDatabase { database in
+            database.add(
+                function: DatabaseFunction(
+                    AsyncStreamInjectedBusyExpression.functionName,
+                    argumentCount: 0
+                ) { _ in
+                    try resolvedFunctionState.invoke()
+                }
+            )
+        }
+
+        let pool = try DatabasePool(path: databaseURL.path, configuration: configuration)
+        let fixtureDatabase = try GRDBDatabase(
+            databasePool: pool,
+            formatter: XLiteFormatter(),
+            logger: nil,
+            liveQueryRetryPolicy: policy,
+            liveQueryRetryScheduler: retryScheduler ?? .mainQueue
+        )
+        try pool.write { database in
+            try database.execute(
+                sql: """
+                    CREATE TABLE AsyncStreamRetryRecord (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        value INT NOT NULL
+                    )
+                    """
+            )
+            try database.execute(
+                sql: "INSERT INTO AsyncStreamRetryRecord (id, value) VALUES (?, ?)",
+                arguments: ["initial", 1]
+            )
+        }
+
+        let statement: any XLQueryStatement<AsyncStreamRetryRecord> = sql { schema in
+            let table = schema.table(AsyncStreamRetryRecord.self)
+            Select(table)
+            From(table)
+            Where(AsyncStreamInjectedBusyExpression() == 1)
+            OrderBy(table.id.ascending())
+        }
+
+        return InjectedBusyFixture(
+            database: fixtureDatabase,
+            directoryURL: directoryURL,
+            functionState: resolvedFunctionState,
+            statement: statement
+        )
+    }
+}

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -2835,6 +2835,20 @@ extension XLDocumentationTests {
         let _: (XLGRDBLiveQueryRetryTests) -> () throws -> Void =
             XLGRDBLiveQueryRetryTests
                 .testRealGRDBObservationRecoversFromInjectedBusyAndKeepsObserving
+
+        // #308: `stream()`/`streamOne()`/`stream(bindings:)` async live-query examples above are
+        // exercised by real-GRDB-database tests, mirroring how the publish()/publishOne() examples
+        // above are exercised by XLPublisherTests rather than inline here.
+        let _: (GRDBLiveQueryAsyncStreamTests) -> () async throws -> Void =
+            GRDBLiveQueryAsyncStreamTests.testStreamEmitsFreshInitialSnapshotAndRelevantWriteRefresh
+        let _: (GRDBLiveQueryAsyncStreamTests) -> () async throws -> Void =
+            GRDBLiveQueryAsyncStreamTests.testStreamOneEmitsFreshInitialSnapshotAndRelevantWriteRefresh
+        let _: (GRDBLiveQueryAsyncStreamTests) -> () async throws -> Void =
+            GRDBLiveQueryAsyncStreamTests.testStreamBindingsCapturesPacketOnceAcrossInitialFetchAndRefresh
+        let _: (GRDBLiveQueryAsyncStreamTests) -> () async throws -> Void =
+            GRDBLiveQueryAsyncStreamTests.testCancellingConsumingTaskTearsDownObservationAndStopsFurtherFetches
+        let _: (SQLRequestCompatibilityTests) -> () async throws -> Void =
+            SQLRequestCompatibilityTests.testLegacyReadConformerStreamBridgesFromPublishLazily
     }
 
     func testDocumentationDeclaredQueries() throws {

--- a/Tests/SQLTests/SQLRequestCompatibilityTests.swift
+++ b/Tests/SQLTests/SQLRequestCompatibilityTests.swift
@@ -156,6 +156,11 @@ final class SQLRequestCompatibilityTests: XCTestCase {
 
         let first = try await iterator.next()
         XCTAssertEqual(first, 82)
+
+        // `Just`-backed publishers deliver exactly one value then finish: the
+        // compatibility bridge must end iteration afterward, not hang or repeat.
+        let second = try await iterator.next()
+        XCTAssertNil(second)
     }
 
     func testLegacyReadConformerStreamBindingsBridgesFromPublishBindingsLazily() async throws {
@@ -166,6 +171,11 @@ final class SQLRequestCompatibilityTests: XCTestCase {
         var iterator = stream.makeAsyncIterator()
         let first = try await iterator.next()
         XCTAssertEqual(first, [82])
+
+        // `Just`-backed publishers deliver exactly one value then finish: the
+        // compatibility bridge must end iteration afterward, not hang or repeat.
+        let second = try await iterator.next()
+        XCTAssertNil(second)
     }
 
     func testLegacyReadConformerStreamBindingsRejectsUnsupportedPacketLazily() async throws {

--- a/Tests/SQLTests/SQLRequestCompatibilityTests.swift
+++ b/Tests/SQLTests/SQLRequestCompatibilityTests.swift
@@ -124,6 +124,86 @@ final class SQLRequestCompatibilityTests: XCTestCase {
         }
     }
 
+    // MARK: - #308 stream()/streamOne() compatibility defaults
+    //
+    // `LegacyReadRequest` only implements `publish()`/`publishOne()`, exactly like a
+    // third-party `XLRequest` conformer written before #308. These tests exercise the
+    // protocol-extension default that bridges those Combine pipelines into
+    // `AsyncThrowingStream`, proving it stays lazy (the underlying `publish()` is not
+    // invoked merely by calling `stream()`) and does not recurse.
+
+    func testLegacyReadConformerStreamBridgesFromPublishLazily() async throws {
+        let request = LegacyReadRequest(rows: [82])
+
+        // Constructing the stream performs no work: LegacyReadRequest.publish() is
+        // invoked only once the stream is iterated below.
+        let stream = request.stream()
+        var iterator = stream.makeAsyncIterator()
+
+        let first = try await iterator.next()
+        XCTAssertEqual(first, [82])
+
+        // `Just`-backed publishers deliver exactly one value then finish: the
+        // compatibility bridge must end iteration afterward, not hang or repeat.
+        let second = try await iterator.next()
+        XCTAssertNil(second)
+    }
+
+    func testLegacyReadConformerStreamOneBridgesFromPublishOneLazily() async throws {
+        let request = LegacyReadRequest(rows: [82])
+        let stream = request.streamOne()
+        var iterator = stream.makeAsyncIterator()
+
+        let first = try await iterator.next()
+        XCTAssertEqual(first, 82)
+    }
+
+    func testLegacyReadConformerStreamBindingsBridgesFromPublishBindingsLazily() async throws {
+        let request = LegacyReadRequest(rows: [82])
+        let packet = XLInvocationBindings<XLSQLiteValue>(layout: .empty)
+
+        let stream = request.stream(bindings: packet)
+        var iterator = stream.makeAsyncIterator()
+        let first = try await iterator.next()
+        XCTAssertEqual(first, [82])
+    }
+
+    func testLegacyReadConformerStreamBindingsRejectsUnsupportedPacketLazily() async throws {
+        let request = LegacyReadRequest(rows: [82])
+        let slot = XLParameterSlot(
+            index: XLLogicalParameterIndex(0),
+            key: .named("value"),
+            valueTypeIdentifier: XLValueTypeIdentifier(rawValue: "swift.int"),
+            valueTypeName: String(reflecting: Int.self),
+            nullability: .required,
+            codecIdentity: nil,
+            codingContext: XLValueCodingContext(
+                site: .parameter,
+                path: XLValueCodingPath("value")
+            )
+        )
+        let layout = try XLParameterLayout(slots: [slot])
+        let nonemptyPacket = try XLInvocationBindings<XLSQLiteValue>(
+            layout: layout,
+            bindings: [try XLInvocationBinding(slot: slot, value: .integer(1))]
+        )
+
+        let stream = request.stream(bindings: nonemptyPacket)
+        var iterator = stream.makeAsyncIterator()
+
+        do {
+            _ = try await iterator.next()
+            XCTFail("Expected unsupportedInvocationBindings.")
+        }
+        catch let error as XLRequestBindingError {
+            guard case .unsupportedInvocationBindings(let requestType, let rejectedLayout) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(requestType.contains("LegacyReadRequest"))
+            XCTAssertEqual(rejectedLayout, layout)
+        }
+    }
+
     func testLegacyWriteConformerUsesDefaultPacketRequirement() throws {
         var request = LegacyWriteRequest()
         let parameter = XLNamedBindingReference<Int>(name: "value")

--- a/Tests/SQLTests/SQLRequestCompatibilityTests.swift
+++ b/Tests/SQLTests/SQLRequestCompatibilityTests.swift
@@ -138,29 +138,45 @@ final class SQLRequestCompatibilityTests: XCTestCase {
         // Constructing the stream performs no work: LegacyReadRequest.publish() is
         // invoked only once the stream is iterated below.
         let stream = request.stream()
+        XCTAssertEqual(request.publishCallCounter.publishCount, 0)
         var iterator = stream.makeAsyncIterator()
+        XCTAssertEqual(request.publishCallCounter.publishCount, 0)
 
         let first = try await iterator.next()
         XCTAssertEqual(first, [82])
+        XCTAssertEqual(request.publishCallCounter.publishCount, 1)
 
         // `Just`-backed publishers deliver exactly one value then finish: the
         // compatibility bridge must end iteration afterward, not hang or repeat.
         let second = try await iterator.next()
         XCTAssertNil(second)
+        XCTAssertEqual(
+            request.publishCallCounter.publishCount,
+            1,
+            "Resuming iteration after natural completion must not re-subscribe."
+        )
     }
 
     func testLegacyReadConformerStreamOneBridgesFromPublishOneLazily() async throws {
         let request = LegacyReadRequest(rows: [82])
         let stream = request.streamOne()
+        XCTAssertEqual(request.publishCallCounter.publishOneCount, 0)
         var iterator = stream.makeAsyncIterator()
+        XCTAssertEqual(request.publishCallCounter.publishOneCount, 0)
 
         let first = try await iterator.next()
         XCTAssertEqual(first, 82)
+        XCTAssertEqual(request.publishCallCounter.publishOneCount, 1)
 
         // `Just`-backed publishers deliver exactly one value then finish: the
         // compatibility bridge must end iteration afterward, not hang or repeat.
         let second = try await iterator.next()
         XCTAssertNil(second)
+        XCTAssertEqual(
+            request.publishCallCounter.publishOneCount,
+            1,
+            "Resuming iteration after natural completion must not re-subscribe."
+        )
     }
 
     func testLegacyReadConformerStreamBindingsBridgesFromPublishBindingsLazily() async throws {
@@ -349,9 +365,21 @@ private struct LegacyDirectNamedBindingExpression: XLExpression {
 }
 
 
+/// Records how many times `LegacyReadRequest.publish()`/`publishOne()` were
+/// actually invoked, so tests can prove the `stream()`/`streamOne()`
+/// compatibility bridge is lazy rather than merely asserting it delivers the
+/// right value (which would also pass under eager subscription).
+private final class LegacyPublishCallCounter {
+    var publishCount = 0
+    var publishOneCount = 0
+}
+
+
 private struct LegacyReadRequest: XLRequest {
 
     let rows: [Int]
+
+    let publishCallCounter = LegacyPublishCallCounter()
 
     private(set) var assignedValue: Int? = nil
 
@@ -378,13 +406,15 @@ private struct LegacyReadRequest: XLRequest {
     }
 
     func publish() -> AnyPublisher<[Int], Error> {
-        Just(rows)
+        publishCallCounter.publishCount += 1
+        return Just(rows)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
     }
 
     func publishOne() -> AnyPublisher<Int?, Error> {
-        Just(rows.first)
+        publishCallCounter.publishOneCount += 1
+        return Just(rows.first)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
     }


### PR DESCRIPTION
## Summary

Stacked on #445 (#291's buffering/cancellation policy) — **retarget to `version/1.5.5` once #445 merges.**

- Adds canonical `AsyncThrowingStream` live-query observation to `XLRequest`:
  ```swift
  func stream() -> AsyncThrowingStream<[Row], Error>
  func stream(bindings: any XLInvocationBindingPacket) -> AsyncThrowingStream<[Row], Error>
  func streamOne() -> AsyncThrowingStream<Row?, Error>
  func streamOne(bindings: any XLInvocationBindingPacket) -> AsyncThrowingStream<Row?, Error>
  ```
- `Sources/SwiftQL/GRDBLiveQueryAsyncStream.swift` (new): `GRDBLiveQueryAsyncBridge<Value>`, the GRDB-native source built directly on `ValueObservation.start(in:onError:onChange:)` — never routes through Combine. Lazily started (observation begins with iteration, not construction), cancelled via `withTaskCancellationHandler` (required since `AsyncThrowingStream`'s `unfolding:` initializer has no `onCancel`).
- `Sources/SwiftQL/XLSingleSlotAsyncBuffer.swift` (new): the #291 bound-1 "newest wins" buffering policy, shared by the GRDB-native bridge and the compatibility bridge — one canonical implementation, not duplicated per adapter.
- `GRDBLiveQueryRetryPolicy.swift`: widened `GRDBLiveQueryRetryState` to internal so the async path reuses the exact same retry/generation-counter engine the Combine path uses — no forked retry logic.
- `GRDBSQLDatabase.swift`: `GRDBRequest` overrides with the true async-native source.
- `SQLDatabase.swift`: protocol requirements plus a source-compatible default (`XLRequestPublisherAsyncBridge`) for external `XLRequest` conformers, built by lazily bridging their existing `publish()`/`publishOne()` — documented as non-recursive (it never calls `stream()`/`streamOne()` itself).
- `LiveQueries.md`: new "Async live-query streams (#308)" section with `for try await` examples, distinguishing complete-snapshot observation from #249's row-by-row `XLResultSet`.
- `Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift` (new, 22 tests): real temporary-GRDB coverage — lazy start, initial/refresh delivery, transaction coalescing, rollback exclusion, irrelevant-write exclusion, immutable packet capture, missing/nullable bindings, cancellation (before-first-value, during backoff, of the consuming `Task`), bounded buffering under rapid commits, independent streams/databases (including identically-named tables across pools), BUSY retry/recovery/exhaustion, permanent failure, RETURNING/transaction-scoped rejection, and a repeated-stress run.
- Also fixed a cancellation race found along the way: a concurrent `cancel()` racing a retry attempt/backoff completion could store a fresh `AnyDatabaseCancellable`/delay subscription *after* `cancel()` already read and cleared the old one, leaking a live observation or timer. Fixed with a check-after-store re-verification against `retryState.shouldDeliver(generation:)`, mirroring the existing pattern in `GRDBOpenCombineValuePublisher.swift`.

Closes #308.

## Test plan
- [x] `swift build`
- [x] `swift package generate-documentation --target SwiftQL` — clean, no unresolved DocC links
- [x] `swift test` — 1146 tests, 0 failures (new async suite re-run 3x, no flakiness)
