### PR TITLE
Fix weak let compiler(>=6.1) threshold: Xcode 16.4 doesn't support it

### DIFF
--- a/Tests/SQLTests/XLObservableLiveQueryTests.swift
+++ b/Tests/SQLTests/XLObservableLiveQueryTests.swift
@@ -161,9 +161,11 @@ final class XLObservableLiveQueryTests: XCTestCase {
         )
         try await waitUntil { !(model?.isLoading ?? true) }
 
-        // `weak let` is Swift 6.1+ syntax; the pinned Swift 5.9/6.0 cells reject it ("'weak' must be
-        // a mutable variable"), while 6.1+ warns that an unmutated `weak var` should be a `let` --
-        // both are warnings-as-errors gated, so the binding's own mutability must switch per compiler.
+        // `weak let` needs Swift 6.2+: the pinned Swift 5.9/6.0 cells reject it ("'weak' must be
+        // a mutable variable"), and Swift 6.1 (Xcode 16.4) does too, despite `#if compiler(>=6.1)`
+        // gating exactly this pattern successfully elsewhere for other syntax -- 6.2+ instead warns
+        // that an unmutated `weak var` should be a `let`, so the binding's own mutability must switch
+        // per compiler, both being warnings-as-errors gated.
         #if compiler(>=6.2)
         weak let weakModel = model
         #else

--- a/Tests/SQLTests/XLObservableLiveQueryTests.swift
+++ b/Tests/SQLTests/XLObservableLiveQueryTests.swift
@@ -164,7 +164,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
         // `weak let` is Swift 6.1+ syntax; the pinned Swift 5.9/6.0 cells reject it ("'weak' must be
         // a mutable variable"), while 6.1+ warns that an unmutated `weak var` should be a `let` --
         // both are warnings-as-errors gated, so the binding's own mutability must switch per compiler.
-        #if compiler(>=6.1)
+        #if compiler(>=6.2)
         weak let weakModel = model
         #else
         weak var weakModel = model
@@ -258,8 +258,8 @@ final class XLObservableLiveQueryTests: XCTestCase {
         // Releasing the first model and constructing a second with a different packet is how binding
         // replacement happens for this Observation-native surface: each model owns one immutable
         // packet for its whole lifetime, exactly like `stream(bindings:)`/`publish(bindings:)`.
-        // See the matching compiler(>=6.1) note above for why this binding's mutability is conditional.
-        #if compiler(>=6.1)
+        // See the matching compiler(>=6.2) note above for why this binding's mutability is conditional.
+        #if compiler(>=6.2)
         weak let weakModelA = modelA
         #else
         weak var weakModelA = modelA
@@ -353,8 +353,8 @@ final class XLObservableLiveQueryTests: XCTestCase {
         )
         try await waitUntil { !(model?.isLoading ?? true) }
 
-        // See the compiler(>=6.1) note in testReleasedModelPerformsNoFurtherWorkAfterRelease above.
-        #if compiler(>=6.1)
+        // See the compiler(>=6.2) note in testReleasedModelPerformsNoFurtherWorkAfterRelease above.
+        #if compiler(>=6.2)
         weak let weakModel = model
         #else
         weak var weakModel = model


### PR DESCRIPTION
## Summary

`main`'s push-triggered CI matrix runs three compiler cells (`6.1`/`6.2`/`6.3` "Apple clean resolution") that are intentionally skipped for pull requests — PR compatibility signal comes from the pinned `5.9`/`6.0` cells only (see the job's own comment in `.github/workflows/swift.yml`). This exact combination (this file + those cells) was never exercised until [PR #457](https://github.com/lukevanin/swiftql/pull/457) merged and triggered a fresh push-to-`main` run.

That run failed: Swift 6.1 (Xcode 16.4) rejects `weak let` outright (`'weak' must be a mutable variable, because it may change at runtime`) — the exact same error the pinned Swift 5.9/6.0 cells hit, which is why `XLObservableLiveQueryTests.swift` already gates this with `#if compiler(>=6.1)`. The threshold was just one Swift series too low: Swift 6.2 (Xcode 26.3) supports `weak let` cleanly in that same failing run.

## What changed

- Bumped `#if compiler(>=6.1)` to `#if compiler(>=6.2)` in `Tests/SQLTests/XLObservableLiveQueryTests.swift`'s three `weak let`/`weak var` occurrences.

## Test plan

- [x] `swift build --build-tests` — clean
- [x] `./scripts/ci/check-first-party-warnings.sh` — clean
- [x] `swift test` — 1184 tests, 0 failures
- [ ] Cannot verify the exact Swift 6.1 (Xcode 16.4) cell locally — only Xcode 26.5 is available in this environment. Relying on this PR's own CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
