### PR TITLE
Publish the query-plan and index-advice spike evidence to ROADMAP.md

### DIFF
--- a/Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md
+++ b/Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md
@@ -1,0 +1,145 @@
+# Normalised query-plan capture and shape classification (issue #391)
+
+Milestone 29, "Spike: SQLite query-plan analysis and index advice." This
+document is the prototype write-up issue #391 asks for: a normalised plan
+tree built from raw EQP rows, plus a classifier that turns each node into a
+named shape. It builds directly on [#390's EQP variance evidence and
+capture pipeline](SQLiteEQPVariance.md) rather than duplicating it.
+
+## Non-goals
+
+Research target only (`SwiftQLSQLitePlanShapePrototype`), per this issue's
+hard constraints: no public SwiftQL API, no shipping report schema, no
+build-plugin work, no index creation or snapshot mutation. Classification is
+a pure function of captured rows plus recorded SQLite provenance - nothing
+here opens a database connection.
+
+## Model
+
+- **`EQPPlanNode`** (`EQPPlanShapeModels.swift`): `detail` (raw, always
+  preserved), `shape` (`EQPPlanShapeKind`), `attributes`
+  (`EQPPlanShapeAttributes`), `children`.
+- **`EQPPlan`**: a statement's normalised plan is a *forest* of `EQPPlanNode`
+  roots, not a single tree - most statements have more than one top-level
+  node (e.g. a table scan alongside a sibling `USE TEMP B-TREE FOR ORDER BY`).
+  No timestamp, host, or SQLite-version field: the same rows always
+  normalise to the same plan, a requirement this issue states explicitly.
+- **`EQPPlanShapeAttributes`**: `table`, `indexName`, `constrainedColumns`,
+  `isCovering`, `isAutomatic` - populated only where the shape carries them.
+
+### Why more than the seven required shapes
+
+The issue requires classifying "at least" seven shapes. The real #390
+corpus's captures also contain compound-query, CTE-coroutine, and recursive-
+CTE structural nodes that are none of those seven - forcing them into one
+would be exactly the coercion this issue forbids ("never coerce an unknown
+shape into a known one"). `EQPPlanShapeKind` therefore has 17 cases: the
+seven required shapes, plus ten more precisely-named patterns actually
+observed in the real corpus (`covering_index_scan`, `list_subquery`,
+`co_routine_subquery_or_cte`, `compound_query_strategy`,
+`recursive_cte_step`, `constant_row_scan`, `bloom_filter`,
+`temp_b_tree_for_distinct_aggregate`, `temp_b_tree_for_compound_operation`),
+plus `unclassified` as the honest fallback for genuinely unrecognised text.
+
+## Classification
+
+`EQPPlanShapeClassifier.classify(rows:statementID:)` first indexes rows by
+`parent` id, then recursively builds the tree top-down from the roots
+(`parent == 0`) through that index. Parent-child adjacency comes entirely
+from each row's own `parent` field, not from its position in the row list.
+Sibling order is not independent of input order, though: children of the
+same parent (and the top-level roots) keep the relative order they had in
+the input rows, so this is deterministic for a given capture but not
+permutation-invariant against an arbitrary reordering of the same rows.
+Building top-down means a node's children are classified after - and with
+knowledge of - their parent's already-known shape. That parent-awareness is
+needed for exactly one distinction:
+
+### Correlated vs. uncorrelated scalar subquery
+
+SQLite's raw EQP text does not literally say "correlated" - both cases print
+identically as `SCALAR SUBQUERY N`. The only signal available from the
+captured rows is structural: a scalar subquery SQLite can evaluate once
+(uncorrelated) is hoisted as a sibling of the driving row source, with
+`parent == 0`; one it must re-evaluate per outer row (correlated) is nested
+as a child of whatever row-producing node supplies the correlation - a table
+scan, index search, or another per-row-loop shape. `isRowLoopingShape`
+implements this rule. It is a heuristic on tree structure, not a guarantee:
+the real corpus contains no correlated scalar subquery to validate it
+against (every `SCALAR SUBQUERY` node in both checked-in plan evidence files
+classifies as plain `scalar_subquery`, 1 occurrence, 0
+`correlated_scalar_subquery`), so this distinction is exercised only by a
+clearly-labelled synthetic fixture (`testSyntheticCorrelatedScalarSubqueryUsesParentShapeHeuristic`).
+
+### Structured attribute extraction
+
+`SEARCH`/`SCAN` detail text is parsed into table, access method, and
+constraint clause, then further classified:
+
+| Raw pattern | Shape | Notes |
+|---|---|---|
+| `SCAN <table>` | `full_table_scan` | |
+| `SCAN <table> USING COVERING INDEX <name>` | `covering_index_scan` | full scan optimized via a covering index; still visits every row |
+| `SEARCH <table> USING INDEX <name> (<constraint>)` | `index_search` | `constrainedColumns` parsed from `<constraint>` |
+| `SEARCH <table> USING INTEGER PRIMARY KEY (<constraint>)` | `index_search` | `indexName = "INTEGER PRIMARY KEY"` |
+| `SEARCH <table> USING COVERING INDEX <name> (<constraint>)` | `index_search` | `isCovering = true` |
+| `SEARCH <table> USING AUTOMATIC [PARTIAL] COVERING INDEX (<constraint>)` | `automatic_covering_index` | SQLite's on-the-fly ephemeral index - distinct from a real named index, including a named `sqlite_autoindex_*`; requires the literal `AUTOMATIC` marker |
+| any other `SEARCH`/`SCAN … USING …` | `unclassified` | table still captured for audit; access method not guessed |
+
+## Evidence
+
+Classified both checked-in #390 captures
+(`capture_apple-system-3.51.0.json`, `capture_homebrew-3.53.2.json`) end to
+end; results checked in as `plans_apple-system-3.51.0.json` and
+`plans_homebrew-3.53.2.json`.
+
+| Shape | apple-system-3.51.0 | homebrew-3.53.2 |
+|---|---:|---:|
+| `full_table_scan` | 114 | 114 |
+| `index_search` | 64 | 64 |
+| `covering_index_scan` | 17 | 17 |
+| `constant_row_scan` | 93 | 93 |
+| `co_routine_subquery_or_cte` | 14 | 14 |
+| `recursive_cte_step` | 8 | 8 |
+| `bloom_filter` | 5 | 5 |
+| `list_subquery` | 5 | 5 |
+| `scalar_subquery` | 1 | 1 |
+| `temp_b_tree_for_group_by` | 10 | 10 |
+| `temp_b_tree_for_distinct_aggregate` | 6 | 6 |
+| `compound_query_strategy` | 33 | 42 |
+| `temp_b_tree_for_order_by` | 20 | 29 |
+| `temp_b_tree_for_compound_operation` | 9 | 0 |
+| `automatic_covering_index` | 0 | 0 |
+| `correlated_scalar_subquery` | 0 | 0 |
+| `unclassified` | **0** | **0** |
+
+**Zero unclassified nodes on either build, across all 214 real statements.**
+The three rows that differ between builds are exactly #390's Finding 2 (the
+9 CTE × compound-operator cases): 3.51.0's `<OP> USING TEMP B-TREE` node
+becomes 3.53.2's `USE TEMP B-TREE FOR ORDER BY` (accounting for the +9/+9
+shift), while `compound_query_strategy`'s count rises from 33 to 42 because
+the newer `MERGE (<OP>)`/`LEFT`/`RIGHT` shape has more nodes than the older
+`COMPOUND QUERY`/`LEFT-MOST SUBQUERY` shape for the same 9 statements. This
+is the classifier correctly *naming* the variance #390 measured, not
+disagreeing with it.
+
+### Determinism and id-renumbering robustness
+
+- `testClassificationIsDeterministicAcrossRepeatedRuns`: classifying the same
+  captured rows twice produces byte-identical `EQPPlan` values.
+- `testIDRenumberedJoinStatementNormalisesIdenticallyAcrossBuilds`: the
+  five-table Northwind join (#390 Finding 1 - its raw `id`/`parent` values
+  differ between builds) produces a **byte-identical** normalised plan on
+  both builds, because `EQPPlanNode` never encodes `id`/`parent`. This is the
+  concrete proof that #390's recommendation ("never use `id`/`parent` as a
+  diagnostic key") is followed here, not just stated.
+
+## Reproducing this evidence
+
+```bash
+swift run SwiftQLSQLitePlanShapeCLI classify \
+  --capture path/to/capture.json --output plans.json
+```
+
+Prints a shape-count summary to stdout and writes the full classified forest,
+per statement, as canonical JSON.

