### PR TITLE
Name the validator's executable target after its product so Xcode builds it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.5.6] - Unreleased
+
+### Fixed
+
+- Fixed `SwiftQLSQLiteBuildValidationPlugin` failing every Xcode build of a
+  plugin-adopting target (issue #492). `context.tool(named:)` resolves a
+  build-tool plugin's tool to `$BUILD_DIR/$CONFIGURATION/<target name>`, while
+  Xcode's build system names a package executable after its *product*. The
+  validator's target (`SwiftQLSQLiteBuildValidationValidatorCLI`) and product
+  (`swiftql-build-validate`) had different names, so Xcode built the
+  validator's library dependencies, left the executable out of the adopting
+  target's dependency graph, and failed with `Build input file cannot be found`
+  before validation ran — on a valid manifest as much as an invalid one.
+  `swift build` resolved the same graph correctly, which is why only Xcode was
+  affected. The executable target is now named `swiftql-build-validate`,
+  matching its product; its source directory is unchanged. Both build systems
+  now agree: a valid manifest builds, and an invalid one fails with the
+  validator's own diagnostic.
+  `IntegrationTests/BuildValidationPluginFixture/verify-xcode.sh` drives that
+  agreement through `xcodebuild` so the two names cannot drift apart again. No
+  public API changed, and the `swiftql-build-validate` product and its CLI
+  contract are unchanged.
+
 ## [1.5.5] - 2026-07-30
 
 ### Added
@@ -254,7 +277,8 @@ new, additive surfaces with no changes to any existing public API.
 - The plugin is verified under `swift build`. Building a plugin-adopting
   package in Xcode 26.5 fails before validation runs, reporting `Build input
   file cannot be found` for the validator executable, on a valid manifest as
-  well as an invalid one (#492).
+  well as an invalid one (#492). Fixed in v1.5.6; on v1.5.2 through v1.5.5 the
+  plugin is usable from `swift build` and CI only.
 
 ## [1.5.1] - 2026-07-26
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -46,6 +46,28 @@ surface. The core protocols are extension seams, not claims that another
 dialect, driver, nested transaction/savepoint API, asynchronous cursor, or
 Swift 6 language mode is supported.
 
+## Build-validation plugin build systems
+
+`SwiftQLSQLiteBuildValidationPlugin` is supported under both SwiftPM's build
+system (`swift build`) and Xcode's, from v1.5.6 onwards. Both are verified
+against `IntegrationTests/BuildValidationPluginFixture`: `verify.sh` drives
+`swift build` and `verify-xcode.sh` drives `xcodebuild -destination
+'platform=macOS'`, and both assert the same outcomes — a valid manifest builds,
+and an invalid one fails with the validator's own diagnostic.
+
+On v1.5.2 through v1.5.5 the plugin is `swift build`-only. Adopting it in a
+target that Xcode builds fails that build with `Build input file cannot be
+found` naming the validator executable, before validation runs, on a valid
+manifest as much as an invalid one. The cause was a name mismatch between the
+validator's executable target and its product, which Xcode's build system does
+not tolerate (#492); v1.5.6 renames the target to match. On those versions, run
+the validator from CI or a `swift build` step rather than from an Xcode target.
+
+Verified on Xcode 26.5 (17F42), macOS 26.5 arm64. Xcode is not part of the
+pinned compatibility matrix below, so this is a verified support point rather
+than a per-commit CI gate. `verify-xcode.sh` is the check to run whenever the
+plugin's declaration or its tool resolution changes.
+
 ## SQLite conformance inventory
 
 The [SQLite conformance report](Conformance/SQLite/REPORT.md) summarizes the

--- a/Documentation/Architecture/SQLiteBuildValidationPlugin.md
+++ b/Documentation/Architecture/SQLiteBuildValidationPlugin.md
@@ -12,9 +12,12 @@ and runs the already-built `swiftql-build-validate` executable.
 
 `SwiftQLSQLiteBuildValidationPlugin` (`Plugins/SwiftQLSQLiteBuildValidationPlugin`)
 is a `.plugin(capability: .buildTool())` target, exposed as a product of the
-same name, depending on the `SwiftQLSQLiteBuildValidationValidatorCLI`
-executable target so it can resolve the validator's built path via
-`context.tool(named:)`.
+same name, depending on the `swiftql-build-validate` executable target so it
+can resolve the validator's built path via `context.tool(named:)`.
+
+That executable's target name and its product name are both
+`swiftql-build-validate`, and they have to stay identical — see
+[Build systems](#build-systems) below.
 
 ## Opting in
 
@@ -79,6 +82,8 @@ bundle resources for the target's own product.
 For a self-contained, runnable version of this walkthrough see
 `IntegrationTests/BuildValidationPluginFixture` and its `verify.sh`, which
 drives exactly these steps against the real pinned Northwind snapshot.
+`verify-xcode.sh` next to it drives the same steps through Xcode's build
+system (see [Build systems](#build-systems)).
 
 ## Package layout example
 
@@ -87,8 +92,9 @@ example: a standalone SwiftPM package depending on this repository by local
 path, with one target (`ValidatedLibrary`) that opts into the plugin against
 the real pinned Northwind snapshot. `verify.sh` in that directory drives
 `swift build` through both a valid and an invalid manifest and asserts on
-exit codes, forwarded diagnostics, and incremental-build behavior — this is
-the plugin's invocation-contract test, since a build-tool plugin's
+exit codes, forwarded diagnostics, and incremental-build behavior, and
+`verify-xcode.sh` drives the valid/invalid pair through `xcodebuild` — these
+are the plugin's invocation-contract tests, since a build-tool plugin's
 `createBuildCommands` cannot be meaningfully unit-tested without a live
 `PluginContext` supplied by SwiftPM itself.
 
@@ -149,6 +155,39 @@ exiting nonzero, and SwiftPM's build system surfaces a failing build
 command's stderr directly in `swift build` output. A `failed` or
 `unsupported` verdict exits `1`; the build command — and therefore
 `swift build` for the whole package — fails accordingly.
+
+## Build systems
+
+The plugin runs under both SwiftPM's build system (`swift build`) and Xcode's,
+and the two agree: a valid manifest builds, an invalid one fails with the
+validator's own diagnostic. `verify.sh` covers the first and `verify-xcode.sh`
+the second.
+
+Getting Xcode to agree took one constraint on the validator's declaration.
+`context.tool(named:)` resolves a build-tool plugin's tool to
+`$BUILD_DIR/$CONFIGURATION/<target name>`, but Xcode's build system names a
+package executable after its *product*. Through v1.5.5 those names differed:
+the target was `SwiftQLSQLiteBuildValidationValidatorCLI` and the product was
+`swiftql-build-validate`. Xcode then dropped the executable from the adopting
+target's dependency graph — it built the validator's *library* dependencies but
+never the executable itself — and every plugin-adopting target failed with:
+
+```
+Build input file cannot be found:
+'.../Build/Products/Debug/SwiftQLSQLiteBuildValidationValidatorCLI'.
+Did you forget to declare this file as an output of a script phase or custom
+build rule which produces it?
+```
+
+`swift build` resolved the same graph correctly, so the failure only ever
+appeared in Xcode, on a valid manifest as much as an invalid one (#492).
+
+Since v1.5.6 the executable target is named `swiftql-build-validate`, matching
+its product, and both build systems find it. Vending a same-named alias product
+alongside the differently-named one does *not* work — Xcode still builds only
+one executable per target, under one name — so the names have to match rather
+than merely overlap. Anything that renames the target or the product has to
+rename both together; `verify-xcode.sh` fails if they drift apart.
 
 ## Toolchain and compatibility
 

--- a/Documentation/Architecture/SQLiteBuildValidationValidator.md
+++ b/Documentation/Architecture/SQLiteBuildValidationValidator.md
@@ -13,8 +13,12 @@ prototype's own local model.
 
 `SwiftQLSQLiteBuildValidationValidator` (`Sources/SwiftQLSQLiteBuildValidationValidator`)
 is a library target depending on `SwiftQLCore`, `SwiftQLSQLiteBuildValidationManifest`,
-GRDB, and CSQLite. `SwiftQLSQLiteBuildValidationValidatorCLI` wraps it as the
-`swiftql-build-validate` executable product.
+GRDB, and CSQLite. The `swiftql-build-validate` executable target
+(`Sources/SwiftQLSQLiteBuildValidationValidatorCLI`) wraps it as the
+`swiftql-build-validate` executable product. Target and product carry the same
+name on purpose: the [#294 plugin](SQLiteBuildValidationPlugin.md) resolves
+this executable through `context.tool(named:)`, and Xcode's build system cannot
+find it when the two names disagree (#492).
 
 ```
 swiftql-build-validate \

--- a/IntegrationTests/BuildValidationPluginFixture/verify-xcode.sh
+++ b/IntegrationTests/BuildValidationPluginFixture/verify-xcode.sh
@@ -91,9 +91,19 @@ if [ "$REPORT_COUNT" -ne 2 ]; then
     printf '%s\n' "$REPORTS"
     exit 1
 fi
+# Split on newlines only. These paths sit under $DERIVED_DATA, hence under
+# $TMPDIR, so the default IFS would break every check below the moment someone
+# runs this with a temporary directory whose path contains a space. A
+# `find ... | while read` pipeline would not do: its body runs in a subshell,
+# where assert_passed_report's `exit 1` would end the subshell and let the
+# script carry on reporting success.
+OLD_IFS=$IFS
+IFS='
+'
 for REPORT in $REPORTS; do
     assert_passed_report "$REPORT"
 done
+IFS=$OLD_IFS
 echo "OK"
 
 echo "== 2. Validator executable lands where the plugin's tool resolution expects =="

--- a/IntegrationTests/BuildValidationPluginFixture/verify-xcode.sh
+++ b/IntegrationTests/BuildValidationPluginFixture/verify-xcode.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# Verifies SwiftQLSQLiteBuildValidationPlugin under *Xcode's* build system,
+# which is a different build system from the one `verify.sh` exercises and
+# which regressed independently of it (#492).
+#
+# Xcode names a package executable after its product, while a plugin's
+# `context.tool(named:)` resolves the tool by target name. When the validator
+# executable's target name and product name disagree, Xcode drops it from the
+# adopting target's dependency graph and every plugin-adopting target fails
+# with "Build input file cannot be found" before validation runs — on a valid
+# manifest as much as an invalid one. `swift build` tolerates the mismatch, so
+# verify.sh alone cannot catch this.
+#
+# Checks, in order:
+#   1. A valid manifest builds, both opted-in targets report "passed", and no
+#      target reports the #492 "Build input file cannot be found" error.
+#   2. The validator executable is built at the exact path the plugin's tool
+#      resolution expects, `Products/<config>/swiftql-build-validate` — the
+#      target-name/product-name invariant #492 turned on.
+#   3. An invalid manifest fails the Xcode build with the validator's own
+#      diagnostic, not with a missing-input-file error.
+#   4. Restoring the valid manifest builds successfully again.
+set -eu
+cd "$(dirname "$0")"
+
+SCHEME="SwiftQLBuildValidationPluginFixture-Package"
+CONFIGURATION="Debug"
+VALIDATOR_EXECUTABLE="swiftql-build-validate"
+MISSING_INPUT_ERROR="Build input file cannot be found"
+
+if ! command -v xcodebuild > /dev/null 2>&1; then
+    echo "SKIP: xcodebuild is not available; this script needs Xcode on macOS."
+    echo "      Run verify.sh for the swift build path."
+    exit 0
+fi
+
+MANIFEST="Sources/ValidatedLibrary/swiftql-build-validation-manifest.json"
+# Explicit template so this works identically across BSD (macOS) and GNU
+# mktemp implementations, which differ on bare invocations.
+VALID_MANIFEST_BACKUP=$(mktemp "${TMPDIR:-/tmp}/swiftql-plugin-verify-xcode.XXXXXX")
+cp "$MANIFEST" "$VALID_MANIFEST_BACKUP"
+DERIVED_DATA=$(mktemp -d "${TMPDIR:-/tmp}/swiftql-plugin-verify-xcode-dd.XXXXXX")
+trap 'cp "$VALID_MANIFEST_BACKUP" "$MANIFEST"; rm -f "$VALID_MANIFEST_BACKUP"; rm -rf "$DERIVED_DATA"' EXIT
+
+PRODUCTS_DIR="$DERIVED_DATA/Build/Products/$CONFIGURATION"
+
+xcode_build() {
+    # `platform=macOS` matches the fixture's `platforms: [.macOS(.v13)]`.
+    xcodebuild build \
+        -scheme "$SCHEME" \
+        -destination 'platform=macOS' \
+        -configuration "$CONFIGURATION" \
+        -derivedDataPath "$DERIVED_DATA" \
+        > "$1" 2>&1
+}
+
+assert_no_missing_input_error() {
+    if grep -q "$MISSING_INPUT_ERROR" "$1"; then
+        echo "FAIL: #492 regressed — Xcode could not find the validator executable"
+        grep "$MISSING_INPUT_ERROR" "$1"
+        exit 1
+    fi
+}
+
+assert_passed_report() {
+    if ! grep -Eq '"overall_verdict"[[:space:]]*:[[:space:]]*"passed"' "$1"; then
+        echo "FAIL: expected overall_verdict passed in $1"
+        cat "$1"
+        exit 1
+    fi
+}
+
+echo "== 1. Valid manifest builds under Xcode and reports passed =="
+if ! xcode_build /tmp/swiftql-plugin-verify-xcode-1.log; then
+    echo "FAIL: expected the Xcode build to succeed with a valid manifest"
+    assert_no_missing_input_error /tmp/swiftql-plugin-verify-xcode-1.log
+    tail -50 /tmp/swiftql-plugin-verify-xcode-1.log
+    exit 1
+fi
+assert_no_missing_input_error /tmp/swiftql-plugin-verify-xcode-1.log
+# Scoped to the plugin's own declared-output directory: Xcode also copies each
+# target's declared plugin outputs into that target's resource bundle, which
+# would otherwise double-count these.
+REPORTS=$(find "$DERIVED_DATA/Build/Intermediates.noindex/BuildToolPluginIntermediates" \
+    -name swiftql-build-validation-report.json 2>/dev/null | sort)
+# `grep -c` exits 1 when it counts zero matches, which would trip `set -e` and
+# skip the explicit failure message below before it can print.
+REPORT_COUNT=$(printf '%s\n' "$REPORTS" | grep -c . || true)
+if [ "$REPORT_COUNT" -ne 2 ]; then
+    echo "FAIL: expected 2 report files (one per opted-in target), found $REPORT_COUNT"
+    printf '%s\n' "$REPORTS"
+    exit 1
+fi
+for REPORT in $REPORTS; do
+    assert_passed_report "$REPORT"
+done
+echo "OK"
+
+echo "== 2. Validator executable lands where the plugin's tool resolution expects =="
+if [ ! -x "$PRODUCTS_DIR/$VALIDATOR_EXECUTABLE" ]; then
+    echo "FAIL: expected an executable at $PRODUCTS_DIR/$VALIDATOR_EXECUTABLE"
+    echo "      The validator's target name and product name must both be"
+    echo "      '$VALIDATOR_EXECUTABLE' — see #492."
+    ls "$PRODUCTS_DIR" || true
+    exit 1
+fi
+echo "OK"
+
+echo "== 3. Invalid manifest fails the Xcode build with the actionable diagnostic =="
+cp Fixtures/invalid-manifest.json "$MANIFEST"
+if xcode_build /tmp/swiftql-plugin-verify-xcode-3.log; then
+    echo "FAIL: expected the Xcode build to fail with an invalid manifest"
+    tail -50 /tmp/swiftql-plugin-verify-xcode-3.log
+    exit 1
+fi
+assert_no_missing_input_error /tmp/swiftql-plugin-verify-xcode-3.log
+if ! grep -q "no such table: totally_missing_table" /tmp/swiftql-plugin-verify-xcode-3.log; then
+    echo "FAIL: expected the validator's diagnostic to be forwarded to build output"
+    tail -50 /tmp/swiftql-plugin-verify-xcode-3.log
+    exit 1
+fi
+echo "OK"
+
+echo "== 4. Restoring the valid manifest builds successfully again =="
+cp "$VALID_MANIFEST_BACKUP" "$MANIFEST"
+if ! xcode_build /tmp/swiftql-plugin-verify-xcode-4.log; then
+    echo "FAIL: expected the Xcode build to succeed again after restoring the valid manifest"
+    assert_no_missing_input_error /tmp/swiftql-plugin-verify-xcode-4.log
+    tail -50 /tmp/swiftql-plugin-verify-xcode-4.log
+    exit 1
+fi
+assert_no_missing_input_error /tmp/swiftql-plugin-verify-xcode-4.log
+echo "OK"
+
+echo
+echo "All SwiftQLSQLiteBuildValidationPlugin Xcode build-system checks passed."

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         ),
         .executable(
             name: "swiftql-build-validate",
-            targets: ["SwiftQLSQLiteBuildValidationValidatorCLI"]
+            targets: ["swiftql-build-validate"]
         ),
         .plugin(
             name: "SwiftQLSQLiteBuildValidationPlugin",
@@ -164,9 +164,20 @@ let package = Package(
             ]
         ),
 
+        // The target name has to match the `swiftql-build-validate` product
+        // name above, because this executable is a build-tool plugin's tool
+        // (#492). `context.tool(named:)` resolves to
+        // `$BUILD_DIR/$CONFIGURATION/<target name>`, while Xcode's build
+        // system names a package executable after its *product*. When the two
+        // names differ, Xcode drops the executable from the plugin-adopting
+        // target's dependency graph entirely and the build fails with "Build
+        // input file cannot be found" before validation ever runs. `swift
+        // build` tolerates the mismatch; Xcode does not. The source directory
+        // keeps its descriptive name via `path:`.
         .executableTarget(
-            name: "SwiftQLSQLiteBuildValidationValidatorCLI",
-            dependencies: ["SwiftQLSQLiteBuildValidationValidator"]
+            name: "swiftql-build-validate",
+            dependencies: ["SwiftQLSQLiteBuildValidationValidator"],
+            path: "Sources/SwiftQLSQLiteBuildValidationValidatorCLI"
         ),
 
         // Thin SwiftPM build-tool plugin wrapper around the standalone
@@ -176,7 +187,7 @@ let package = Package(
         .plugin(
             name: "SwiftQLSQLiteBuildValidationPlugin",
             capability: .buildTool(),
-            dependencies: ["SwiftQLSQLiteBuildValidationValidatorCLI"]
+            dependencies: ["swiftql-build-validate"]
         ),
 
         // Package-private research engine for issue #132. This deliberately

--- a/Plugins/SwiftQLSQLiteBuildValidationPlugin/Plugin.swift
+++ b/Plugins/SwiftQLSQLiteBuildValidationPlugin/Plugin.swift
@@ -25,12 +25,25 @@ import PackagePlugin
 ///
 /// If a target lists the plugin but is missing either file, the build fails
 /// with a clear plugin error rather than silently skipping validation.
+///
+/// ## Build systems
+///
+/// Both `swift build` and Xcode's build system run the plugin, and they
+/// agree on the outcome: a valid manifest builds, and an invalid one fails
+/// with the validator's own diagnostic. Xcode names a package executable
+/// after its product while `context.tool(named:)` resolves the tool by
+/// target name, so the validator's target and product names are deliberately
+/// both `swiftql-build-validate`. Splitting them breaks Xcode builds of every
+/// adopting target with "Build input file cannot be found" (#492).
 @main
 struct SwiftQLSQLiteBuildValidationPlugin: BuildToolPlugin {
     static let manifestFileName = "swiftql-build-validation-manifest.json"
     static let snapshotFileName = "swiftql-build-validation-snapshot.sqlite"
     static let reportFileName = "swiftql-build-validation-report.json"
-    static let validatorToolName = "SwiftQLSQLiteBuildValidationValidatorCLI"
+    // Both the validator executable's target name and its product name; the
+    // two must stay identical. See the "Build systems" note above, #492, and
+    // the comment on the target in Package.swift.
+    static let validatorToolName = "swiftql-build-validate"
 
     func createBuildCommands(
         context: PluginContext,

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -511,7 +511,10 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         let firstReleaseHeading = changelog
             .components(separatedBy: .newlines)
             .first(where: { $0.hasPrefix("## [") })
-        XCTAssertEqual(firstReleaseHeading, "## [1.5.5] - 2026-07-30")
+        // RELEASING.md step 4 dates this heading during release preparation,
+        // replacing `Unreleased` with the release date; update this pin in the
+        // same change.
+        XCTAssertEqual(firstReleaseHeading, "## [1.5.6] - Unreleased")
     }
 
     func testREADMERepositoryLinksResolveWithExactCase() throws {


### PR DESCRIPTION
Closes #492

## Summary

Adopting `SwiftQLSQLiteBuildValidationPlugin` made a package unbuildable in Xcode. Every plugin-adopting target failed before validation ran, on a valid manifest as much as an invalid one, while `swift build` succeeded on identical inputs:

```
Build input file cannot be found:
'.../Build/Products/Debug/SwiftQLSQLiteBuildValidationValidatorCLI'.
Did you forget to declare this file as an output of a script phase or custom
build rule which produces it?
```

This is fixable here, and the fix is one line of `Package.swift`.

## Root cause

`context.tool(named:)` resolves a build-tool plugin's tool to `$BUILD_DIR/$CONFIGURATION/<target name>`. Xcode's build system names a package executable after its **product**. The validator's names disagreed: target `SwiftQLSQLiteBuildValidationValidatorCLI`, product `swiftql-build-validate`.

Xcode's own dependency graph, from the failing build log, shows what that costs. The plugin target carries the executable's *dependencies* but not the executable:

```
Target 'SwiftQLSQLiteBuildValidationPlugin' in project 'SwiftQL'
    ➜ Explicit dependency on target 'SwiftQLCore' in project 'SwiftQL'
    ➜ Explicit dependency on target 'SwiftQLSQLiteBuildValidationManifest' ...
    ➜ Explicit dependency on target 'SwiftQLSQLiteBuildValidationValidator' ...
    ➜ Explicit dependency on target 'GRDB' in project 'GRDB'
    ➜ Explicit dependency on target 'CSQLite' in project 'GRDB'
```

So Xcode compiled the validator library and left `Products/Debug` with no executable of any name, then failed the build command whose input that executable was. SwiftPM's build system resolved the same graph correctly, which is why only Xcode was affected and why `verify.sh` could not see it.

I isolated this in a throwaway three-target package before touching anything here, because "Xcode plugin ordering bug" has a well-known unfixable variant and I did not want to guess. Same plugin, same consumer shape, one variable:

| Executable target's product declaration | Xcode build |
| --- | --- |
| No product at all | succeeds, tool runs |
| Product name differs from target name | **fails with the exact #492 error** |
| Product name matches target name | succeeds, tool runs |
| Differently-named product **plus** a same-named alias product | **fails** — Xcode builds one executable per target, under one name |

The last row is why the fix has to make the names identical rather than merely add an alias.

## Changes

- `Package.swift`: renamed the executable target to `swiftql-build-validate`, matching its product, keeping its source directory via `path:`. Comment explains why the two names are now load-bearing.
- `Plugins/SwiftQLSQLiteBuildValidationPlugin/Plugin.swift`: `validatorToolName` follows, plus a "Build systems" doc-comment section stating the constraint.
- `IntegrationTests/BuildValidationPluginFixture/verify-xcode.sh`: new, the Xcode counterpart to `verify.sh`. Asserts a valid manifest builds with both opted-in targets reporting `passed`, that the validator lands at the exact path tool resolution expects, and that an invalid manifest fails with the validator's own diagnostic and not a missing-input error. Skips with a message when `xcodebuild` is absent, so it is safe to run on Linux.
- `CHANGELOG.md`: new `## [1.5.6] - Unreleased` / `### Fixed` entry; v1.5.2's known-limitation bullet now says which versions are affected and where it was fixed.
- `COMPATIBILITY.md`: new "Build-validation plugin build systems" section — both build systems supported from v1.5.6, `swift build`-only on v1.5.2 through v1.5.5, with the verified Xcode/macOS versions.
- `Documentation/Architecture/SQLiteBuildValidationPlugin.md` and `SQLiteBuildValidationValidator.md`: the same constraint at the architecture level, including the alias-product dead end so nobody re-tries it.
- `Tests/SQLTests/SQLDocumentationCatalogTests.swift`: `testV13PublicDocumentsShareReleaseAndBoundaryContract` pins CHANGELOG.md's first version heading, so the new section broke it against the v1.5.5 heading. Re-pinned to `## [1.5.6] - Unreleased`, which is the pre-release state RELEASING.md step 4 describes ("date the heading ... replacing `## [X.Y.Z] - Unreleased`"), with a comment saying to re-pin it when the heading is dated.

The `swiftql-build-validate` product, its CLI contract, and every public API are unchanged. `swift run swiftql-build-validate` still resolves.

## Test plan

- [x] Reproduced the failure first, on the committed fixture and unmodified manifest: `xcodebuild build -scheme SwiftQLBuildValidationPluginFixture-Package -destination 'platform=macOS'` → 2 errors, one per opted-in target, the exact #492 message
- [x] `verify-xcode.sh` — 4/4 checks pass after the fix
- [x] Confirmed `verify-xcode.sh` actually catches a regression: temporarily restored the old target/product names, re-ran, check 1 failed with `FAIL: #492 regressed — Xcode could not find the validator executable`
- [x] Xcode build with `Fixtures/invalid-manifest.json` fails with the validator's own diagnostic (`no such table: totally_missing_table`), not a missing-input error
- [x] `verify.sh` — 5/5 checks pass, `swift build` path unaffected
- [x] `swift build` — clean
- [x] `swift test --filter SwiftQLSQLiteBuildValidation` — 87/87 pass
- [x] `swift run swiftql-build-validate` — product still builds and runs
- [x] `swift test --filter 'SQLDocumentationCatalogTests|SQLSkillDocumentationTests|XLDocumentationTests'` — 51/51 pass

Validated against Xcode 26.5 (17F42), Swift 6.3.2, macOS 26.5 / arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
