### PR TITLE
Correct v1.5.2's known limitations for the build validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,11 +241,20 @@ new, additive surfaces with no changes to any existing public API.
 
 - The validator proves schema/parameter/capability agreement with the real
   SQLite parser, not result values, row counts, or application behavior.
-- A target's manifest and snapshot are hand-authored or externally generated;
-  no macro or tool in this release produces a #292 manifest from source
-  (tracked as a future #26 boundary).
-- The plugin runs `swift build`; it is not integrated into Xcode's own build
-  system UI beyond what SwiftPM plugins already provide there.
+- Manifest entries can be generated in-process:
+  `SQLiteBuildValidationQueryEntry(id:descriptor:declaredAliases:)` projects an
+  existing `XLStaticQueryDescriptor` into sidecar form, deriving the SQL,
+  parameter layout, and result columns, and recovering each parameter's
+  physical placeholder index by scanning the rendered SQL. What no macro or
+  tool in this release does is emit a manifest from a `@SQLQuery` declaration:
+  the v1.5.1 declaration macro builds on the transitional `sql { }` statement
+  path and does not lower to a descriptor, so that route stays a future #26
+  boundary gated on the v2 catalog work (#212, #214). A target's snapshot is
+  still supplied by you.
+- The plugin is verified under `swift build`. Building a plugin-adopting
+  package in Xcode 26.5 fails before validation runs, reporting `Build input
+  file cannot be found` for the validator executable, on a valid manifest as
+  well as an invalid one (#492).
 
 ## [1.5.1] - 2026-07-26
 


### PR DESCRIPTION
## Summary

Two entries under v1.5.2's **Known limitations** misdescribe what actually shipped. Both were found while writing setup documentation for the validator.

### Manifest generation was understated

The entry said a target's manifest is "hand-authored or externally generated" and that "no macro or tool in this release produces a #292 manifest from source".

`SQLiteBuildValidationQueryEntry(id:descriptor:declaredAliases:)` does exactly that: it projects an existing `XLStaticQueryDescriptor` into sidecar form, deriving the SQL, parameter layout, and result columns, and recovering each parameter's *physical* placeholder index by scanning the rendered SQL (so a query whose logical argument order differs from its `?N` positions still gets correct indices). Combined with `SQLiteBuildValidationManifest.canonicalJSONData()` that is a complete generate-and-write path, and it is covered by `SQLiteBuildValidationManifestTests`.

The real gap is narrower and is now stated as such: `@SQLQuery` declarations build on the transitional `sql { }` statement path and do not lower to a descriptor, so there is no route from a *declaration* to a manifest entry. That stays a future #26 boundary, gated on the v2 catalog work (#212, #214).

### The Xcode entry understated a hard failure

The entry said the plugin "is not integrated into Xcode's own build system UI beyond what SwiftPM plugins already provide there", which reads as reduced functionality.

A plugin-adopting package does not build in Xcode 26.5 at all. It fails before validation runs with `Build input file cannot be found` naming the validator executable, for a valid manifest as well as an invalid one, while `swift build` succeeds on identical inputs. Filed as #492 with reproduction steps, and referenced from the entry.

## Scope

`CHANGELOG.md` only. No code, no behaviour change. The v1.5.2 entry's Added section is untouched; only the two inaccurate limitation bullets change.

## Test plan

- [x] `swift test --filter SQLDocumentationCatalogTests` - 7 tests, 0 failures (this suite pins CHANGELOG content, though not these particular lines)
- [x] Confirmed the pinned CHANGELOG phrases in `SQLDocumentationCatalogTests` cover v1.3.0 headings and conformance counts, none of which are in the edited region

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