--- a/Documentation/Architecture/SQLiteEQPVariance.md
+++ b/Documentation/Architecture/SQLiteEQPVariance.md
@@ -1,0 +1,239 @@
+# SQLite `EXPLAIN QUERY PLAN` variance measurement (issue #390)
+
+Milestone 29, "Spike: SQLite query-plan analysis and index advice." This
+document is the measurement write-up issue #390 asks for: how much does
+`EXPLAIN QUERY PLAN` (EQP) output vary across the SQLite builds SwiftQL
+actually encounters, and which properties of that output are stable enough
+to build advisory diagnostics on. It is evidence and a recommendation, not a
+diagnostic, a report schema, or a public API - see [Non-goals](#non-goals).
+
+## Inputs audited
+
+- [`Conformance/SQLite/COMBINATORIAL_CASES.json`](../../Conformance/SQLite/COMBINATORIAL_CASES.json)
+  - issue #191's 208-case pairwise/targeted SELECT corpus, reused unmodified
+  via `SQLiteCombinatorialSuite.makeManifest()`.
+- [`Tests/SwiftQLNorthwindFixtures/Resources/Northwind/`](../../Tests/SwiftQLNorthwindFixtures/Resources/Northwind)
+  - issue #254's pinned, checksum-verified Northwind snapshot.
+- [`Tests/SQLTests/NorthwindSemanticCorpusTests.swift`](../../Tests/SQLTests/NorthwindSemanticCorpusTests.swift)
+  - the only place in the repo defining Northwind join/CTE/subquery shapes as
+  literal SQL; six of those shapes are cribbed verbatim as this corpus's
+  Northwind anchor statements (`EQPVarianceCorpus.northwindAnchorStatements()`).
+- [`Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationRuntime.swift`](../../Research/SQLiteBuildValidation/Sources/SwiftQLSQLiteBuildValidationPrototype/SQLiteBuildValidationRuntime.swift)
+  - issue #132's capability-audit capture (`sqlite_version()`,
+  `sqlite_source_id()`, `PRAGMA compile_options`, `function_list`,
+  `collation_list`, `module_list`, a schema fingerprint), reused as-is for
+  every capture's runtime provenance.
+
+## Question and non-goals
+
+**Question:** how much does EQP output move across SQLite versions, along
+which axes, and which properties can advisory tooling trust?
+
+**Non-goals**, per this issue's hard constraints:
+
+- No diagnostics, candidate generation, report schema, or public API. That is
+  #391/#392/the v1.8 issues, contingent on this write-up's recommendation.
+- No mutation of the pinned Northwind snapshot. Every capture in this
+  pipeline opens a validator-owned copy read-only with `PRAGMA query_only =
+  ON`; the pinned file's SHA-256 (`cb6f0071…3381d8`) is asserted unchanged
+  after every run (`EQPVarianceCaptureTests.testCaptureNeverMutatesThePinnedNorthwindSnapshot`).
+- No conclusion drawn from a single SQLite version or a single host (see
+  [Methodology](#methodology)).
+- Honest `unsupported` results where a version isn't reachable, not
+  interpolation (see [Coverage and limitations](#coverage-and-limitations)).
+
+## Methodology
+
+**Corpus** (`EQPVarianceCorpus.assemble()`, 214 statements, deterministic -
+`EQPVarianceCorpusTests.testCorpusAssemblyIsDeterministic`):
+
+- 208 statements from the #191 combinatorial manifest, verbatim
+  (`rendered_sql` + resolved `bindings`, unmodified).
+- 6 hand-authored Northwind anchor statements the pairwise grid doesn't
+  itself exercise against real data: a five-table inner join, a self
+  left-join with NULLs, `GROUP BY`/`HAVING`, a scalar subquery, a `UNION`
+  compound, and a `WITH` aggregate CTE - each tagged with its
+  `SQLiteNorthwindConformanceCaseID` from #254's registry.
+
+**Capture** (`EQPVarianceCapture.capture(from:corpus:label:)`): for every
+statement, binds the same resolved values the #191 harness uses
+(`arguments(for:)`, mirroring `SQLiteCombinatorialConformanceTests`), runs
+`EXPLAIN QUERY PLAN <rendered_sql>`, and records every row's `id`, `parent`,
+`notused`, and `detail` verbatim - plus the #132 runtime metadata from the
+same connection. Two capture methods feed the same schema
+(`EQPCaptureRun`/`EQPStatementCapture`/`EQPRow` in `EQPVarianceModels.swift`):
+
+1. **In-process, GRDB** (`swift run SwiftQLSQLiteEQPVarianceCLI capture`) - whatever SQLite
+   the Swift toolchain links (this repo's system libsqlite3, unpinned).
+2. **Out-of-process, Python's `sqlite3` module**
+   (`Research/SQLiteBuildValidation/Scripts/capture_eqp.py`) - a second,
+   genuinely distinct SQLite build reachable without vendoring a custom
+   SQLite into the shipping package. The script ports the #132 runtime-
+   metadata capture (including the FNV-1a-64 schema fingerprint) into Python
+   field-for-field; both captures against a copy of the pinned snapshot
+   produced the identical fingerprint `e2c8fadbd38c2313`, cross-validating
+   the port and confirming both runs saw byte-identical schemas.
+
+**Classification** (`EQPVarianceClassifier`): compares two capture runs
+statement-by-statement. Row `id`/`parent` values are first renumbered to
+their position in emission order (EQP always emits a parent before its
+children, so this is a valid, order-preserving renumbering) before any other
+comparison - see [why](#finding-1-idparent-numbering-is-not-a-stable-identifier).
+Remaining differences are bucketed into the classes below by pattern-matching
+`detail` text for table/access-method tokens and known materialization
+markers (`SEARCH`/`SCAN`, `USING INDEX`, `TEMP B-TREE`, `MERGE (`, etc.).
+
+## Evidence: two real SQLite builds, one pinned corpus
+
+| | Build A | Build B |
+|---|---|---|
+| Label | `apple-system-3.51.0` | `homebrew-3.53.2` |
+| `sqlite_version()` | 3.51.0 | 3.53.2 |
+| `sqlite_source_id()` | 2025-06-12 13:14:41 f0ca7bb… | 2026-06-03 19:12:13 d6e03d8… |
+| Capture method | in-process, GRDB (Swift toolchain's linked SQLite) | out-of-process, `python3`'s `sqlite3` module (Homebrew's `libsqlite3`) |
+| Schema fingerprint | `e2c8fadbd38c2313` | `e2c8fadbd38c2313` (match) |
+| Statements captured | 214 | 214 |
+
+Checked-in evidence (`Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteEQPVariancePrototypeTests/Evidence/`):
+`corpus.json`, `capture_apple-system-3.51.0.json`, `capture_homebrew-3.53.2.json`,
+`comparison_apple-system-3.51.0_vs_homebrew-3.53.2.json`.
+
+### Classification result (214 statements)
+
+| Class | Count | Stable enough for diagnostics? |
+|---|---:|---|
+| `identical` | 203 | Yes - byte-identical, including `id`/`parent` |
+| `id_renumbering_only` | 2 | Structure only - see Finding 1 |
+| `materialization_strategy_change` | 9 | No - see Finding 2 |
+| `access_path_change` | 0 (not observed) | Not evaluated by this pair |
+| `join_order_change` | 0 (not observed) | Not evaluated by this pair |
+| `cosmetic_wording_change` | 0 (not observed) | Not evaluated by this pair |
+| `unclassified` | 0 | - |
+
+### Finding 1: `id`/`parent` numbering is not a stable identifier
+
+Two statements - the five-table Northwind join
+(`c390.northwind.join.customer-order-employee-product`) and the scalar-
+subquery Northwind case (`c390.northwind.subquery.products-above-average`) -
+produced **identical plan structure and `detail` text** on both builds, but
+every `id` and `parent` value was offset by a constant (e.g. `9→12`,
+`12→15`, `18→21`, …). The chosen indexes, join order, and access methods were
+completely unaffected; only SQLite's internal EQP row-numbering counter
+differed. **Any future diagnostic must key on structure (parent shape plus
+`detail` text) and never on raw `id`/`parent` values.**
+
+### Finding 2: compound-query execution strategy changed between builds
+
+All 9 `materialization_strategy_change` cases are #191's CTE ×
+compound-operator cases (`UNION`/`EXCEPT`/`INTERSECT` over ordinary and
+recursive CTEs). 3.51.0 renders the older `COMPOUND QUERY` /
+`LEFT-MOST SUBQUERY` / `<OP> USING TEMP B-TREE` shape; 3.53.2 renders a
+`MERGE (<OP>)` / `LEFT` / `RIGHT` shape with `USE TEMP B-TREE FOR ORDER BY`
+attached differently. Example (`c191.v1.cte.ordinary-nullable.union`):
+
+```
+# apple-system-3.51.0
+COMPOUND QUERY
+├─ LEFT-MOST SUBQUERY
+│  ├─ CO-ROUTINE nullable_seed
+│  │  └─ SCAN CONSTANT ROW
+│  └─ SCAN nullable_rows
+└─ UNION USING TEMP B-TREE
+   └─ SCAN CONSTANT ROW
+
+# homebrew-3.53.2
+MERGE (UNION)
+├─ LEFT
+│  ├─ CO-ROUTINE nullable_seed
+│  │  └─ SCAN CONSTANT ROW
+│  ├─ SCAN nullable_rows
+│  └─ USE TEMP B-TREE FOR ORDER BY
+└─ RIGHT
+   └─ SCAN CONSTANT ROW
+```
+
+Both are legitimate plans for the same query; SQLite changed how it *executes*
+compound queries between these versions. This is real evidence that
+materialization/execution-strategy diagnostics are the least stable of the
+four axes named in this issue, at least for compound queries. **This is
+exactly the class of variance SQLite explicitly does not promise stability
+on**, and would show up as false-positive "regression" noise in any
+per-plan-shape diagnostic keyed on this wording.
+
+For the other 205 statements (203 identical + 2 renumbered), the chosen
+index, join order, and access method were completely stable across this
+version pair - including the five-table join, the self left-join, the
+`GROUP BY`/`HAVING`, and the `UNION`/CTE Northwind anchors that were not
+compound-CTE cases.
+
+## Coverage and limitations
+
+This pass measured two real, distinct SQLite builds reachable from this
+delivery's environment directly (no custom SQLite build, no vendored
+amalgamation): the system libsqlite3 this repo's Swift toolchain links, and
+Homebrew's separately-installed libsqlite3. It did **not** capture the
+additional builds this repo's CI matrix (`.github/workflows/swift.yml`)
+actually reaches - Linux's custom-built SQLite 3.53.3
+(`compatibility` job), or the system SQLite bundled with Xcode 16.2, 16.4,
+26.3, and 26.5 (`apple-clean-resolution` job) - because provisioning those
+Xcode versions or a from-source SQLite build was out of scope for this pass.
+Per this issue's hard constraint, that is recorded as **honestly not
+reachable in this delivery**, not interpolated from the two builds that were
+measured. `swift run SwiftQLSQLiteEQPVarianceCLI capture` is a small, self-contained CLI
+already wired to run inside any of those CI legs unchanged; wiring an actual
+CI step to capture and archive that evidence is left as follow-up (recorded
+for #393 to schedule against a milestone).
+
+No conclusion here should be read as "SQLite's query planner is stable
+across arbitrary versions" - only that it was stable, for this specific
+214-statement corpus, across these two specific builds, except for compound
+queries.
+
+## Recommendation
+
+1. **Plan records belong in a sidecar, not the canonical report.** EQP output
+   is not a stability contract (SQLite's own documentation says so), and
+   Finding 2 demonstrates real, version-driven variance for at least one
+   query shape family even between two builds ~a year apart. Folding raw EQP
+   into the canonical validation report (`SQLiteBuildValidationReport`) would
+   make report diffs noisy across environments for reasons unrelated to
+   SwiftQL. A sidecar (opt-in, clearly advisory) keeps that noise out of the
+   pass/fail contract.
+2. **`id`/`parent` must never be used as a diagnostic key.** Any classifier
+   or diagnostic built in #391 must normalize on structure (Finding 1) before
+   comparing captures, exactly as `EQPVarianceClassifier.normalize` does here.
+3. **Materialization-strategy diagnostics need the widest safety margin.**
+   Of the four axes, this pass found real variance only in materialization
+   strategy (compound-query execution), and only for compound-CTE queries.
+   Access-path and join-order diagnostics were not observed to vary in this
+   pair; #391/#392 should not assume this generalizes to a wider version
+   matrix, and should re-check against whatever additional builds a future
+   CI-wired capture reaches.
+4. **Proceed to #391** (normalised plan capture and shape classification)
+   using this corpus, capture pipeline, and the renumbering-first comparison
+   discipline established here.
+
+## Reproducing this evidence
+
+```bash
+# In-process capture (whatever SQLite this Swift toolchain links)
+swift run SwiftQLSQLiteEQPVarianceCLI export-corpus --output corpus.json
+swift run SwiftQLSQLiteEQPVarianceCLI capture \
+  --database path/to/northwind-copy.db --label <label> --output capture.json
+
+# Out-of-process capture against a different installed SQLite build
+python3 Research/SQLiteBuildValidation/Scripts/capture_eqp.py \
+  --corpus corpus.json --database path/to/northwind-copy.db \
+  --label <label> --output capture.json
+
+# Classify the difference between two captures
+swift run SwiftQLSQLiteEQPVarianceCLI compare \
+  --baseline capture_a.json --comparison capture_b.json --output comparison.json
+```
+
+`EQPVarianceCaptureTests.testCheckedInAppleSystemEvidenceMatchesWhenRuntimeIsIdentical`
+re-runs the in-process capture on every `swift test` invocation and asserts
+byte-identity with the checked-in `apple-system` evidence - but only when the
+host's linked SQLite version and source ID match the pinned evidence exactly;
+otherwise it skips with an explicit message naming both versions, rather than
+failing CI legs that (correctly, per this issue) link a different SQLite.

--- a/Documentation/Architecture/SQLiteIndexAdvisor.md
+++ b/Documentation/Architecture/SQLiteIndexAdvisor.md
@@ -1,0 +1,291 @@
+# Scratch-copy index-candidate generation and re-plan verification (issue #392)
+
+Milestone 29, "Spike: SQLite query-plan analysis and index advice." This
+document is the prototype write-up issue #392 asks for: deriving index
+candidates from a statement's predicates, joins, and sort order, then
+verifying each one by creating it on a scratch copy of the pinned Northwind
+snapshot and re-planning. It builds on [#390's capture pipeline](SQLiteEQPVariance.md)
+and [#391's shape classifier](SQLiteEQPPlanShapeClassifier.md) rather than
+duplicating either.
+
+## Non-goals
+
+Research target only (`SwiftQLSQLiteIndexAdvisorPrototype`), per this
+issue's hard constraints: no public SwiftQL API, no report schema change, no
+build-plugin work, no typed index DDL. Candidate creation runs only against
+a scratch copy of the pinned snapshot, opened by
+`NorthwindFixture.withTemporaryCopy` - never the canonical file and never a
+long-lived application connection. No `sqlite3expert.c`, no custom SQLite
+build. Partial and expression indices are **not implemented** - noted below
+as future candidate-space extensions, not attempted here.
+
+## Methodology
+
+### Deriving candidate columns
+
+`IndexCandidateExtraction` (a narrow, pattern-based extractor, not a SQL
+parser - see its doc comment for exactly what it recognises and what it
+deliberately refuses to guess at) reads, for one table alias in one
+statement's rendered SQL:
+
+- `WHERE`-clause equality and range comparisons (conjuncts joined only by
+  top-level `AND`; an `OR` anywhere in the clause - a blunt substring check,
+  deliberately more conservative than "does this `OR` actually change
+  precedence" - or a conjunct that isn't a plain column/operator
+  comparison, yields nothing for that clause rather than a guess).
+- `JOIN … ON` equality (or `IS`, for a nullable left join) key columns.
+- `ORDER BY` columns, ignoring `COLLATE`/`ASC`/`DESC`.
+- The alias→real-table-name map (`tableAliasMap`), which explicitly excludes
+  two situations rather than resolving them wrong: a CTE name masquerading
+  as a table (`WITH "cte0" AS (…) … FROM "cte0" AS "t0"` - `"cte0"` isn't a
+  real table `CREATE INDEX` could target), and an alias reused for a
+  different table in a nested scope (`FROM "Orders" AS "t0" WHERE … IN
+  (SELECT … FROM "Employees" AS "t0" …)` - resolving this correctly needs
+  real scope tracking this extractor doesn't do, so a conflicting rebinding
+  drops the alias entirely).
+
+`IndexCandidateGenerator.candidateColumns(for:in:)` orders the derived
+columns by precedence, per SQLite's own left-to-right composite-index rule:
+**every equality-constrained column first - a join key is an equality
+constraint too** (SQLite seeks on it per outer row exactly like a `WHERE`
+equality; it just supplies the bound value at run time instead of from the
+statement text) - **then at most one range column** (a second range column
+after the first cannot narrow a B-tree seek any further - SQLite stops
+using the index to narrow at the first range term), **then `ORDER BY`
+columns** (so the index can also satisfy sort order without a temp
+B-tree). Each column appears once, at its highest-precedence position.
+
+This ordering is confirmed by a real scratch-copy re-plan, not assumed: see
+[Finding: join keys must precede range columns](#finding-join-keys-must-precede-range-columns)
+below.
+
+### Finding remediable statements
+
+`IndexCandidateGenerator.remediableCandidates(for:plan:)` walks a #391
+classified plan's root nodes for `full_table_scan` **or
+`automatic_covering_index`** shapes, and - where the statement's SQL yields
+a non-empty candidate column list for that node's alias, and the alias
+resolves to a real table - produces a `RemediableCandidate`. No signal, no
+resolvable table, no candidate. (`automatic_covering_index` was added here
+for the same reason it was added to the improvement rule below: the
+join-key/range-column finding's fixture has its remediable root classified
+as `automatic_covering_index`, not `full_table_scan`, so the improvement
+rule accepting that shape was unreachable end to end until this scan also
+looked for it - caught by Copilot review, confirmed by
+`IndexCandidateGeneratorTests.testRemediableCandidatesIncludesAutomaticCoveringIndexRoots`.)
+
+### Deduplication
+
+`IndexCandidateGenerator.deduplicate(_:)` merges candidates with the exact
+same `(table, columns)` (recording every contributing statement id, and
+keeping the first occurrence as the concrete statement to verify against),
+then drops any candidate whose column list is an **exact prefix** of
+another surviving candidate on the same table - a wider index already
+serves every query the narrower prefix would have. A dropped prefix
+candidate's source statement ids are folded into every wider candidate it
+prefixes before being discarded, so a statement that only ever produced the
+narrower prefix is still attributed to the index that now serves it,
+instead of silently disappearing from the evidence (caught by Copilot
+review; confirmed by
+`IndexCandidateGeneratorTests.testDeduplicatePreservesPrefixCandidateSourceStatementIDs`).
+
+### Scratch-copy verification
+
+`IndexCandidateVerifier.verify(candidate:statement:)` opens one temporary
+copy of the pinned snapshot via `NorthwindFixture.withTemporaryCopy`
+(already used by #390/#391's own tests), captures and classifies the
+**before** plan, executes the candidate's `CREATE INDEX` DDL, captures and
+classifies the **after** plan, and returns both plans plus the candidate's
+DDL and a verdict as a single `IndexCandidateEvidence` value -
+`withTemporaryCopy` removes the scratch copy on every exit path (success, a
+thrown error, or a failure creating the copy itself), which is exactly the
+"discard on every path including failure" this issue requires, reused
+rather than reimplemented.
+
+### The improvement rule
+
+Stated once, applied uniformly to every candidate - no per-case judgment:
+
+> A candidate is kept only when the plan node for the target alias changes
+> from `full_table_scan` **or `automatic_covering_index`** to `index_search`
+> or `covering_index_scan`, **and** the after-plan node reports at least one
+> constrained column.
+
+(`automatic_covering_index` was added to the "before" shapes after the join-key/range-column finding below surfaced a real case where SQLite's own ephemeral index, not a full table scan, was the baseline being improved on.)
+
+No cost estimate or row-count comparison is used. The pinned snapshot is
+deliberately unanalyzed (no `sqlite_stat1` - see [#390](SQLiteEQPVariance.md)),
+so a cost-based comparison would not be trustworthy evidence; a structural
+shape change, backed by #391's classifier, is the only signal here that
+isn't itself an unfounded guess.
+
+## Evidence
+
+Generating candidates from #390's checked-in `apple-system-3.51.0` capture
+(214 real statements, 114 `full_table_scan` nodes) and deduplicating
+produced exactly **6 candidates**. Verifying all 6 against the pinned
+Northwind snapshot:
+
+| Table | Columns | Source statement | Verdict |
+|---|---|---|---|
+| `Orders` | `CustomerID`, `EmployeeID` | `c191.v1.select.j-left.w-injection-binding` | **✅ improvement** |
+| `Orders` | `OrderID` | `c191.v1.select.g-customer-id.h-count-greater-than-one.o-ascending` | ❌ false positive |
+| `Orders` | `CustomerID`, `OrderID` | `c191.v1.select.j-inner.o-ascending` | ❌ false positive |
+| `Orders` | `EmployeeID`, `CustomerID` | `c191.v1.select.p-nullable-region…` | ❌ false positive |
+| `Orders` | `EmployeeID`, `OrderID` | `c191.v1.select.j-left.o-ascending` | ❌ false positive |
+| `Employees` | `ReportsTo`, `EmployeeID` | `c390.northwind.join.left-null-manager` | ❌ false positive |
+
+Checked-in evidence (`Research/SQLiteBuildValidation/Tests/SwiftQLSQLiteIndexAdvisorPrototypeTests/Evidence/`):
+`candidates.json`, `verification.json`.
+
+### The one real improvement
+
+`c191.v1.select.j-left.w-injection-binding` is
+`SELECT t0.orderID FROM Orders AS t0 LEFT JOIN Employees AS employees_join ON (t0.employeeID IS employees_join.employeeID) WHERE (t0.customerID == :customer_input)`
+- a genuine `WHERE` equality filter on `Orders`, the driving table of a
+`LEFT JOIN`. `CREATE INDEX ON Orders (CustomerID, EmployeeID)` changes the
+plan from `full_table_scan` to `index_search`, constrained by `["CustomerID"]`
+- `EmployeeID` rides along in the index (derived from the `LEFT JOIN`'s
+join key, per the precedence rule) but doesn't narrow the seek itself, which
+the evidence records honestly rather than overclaiming.
+
+### The five false positives, and why they're honest, not bugs
+
+All five share one root cause the write-up states plainly: **a join-key
+column is only useful to index when the table being indexed is the
+*looked-up* side of the join, not the driving/outer side being scanned to
+feed it.** Four of the five candidates (`Orders(CustomerID, OrderID)`,
+`Orders(EmployeeID, CustomerID)`, `Orders(EmployeeID, OrderID)`,
+`Employees(ReportsTo, EmployeeID)`) were derived from a join key on a table
+with **no `WHERE` filter of its own** - the table must be scanned in full
+regardless of any index, because the join doesn't reduce how many of its own
+rows need visiting. The candidate generator does not currently distinguish
+a join's driving side from its looked-up side; this is a real, documented
+limitation, not silently patched over.
+
+The sixth pattern is distinct: `Orders(OrderID)`, derived purely from an
+`ORDER BY orderID` term with no `WHERE` clause at all. `OrderID` is already
+the table's `INTEGER PRIMARY KEY` (rowid alias - see #390's evidence), so a
+plain table scan already visits rows in that order for free; the redundant
+secondary index is never chosen; `beforePlan == afterPlan` exactly.
+
+**In every case, the false positive was caught by scratch-copy verification
+itself** - the improvement rule rejected all five without needing a
+special case for "driving side of a join" or "already the primary key." That
+is the point of verifying rather than asserting.
+
+### Finding: join keys must precede range columns
+
+The real 214-statement corpus never produced a statement where a table on
+the *looked-up* side of a join carried both a join key and a range
+predicate - so the corpus alone couldn't settle whether a candidate's join
+key should come before or after a range column. Rather than assume either
+ordering (an earlier draft of this prototype used equality → range → join
+→ order-by, which is what the corpus's one real improvement happened to
+produce, coincidentally without ever exercising this exact tiebreak),
+constructing and re-planning a real case settles it:
+
+```sql
+SELECT p.ProductID FROM Categories AS c
+LEFT JOIN Products AS p ON p.CategoryID = c.CategoryID
+WHERE p.UnitPrice > 20 OR p.ProductID IS NULL
+```
+
+`Products` has no existing index beyond its own primary key, and is forced
+onto the looked-up side of the `LEFT JOIN` (the `OR … IS NULL` keeps SQLite
+from converting this into an inner join and reordering the tables).
+SQLite's own baseline plan is its `automatic_covering_index` shape - an
+ephemeral, per-query index on `CategoryID` alone, rebuilt every execution:
+
+```
+SCAN c
+BLOOM FILTER ON p (CategoryID=?)
+SEARCH p USING AUTOMATIC COVERING INDEX (CategoryID=?) LEFT-JOIN
+```
+
+`CREATE INDEX ON Products(CategoryID, UnitPrice)` - join key first - is the
+index SQLite actually adopts, replacing the ephemeral one and dropping the
+bloom-filter step entirely:
+
+```
+SCAN c
+SEARCH p USING COVERING INDEX ix_a (CategoryID=?) LEFT-JOIN
+```
+
+`CREATE INDEX ON Products(UnitPrice, CategoryID)` - range first - is
+**silently ignored**. The after-plan is byte-for-byte identical to the
+baseline, as if the candidate didn't exist:
+
+```
+SCAN c
+BLOOM FILTER ON p (CategoryID=?)
+SEARCH p USING AUTOMATIC COVERING INDEX (CategoryID=?) LEFT-JOIN
+```
+
+This is real, unambiguous confirmation of the general SQLite rule
+`candidateColumns` now implements: **equality-style columns - `WHERE`
+equality and join keys alike - must precede any range column**, because a
+composite index can only be seeded by an equality prefix; nothing after the
+first range column narrows a seek at all. It also surfaced a second,
+directly related gap: the improvement rule's original precondition only
+recognised `full_table_scan` as a remediable "before" shape. Replacing
+SQLite's own ephemeral `automatic_covering_index` with a real, persistent
+one is exactly the same category of improvement, so the rule now accepts
+either shape as the starting point. Both fixes are proven end to end by
+`IndexCandidateVerifierTests.testJoinKeyPrecedesRangeColumnConfirmedByRealScratchCopyReplan`.
+
+## Coverage and limitations
+
+- **Missing statistics cap advice at shape-derived, not distribution-
+  derived**, exactly as #390 anticipated: this prototype cannot tell a
+  highly-selective equality predicate from a nearly-useless one - it can
+  only observe *whether* SQLite's planner chose to narrow with an index,
+  not *how much* that narrowing helps. The one real improvement found here
+  happens to be a case where narrowing is obviously worthwhile (`CustomerID`
+  equality); a stats-driven advisor might reject candidates this prototype
+  accepts, or vice versa, on a differently-shaped dataset.
+- **Only root-level `full_table_scan`/`automatic_covering_index` nodes are
+  considered - never a nested node inside a subquery or CTE.** A plan's
+  roots are a generic forest of top-level nodes (any of the tables involved,
+  plus non-table nodes like a temp B-tree), not just one "driving" table;
+  extending detection to remediate a `temp_b_tree_for_order_by`/
+  `temp_b_tree_for_group_by` node (eliminating a sort, not just avoiding a
+  scan), or to a remediable node nested inside a subquery, is straightforward
+  future work using the same #391 shapes, not attempted in this pass.
+- **Partial and expression indices are not implemented.** A partial index
+  (`CREATE INDEX … WHERE …`) could serve some of the false-positive cases
+  above if the filtered subset were small - e.g. an index on `Employees`
+  filtered to `ReportsTo IS NOT NULL` doesn't apply here (the join key issue
+  is structural, not selectivity), but could plausibly help other,
+  differently-shaped statements. An expression index could serve a
+  predicate on a computed value. Both extend the candidate space this
+  prototype's precedence rule already establishes, but adding either is
+  deferred.
+- **No vendored `sqlite3expert`, no custom SQLite build** - every candidate
+  is verified using only public SQLite API (`CREATE INDEX` DDL plus
+  `EXPLAIN QUERY PLAN`), reusing #390/#391's existing capture and
+  classification pipeline unchanged.
+
+## Reproducing this evidence
+
+```bash
+swift run SwiftQLSQLiteIndexAdvisorCLI generate \
+  --capture path/to/capture.json --output candidates.json
+
+swift run SwiftQLSQLiteIndexAdvisorCLI verify \
+  --candidates candidates.json --output verification.json
+```
+
+`IndexCandidateGeneratorTests.testRealCorpusCandidatesMatchCheckedInEvidence`
+and `IndexCandidateVerifierTests.testCheckedInVerificationEvidenceMatchesFreshRun`
+re-run this exact pipeline on every `swift test` invocation and assert
+byte-identity with the checked-in evidence. Neither `IndexCandidate` nor
+`IndexCandidateEvidence` embeds an SQLite version field, so unlike #390's
+equivalent check this assertion is unconditional rather than runtime-gated
+- but that reflects what #390 actually measured (these particular
+index-search/full-scan decisions were stable between the two real builds
+tested there), not a guarantee that every SQLite build plans them
+identically forever. EQP choices remain SQLite-version-dependent in
+principle; if this test ever fails on a different host, its failure message
+prints that host's `sqlite_version()`/`sqlite_source_id()` so the
+difference is diagnosable rather than a bare JSON diff.

--- a/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
+++ b/Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md
@@ -1,0 +1,181 @@
+# Query-plan analysis and index advice: spike go/no-go (issue #393)
+
+Milestone 29, "Spike: SQLite query-plan analysis and index advice." This is
+the closing write-up: a go/no-go on advisory query-plan analysis and index
+advice, backed by the measured evidence from the spike's three prototypes,
+and the confirmed (or revised) split of the provisional v1.8 issues. Per
+this milestone's own charter, **this document - not the v1.8 scaffold - is
+authoritative** on how that work is divided.
+
+Research only: no product code, public API, or build-plugin change ships
+from this issue. The three prototype PRs it synthesizes are
+[#412](https://github.com/lukevanin/swiftql/pull/412) (issue #390),
+[#422](https://github.com/lukevanin/swiftql/pull/422) (issue #391), and
+[#427](https://github.com/lukevanin/swiftql/pull/427) (issue #392).
+
+## Verdict: **GO**, with two scoped corrections to the v1.8 issues
+
+Advisory query-plan analysis and index advice are worth building in v1.8.
+All three legs of the spike produced real, reproducible evidence on the
+pinned Northwind snapshot, not merely a plausible design:
+
+- EQP capture is deterministic and, for the shapes that matter, stable
+  across two real SQLite builds (#390).
+- Plan-shape classification handles 100% of a 214-statement real corpus
+  with zero unclassified nodes, and is provably robust to the one
+  cross-build instability #390 found (`id`/`parent` renumbering) (#391).
+- Index-candidate generation and scratch-copy verification produced one
+  genuine, evidenced improvement and caught its own five false positives
+  structurally - without a single special case (#392).
+
+The GO is **scoped**, not unconditional: §"Confirmed and revised v1.8
+issues" below corrects one real discrepancy the spike found and then
+settled with a real fixture (issue #396's candidate-column precedence -
+see [the finding](SQLiteIndexAdvisor.md#finding-join-keys-must-precede-range-columns))
+and adds an evidence-backed caveat to one more (issue #395). Nothing in the
+milestone is closed - see [Hard constraint check](#hard-constraint-check).
+
+**Build-host plans are not device plans.** Every measurement in this spike
+ran on this delivery's build host and one additional local SQLite install.
+Apple ships a different SQLite per OS release (#390), so nothing here
+predicts what a specific customer device's query planner will choose. v1.8
+must carry this caveat to every place it surfaces plan-derived advice -
+issues #395 and #398 already say so; that language is confirmed, not new.
+
+## Evidence behind the verdict
+
+### EQP variance by class (#390)
+
+214 real statements (208 from the #191 combinatorial manifest, 6 hand-authored
+Northwind joins/CTEs), captured against two real, distinct SQLite builds
+(Apple system 3.51.0, Homebrew 3.53.2) on the pinned, checksum-verified
+Northwind snapshot:
+
+| Class | Count | Stable across the two builds? |
+|---|---:|---|
+| Byte-identical | 203 | Yes |
+| `id`/`parent` renumbered, structure identical | 2 | Structurally yes, raw ids no |
+| Materialization strategy changed (compound-query CTEs) | 9 | No |
+
+Full detail: [`SQLiteEQPVariance.md`](SQLiteEQPVariance.md).
+
+### Classifier stability (#391)
+
+The same 214 statements, on both builds, classified through `EQPPlanShapeClassifier`:
+**zero** nodes fell back to `unclassified` on either build. The two
+`id`/`parent`-renumbered statements produced byte-identical *normalised*
+plans on both builds (proving the classifier's `id`/`parent`-blind design
+actually delivers on #390's recommendation, not just states it). The nine
+materialization-strategy statements classified fully and differently on each
+build - the classifier *named* the variance #390 measured, which is its job,
+not a failure.
+
+Full detail: [`SQLiteEQPPlanShapeClassifier.md`](SQLiteEQPPlanShapeClassifier.md).
+
+### Index-advice quality on Northwind (#392)
+
+Generating and verifying candidates from the same 214-statement capture
+produced exactly 6 deduplicated candidates:
+
+- **1 confirmed improvement**: a real `WHERE`-equality filter, verified to
+  change the plan from `full_table_scan` to `index_search`.
+- **5 false positives**, all caught by scratch-copy verification itself:
+  4 from indexing a join key on the *driving* side of a join (which must be
+  scanned in full regardless), 1 from indexing a column that was already the
+  table's `INTEGER PRIMARY KEY`.
+
+That is a 1-in-6 yield on a snapshot deliberately picked for correctness
+coverage, not for having many indexable hot paths - the meaningful result is
+not the yield, it's that **every rejection was structural, not asserted**.
+No case required a hand-written exception.
+
+A follow-up fixture (a `Categories LEFT JOIN Products` statement with both a
+join key and a range predicate on the looked-up table, deliberately built
+to test the case the real corpus never contained) additionally **confirmed
+the candidate-column precedence rule and found a real bug in it**: a
+candidate index with the join key before the range column is the one
+SQLite actually adopts; the reverse order is silently ignored. Fixing this
+also required accepting SQLite's own `automatic_covering_index` shape, not
+only `full_table_scan`, as a remediable "before" state. See
+[the finding](SQLiteIndexAdvisor.md#finding-join-keys-must-precede-range-columns).
+
+Full detail: [`SQLiteIndexAdvisor.md`](SQLiteIndexAdvisor.md).
+
+## Decided design questions
+
+Per this issue's Required Approach, each open question the milestone
+scaffold left open is settled here:
+
+1. **Do plan records live in the canonical build-validation report, or a
+   sidecar?** **Sidecar.** #390's Finding 2 (real materialization-strategy
+   variance between two ordinary point releases) means folding raw EQP into
+   the pass/fail report would make report diffs noisy for reasons unrelated
+   to SwiftQL correctness. A sidecar keeps that noise out of the
+   correctness contract #293/#294 own. (#394's body is updated to state
+   this directly rather than "where the spike decides.")
+2. **What is the improvement rule for keeping a candidate?** The rule
+   #392 stated and applied uniformly: kept only when the target alias's
+   plan node changes from `full_table_scan` **or `automatic_covering_index`**
+   to `index_search` or `covering_index_scan` *and* the after-plan reports
+   at least one constrained column. No cost estimate - the pinned snapshot
+   is deliberately unanalyzed (see decision 4). This is the "rule version"
+   #397 asks to record in its report.
+3. **How are unclassified shapes surfaced?** Never coerced into a named
+   shape. `EQPPlanShapeKind.unclassified`, with the raw `detail` string
+   always retained, so a misclassification is auditable rather than silent.
+   #395's diagnostics must key only on named shapes, per its own hard
+   constraint, and #391 proved a 0%-unclassified rate is achievable on a
+   real corpus without ever needing to fall back to that case.
+4. **Should the pinned snapshot's no-statistics policy change?** **No.**
+   #392's structural improvement rule needed no `sqlite_stat1` to find a
+   real improvement and reject five plausible false positives. Adding
+   statistics now would only serve the deferred `sqlite3_stmt_scanstatus`
+   exploration (see below), which is a separate future prototype, not a
+   reason to change today's pinned-snapshot policy.
+
+## Confirmed and revised v1.8 issues
+
+Milestone 30 ("v1.8", #394–#399). Every issue is **confirmed** as scoped
+except the one correction below; two more carry a new evidence-backed
+caveat. None are closed - the GO verdict means proceed, not "some of this
+was wrong."
+
+| Issue | Disposition | Why |
+|---|---|---|
+| #394 - Capture normalised plans in build validation | **Confirmed**, body updated | Directly matches #390/#391's proven pipeline. Updated to state the sidecar decision explicitly (design question 1) instead of leaving it open. Still blocked on #292/#293 (v1.5.2 build validator), independent of this spike. |
+| #395 - Emit advisory shape diagnostics | **Confirmed**, caveat added | Full table scan, temp B-tree (`ORDER BY`/`GROUP BY`) are backed by real, cross-build-stable evidence (#390/#391). **Correlated scalar subquery is not** - the real corpus contains zero correlated scalar subqueries; #391's classifier distinguishes it from a plain scalar subquery by a parent-shape heuristic validated only against one synthetic fixture. Issue body updated to require a real correlated-subquery fixture (extending the Northwind anchor corpus) as part of this issue's own Done-When, not assumed proven. |
+| #396 - Generate index candidates from static descriptors | **Revised**: precedence question settled with a real fixture | The issue's provisional body assumed equality → **join** → range → order-by. #392's originally-validated implementation instead used equality → **range** → join → order-by, matching the one real corpus improvement found - but that statement never exercised a join key competing with a range column, so the ordering wasn't actually proven. A follow-up fixture (`Categories LEFT JOIN Products` with both a join key and a range predicate on the looked-up table) settled it with a real scratch-copy re-plan: the join key **must** precede the range column - `Products(CategoryID, UnitPrice)` is the index SQLite adopts, `Products(UnitPrice, CategoryID)` is silently ignored. `IndexCandidateGenerator.candidateColumns` is corrected to equality-and-join-merged → range → order-by, and the improvement rule now also accepts `automatic_covering_index` as a remediable "before" shape (this fixture's baseline, not a full scan). Issue body updated to state the settled rule directly. Every other requirement (dedup, prefix-collapse, decline-on-unclassified, deterministic ordering) is confirmed by #392's implementation and tests. |
+| #397 - Verify candidates by re-planning on a scratch copy | **Confirmed as-is** | This is, almost line for line, what #392 built and evidenced: scratch-copy-per-run, same classifier, explicit improvement rule with a recorded version, reject-with-reason, digest-verified cleanup on every path. The one requirement #392 did not address - "note the interaction between a candidate and the write cost it implies" - remains open for #397's implementation; the spike was read-plan-only. |
+| #398 - Surface advice through the SwiftPM build plugin | **Confirmed as-is** | Out of scope for all three spike PRs by design (no build-plugin changes). A downstream consumer of #394/#395/#397's artifacts; nothing in the spike bears on its own requirements. |
+| #399 - `swiftql-index-advisor` codemod | **Confirmed as-is** | Same as #398: downstream consumer, untouched by spike evidence. The fixit-unreachability rationale in its body stands (SwiftPM build-tool plugins cannot emit fixits; a macro cannot open a database). |
+
+### Hard constraint check
+
+Per this issue's own hard constraints: no product code, public API, or
+build-plugin change ships here (confirmed - this delivery is documentation
+and issue-body edits only); no claim that a build-host plan predicts a
+device plan (confirmed - stated explicitly above and already present in
+#395/#398); and since the verdict is **GO**, not no-go, the "close v1.8
+honestly instead of downgrading to vague follow-ups" constraint doesn't
+apply - nothing is closed.
+
+## Deferred, with a named future owner
+
+| Item | Why deferred | Future owner milestone |
+|---|---|---|
+| Partial indices (`CREATE INDEX … WHERE …`) | Would extend #392's candidate space but no real corpus statement in this pass needed one to resolve a false positive (the join-key false positives are structural, not selectivity-driven) | **v1.8** (milestone 30), issue #396, as a scoped enhancement once the base precedence question above is settled |
+| Expression indices | Same - extends the candidate space, unexercised by this pass's corpus | **v1.8** (milestone 30), issue #396, same as above |
+| Vendored `sqlite3expert.c` | Rejected at scaffolding time (needs a custom SQLite build; the scratch-copy approach #392 validated needs only public API) and re-confirmed here: #392 never needed it | **None.** A deliberate rejection, not a deferred task - no milestone owns work that isn't going to happen. |
+| `sqlite3_stmt_scanstatus` measured costs | Named in this issue's own Required Approach as something to record; **not actually evaluated** by any of #390/#391/#392 - this write-up states that gap honestly rather than retroactively claiming coverage | **TBD, no milestone yet.** No issue is filed and no existing milestone (v1.8 or otherwise) scopes this work; it needs triage - likely a v1.8.x follow-up or a v1.9 research spike, once v1.8's structural approach has real usage to compare a graded, measured-cost rule against - before either an issue or a milestone is assigned. |
+
+## Milestone closure
+
+Milestone 29's four issues (#390, #391, #392, #393) were each delivered via
+a PR and a written architecture doc - [#412](https://github.com/lukevanin/swiftql/pull/412),
+[#422](https://github.com/lukevanin/swiftql/pull/422),
+[#427](https://github.com/lukevanin/swiftql/pull/427), and this issue's PR,
+stacked in dependency order. Milestone 29 is ready to close once all four
+merge; that merge, and the milestone close itself, is left for the
+maintainer rather than done as part of writing this document. Milestone 30
+("v1.8") remains open with its six issues as confirmed/revised above, still
+gated on v1.5.2's build validator (#292, #293) landing first.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,6 +55,7 @@ Version numbers express the intended order of work, not release dates.
 | [v1.3](https://github.com/lukevanin/swiftql/milestone/8) | Existing SQLite-surface conformance | Current public syntax proven against real SQLite |
 | [v1.4](https://github.com/lukevanin/swiftql/milestone/9) | Common SQLite feature coverage | A documented, useful SQLite subset |
 | [v1.5](https://github.com/lukevanin/swiftql/milestone/1) | Query declarations, ergonomics, and v2 preview | The future API validated without silently raising the v1 toolchain floor |
+| [v1.8](https://github.com/lukevanin/swiftql/milestone/30) | Query-plan analysis and index advice | Advisory `EXPLAIN QUERY PLAN` diagnostics and verified index recommendations layered onto the v1.5.2 build validator, never affecting build exit status |
 | [v2](https://github.com/lukevanin/swiftql/milestone/10) | Generated database catalogs, Swift 6, and a stable dialect-aware API | Fluent catalog-scoped queries plus intentional naming, package, DDL, and adapter cleanup |
 | [v2.1](https://github.com/lukevanin/swiftql/milestone/2) | Native SQLite adapter | Direct SQLite C execution as an alternative to GRDB |
 | [v2.2](https://github.com/lukevanin/swiftql/milestone/5) | PostgreSQL | Native PostgreSQL syntax and adapter |
@@ -75,6 +76,7 @@ Key planning and foundation issues:
 | v1.3 | [syntax conformance inventory](https://github.com/lukevanin/swiftql/issues/190), [combinatorial conformance cases](https://github.com/lukevanin/swiftql/issues/191), [build-time SQLite validation research](https://github.com/lukevanin/swiftql/issues/132), [Northwind correctness corpus](https://github.com/lukevanin/swiftql/issues/254), [observation stress contracts](https://github.com/lukevanin/swiftql/issues/255) |
 | v1.4 | [SQLite coverage index](https://github.com/lukevanin/swiftql/issues/115), [direct scalar CTE rows](https://github.com/lukevanin/swiftql/issues/43) |
 | v1.5 | [ergonomics index](https://github.com/lukevanin/swiftql/issues/116), [macro index](https://github.com/lukevanin/swiftql/issues/117), [prepared handles](https://github.com/lukevanin/swiftql/issues/18), [lazy typed result set](https://github.com/lukevanin/swiftql/issues/249), [@SQLQuery prototype](https://github.com/lukevanin/swiftql/issues/26), [Date text](https://github.com/lukevanin/swiftql/issues/61) and [numeric codecs](https://github.com/lukevanin/swiftql/issues/62), [UUID codecs](https://github.com/lukevanin/swiftql/issues/192), [interactive DocC tutorial](https://github.com/lukevanin/swiftql/issues/27), [macro regression corpus](https://github.com/lukevanin/swiftql/issues/256), [compile scalability benchmarks](https://github.com/lukevanin/swiftql/issues/257), [runtime workload research](https://github.com/lukevanin/swiftql/issues/259) |
+| v1.8 | [query-plan capture](https://github.com/lukevanin/swiftql/issues/394), [advisory shape diagnostics](https://github.com/lukevanin/swiftql/issues/395), [index-candidate generation](https://github.com/lukevanin/swiftql/issues/396), [scratch-copy verification](https://github.com/lukevanin/swiftql/issues/397), [SwiftPM plugin surface](https://github.com/lukevanin/swiftql/issues/398), [swiftql-index-advisor codemod](https://github.com/lukevanin/swiftql/issues/399), [spike go/no-go](https://github.com/lukevanin/swiftql/issues/393) |
 | v2 | [generated database catalogs and fluent table references](https://github.com/lukevanin/swiftql/issues/217), [Swift 6 mode](https://github.com/lukevanin/swiftql/issues/133), [typed DDL](https://github.com/lukevanin/swiftql/issues/139), [FluentQL and DynamicQL extraction](https://github.com/lukevanin/swiftql/issues/326), [GRDB adapter boundary](https://github.com/lukevanin/swiftql/issues/113), [XL migration](https://github.com/lukevanin/swiftql/issues/33), [catalog stress fixtures](https://github.com/lukevanin/swiftql/issues/258) |
 | v2.1 | [native SQLite adapter](https://github.com/lukevanin/swiftql/issues/136), [Linux CI](https://github.com/lukevanin/swiftql/issues/135), [VDBE research](https://github.com/lukevanin/swiftql/issues/138), [shared-corpus adapter parity](https://github.com/lukevanin/swiftql/issues/260) |
 | v2.2 | [PostgreSQL vertical slice](https://github.com/lukevanin/swiftql/issues/137) |
@@ -410,6 +412,36 @@ remains a research track until benchmarks show material value and a prototype
 demonstrates correctness, portability, invalidation, and a safe fallback.
 SwiftQL must not claim persisted or zero-parse preparation until that evidence
 exists.
+
+### Query-Plan Analysis and Index Advice
+
+Milestone 29 spiked whether `EXPLAIN QUERY PLAN` output can be captured
+deterministically enough to build advisory diagnostics and index
+recommendations on top of the build validator above, and concluded **go**:
+[measured EQP variance](https://github.com/lukevanin/swiftql/pull/412), a
+[normalised plan-shape classifier proven against a real 214-statement
+corpus](https://github.com/lukevanin/swiftql/pull/422), and
+[scratch-copy-verified index candidates that caught their own false
+positives structurally](https://github.com/lukevanin/swiftql/pull/427) are
+checked in as evidence, synthesized in the closing
+[go/no-go write-up](Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md).
+
+Two findings shape everything v1.8 builds on this foundation: SQLite's own
+`id`/`parent` row numbering is not a stable diagnostic key even when a plan
+is otherwise unchanged across versions, and a build-host plan is not a
+device plan - Apple ships a different SQLite per OS release, so plan
+analysis is advisory only and must never affect build exit status. Plan
+records live in a sidecar, not the correctness report this section
+describes, to keep that advisory noise out of the pass/fail contract.
+
+v1.8 ("Query-plan analysis and index advice", tracked
+[here](https://github.com/lukevanin/swiftql/milestone/30)) carries this
+forward once the v1.5.2 build validator above ships: normalised plan
+capture, advisory shape diagnostics, index-candidate generation and
+scratch-copy verification, a SwiftPM plugin surface, and a
+`swiftql-index-advisor` codemod as the fixit-equivalent - build-tool
+plugins cannot emit Swift fixits, and a macro cannot open a database
+without breaking hermetic, incremental builds.
 
 ## Conformance and Documentation Strategy
 


### PR DESCRIPTION
## Summary

Milestone 29 ("Spike: SQLite query-plan analysis and index advice") already closed with a **GO** verdict on issue #393, backed by real measured evidence: deterministic EQP capture, a plan-shape classifier with zero unclassified nodes across 214 real statements, and scratch-copy-verified index candidates that caught their own false positives structurally. But that write-up and its three supporting evidence documents only ever merged into the isolated `experiment/query-plan-index-advice` branch stack - no PR ever targeted a release branch, so no `ROADMAP.md` on any branch anyone actually reads records the decision or the v1.8 milestone it authorizes.

This PR carries that evidence over to `version/1.8.0`:

- `Documentation/Architecture/SQLiteEQPVariance.md` (issue #390 - EQP determinism across two SQLite builds)
- `Documentation/Architecture/SQLiteEQPPlanShapeClassifier.md` (issue #391 - plan-shape classifier)
- `Documentation/Architecture/SQLiteIndexAdvisor.md` (issue #392 - index-candidate generation and scratch-copy verification)
- `Documentation/Architecture/SQLiteQueryPlanIndexAdviceGoNoGo.md` (issue #393 - the closing go/no-go, verdict **GO**)
- `ROADMAP.md` - adds the v1.8 milestone rows and a new "Query-Plan Analysis and Index Advice" section

Content is unchanged from what's on `experiment/query-plan-index-advice`, aside from replacing em-dashes with hyphens to match this repo's house style.

## What this is not

Docs only - no product code, no `Package.swift` target, no tests. The six v1.8 implementation issues (#394-399) remain open and unbuilt; this PR only records that the spike backing them is complete and answered "go."

## Test plan

- [x] Diffed each copied file against its source on `experiment/query-plan-index-advice` - confirmed the only changes are em-dash to hyphen substitutions
- [x] Confirmed `ROADMAP.md`'s diff is purely additive (no existing content removed or altered)
- [x] Confirmed `ROADMAP.md` is not one of `SQLDocumentationCatalogTests`' pinned-content files (only referenced as a valid README link target)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
