### PR TITLE
Upload LCOV coverage to Codecov and add a README badge

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -130,6 +130,14 @@ jobs:
           cat "$RUNNER_TEMP/swiftql-coverage-run-1/summary.md" \
             >> "$GITHUB_STEP_SUMMARY"
 
+      # Diagnostic evidence upload, not a release gate (Coverage/README.md) -- failure here
+      # must never fail this job, hence fail_ci_if_error: false.
+      - name: Upload coverage evidence to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ${{ runner.temp }}/swiftql-coverage-run-1/llvm-coverage.lcov
+          fail_ci_if_error: false
+
       - name: Prepare retained source coverage evidence
         if: ${{ always() && !cancelled() }}
         env:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 <p align="center">
   <a href="https://github.com/lukevanin/swiftql/actions/workflows/swift.yml?query=branch%3Amain"><img alt="Build and CI status" src="https://img.shields.io/github/actions/workflow/status/lukevanin/swiftql/swift.yml?branch=main&amp;label=build%20%26%20CI"></a>
   <a href="https://github.com/lukevanin/swiftql/actions/workflows/documentation.yml?query=branch%3Amain"><img alt="Documentation status" src="https://img.shields.io/github/actions/workflow/status/lukevanin/swiftql/documentation.yml?branch=main&amp;label=documentation"></a>
+  <a href="https://codecov.io/gh/lukevanin/swiftql"><img alt="Code coverage" src="https://img.shields.io/codecov/c/github/lukevanin/swiftql?logo=codecov&amp;label=coverage"></a>
   <a href="COMPATIBILITY.md#pinned-compiler-support-points"><img alt="Swift 5.9 CI" src="https://img.shields.io/badge/Swift-5.9-F05138?logo=swift&amp;logoColor=white"></a>
   <a href="COMPATIBILITY.md#swift-6-series-coverage"><img alt="Swift 6.0 CI" src="https://img.shields.io/badge/Swift-6.0-F05138?logo=swift&amp;logoColor=white"></a>
   <a href="COMPATIBILITY.md#swift-6-series-coverage"><img alt="Swift 6.1 CI" src="https://img.shields.io/badge/Swift-6.1-F05138?logo=swift&amp;logoColor=white"></a>


### PR DESCRIPTION
Closes #439, #438

## Summary

SwiftQL's `coverage` job in `swift.yml` already produces first-party LLVM coverage evidence -- including a standard `llvm-coverage.lcov` export (`Coverage/README.md`) -- on every push to `main` and every release `workflow_call` run. That evidence never left the retained CI artifact.

## Changes

- Added a Codecov upload step to the `coverage` job, right after the reproducibility check confirms the evidence is trustworthy, pointing at `coverage-run-1`'s `llvm-coverage.lcov`. `fail_ci_if_error: false` -- this is diagnostic evidence per `Coverage/README.md`, not a release gate.
- Pinned `codecov/codecov-action` by commit SHA (`fb8b3582c8e4def4969c97caa2f19720cb33a72f`, tag `v7.0.0`, the current latest release) with a version comment, matching `actions/checkout`/`actions/upload-artifact`'s existing pinning style in this file.
- Added a Codecov badge to the README's badge row (after "Documentation status"), styled like the existing shields.io badges, linking to `https://codecov.io/gh/lukevanin/swiftql`.
- No change to what the coverage job measures, when it runs, or to any other job -- PR-triggered runs stay coverage-free (#371's CI-cost tradeoff).

## Manual prerequisite (per the issue's own assumptions)

The repo owner needs to enable `lukevanin/swiftql` on codecov.io. This is a public repo, so tokenless upload should work without a `CODECOV_TOKEN` secret; if Codecov's tokenless rate limits become a problem in practice, a `CODECOV_TOKEN` secret can be added later with zero workflow changes -- `codecov-action` picks it up automatically when present. Until the repo is enabled on codecov.io, the badge will show "unknown" rather than a percentage.

## Test plan

- [x] `ruby -ryaml -e "YAML.load_file('.github/workflows/swift.yml')"` -- valid YAML
- [x] `python3 scripts/ci/test-source-coverage-report.py` -- 26/26 pass, unchanged
- [x] No doc-contract test pins README badge-row content

🤖 Generated with [Claude Code](https://claude.com/claude-code)