### PR TITLE
Explain what SwiftQL is for, and require a summary and announcement for every release

### DIFF
--- a/Documentation/DESIGN.md
+++ b/Documentation/DESIGN.md
@@ -1,0 +1,334 @@
+# Designing SwiftQL
+
+Why SwiftQL looks the way it does, what was tried before it, and what it cost.
+
+This document records design rationale. [ROADMAP.md](../ROADMAP.md) states
+current direction, and [COMPATIBILITY.md](../COMPATIBILITY.md) records what is
+actually supported. Where they disagree with this document, they are right and
+this one is out of date.
+
+## The problem this came from
+
+Every iOS app I have worked on that stored real data eventually forced the same
+choice, and both options were bad.
+
+Core Data is an object-graph manager. Apple is careful to say it is not an ORM,
+and that is technically true, but it presents the same bargain: you work with
+objects and the store is someone else's problem. In practice queries are hard to
+reason about and slow, ordinary object-graph inserts and updates are slow in a
+way that is difficult to fix, and the memory and threading model is
+unpredictable. Managed objects are heap-allocated and comparatively expensive,
+and they are bound to their context, so moving data across threads means passing
+object IDs and re-faulting on the other side rather than passing values. The
+batch APIs exist and are genuinely faster, but they work by bypassing the object
+graph - which is the tell. The abstraction that was supposed to save work
+generates its own work, and its fast path is the one that steps around it.
+
+SQLite is the other option. It is stable, efficient, predictable, and simple.
+But in Swift its queries are strings, which means no compile-time checking at
+all. Every query is a shot in the dark that breaks at runtime the moment
+anything changes.
+
+This came to a head on EventCloud, a white-label events product whose iOS app I
+built: offline-first, large data set, and it needed
+sync. It started on Core Data, and a disproportionate share of both development
+time and runtime went to the database layer. I ended up writing a system that
+generated managed objects and the server API from a backend schema, which helped
+with the boilerplate but not with the underlying model. While trying to make it
+faster and more stable, it became clear SQLite was the better foundation. That
+solved the performance and predictability problems and replaced them with a new
+one: hand-rolled query strings.
+
+I had used LINQ previously, and the idea followed from there. Swift should be
+able to express SQL natively, so queries are type-checked like any other code.
+
+## What "native" had to mean
+
+The goal was first-class support for *SQL*, not a new query language that
+happens to be written in Swift.
+
+Most persistence libraries invent a proprietary API and, with it, a switching
+cost. What you learn is not transferable, and what you write cannot be moved
+back out. SwiftQL's constraint from the start was that code should be directly
+translatable in both directions: read SQL, write the SwiftQL, and vice versa,
+without a mental compiler in between.
+
+That constraint is the reason the library is SQL-shaped rather than
+ORM-shaped, and the reason clause names and clause order match SQL exactly. It
+also sets the boundary on what SwiftQL is willing to do: it does not hide the
+relational model, and it does not attempt to be the authority on semantics
+SQLite already owns.
+
+### On ORMs
+
+The stronger claim underneath that: relational databases are the correct way to
+handle data, and ORMs are an unnecessary layer of indirection that misrepresents
+what is actually happening.
+
+Most languages do not expose the relational model directly. They ship an ORM
+instead, on the theory that objects are easier for programmers than tables. The
+theory does not survive contact with real schemas, and it fails in a consistent
+pattern:
+
+- **Relationships that are not object-shaped.** An object graph models
+  containment and reference well. It does not model a left join, a grouped
+  aggregate, or a projection across three tables, because none of those produce
+  an object - they produce a row shape that exists only for that query.
+- **Performance that degrades invisibly.** Fetching an object with many children
+  is the case every ORM handles badly, and every ORM answers with a set of
+  workarounds: prefetching hints, fault batching, relationship faulting rules.
+  These are configuration knobs for a problem the relational model does not
+  have, because a join is one query.
+- **A query syntax with no fixed form.** Predicates, chained methods, functional
+  combinators, or plain loops over in-memory collections all end up expressing
+  queries, often in the same codebase. There is no canonical way to say what you
+  mean, so equivalent queries look nothing alike and their cost is impossible to
+  read off the page.
+
+Each workaround adds complexity, and the complexity is spent buying back
+performance the abstraction gave away. The indirection is dishonest in a
+specific sense: it advertises that the relational model is gone, while the
+relational model is still doing all of the work underneath and still determines
+whether the program is fast or slow. When it leaks, and it always leaks, the
+programmer has to understand both the database and the abstraction over it.
+
+SQL is a good language for this. It is declarative, it has been in use for
+roughly fifty years, it is
+the same across projects and largely across engines, and it already expresses
+exactly the operations that object graphs struggle with. The problem was never
+SQL. The problem was that Swift could not see it.
+
+## Three attempts before macros
+
+The idea was viable long before Swift could express it well.
+
+The first exploratory versions used a third-party code generator, which was the
+standard approach before Swift macros existed. It worked, but it put a separate
+tool and a generated-file lifecycle between you and your code.
+
+The second required programmers to annotate their structs by hand. It was
+rudimentary and needed a lot of manual boilerplate, but it proved the core idea:
+if the compiler knows the shape of the table, it can check the query.
+
+The third tried to remove that boilerplate with the tools Swift had at the time:
+`Codable`, property wrappers, and `Mirror`. This is where it stalled. Those
+mechanisms can describe a type at runtime, but the entire point was to be
+checked at *compile* time. Reflection was the wrong shape for the problem.
+
+By then it was clear what the missing piece was. When a member of the Swift team
+asked on Twitter what people wanted from the language, my answer was macros:
+compile-time code generation, in the language, without a separate tool. Macros
+arrived in Swift 5.9 in September 2023, and SwiftQL moved onto them immediately.
+
+Macros have since become, in my view, the most useful addition to Swift after
+generics and the concurrency primitives. They are also the reason the earlier
+approaches are gone rather than rejected: native compile-time code generation is
+simply the right mechanism for this, and everything before it was working around
+its absence.
+
+## Why result builders, in SQL order
+
+The current syntax was not obvious, and it was not first.
+
+Early versions used functional chaining, the way most Swift query libraries do.
+That syntax still works today. When I started, result builders could not express
+what SwiftQL needed: without partial block support, every combination of clauses
+needed its own overload, and the method count exploded combinatorially.
+
+`buildPartialBlock` arrived in Swift 5.7 in September 2022, and everything fell
+into place. That proposal exists precisely because of this problem: its stated
+purpose is to collapse the combinatorial overloads that complex result builders
+would otherwise need, and it is part of what made Swift's own regex builders
+possible.
+
+The result was better than the chaining version in a way that was immediately
+obvious, and familiar along two axes at once. It looks like the SQL I would have
+written by hand, and it looks like SwiftUI. Swift had by then established this
+shape as idiomatic - in SwiftUI, and then in RegexBuilder - so a query written
+this way reads as ordinary modern Swift rather than as a library's private
+convention.
+
+Macros, result builders, and SQL turn out to fit together unusually well: macros
+supply the compile-time knowledge of the schema, and result builders supply a
+statement syntax that can consume it in SQL's own order.
+
+The chaining syntax has aged less well. The extra punctuation now reads as
+obtuse next to the builder form, so the plan is to move it into a separate
+library for people who prefer it, and leave result builders as the single way to
+use SwiftQL.
+
+## Swift types, not SQL types
+
+The largest single design decision was whether column values should be
+SQLite's types or Swift's.
+
+The alternative was a parallel type system: `SQL.Integer`, `SQL.Real`,
+`SQL.Blob`, mirroring SQLite's storage classes and affinity rules. I chose
+native Swift types instead: `Int`, `Double`, `Data`.
+
+Four reasons:
+
+1. **SQLite does not enforce types anyway.** Modelling its type affinity
+   faithfully means faithfully modelling something the database itself treats as
+   advisory. `STRICT` tables, added in SQLite 3.37, are the exception, but they
+   are opt-in and they make the column's declared type authoritative - which is
+   the behavior Swift's own types already give you.
+2. **It would trade away Swift's actual strength.** Affinity conventions are
+   resolved at runtime. Swift's value here is compile-time guarantees, and a
+   type system that defers to runtime coercion gives that up.
+3. **It introduces a foreign type system** that users must learn, hold in their
+   heads, and convert across at every boundary.
+4. **The data ends up in a typed Swift struct regardless.** The SQL-typed layer
+   would be a stop on the way to the destination, adding inconvenience for
+   little practical return. It is mostly a vanity goal.
+
+The payoff is that table definitions look like ordinary Swift structs, which is
+most of the learning curve gone. The cost is real and is paid in codecs: types
+without a native SQLite equivalent, notably `Date` and `UUID`, need conversion
+declared somewhere. How that is declared has itself been revised, discussed
+below.
+
+## Standing on GRDB
+
+SwiftQL executes through GRDB rather than talking to SQLite directly.
+
+GRDB provides connection pooling and observation. Both are necessary, and both
+would otherwise have to be built before any of the interesting work could start.
+I have written that layer before, and an early version of SwiftQL used my own.
+Choosing GRDB was a decision about where to spend attention: the query syntax
+was the unsolved problem, and SQLite boilerplate was not.
+
+This is also why SwiftQL is not an alternative to GRDB. It is a typed query
+layer above it, and the two compose deliberately. Schema migrations, for
+instance, are GRDB's `DatabaseMigrator` and SwiftQL does not attempt to replace
+them.
+
+The intended end state is a thin SQLite wrapper optimized for SwiftQL's own
+access patterns, with GRDB compatibility retained for projects that want or need
+it. That is motivated by performance rather than by any dissatisfaction with
+GRDB. See the studies in [`Research/`](../Research) for the drivers that were
+evaluated.
+
+## The hard part
+
+The difficult problem was not any single feature. It was arriving at a
+translation from Swift to SQL that is checked by the compiler and still produces
+a *cacheable prepared statement*.
+
+Those two requirements pull against each other. Compile-time checking wants
+everything expressed in the type system, where it is static and known. Prepared
+statement caching wants a stable SQL string with bound parameters, where the
+values are explicitly *not* part of the statement. Satisfying both means the
+type-level structure has to describe a statement shape while the values travel
+separately, and it means writing code whose purpose is to generate other code.
+Holding both levels in your head at once takes some getting used to, and the
+solution needed several layers of indirection before it worked.
+
+Some of the result builders were genuinely mind-bending. Recursive common table
+expressions are the extreme case: expressing a CTE that refers to itself, inside
+a builder, while keeping the whole thing typed. I am still not entirely sure how
+I did it. That construction is written up separately in
+[`Architecture/RecursiveCTEConstruction.md`](Architecture/RecursiveCTEConstruction.md).
+
+## What it costs
+
+**Compile time.** Large table types generate a lot of code, and that code is
+recompiled whenever they change. The mitigation is structural: put database
+objects in their own package, so they rebuild only when the data model changes
+rather than on every build of the app. The intent is to make this a one-off
+cost paid when the schema changes, in exchange for full type checking of every
+query that touches it. That is the trade the whole library makes, and it is
+worth being explicit that it is a trade.
+
+**Runtime performance.** Current performance is lower than it should be, mostly
+in the mechanics of decoding rows out of SQLite. Moving to the native SQLite C
+interface should remove that overhead. I expect a large improvement, possibly an
+order of magnitude, but that is an expectation and not a measurement - the
+current numbers are in [BENCHMARKS.md](../BENCHMARKS.md) and the comparison does
+not exist yet.
+
+## What is still wrong
+
+**Too much boilerplate, particularly around variables.** This is the most
+visible remaining wart and is targeted for upcoming versions.
+
+**Two syntaxes.** Supporting both chaining and result builders splits the
+surface area and the documentation. Chaining moves to its own library.
+
+**The builder entry points.** `sql { }` and `sqlResult { }` are result builders
+because that was what the language offered. A function macro is a better fit,
+and the relevant proposal is in Swift Evolution. When it lands, these go.
+
+**Custom encoding, now fixed but instructive.** SwiftQL originally supported
+custom value encoding through protocol conformance. Adding that to an existing
+type such as `Date` means writing an extension, which breaks down as soon as an
+application needs more than one encoding for the same type. Multiple date
+encodings are common, not exotic. Installable codecs solve this properly,
+because the encoding becomes a property of the column rather than of the type.
+
+**Macros remain sharp-edged.** I have used them since their first release, when
+it was easy to crash the compiler. They have matured enormously, but the `#row`
+episode shows the ceiling has not gone away: the macro shipped, was reverted
+after an IRGen crash on the pinned Swift 5.9.2 and 6.0 toolchains, and was
+restored with its multi-column shapes gated to Swift 6.1 and later. That is
+SwiftQL's first source-level API difference across compiler cells, and it exists
+because of a compiler bug rather than a design choice.
+
+## Who this is for
+
+Any Swift project that uses SQLite.
+
+Type-safe queries that still look like SQL are, I think, the lowest-friction way
+to use SQLite from Swift.
+
+Type safety is not the distinguishing property. Several Swift libraries offer
+compile-time checked queries over SQLite without becoming ORMs. What separates
+them is the shape of the source, and specifically whether it corresponds to the
+statement it produces.
+
+Chained builders do not. A query is assembled by attaching clauses to a table
+type, in an order the builder accepts rather than the order SQL defines, using
+method names that approximate SQL keywords without being them. The output is
+SQL; the input is a Swift API that has to be learned on its own terms.
+
+SwiftQL writes the statement in SQL's own clause order:
+
+```swift
+sql { schema in
+    let person = schema.table(Person.self)
+    Select(person)
+    From(person)
+    Where(person.name == "Fred")
+}
+```
+
+Each clause appears once, under its SQL name, in SQL's grammatical order. There
+is no rule to learn about where `WHERE` attaches or which receiver a clause
+hangs off, because the answer is the one SQL already gave. The source is the
+statement.
+
+That is the bet the whole library makes, and it is what SQL as a first-class
+construct actually means: not that queries are type-checked, and not that they
+avoid strings, but that the language is present in the source with its own
+grammar intact rather than paraphrased into an API. A query moves between SQL
+and SwiftQL a clause at a time, in both directions, which is why porting is
+mechanical and why what you already know about SQL keeps its value.
+
+The other half of that goal is coverage. A first-class construct that only
+handles simple statements is a demo. SwiftQL's aim is to express what SQLite
+expresses: joins, grouping and `HAVING`, subqueries, compound queries, and
+ordinary and recursive common table expressions today, with the remaining
+surface tracked as conformance work rather than left undefined. See
+[COMPATIBILITY.md](../COMPATIBILITY.md#sqlite-conformance-inventory) for the
+evidence boundary.
+
+There is also a broader point, aimed at the status quo rather than at any
+library. Most SQLite code in Swift applications is still a string handed to a C
+API or a driver, checked by nothing until it runs. That is the practice SwiftQL
+exists to replace.
+
+Once the PostgreSQL, MySQL, and SQL Server dialects land, the same argument
+should apply to those.
+
+One caveat worth stating plainly: the 1.x line is under active and fast-paced
+development. v2 is the version to adopt.

--- a/Documentation/PortingFromSQL.md
+++ b/Documentation/PortingFromSQL.md
@@ -1,0 +1,328 @@
+# Porting SQL to SwiftQL
+
+A guide for moving existing SQLite queries into SwiftQL, and for reading
+SwiftQL if you already know SQL.
+
+SwiftQL is designed so that this is a mechanical exercise. Every clause appears
+once, under its SQL name, in SQL's grammatical order. Porting a query means
+rewriting it clause by clause, top to bottom, without first redesigning it to
+fit a builder's vocabulary. The same property works in reverse: a SwiftQL query
+can be read out as SQL by anyone who knows SQL and has never seen this library.
+
+If you find a query that does not port this way, that is a defect worth
+reporting, not a limitation you should work around.
+
+## The shape of a port
+
+Start with a query you already have:
+
+```sql
+SELECT * FROM Person WHERE name = 'Fred'
+```
+
+The port keeps the clauses, in order, and replaces the table and column names
+with typed references:
+
+```swift
+let query = sql { schema in
+    let person = schema.table(Person.self)
+    Select(person)
+    From(person)
+    Where(person.name == "Fred")
+}
+```
+
+Three lines of SQL, three statements of Swift, same order. The only additions
+are the `sql { schema in ... }` entry point and the `let person =` binding that
+gives you a typed handle to the table.
+
+That handle is the one genuine difference from SQL, and it is what buys the type
+checking: `person.name` is a typed column reference, so a typo does not compile
+and a rename leads the compiler to every query affected.
+
+## Clause mapping
+
+| SQL | SwiftQL |
+| --- | --- |
+| `SELECT *` | `Select(person)` |
+| `SELECT a, b` | `Select(#row(person.name, occupation.name))` or a `@SQLResult` projection |
+| `FROM t` | `From(person)` |
+| `INNER JOIN t ON x` | `Join.Inner(occupation, on: occupation.id == person.occupationId)` |
+| `LEFT JOIN t ON x` | `Join.Left(occupation, on: ...)` with `schema.nullableTable(...)` |
+| `CROSS JOIN t` | `Join.Cross(occupation)` |
+| `WHERE x` | `Where(person.age > 21)` |
+| `GROUP BY x` | `GroupBy(person.occupationId)` |
+| `HAVING x` | `Having(row.numberOfPeople >= 2)` |
+| `ORDER BY x ASC, y DESC` | `OrderBy(person.name.ascending(), person.age.descending())` |
+| `LIMIT n` | `Limit(5)` |
+| `OFFSET n` | `Offset(10)` |
+| `UNION` | `Union()` |
+| `UNION ALL` | `UnionAll()` |
+| `WITH name AS (...)` | `schema.commonTableExpression { ... }` plus `With(cte)` |
+| `WITH RECURSIVE name AS (...)` | `schema.recursiveCommonTableExpression(Row.self) { schema, this in ... }` plus `With(cte)` |
+| `(SELECT ...)` as a value or source | `subqueryExpression { ... }` |
+| `x IN (SELECT ...)` | `org.name.in(cte)` |
+| `COUNT(x)` | `person.id.count()` |
+| `MIN(x)` / `MAX(x)` / `SUM(x)` | `person.age.minOrNull()` / `.maxOrNull()` / `.sumOrNull()` |
+| `COALESCE(x, 0)` | `person.age.sumOrNull().coalesce(0)` |
+| `x IS NULL` / `x IS NOT NULL` | `family.died.isNull()` / `person.occupationId.notNull()` |
+| `AND` / `OR` / `NOT` | `&&` / `\|\|` / `!` |
+| `CREATE TABLE` | `sqlCreate(Person.self)` |
+| `INSERT INTO t VALUES (...)` | `sqlInsert(person)` |
+| `UPDATE t SET c = v` | `Update(person)` plus `Setting(person) { row in row.age = 42 }` |
+| `DELETE FROM t` | `Delete(person)` |
+| `:name` bind parameter | `XLNamedBindingReference<String>(name: "name")` |
+
+Read statements take their table from `schema.table(_:)`. Write statements take
+theirs from `schema.into(_:)`.
+
+## Worked ports
+
+### 1. Filter and order
+
+```sql
+SELECT * FROM Person
+ORDER BY age ASC
+LIMIT 5 OFFSET 10
+```
+
+```swift
+let query = sql { schema in
+    let person = schema.table(Person.self)
+    Select(person)
+    From(person)
+    OrderBy(person.age.ascending())
+    Limit(5)
+    Offset(10)
+}
+```
+
+### 2. Left join with a projection
+
+```sql
+SELECT Person.id, Person.name, Occupation.id, Occupation.name
+FROM Person
+LEFT JOIN Occupation ON Occupation.id = Person.occupationId
+```
+
+A projection that is not a whole table needs a result type, so the decoded rows
+have somewhere to land:
+
+```swift
+@SQLResult struct PersonOccupation {
+    let personId: String
+    let personName: String
+    let occupationId: String?
+    let occupationName: String?
+}
+
+let query = sql { schema in
+    let person = schema.table(Person.self)
+    let occupation = schema.nullableTable(Occupation.self)
+    Select(
+        PersonOccupation.columns(
+            personId: person.id,
+            personName: person.name,
+            occupationId: occupation.id,
+            occupationName: occupation.name
+        )
+    )
+    From(person)
+    Join.Left(occupation, on: occupation.id == person.occupationId)
+}
+```
+
+Note `schema.nullableTable` on the joined side. A left join can produce no
+matching row, so its columns are optional, and SwiftQL makes you say so. The
+result type's `occupationId` and `occupationName` are `String?` for the same
+reason. In SQL this is a runtime surprise; here it is a compile-time fact.
+
+For a quick two-column projection with no named type, `#row` avoids declaring
+one:
+
+```swift
+Select(#row(person.name, occupation.name))
+```
+
+### 3. Group and aggregate
+
+```sql
+SELECT occupationId, COUNT(id) AS numberOfPeople
+FROM Person
+GROUP BY occupationId
+HAVING numberOfPeople >= 2
+```
+
+```swift
+@SQLResult struct OccupationAggregate {
+    var occupationId: String?
+    var numberOfPeople: Int
+}
+
+let query = sql { schema in
+    let person = schema.table(Person.self)
+    let row = OccupationAggregate.columns(
+        occupationId: person.occupationId,
+        numberOfPeople: person.id.count()
+    )
+    Select(row)
+    From(person)
+    GroupBy(person.occupationId)
+    Having(row.numberOfPeople >= 2)
+}
+```
+
+Binding the projection to `row` first lets `Having` refer to the aggregate by
+name, the same way SQL refers to the alias.
+
+### 4. Recursive common table expression
+
+The showpiece, because this is where most typed query builders stop. Walking an
+org chart upward from a starting employee:
+
+```sql
+WITH RECURSIVE cte(value) AS (
+    SELECT 'Alice'
+    UNION
+    SELECT Org.name FROM Org CROSS JOIN cte WHERE Org.boss = cte.value
+)
+SELECT Org.name FROM Org WHERE Org.name IN cte
+```
+
+```swift
+@SQLResult struct ScalarString {
+    var value: String?
+}
+
+let query = sql { schema in
+
+    let cte = schema.recursiveCommonTableExpression(ScalarString.self) { schema, cte in
+        let org = schema.table(Org.self)
+        // Define the initial value for the starting condition.
+        let initialResult = ScalarString.columns(value: "Alice".toNullable())
+        Select(initialResult)
+        // Union the initial value with successive values.
+        Union()
+        // Select members from the org whose boss matches the current member
+        Select(ScalarString.columns(value: org.name))
+        From(org)
+        Join.Cross(cte)
+        Where(org.boss == cte.value)
+    }
+
+    let org = schema.table(Org.self)
+    With(cte)
+    Select(org.name)
+    From(org)
+    Where(org.name.in(cte))
+}
+```
+
+The recursive self-reference is the `cte` parameter of the closure. It is a
+typed table reference like any other, so `cte.value` is checked the same way
+`org.name` is.
+
+Multiple CTEs are listed in one `With`, in dependency order, exactly as SQL
+requires:
+
+```swift
+With(parentOfCommonTable, ancestorOfAliceCommonTable)
+```
+
+## Values, parameters, and types
+
+Literal values are ordinary Swift values. Columns are ordinary Swift types:
+`Int`, `Double`, `String`, `Data`, and their optionals. There is no parallel
+`SQL.Integer` type system to learn, and no affinity rules to remember.
+
+Bind parameters become named references, declared once and reused:
+
+```swift
+let personIDParameter = XLNamedBindingReference<String>(name: "id")
+let ageParameter = XLNamedBindingReference<Int>(name: "age")
+
+let updateAgeStatement = sql { schema in
+    let person = schema.into(Person.self)
+    Update(person)
+    Setting(person) { row in
+        row.age = ageParameter
+    }
+    Where(person.id == personIDParameter)
+}
+```
+
+The statement is built once and prepared once. Values arrive separately at
+invocation time through `XLInvocationBindings`, which is what keeps the prepared
+statement cacheable. If you are porting code that concatenates values into a SQL
+string, this is the change that matters most: the values stop being part of the
+statement.
+
+Types without a native SQLite representation, notably `Date` and `UUID`, are
+handled by codecs rather than by conversion at every call site. SwiftQL ships
+presets for the common encodings (`Date` as text or as a numeric value, `UUID`
+as text or as a blob) and `@SQLCodec` selects one per property. See
+[CustomTypes](../Sources/SwiftQL/SwiftQL.docc/CustomTypes.md) and
+[NumericDateCodecs](../Sources/SwiftQL/SwiftQL.docc/NumericDateCodecs.md).
+
+## Where the correspondence is not exact
+
+Four differences are structural, and they are the price of compile-time
+checking:
+
+1. **Tables must be declared as Swift types.** `@SQLTable` on a struct is how
+   the compiler learns your schema. Porting starts by writing those structs to
+   match your existing tables.
+2. **Table references are values.** `let person = schema.table(Person.self)`
+   has no SQL counterpart. It is what makes `person.name` typed.
+3. **Projections need a result type.** Selecting a whole table decodes into that
+   table's struct. Anything else needs `@SQLResult` or `#row`, because the
+   decoded row has to have a Swift type.
+4. **Outer-joined tables are declared nullable at the source**, via
+   `schema.nullableTable`, rather than only being nullable in the result.
+
+Beyond those, the current gaps are recorded rather than hidden. As of the v1.3
+conformance inventory, of 111 tracked features, 104 are supported with evidence
+from a real SQLite engine, and the exceptions are:
+
+- `NATURAL` and `USING` join forms are not implemented. Use an explicit `ON`
+  condition.
+- CTE materialization hints (`MATERIALIZED`, `NOT MATERIALIZED`) are not
+  implemented.
+- A typed DDL model is not implemented. `sqlCreate` creates a basic table and
+  **does not migrate an existing schema**. Use GRDB's `DatabaseMigrator`
+  alongside SwiftQL for migrations.
+- One compound-query direct-scalar form is not implemented.
+- Nested transactions and single-connection visibility are capability-gated,
+  meaning they depend on the driver in use.
+
+The inventory is the source of truth and is versioned with the library. See the
+[conformance report](../Conformance/SQLite/REPORT.md) and
+[COMPATIBILITY.md](../COMPATIBILITY.md#sqlite-conformance-inventory).
+
+## Coming from raw SQLite or string-built SQL
+
+If your current code calls `sqlite3_prepare_v2` directly, or builds strings for
+GRDB or another driver, the port has three parts:
+
+1. **Schema.** Write an `@SQLTable` struct per table. Column names and types
+   must match what is already in the database; SwiftQL does not create or
+   migrate it for you.
+2. **Statements.** Port each query clause by clause using the table above.
+   Statements are values, so they can be built once and stored.
+3. **Values.** Replace interpolated values with named binding references, and
+   pass them at invocation. Anything you were escaping by hand stops needing to
+   be escaped, because it is no longer text.
+
+Execution, pooling, transactions, and observation stay with GRDB underneath, so
+an existing GRDB setup keeps working. SwiftQL replaces the part where queries
+became strings, not the part that runs them.
+
+## Checklist
+
+- [ ] An `@SQLTable` struct for each table, matching the live schema
+- [ ] `@SQLResult` types for projections that are not whole tables
+- [ ] Outer-joined tables declared with `schema.nullableTable`
+- [ ] Interpolated values replaced with `XLNamedBindingReference`
+- [ ] `Date` and `UUID` columns given an explicit codec
+- [ ] Migrations left with GRDB's `DatabaseMigrator`
+- [ ] Queries that would not port cleanly reported as issues

--- a/Documentation/ReleaseNotes/v1.5.4.md
+++ b/Documentation/ReleaseNotes/v1.5.4.md
@@ -1,0 +1,36 @@
+## Live queries in SwiftUI, without a hand-written Combine sink
+
+A SwiftUI view model can now adopt a typed live query directly.
+`XLQueryObserver` and `XLQueryRowObserver` wrap `publish()` and `publishOne()`
+as `ObservableObject`s that expose `@Published` rows and errors, so observing a
+query no longer means managing a `Cancellable` by hand:
+
+```swift
+final class PeopleListModel: ObservableObject {
+    let people: XLQueryObserver<Person>
+
+    init(database: some XLDatabase, query: some XLQueryStatement<Person>) {
+        people = XLQueryObserver(database.makeRequest(with: query))
+    }
+}
+```
+
+Observation starts on initialization and stops on deallocation, with the same
+transaction and cancellation semantics as the underlying publishers. This adds
+no package dependency - SwiftQL conforms to `Combine.ObservableObject`, or
+OpenCombine's equivalent on Linux, without importing SwiftUI.
+
+This release also restores the `#row` ad hoc projection macro, and moves the
+remaining scalar expression functions to the method style used everywhere else
+in the library: `all().count()`, `a.min(b)`, `condition.iif(then:else:)`, and
+`"...".printf(...)`.
+
+**Upgrade impact.** The previous free functions `count(_:)`, `min(_:)`/`max(_:)`,
+`iif(_:then:else:)`, and `printf(format:_:)` are deprecated in favor of the
+method forms; existing code continues to compile. `#row`'s single-column shape
+is available on every supported compiler, while its two-to-six column shapes
+require Swift 6.1 or later - SwiftQL's first source-level API difference across
+compiler cells, recorded in
+[COMPATIBILITY.md](../../COMPATIBILITY.md#swift-59-and-swift-60-api-surface-gaps).
+
+Full detail in the [changelog](../../CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Tables are Swift structs. Columns are typed properties. Statements are values
 written in SQL order. Selected rows decode back into the Swift type you asked
 for.
 
+Concretely: **rename a column and the compiler finds every query that used it,
+instead of your users finding them at runtime.** A string-based query survives
+the rename, ships, and fails on a device you cannot reach.
+
 <!-- test: XLDocumentationTests.testDocumentationREADME -->
 ```swift
 import Foundation
@@ -110,6 +114,58 @@ If you know SQLite, you already know the shape of SwiftQL: `Select`, `From`,
 `Join`, `Where`, `GroupBy`, `Having`, and `With` appear in SQL order and retain
 their SQL meaning.
 
+## How SwiftQL compares
+
+Swift has good persistence libraries. They differ mainly in how much of the
+relational model they ask you to give up.
+
+| | Shape | Where the SQL lives | Type safety comes from |
+|---|---|---|---|
+| **SwiftQL** | Result builder, one clause per statement in SQL order | Visible, in SQL order, in Swift | Macros + generics, checked at compile time |
+| **StructuredQueries** | Chained methods with typed closures and key paths | Emitted in SQL order; `#sql` escape hatch for typed SQL strings | `@Table` macro + key paths |
+| **GRDB** | Records + query interface, with raw SQL always available | Visible when you write it; strings when you drop down | Codable records and column definitions |
+| **SQLite.swift** | Expression DSL | Behind the DSL | Generic `Expression` types |
+| **SwiftData** | Object graph | Hidden - no SQL surface | `@Model` macro over an opaque store |
+| **Fluent** | Server-side ORM | Hidden behind the model layer | Model definitions and property wrappers |
+
+**SwiftQL is not a GRDB alternative - it is a typed query layer above it.**
+Execution, connection management, transactions, and observation are GRDB's,
+and deliberately so: that part is mature, well understood, and not worth
+reimplementing. SwiftQL replaces the part where queries become strings.
+
+**What sets SwiftQL apart is positional correspondence with SQL.** Every other
+typed query library in this table reaches SQL through a method chain: you start
+from a table type and attach clauses to it, in an order the library accepts
+rather than the order SQL defines. SwiftQL writes each clause once, under its
+SQL name, in SQL's grammatical order. The Swift source and the statement it
+produces have the same shape.
+
+That is what makes porting mechanical rather than interpretive. A query moves
+between SQL and SwiftQL a clause at a time, in both directions, without first
+being redesigned into somebody's builder vocabulary. The
+[porting guide](Documentation/PortingFromSQL.md) is the proof: a clause-by-clause
+mapping table, worked ports up to recursive common table expressions, and an
+explicit list of the places the correspondence is not exact.
+
+### Choose something else when
+
+- **You need schema migrations.** SwiftQL does not provide them. `sqlCreate`
+  creates a table but does not migrate an existing schema. Use GRDB's
+  `DatabaseMigrator` alongside SwiftQL - they compose, because SwiftQL sits on
+  GRDB rather than replacing it.
+- **You prefer a chained query builder.** Several Swift libraries express typed
+  queries as method chains. If `.select { }.where { }` reads better to you than
+  `Select` / `From` / `Where`, that preference is the whole argument.
+- **You want the database to disappear.** SwiftData is a better fit if you
+  would rather model an object graph than think about tables, and you can
+  require recent Apple platforms.
+- **You are writing a server with a non-SQLite backend.** Fluent covers
+  PostgreSQL and MySQL today. SwiftQL is SQLite-only; other dialects are
+  [roadmap](ROADMAP.md) work, not shipped work.
+- **Your queries are already written and working.** The cost of SwiftQL is
+  learning its expression surface. The benefit arrives when the schema
+  changes, so a stable schema you rarely touch may not repay it.
+
 ## What becomes first-class
 
 - **[Tables](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/)
@@ -161,10 +217,10 @@ Add the following line to the `dependencies` section in your `Package.swift`
 file:
 
 ```text
-.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.5.3")
+.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.5.4")
 ```
 
-`1.5.3` is the latest published package. The examples above use APIs retained
+`1.5.4` is the latest published package. The examples above use APIs retained
 by v1.3; the static-query surface remains available from version 1.2.0. Pin a
 source revision only when intentionally testing later changes from `main`.
 
@@ -184,8 +240,15 @@ Start with the
 Its examples are connected to executable test scenarios, so the API shown in
 the guides stays aligned with the library.
 
+Already know SQL? The [porting guide](Documentation/PortingFromSQL.md) maps
+every clause to its SwiftQL form and works through ports up to recursive common
+table expressions.
+
 For project guarantees and direction:
 
+- [Design rationale](Documentation/DESIGN.md) explains why SwiftQL is
+  SQL-shaped, why queries are result builders in SQL order, why column values
+  are Swift types rather than SQLite types, and what those choices cost.
 - [Compiler compatibility](COMPATIBILITY.md) records the supported Swift
   toolchains and reproducible CI matrix.
 - [SQLite conformance](COMPATIBILITY.md#sqlite-conformance-inventory) records

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -167,6 +167,153 @@ release_sha="$(git rev-parse origin/main)"
 git merge-base --is-ancestor "$release_sha" origin/main
 ```
 
+Complete "Documentation currency" and "Release notes" below before recording the
+release commit. Both produce changes that must be present on the tagged commit,
+and neither can be applied to a published release afterwards.
+
+## Documentation currency
+
+A published release is immutable, and the documentation that ships with it is
+whatever the tagged commit contains. A README describing the previous release's
+capabilities cannot be corrected in place; it can only be superseded by another
+release. Documentation currency is therefore a pre-tag gate, completed before
+step 7 records the release commit.
+
+### Reader-facing documents
+
+Required for every minor and major release, and for any patch that changes
+documented behavior.
+
+Re-read [README.md](README.md) and
+[Documentation/PortingFromSQL.md](Documentation/PortingFromSQL.md) against what
+the milestone actually shipped, and correct:
+
+- **Capability claims.** The README's "What becomes first-class" list, and any
+  statement about what SwiftQL supports.
+- **The comparison table.** SwiftQL's own row when its shape or coverage
+  changed, and any other row whose facts have changed. A comparison against
+  another library is a factual claim about that library, so re-verify it against
+  that project's current documentation rather than against memory.
+- **"Choose something else when".** A caveat the milestone has resolved must be
+  removed. This section ages faster than the rest of the README because it is a
+  list of current limitations.
+- **The clause mapping in PortingFromSQL.** New clauses, statements, functions,
+  or syntax forms get rows. A mapping table that omits shipped syntax is worse
+  than no table, because readers treat it as exhaustive.
+- **"Where the correspondence is not exact" in PortingFromSQL.** This restates
+  the conformance inventory's gaps and must agree with it exactly. Update it
+  from the inventory, not from recollection.
+- **Version numbers** in the installation instructions.
+
+The landing page at [Website/index.html](Website/index.html) restates the
+tagline, the comparison table, the "Choose something else when" list, and the
+Swift Package Manager version. It is the first page a visitor sees, so it is
+part of this gate rather than an afterthought: whatever changed in the README
+above almost certainly changed here too. It carries no generated content, so
+nothing warns you when it drifts.
+
+Review [Documentation/DESIGN.md](Documentation/DESIGN.md) as well when the
+release changes a decision it records, such as retiring the chaining syntax or
+replacing the `sql { }` and `sqlResult { }` builders with a function macro. Its
+"What is still wrong" section is a list of open problems and should shrink as
+they are fixed.
+
+Record in the release issue which documents were reviewed and what changed, or
+state explicitly that no change was required. Silence is not evidence of review.
+
+### Conformance inventory
+
+The
+[inventory](Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json)
+is the source of truth for what SwiftQL supports. The
+[report](Conformance/SQLite/REPORT.md) is its generated view, and
+[COMPATIBILITY.md](COMPATIBILITY.md#sqlite-conformance-inventory), the README,
+and PortingFromSQL restate its totals. All of them must agree on the tagged
+commit.
+
+For any release that adds or changes SQLite surface:
+
+1. Add or adjust feature records and their evidence for what shipped, and move
+   features out of `unimplemented` as they land. A feature counts as supported
+   only when it links to successful preparation by a real SQLite engine whose
+   version and source ID are recorded. Unit tests alone do not promote a
+   feature.
+2. Bump `INVENTORY_VERSION` in
+   [`scripts/ci/sqlite-conformance-inventory.py`](scripts/ci/sqlite-conformance-inventory.py)
+   when the inventory's contents change with the release line. The constant is
+   in the script, not in the JSON, and is easy to leave behind.
+3. Regenerate and verify:
+
+   ```sh
+   python3 scripts/ci/sqlite-conformance-inventory.py write
+   python3 scripts/ci/sqlite-conformance-inventory.py check
+   ```
+
+4. Update the totals restated in COMPATIBILITY.md, the README, and
+   PortingFromSQL to match the regenerated report.
+
+**Check for drift before starting.** When the inventory version trails the
+release line, features shipped in between are missing from it. Confirm that every
+closed issue in the milestone that changed SQL surface has a corresponding
+inventory record, and treat an unexplained gap as unfinished release work rather
+than as a documentation nicety. An inventory that understates the library is
+still wrong, and it is the number readers quote.
+
+## Release notes
+
+The published release body is the project's most widely read artifact. Swift
+Package Index surfaces it, watchers receive it by email, and every
+announcement links to it. It is read by people deciding whether SwiftQL is
+worth their attention, not only by maintainers upgrading a pinned version.
+
+An auto-generated pull-request list does not serve that reader. Every minor and
+major release therefore carries a hand-written summary at the top of the body,
+authored in `Documentation/ReleaseNotes/vX.Y.Z.md`.
+
+### Authoring the summary
+
+Write the summary on the release-preparation commit - the same commit that
+carries the dated changelog heading. `publish-release.sh` reads the file from
+the checked-out tag, so the summary is covered by the same exact-commit and
+immutability guarantees as every other release artifact. A summary added after
+publication cannot be applied: published releases are immutable by design.
+
+The file is required for `vX.Y.0` and any major release, and optional for a
+patch. When it is absent the body falls back to the provenance block and
+generated notes alone, which is the correct shape for a patch that carries no
+narrative.
+
+Keep it to four elements, in this order:
+
+1. **One sentence naming the theme.** Not "this release contains 14 pull
+   requests" - what changed, in the reader's terms. A release is worth
+   announcing precisely when this sentence is easy to write.
+2. **Two or three sentences of detail**, each tied to something a reader might
+   want. Name the capability, not the issue number.
+3. **A short code example** when the release changes what user code looks
+   like. This is the single highest-value element for a reader who has never
+   used SwiftQL, and the part most likely to be quoted elsewhere.
+4. **Upgrade impact** - deprecations, behavior changes, and platform or
+   compiler requirements. State plainly when there are none.
+
+Link to the changelog for the exhaustive list rather than reproducing it. The
+changelog is the complete record for someone upgrading; the summary is the
+argument for someone deciding.
+
+`Documentation/ReleaseNotes/v1.5.4.md` is the worked example.
+
+### What the published body contains
+
+The publisher composes the body in this order:
+
+1. the hand-written summary, when the file exists;
+2. the provenance block - verified commit, validation run, and the exact
+   commit marker; and
+3. GitHub's generated notes, appended by the release API.
+
+The marker and generated-notes checks in `validate_release_record` are
+unchanged, so the existing verification gates still apply to the composed body.
+
 ## Releasing a commit that is not at `main`'s tip
 
 The changelog gate requires the *tagged commit* to carry a dated
@@ -303,6 +450,51 @@ published. Before tagging, create or identify one dedicated release issue for
 attestation, and ruleset evidence there; close it only after every check above
 passes. Re-fetch the issue to confirm closure. Do not reopen the audit issue or
 the closed milestone merely to store post-tag evidence.
+
+## Announcing a release
+
+Publication makes a release *available*. Announcement makes it *known*. A
+release that nobody is told about reaches only the people already watching the
+repository, which is the audience that needs it least.
+
+Announce after the verification checks above pass, never before - an
+announcement that links to a release still under audit cannot be retracted.
+
+### What gets announced
+
+**Minor and major versions are announced. Patches ship silently.** SwiftQL
+frequently publishes several patches in a week; announcing at that cadence
+exhausts every channel that matters and trains readers to ignore the project.
+Batching to minor versions also forces each announcement to carry a theme,
+which is the same discipline the summary above requires.
+
+A patch that fixes a security issue or a data-correctness bug is the exception
+and is announced immediately, regardless of cadence.
+
+### Where
+
+Repeatable channels, used for every announced release:
+
+- **The GitHub release itself.** Already done by the time you reach this
+  section, provided the summary file existed at tag time.
+- **Social - Mastodon and Bluesky.** Lead with the problem the release solves
+  and a code screenshot. The release link belongs in a reply, not the opening
+  post.
+- **The [Swift Forums showcase thread](https://forums.swift.org/t/swiftql/82441).**
+  Reply for releases that carry a substantial theme, not for every minor.
+  Roughly every second or third is the right frequency.
+
+Channels reserved for a major version, and deliberately not spent on a minor:
+a new Swift Forums thread, Hacker News, iOS Dev Weekly, and Reddit. Each is
+effectively one-shot; using one on a point release forfeits it for the release
+that needed it.
+
+### Recording it
+
+Add the announcement links to the release issue before closing it, in the same
+way the tag-run and asset evidence is recorded. An unannounced minor release is
+a process failure, not merely a missed opportunity, and the release issue is
+where that is visible.
 
 ## Recovery
 

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -17,10 +17,10 @@ introduction to SQL, see the
 Add the latest published SwiftQL package to your dependencies:
 
 ```text
-.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.5.3")
+.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.5.4")
 ```
 
-Version 1.5.3 is the published package. This guide's basic request path remains
+Version 1.5.4 is the published package. This guide's basic request path remains
 supported in v1.3, and its static-query and contextual-codec APIs remain
 available from version 1.2.0 or later. Pin a source revision only when
 intentionally testing later changes from `main`.

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -98,7 +98,7 @@ Its internal prototype prepares static SQL against a pinned, read-only schema
 snapshot and emits deterministic diagnostics, but v1.3 does not ship a public
 validator, build plugin, query macro, schema system, or new query-declaration
 API. It neither persists prepared statements nor removes runtime preparation
-on each physical connection. Version 1.5.3 is the latest published package.
+on each physical connection. Version 1.5.4 is the latest published package.
 
 ## When to use SwiftQL
 

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -342,7 +342,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
 
         let requiredPhrasesByPath = [
             "README.md": [
-                "`1.5.3` is the latest published package",
+                "`1.5.4` is the latest published package",
             ],
             "COMPATIBILITY.md": [
                 "## v1.3 public products and runtime boundaries",
@@ -383,10 +383,10 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "not a claim of complete SQLite",
                 "v1.3 does not ship a public",
                 "validator, build plugin, query macro, schema system",
-                "Version 1.5.3 is the latest published package",
+                "Version 1.5.4 is the latest published package",
             ],
             "Sources/SwiftQL/SwiftQL.docc/GettingStarted.md": [
-                "Version 1.5.3 is the published package",
+                "Version 1.5.4 is the published package",
                 "This guide's basic request path remains",
                 "from version 1.2.0 or later",
                 "research-only schema-snapshot preparation prototype",
@@ -488,6 +488,8 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "COMPATIBILITY.md",
                 "COMPATIBILITY.md#sqlite-conformance-inventory",
                 "Coverage/README.md",
+                "Documentation/DESIGN.md",
+                "Documentation/PortingFromSQL.md",
                 "LICENSE.md",
                 "RELEASING.md",
                 "ROADMAP.md",

--- a/scripts/ci/publish-release.sh
+++ b/scripts/ci/publish-release.sh
@@ -434,10 +434,28 @@ verify_local_assets
 run_id="$(jq -er '.run_id | select(type == "string")' "$manifest_path")" ||
     fail 'release manifest has no run ID'
 server_url="${GITHUB_SERVER_URL:-https://github.com}"
-release_body_prefix="$(printf \
+release_provenance_block="$(printf \
     'Verified commit: [`%s`](%s/%s/commit/%s)\n\nValidation run: [%s](%s/%s/actions/runs/%s)\n\n%s\n' \
     "$commit_sha" "$server_url" "$repository" "$commit_sha" \
     "$run_id" "$server_url" "$repository" "$run_id" "$release_marker")"
+
+# A hand-written summary for the tag, when the tagged commit carries one, leads
+# the published body; the provenance block and GitHub's generated notes follow
+# it. The file is read from the checked-out tag, so it is covered by the same
+# exact-commit guarantees as every other release artifact. Absent, the body
+# keeps its previous shape. See "Release notes" in RELEASING.md.
+repository_root="$(cd "$script_directory/../.." && pwd -P)"
+release_summary_path="$repository_root/Documentation/ReleaseNotes/$release_tag.md"
+if [[ -f "$release_summary_path" ]]; then
+    release_summary="$(cat "$release_summary_path")"
+    if [[ -z "${release_summary//[[:space:]]/}" ]]; then
+        fail "release summary $release_summary_path is empty"
+    fi
+    release_body_prefix="$(printf '%s\n\n---\n\n%s' \
+        "$release_summary" "$release_provenance_block")"
+else
+    release_body_prefix="$release_provenance_block"
+fi
 
 releases_json="$(release_api list-releases)"
 if ! jq -e 'type == "array"' <<< "$releases_json" > /dev/null; then


### PR DESCRIPTION
Two independently reviewable commits.

## 1. Explain what SwiftQL is for, and how to port SQL into it (`54dcb56`)

The README described the API but never stated what distinguishes SwiftQL from the other typed query libraries in Swift, so a reader had no way to judge whether it was worth the switch. It now names the distinction directly: every clause appears once, under its SQL name, in SQL's grammatical order, so the Swift source and the statement it produces have the same shape.

- **`Documentation/PortingFromSQL.md`** is the evidence for that claim rather than a restatement of it: a clause-by-clause mapping table, four worked ports up to a recursive common table expression, and an explicit list of the four places the correspondence is structural rather than exact.
- **`Documentation/DESIGN.md`** records why the library is SQL-shaped instead of ORM-shaped, why queries are result builders in SQL order, why column values are Swift types rather than SQLite types, and what those choices cost in compile time and unsolved problems.
- **`README.md`** gains the comparison table, "Choose something else when", and the 1.5.3 to 1.5.4 version bump.

Every factual claim about another library in the comparison table was verified against that project's current documentation rather than written from memory. "Choose something else when" is deliberately blunt about the cases where SwiftQL is the wrong choice, migrations most of all.

## 2. Require a written summary and an announcement for every release (`f867358`)

Releases were shipped but not announced, and the published notes were generated provenance with no human-written explanation of what changed or why it mattered.

- **`scripts/ci/publish-release.sh`** prepends `Documentation/ReleaseNotes/<tag>.md` to the release body when that file exists, separated from the provenance block by a rule, and fails if the file is present but empty. Releases without a summary file keep their current body, so this cannot break a release that predates the convention.
- **`Documentation/ReleaseNotes/v1.5.4.md`** is included as a worked example.
- **`RELEASING.md`** gains three sections. "Documentation currency" makes the README, the porting guide, the landing page, and the conformance inventory a pre-tag gate, because a published release is immutable and stale documentation on a tagged commit can only be superseded, never corrected. "Release notes" defines the summary contract. "Announcing a release" separates the channels usable on every minor release from the ones worth spending once, at v2.

## Reviewer notes

**`publish-release.sh` is verified by shell parsing only.** It has never run against a real tag, and it sits in the path that publishes releases. It should be exercised with a `release-test/vX.Y.999` tag before the next production release. Flagging it explicitly rather than letting it look as tested as the rest of this change.

**`PortingFromSQL.md` states "104 of 111"** and lists NATURAL/USING joins, CTE materialization hints, and one compound-query scalar form as unimplemented. A conformance-inventory audit covering releases 1.4.5 to 1.5.4 is in progress and is expected to promote all three, so those figures and three bullets will need a follow-up update. They are accurate against the inventory as it stands on `main` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)