### PR TITLE
Refresh SKILL.md for the v1.5 API surface

### DIFF
--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/DeclaredQueriesFixture.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/DeclaredQueriesFixture.swift
@@ -5,6 +5,10 @@ import SwiftQL
 // under the Swift 5 language-mode floor this fixture package pins to — the
 // same floor `SwiftQLSwift5Client` validates for every other macro in this
 // file.
+//
+// Only one `@SQLQueries` extension is supported per database type, and
+// `SkillQuickStart.swift` owns it, because SKILL.md embeds that container
+// verbatim. This file covers the peer form.
 
 extension GRDBDatabase {
 
@@ -15,25 +19,6 @@ extension GRDBDatabase {
             Select(person)
             From(person)
             Where(person.name == name)
-        }
-    }
-}
-
-
-@SQLQueries
-extension GRDBDatabase {
-
-    // Never referenced by the generated code, so it is safe to keep private
-    // to this file.
-    fileprivate struct Query {
-
-        func skillPeopleByName(name: String) -> [SkillPerson] {
-            sqlResult { schema in
-                let person = schema.table(SkillPerson.self)
-                Select(person)
-                From(person)
-                Where(person.name == name)
-            }
         }
     }
 }

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift
@@ -1,37 +1,149 @@
-// swiftql-skill-example-begin
+// The three regions below are the only Swift SKILL.md is allowed to show.
+// They are compiled by this downstream Swift 5 consumer package and executed
+// by `main.swift`, and `SQLSkillDocumentationTests` fails if SKILL.md and this
+// file ever drift apart.
+
+// swiftql-skill-example-begin: schema
 import SwiftQL
 
 @SQLTable(name: "SkillPerson")
 struct SkillPerson: Equatable {
-    let id: String
-    let name: String
+    var id: String
+    var name: String
 }
 
+@SQLQueries
+extension GRDBDatabase {
+
+    // Generated executors become members of `GRDBDatabase`, never of this
+    // container, so the container stays private to its file.
+    private struct Query {
+
+        // The return type chooses the cardinality: `[Row]` fetches every
+        // match, `Row?` fetches zero or one, and a bare `Row` insists on
+        // exactly one.
+        func skillPeopleByName(name: String) -> [SkillPerson] {
+            sqlResult { schema in
+                let person = schema.table(SkillPerson.self)
+                Select(person)
+                From(person)
+                Where(person.name == name)
+            }
+        }
+    }
+}
+// swiftql-skill-example-end: schema
+
+// swiftql-skill-example-begin: lifecycle
 enum SkillQueryError: Error {
-    case missingNameParameter
+    case missingParameter(String)
 }
 
-func fetchSkillPeople(
-    named name: String,
-    from database: GRDBDatabase
-) throws -> [SkillPerson] {
-    let nameParameter = XLNamedBindingReference<String>(name: "name")
-    let query = sql { schema in
-        let person = schema.table(SkillPerson.self)
-        Select(person)
-        From(person)
-        Where(person.name == nameParameter)
-    }
-    let request = database.makeRequest(with: query)
-    guard let nameSlot = request.parameterLayout.slot(for: .named("name")) else {
-        throw SkillQueryError.missingNameParameter
-    }
-    let bindings = try XLInvocationBindings<XLSQLiteValue>(
-        layout: request.parameterLayout,
-        bindings: [
-            try XLInvocationBinding(slot: nameSlot, value: .text(name)),
-        ]
+// A request owns rendered SQL and an immutable parameter layout. Values for
+// one call live in a separate packet built against that layout.
+func skillTextPacket(
+    _ parameters: [(name: String, value: String)],
+    for layout: XLParameterLayout
+) throws -> XLInvocationBindings<XLSQLiteValue> {
+    try XLInvocationBindings<XLSQLiteValue>(
+        layout: layout,
+        bindings: try parameters.map { parameter in
+            guard let slot = layout.slot(for: .named(parameter.name)) else {
+                throw SkillQueryError.missingParameter(parameter.name)
+            }
+            return try XLInvocationBinding(
+                slot: slot,
+                value: .text(parameter.value)
+            )
+        }
     ).validatingComplete()
-    return try request.fetchAll(bindings: bindings)
 }
-// swiftql-skill-example-end
+
+func runSkillLifecycle(in database: GRDBDatabase) throws -> [SkillPerson] {
+    // `sqlCreate` renders `CREATE TABLE IF NOT EXISTS`. It is not a migration
+    // engine and never alters an existing table.
+    try database.makeRequest(with: sqlCreate(SkillPerson.self)).execute()
+
+    // Statements that must succeed or fail together share one transaction on
+    // one pinned connection. Use `scope`, never the captured `database`.
+    try database.withTransaction { scope in
+        try scope.makeRequest(
+            with: sqlInsert(SkillPerson(id: "ada", name: "Ada Lovelace"))
+        ).execute()
+        try scope.makeRequest(
+            with: sqlInsert(SkillPerson(id: "grace", name: "Grace Hopper"))
+        ).execute()
+    }
+
+    // The declared query renders once per database and reuses one prepared
+    // statement. Each call builds a fresh immutable packet from its arguments.
+    _ = try database.skillPeopleByName(name: "Grace Hopper")
+
+    // Writes are not a declared-query shape in v1.5, so they keep their values
+    // out of the rendered SQL with named bindings instead.
+    let idParameter = XLNamedBindingReference<String>(name: "id")
+    let nameParameter = XLNamedBindingReference<String>(name: "name")
+    let renameRequest = database.makeRequest(
+        with: sql { schema in
+            let person = schema.into(SkillPerson.self)
+            Update(person)
+            Setting(person) { row in
+                row.name = nameParameter
+            }
+            Where(person.id == idParameter)
+        }
+    )
+    try renameRequest.execute(
+        bindings: try skillTextPacket(
+            [
+                (name: "id", value: "grace"),
+                (name: "name", value: "Grace B. Hopper"),
+            ],
+            for: renameRequest.parameterLayout
+        )
+    )
+
+    let deleteRequest = database.makeRequest(
+        with: sql { schema in
+            let person = schema.into(SkillPerson.self)
+            Delete(person)
+            Where(person.id == idParameter)
+        }
+    )
+    try deleteRequest.execute(
+        bindings: try skillTextPacket(
+            [(name: "id", value: "grace")],
+            for: deleteRequest.parameterLayout
+        )
+    )
+
+    return try database.skillPeopleByName(name: "Ada Lovelace")
+}
+// swiftql-skill-example-end: lifecycle
+
+// swiftql-skill-example-begin: live
+func observeSkillPeople(
+    named name: String,
+    in database: GRDBDatabase
+) async throws {
+    let nameParameter = XLNamedBindingReference<String>(name: "name")
+    let request = database.makeRequest(
+        with: sql { schema in
+            let person = schema.table(SkillPerson.self)
+            Select(person)
+            From(person)
+            Where(person.name == nameParameter)
+        }
+    )
+    let bindings = try skillTextPacket(
+        [(name: "name", value: name)],
+        for: request.parameterLayout
+    )
+    // The packet is captured once; every refresh and retry reuses it.
+    // Cancelling the consuming task ends iteration and tears the observation
+    // down, and never throws `CancellationError`.
+    for try await people in request.stream(bindings: bindings) {
+        print("\(people.count) matching rows")
+    }
+}
+// swiftql-skill-example-end: live

--- a/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
+++ b/IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/main.swift
@@ -232,11 +232,9 @@ private func executeFixture(
     try database.makeRequest(
         with: sqlInsert(Person(id: "grace", name: "Grace Hopper", age: 85))
     ).execute()
-    try database.makeRequest(with: sqlCreate(SkillPerson.self)).execute()
-    try database.makeRequest(
-        with: sqlInsert(SkillPerson(id: "ada", name: "Ada Lovelace"))
-    ).execute()
-    let skillPeople = try fetchSkillPeople(named: "Ada Lovelace", from: database)
+    // Creates the table, inserts inside a transaction, reads through the
+    // declared query, then updates and deletes with named bindings.
+    let skillPeople = try runSkillLifecycle(in: database)
     guard skillPeople == [SkillPerson(id: "ada", name: "Ada Lovelace")] else {
         throw FixtureError.unexpectedSkillQueryResult(skillPeople)
     }

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,94 +1,325 @@
 ---
 name: swiftql
-description: Use when Codex works in a Swift package or Apple application that uses SwiftQL to define typed tables or results, build or modify SQLite queries, pass immutable bindings, add contextual codecs, prepare reusable static queries, integrate a database adapter, or diagnose SwiftQL execution boundaries. Use the checked-out public v1 contract; 1.5.3 is the latest published package, adding `@SQLCodec` property-level codec selection plus built-in Date TEXT/numeric, JSON `Codable`, and UUID codec presets on top of v1.5.1's declared-query macros (@SQLQuery/@SQLQueries) and typed transaction scopes on the v1 surface. Do not use this skill to teach SQL generally or claim unshipped features.
+description: Use when Codex works in a Swift package or Apple application that uses SwiftQL to define typed tables and results, declare or modify SQLite queries, run typed transactions, observe live results, pass immutable bindings, add contextual codecs, prepare static queries, integrate a database adapter, or diagnose SwiftQL execution boundaries. Use the checked-out public v1 contract; 1.5.5 is the latest published package, adding async live-query streams, `@Observable` query wrappers, and lazy result sets on top of v1.5.4 method-style scalar functions and observers, v1.5.3 contextual codec presets and `@SQLCodec`, v1.5.2 build-time query validation, and v1.5.1 declared-query macros (`@SQLQuery`/`@SQLQueries`) and typed transaction scopes. Do not use this skill to teach SQL generally or claim unshipped features.
 ---
 
 # SwiftQL
 
-Use SwiftQL as a typed, SQL-shaped SQLite DSL. Keep schema objects, query
-structure, and invocation values separate, and verify every API against the
-checked-out package version before editing consumer code.
+SwiftQL is a typed, SQL-shaped SQLite DSL layered on GRDB. Keep schema objects,
+query structure, and invocation values separate, and verify every API against
+the checked-out package version before editing consumer code. This skill covers
+tables and results, declared and hand-built queries, bindings, decoding,
+transactions, live queries, contextual codecs, build-time validation, and the
+repository's validation commands. It does not teach SQL and never claims
+roadmap work as shipped API.
 
 ## Establish the package boundary
 
 - Add `https://github.com/lukevanin/swiftql.git` with Swift Package Manager and
   attach the `SwiftQL` library product to each application target that imports
-  it.
-- Depend on the application-facing `SwiftQL` product for macros, the DSL,
-  contextual codecs, and the GRDB-backed SQLite driver.
+  it. It carries the macros, the DSL, contextual codecs, and the GRDB-backed
+  SQLite driver.
 - Depend directly on `SwiftQLCore` only when implementing a dialect or database
   adapter. It deliberately contains no usable GRDB connection.
-- Require Swift tools 5.9, Swift 5 language mode, iOS 16 or later, or macOS 13
-  or later. Supported Swift 6 compilers still use Swift 5 mode; Swift 6 mode,
-  non-Apple platforms, non-SQLite dialects, and non-GRDB drivers are unsupported.
+- Require Swift tools 5.9 and Swift 5 language mode, iOS 16 or later, or macOS
+  13 or later. Linux is covered by the pinned Swift 5.9.2 cell through
+  OpenCombine 0.14.0. Swift 6.0 through 6.3 compilers are tested, always in
+  Swift 5 language mode; Swift 6 language mode, non-SQLite dialects, and
+  non-GRDB drivers are unsupported.
+- Two surfaces need more than that floor: `XLObservableQuery` and
+  `XLObservableQueryRow` require iOS 17 or macOS 14 for the `Observation`
+  framework, and `#row`'s two-to-six column shapes (`SQLRow2` through
+  `SQLRow6`) require Swift 6.1 or later, because earlier compilers crash during
+  IR generation. `#row`'s single-column shape works everywhere.
 - Read [the changelog](CHANGELOG.md) before choosing a package requirement.
-  `1.5.3` is the latest published package. Pin a source revision only when
+  `1.5.5` is the latest published package. Pin a source revision only when
   intentionally testing later changes from `main`.
 
-## Prefer the high-level application workflow
+## Prefer the v1.5 declared-query workflow
 
-1. Declare stored rows with `@SQLTable` and projections with `@SQLResult`.
-2. Build a statement with `sql { schema in ... }`; obtain table references from
-   that closure instead of constructing column names as strings.
-3. Create one logical request with `GRDBDatabase.makeRequest(with:)`.
-4. For parameters, retain the request and construct a fresh immutable
-   `XLInvocationBindings<XLSQLiteValue>` packet for every call. Treat a missing
-   binding differently from a present SQL `NULL`.
-5. Call `fetchAll(bindings:)`, `fetchOne(bindings:)`, or `execute(bindings:)`.
-   Let preparation, binding, driver, and decoding errors propagate unless the
+1. Declare stored rows with `@SQLTable` and projections with `@SQLResult`. A
+   stored property may itself be another `@SQLTable`/`@SQLResult` type, which
+   decodes a joined row into a nested value; a composite property must be
+   non-optional.
+2. Declare reads as functions with `@SQLQueries` (the recommended packaging) or
+   `@SQLQuery`. Parameters come from the signature, cardinality from the return
+   type, and the macro renders SQL once per database and builds a fresh
+   immutable binding packet per call.
+3. Group statements that must succeed or fail together in
+   `withTransaction { scope in ... }`, and use only `scope` inside it.
+4. Use `stream()`/`streamOne()` for live data, and the synchronous
+   `fetchAll()`/`fetchOne()`/`withResultSet(_:)`/`execute()` methods otherwise.
+5. Fall back to a hand-built `sql { schema in ... }` statement plus
+   `makeRequest(with:)` for what declared queries cannot express in v1.5, above
+   all writes, which are not yet an accepted declaration shape.
+6. Let preparation, binding, driver, and decoding errors propagate unless the
    application has an explicit error policy.
 
-The following complete example is compiled and executed by the maintained
-Swift 5 consumer fixture.
+Define the table and its declared queries together. Only one `@SQLQueries`
+extension is supported per database type, so put every specification for one
+database in a single container.
 
-<!-- compile-test: IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift -->
+<!-- compile-test: IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift#schema -->
 ```swift
 import SwiftQL
 
 @SQLTable(name: "SkillPerson")
 struct SkillPerson: Equatable {
-    let id: String
-    let name: String
+    var id: String
+    var name: String
 }
 
-enum SkillQueryError: Error {
-    case missingNameParameter
-}
+@SQLQueries
+extension GRDBDatabase {
 
-func fetchSkillPeople(
-    named name: String,
-    from database: GRDBDatabase
-) throws -> [SkillPerson] {
-    let nameParameter = XLNamedBindingReference<String>(name: "name")
-    let query = sql { schema in
-        let person = schema.table(SkillPerson.self)
-        Select(person)
-        From(person)
-        Where(person.name == nameParameter)
+    // Generated executors become members of `GRDBDatabase`, never of this
+    // container, so the container stays private to its file.
+    private struct Query {
+
+        // The return type chooses the cardinality: `[Row]` fetches every
+        // match, `Row?` fetches zero or one, and a bare `Row` insists on
+        // exactly one.
+        func skillPeopleByName(name: String) -> [SkillPerson] {
+            sqlResult { schema in
+                let person = schema.table(SkillPerson.self)
+                Select(person)
+                From(person)
+                Where(person.name == name)
+            }
+        }
     }
-    let request = database.makeRequest(with: query)
-    guard let nameSlot = request.parameterLayout.slot(for: .named("name")) else {
-        throw SkillQueryError.missingNameParameter
-    }
-    let bindings = try XLInvocationBindings<XLSQLiteValue>(
-        layout: request.parameterLayout,
-        bindings: [
-            try XLInvocationBinding(slot: nameSlot, value: .text(name)),
-        ]
-    ).validatingComplete()
-    return try request.fetchAll(bindings: bindings)
 }
 ```
 
-Lower-level boundaries include `SwiftQLCore`, validated driver helpers, raw-value
-prepared handles, and direct GRDB; use them only for the specialized needs below.
+The full lifecycle — create, insert in a transaction, read through the declared
+query, update, and delete — keeping values in bindings rather than in rendered
+SQL:
 
-Use `sqlCreate` only for basic table creation. It does not add declared SQLite
-type names, primary keys, uniqueness, foreign keys, indexes, or migrations, and
-it never upgrades an existing table. Keep production schema evolution in an
-explicit application-owned migration system.
+<!-- compile-test: IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift#lifecycle -->
+```swift
+enum SkillQueryError: Error {
+    case missingParameter(String)
+}
 
-## Use the v1.2 reusable-query boundary retained in v1.3
+// A request owns rendered SQL and an immutable parameter layout. Values for
+// one call live in a separate packet built against that layout.
+func skillTextPacket(
+    _ parameters: [(name: String, value: String)],
+    for layout: XLParameterLayout
+) throws -> XLInvocationBindings<XLSQLiteValue> {
+    try XLInvocationBindings<XLSQLiteValue>(
+        layout: layout,
+        bindings: try parameters.map { parameter in
+            guard let slot = layout.slot(for: .named(parameter.name)) else {
+                throw SkillQueryError.missingParameter(parameter.name)
+            }
+            return try XLInvocationBinding(
+                slot: slot,
+                value: .text(parameter.value)
+            )
+        }
+    ).validatingComplete()
+}
+
+func runSkillLifecycle(in database: GRDBDatabase) throws -> [SkillPerson] {
+    // `sqlCreate` renders `CREATE TABLE IF NOT EXISTS`. It is not a migration
+    // engine and never alters an existing table.
+    try database.makeRequest(with: sqlCreate(SkillPerson.self)).execute()
+
+    // Statements that must succeed or fail together share one transaction on
+    // one pinned connection. Use `scope`, never the captured `database`.
+    try database.withTransaction { scope in
+        try scope.makeRequest(
+            with: sqlInsert(SkillPerson(id: "ada", name: "Ada Lovelace"))
+        ).execute()
+        try scope.makeRequest(
+            with: sqlInsert(SkillPerson(id: "grace", name: "Grace Hopper"))
+        ).execute()
+    }
+
+    // The declared query renders once per database and reuses one prepared
+    // statement. Each call builds a fresh immutable packet from its arguments.
+    _ = try database.skillPeopleByName(name: "Grace Hopper")
+
+    // Writes are not a declared-query shape in v1.5, so they keep their values
+    // out of the rendered SQL with named bindings instead.
+    let idParameter = XLNamedBindingReference<String>(name: "id")
+    let nameParameter = XLNamedBindingReference<String>(name: "name")
+    let renameRequest = database.makeRequest(
+        with: sql { schema in
+            let person = schema.into(SkillPerson.self)
+            Update(person)
+            Setting(person) { row in
+                row.name = nameParameter
+            }
+            Where(person.id == idParameter)
+        }
+    )
+    try renameRequest.execute(
+        bindings: try skillTextPacket(
+            [
+                (name: "id", value: "grace"),
+                (name: "name", value: "Grace B. Hopper"),
+            ],
+            for: renameRequest.parameterLayout
+        )
+    )
+
+    let deleteRequest = database.makeRequest(
+        with: sql { schema in
+            let person = schema.into(SkillPerson.self)
+            Delete(person)
+            Where(person.id == idParameter)
+        }
+    )
+    try deleteRequest.execute(
+        bindings: try skillTextPacket(
+            [(name: "id", value: "grace")],
+            for: deleteRequest.parameterLayout
+        )
+    )
+
+    return try database.skillPeopleByName(name: "Ada Lovelace")
+}
+```
+
+Use `sqlCreate` only for basic table creation. It adds no declared SQLite type
+names, primary keys, uniqueness, foreign keys, indexes, or migrations, and it
+never upgrades an existing table. Keep schema evolution in an explicit
+application-owned migration system such as GRDB's `DatabaseMigrator`.
+
+Read the [declared-queries guide](https://lukevanin.github.io/swiftql/documentation/swiftql/declaredqueries/)
+and [getting started](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/)
+rather than reproducing those contracts in consumer comments;
+[select queries](https://lukevanin.github.io/swiftql/documentation/swiftql/queries/)
+and [expressions](https://lukevanin.github.io/swiftql/documentation/swiftql/expressions/)
+cover joins, grouping, subqueries, common table expressions, and operators.
+
+### Declaration limits to respect
+
+- Only `SELECT`-shaped specifications are supported; a write, with or without
+  `RETURNING`, is not an accepted return shape in v1.5.
+- Collection-typed parameters (`[T]`, `Set`, `Dictionary`) are rejected, because
+  a variable-length `IN` list would change the rendered SQL text.
+- Generated executors are synchronous and throwing; there is no `async` variant.
+- Executor names derive from the specification's base name only, so two
+  specifications sharing a base name collide with a duplicate-declaration error.
+- The frozen-literal guard rejects, at the declaration site, every parameter
+  reference it cannot turn into a named placeholder: string interpolation,
+  nested-closure capture, a direct call argument, a local-binding initializer,
+  a hand-constructed binding, a shadowing declaration, member access on a
+  parameter, a collection parameter, and an unreferenced parameter. Write
+  `column == parameter`; never route around a diagnostic by interpolating.
+
+## Bind parameters and decode results
+
+- For a hand-built request, retain the request and build a fresh immutable
+  `XLInvocationBindings<XLSQLiteValue>` packet per call. Missing is not `NULL`:
+  omitting a binding fails completeness validation, while `.null` is a present
+  value accepted only by a nullable slot.
+- Do not turn runtime values into identifiers, ordering choices, placeholder
+  counts, or SQL grammar. Bind values; keep grammar and identifiers in the
+  Swift expression graph. Use intrinsic `Bool`, `Int`, finite `Double`,
+  `String`, and `Data` storage directly and contextual codecs for everything
+  else, and never render a non-finite `Double` as an inline numeric token.
+- Decode into the selected `@SQLTable` or `@SQLResult` row. Prefer `fetchAll()`
+  for a retained array, `withResultSet(_:)` when the result may be large or
+  iteration may stop early, and `fetchOne()` for zero-or-one. An `XLResultSet`
+  is valid only inside its `withResultSet(_:)` callback and throws
+  `XLResultSetError.closed` afterwards.
+- Treat `XLInvocationBindingError` and `XLRequestBindingError` as caller
+  contract failures. Adapter authors should preserve structured
+  `XLDatabaseContractError` categories; the established GRDB facade can still
+  expose `DatabaseError` or `XLColumnReadError` where its compatibility policy
+  requires those concrete errors.
+
+## Keep transactions explicit
+
+- `withTransaction(_:)` is the shipped typed transaction contract. It runs an
+  ordered sequence of typed requests on one pinned connection, commits when the
+  body returns, and rolls back every write when it throws.
+- Use only the pinned scope inside the body. Re-entering the root database or
+  calling `withTransaction(_:)` again throws
+  `XLTransactionScopeError.nestedTransactionUnsupported`; using a scope after
+  its body returns throws `.scopeEscaped`; starting a live query inside one
+  throws `.liveQueriesUnsupportedInTransaction`.
+- Do not claim nested transactions, savepoints, or mid-transaction cancellation
+  hooks. Cancellation is checked once, before the transaction opens.
+- `@SQLQueries`'s generated `execute(_:)` is sugar over the same primitive, so
+  declared-query and `makeRequest(with:)` calls in one closure commit or roll
+  back together. Migrations stay application or driver work; `sqlCreate` is not
+  a migration engine.
+
+## Observe live results
+
+`stream()` and `streamOne()` are the canonical live-query API; the Combine
+`publish()`/`publishOne()` methods are adapters over that same source rather
+than a second observation engine.
+
+<!-- compile-test: IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift#live -->
+```swift
+func observeSkillPeople(
+    named name: String,
+    in database: GRDBDatabase
+) async throws {
+    let nameParameter = XLNamedBindingReference<String>(name: "name")
+    let request = database.makeRequest(
+        with: sql { schema in
+            let person = schema.table(SkillPerson.self)
+            Select(person)
+            From(person)
+            Where(person.name == nameParameter)
+        }
+    )
+    let bindings = try skillTextPacket(
+        [(name: "name", value: name)],
+        for: request.parameterLayout
+    )
+    // The packet is captured once; every refresh and retry reuses it.
+    // Cancelling the consuming task ends iteration and tears the observation
+    // down, and never throws `CancellationError`.
+    for try await people in request.stream(bindings: bindings) {
+        print("\(people.count) matching rows")
+    }
+}
+```
+
+- Constructing a stream performs no database work; the first `next()` starts the
+  GRDB observation. Each call creates one independent single-consumer stream, so
+  two consumers must call `stream()` twice.
+- At most one undelivered snapshot is buffered per stream, newest wins, and
+  resuming demand never forces a fresh fetch.
+- Fetching is all-or-nothing: a failed execution or row decode throws the
+  original error instead of yielding a truncated result.
+- For SwiftUI, prefer `XLObservableQuery`/`XLObservableQueryRow` on iOS 17 or
+  macOS 14 and later, and `XLQueryObserver`/`XLQueryRowObserver` below that.
+- Read [live queries](https://lukevanin.github.io/swiftql/documentation/swiftql/livequeries/)
+  for the full buffering, cancellation, retry, and delivery contract.
+
+## Respect dialect, driver, and codec ownership
+
+- Let `XLSQLiteDialect` own SQLite grammar, placeholder spelling, identifiers,
+  storage classes, and required capabilities, and let the driver own
+  connections, physical statements, transport binding, execution, and row
+  reads. Keep physical statements on the connection that prepared them: a
+  logical request or prepared handle is database-bound but owns none.
+- Prefer immutable contextual `XLValueCodec` registrations when one Swift type
+  has one or more database representations. Select codecs deterministically,
+  snapshot the configuration in the database or prepared handle, and treat a
+  codec key or version change as a schema/data compatibility decision.
+- v1.5.3 ships named presets rather than implicit defaults: `XLDateTextCodec`,
+  the `UnixMilliseconds`/`UnixSeconds`/`JulianDay` numeric `Date` codecs,
+  `XLJSONValueCodec`, and `XLUUIDValueCodec.text`/`.blob`. Encoding without an
+  explicit selector or a registered database default throws `.ambiguousCodec`.
+  `@SQLCodec(key)` selects a registered codec on one stored property; it does
+  not register one, and an unregistered key fails like any explicit selection.
+
+Read [contextual codecs](https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/) and
+[prepared execution boundaries](https://lukevanin.github.io/swiftql/documentation/swiftql/advancedusage/)
+for the exact selection order, structured errors, row lifetime, and driver
+contracts.
+
+## Use static queries and build-time validation where they earn their keep
 
 Choose a static query when the definition needs durable identity, explicit
 parameter and result metadata, cardinality, registration before a database is
@@ -98,52 +329,51 @@ opened, or a raw-value handle that can cross tasks.
   inferred from bare variables in the runtime DSL.
 - Render and validate the statement, then construct an immutable
   `XLStaticQueryDescriptor`. Never store a database, connection, prepared
-  statement, or invocation value in the descriptor.
-- Give each definition a stable `XLQueryDefinitionIdentity`; persist its
-  canonical bytes or hex, never Swift `hashValue`. Increment the version when
-  the canonical contract intentionally changes.
-- Prepare the descriptor through `GRDBDatabase.prepareInvocation(with:)`, then
-  make a fresh packet for each call. Match the prepared operation to the
-  descriptor cardinality.
-- Use macro-generated static row layouts for contextual-only properties or
-  typed static decoding. The raw `GRDBPreparedStaticQuery` is `Sendable`; the
-  closure-backed typed layout wrapper remains task-local in v1.3.
+  statement, or invocation value in it, and give each definition a stable
+  `XLQueryDefinitionIdentity` persisted as canonical bytes or hex, never as a
+  Swift `hashValue`. Prepare it through
+  `GRDBDatabase.prepareInvocation(with:)`, then make a fresh packet per call
+  matching the descriptor's cardinality.
+- v1.5.2's `swiftql-build-validate` executable and
+  `SwiftQLSQLiteBuildValidationPlugin` check a manifest of static descriptors
+  against a checked-in schema snapshot during `swift build`. They prove the SQL
+  parses and that schema, parameter, and capability metadata agree, and prove
+  nothing about result values, row counts, or behavior. No macro emits a
+  manifest from a `@SQLQuery` declaration yet, and a plugin-adopting package
+  fails to build under Xcode 26.5 before validation runs, so drive it with
+  `swift build`.
 
-Read the canonical [static-query guide](https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/)
+Read the [static-query guide](https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/)
 for descriptor construction, captures, cardinality, preparation, and typed
-layouts rather than reproducing those contracts in consumer comments.
+layouts.
 
-## Respect dialect, driver, and codec ownership
+## Avoid compatibility and escape-hatch traps
 
-- Let `XLSQLiteDialect` own SQLite grammar, placeholder spelling, identifiers,
-  storage classes, and required capabilities. Let the driver own connections,
-  physical statements, transport binding, execution, and row reads.
-- Keep physical statements on the connection that prepared them. A logical
-  request or prepared handle is database-bound but does not own one physical
-  statement across a pool.
-- Prefer immutable contextual `XLValueCodec` registrations when one Swift type
-  has one or more database representations. Select codecs deterministically,
-  snapshot the configuration in the database or prepared handle, and treat a
-  codec key or version change as a schema/data compatibility decision.
-- Use intrinsic `Bool`, `Int`, finite `Double`, `String`, and `Data` storage
-  directly. Use prepared contextual parameters and result codecs for other
-  application values. Reject missing, duplicate, wrong-layout, wrong-storage,
-  and nullability-mismatched bindings before execution.
-- Decode ordinary queries into their selected `@SQLTable` or `@SQLResult` row.
-  For a raw static handle, validate result layout and cardinality before using
-  `resultCodec(_:identifiedBy:)` to decode contextual values.
-- Treat `XLInvocationBindingError` and `XLRequestBindingError` as caller
-  contract failures. Adapter authors should preserve structured
-  `XLDatabaseContractError` categories; the established GRDB facade can still
-  expose `DatabaseError` or `XLColumnReadError` where its compatibility policy
-  requires those concrete errors.
+- Prefer declared queries, `withTransaction(_:)`, and `stream()`/`streamOne()`
+  over the surfaces they wrap. Reach for `makeRequest(with:)`, mutating `set`,
+  raw prepared handles, or direct GRDB only for what the high-level path does
+  not cover. Keep existing `makeRequest(with:)`, mutating `set`, `XLCustomType`,
+  legacy literal readers, and raw `XLSQLiteValue` code working when maintaining
+  v1 clients, but write new code with explicit invocation packets,
+  `XLFieldReader`, contextual codecs, and static descriptors.
+- Do not write the free functions `count(_:)`, `min(_:)`/`max(_:)`,
+  `iif(_:then:else:)`, or `printf(format:_:)` in new code. v1.5.4 deprecated
+  them in favor of `all().count()`, `a.min(b, ...)`/`a.max(b, ...)`,
+  `condition.iif(then:else:)`, and `"...".printf(...)`. The non-optional `min`,
+  `max`, `sum`, `average`, and `groupConcat` aggregates remain deprecated in
+  favor of their `OrNull` spellings.
+- Do not share `XLRequest` across tasks; it is not `Sendable`. Use the raw
+  prepared invocation/static handles for supported cross-task raw-value work.
+- SwiftQL exposes no general raw-fragment API. When unsupported SQL genuinely
+  requires a direct GRDB escape hatch, isolate it at the application boundary,
+  allowlist any dynamic grammar or identifiers, and bind all data values.
+- Do not use deprecated pre-XL names such as `SQLNamedBindingReference`, and do
+  not use `Join.Outer`, removed in favor of `Join.Left` and `Join.FullOuter`.
 
-Read [contextual codecs](https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/) and
-[prepared execution boundaries](https://lukevanin.github.io/swiftql/documentation/swiftql/advancedusage/)
-for the exact selection order, structured errors, row lifetime, and driver
-contracts; the everyday API is [getting started](https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/).
+Check [the README](README.md) and [compatibility matrix](COMPATIBILITY.md) before
+changing product, platform, dependency, or concurrency claims.
 
-## Report v1.3 support from canonical evidence
+## Report SQLite support from canonical evidence
 
 - Treat the versioned [inventory](Tests/SwiftQLSQLiteConformanceFixtures/SQLiteConformanceInventory.json) as
   the source of truth and its [report](Conformance/SQLite/REPORT.md) as a generated
@@ -158,44 +388,9 @@ contracts; the everyday API is [getting started](https://lukevanin.github.io/swi
   counts do not map one to one; never turn this into an exhaustive-SQL claim.
 - The generated corpus holds 208 positives plus one broken-renderer control:
   141 from #191, 27 from #286, 35 from #287, and 5 from #288. #254 adds 18
-  Northwind and #255 adds 12 observation-stress cases; no new syntax.
-- #132 remains package-private research. It ships no public validator, build
-  plugin, query macro, schema system, or new v1.3 API. It neither persists
-  prepared statements nor removes runtime preparation on a physical connection.
-
-## Keep transactions and migrations explicit
-
-- Do not invent a high-level `GRDBDatabase.transaction` API. The shipped v1
-  transaction contract is the lower-level driver's synchronous
-  `withValidatedTransaction` helper.
-- Use only the pinned connection inside its transaction body. Do not re-enter
-  the root pool. A returned body commits; a thrown body rolls back and preserves
-  the body error.
-- Do not claim nested transactions, savepoints, task-cancellation hooks, or a
-  separate single-connection GRDB capability in v1.3.
-- Treat migrations as application or driver work. `sqlCreate` is not a
-  migration engine.
-
-## Avoid compatibility and escape-hatch traps
-
-- Keep existing `makeRequest(with:)`, mutating `set`, `XLCustomType`, legacy
-  literal readers, and raw `XLSQLiteValue` code working when maintaining v1
-  clients. For new code, prefer explicit invocation packets, `XLFieldReader`,
-  contextual codecs, and static descriptors where their added guarantees are
-  needed.
-- Do not share `XLRequest` across tasks; it is not `Sendable`. Use the raw
-  prepared invocation/static handles for supported cross-task raw-value work.
-- Do not turn runtime values into identifiers, ordering choices, placeholder
-  counts, or SQL grammar. Bind values; keep grammar and identifiers in the
-  Swift expression graph.
-- SwiftQL exposes no general raw-fragment API. When unsupported SQL genuinely
-  requires a direct GRDB escape hatch, isolate it at the application boundary,
-  allowlist any dynamic grammar or identifiers, and bind all data values.
-- Do not use deprecated pre-XL names such as `SQLNamedBindingReference`, or
-  represent NaN/non-finite `Double` values as inline SQLite numeric tokens.
-
-Check [the README](README.md) and [compatibility matrix](COMPATIBILITY.md) before
-changing product, platform, dependency, or concurrency claims.
+  Northwind and #255 adds 12 observation-stress cases; no new syntax. This
+  census is separate from v1.5.2's build validator, which checks one target's
+  manifest against one schema snapshot instead.
 
 ## Validate repository changes
 
@@ -204,15 +399,19 @@ ordinary validation; use clean resolution only when dependency behavior is the
 subject of the task.
 
 ```sh
+swift build
 swift test --filter SQLSkillDocumentationTests
+swift test --filter SQLDocumentationCatalogTests
+swift test
 python3 scripts/ci/sqlite-conformance-inventory.py check
 scripts/ci/check-downstream-swift5-client.sh committed
-swift test
 ./make-docs.sh docs
 scripts/ci/check-first-party-warnings.sh
 scripts/ci/check-strict-concurrency.sh
 ```
 
-Run the warnings and strict-concurrency gates with a supported Xcode. Use the
-required GitHub compatibility matrix for exact Swift 5.9 and Swift 6.0-6.3
-evidence; do not silently substitute another local compiler.
+Every Swift snippet above is embedded verbatim from the maintained downstream
+consumer fixture and checked by `SQLSkillDocumentationTests`; edit the fixture
+first, never the fence. Run the warnings and strict-concurrency gates with a
+supported Xcode, and use the required GitHub compatibility matrix for exact
+Swift 5.9 and Swift 6.0-6.3 evidence rather than substituting a local compiler.

--- a/Tests/SQLTests/SQLSkillDocumentationTests.swift
+++ b/Tests/SQLTests/SQLSkillDocumentationTests.swift
@@ -24,7 +24,7 @@ final class SQLSkillDocumentationTests: XCTestCase {
             2,
             "Codex skill metadata must contain only name and description."
         )
-        XCTAssertLessThan(lines.count, 220, "Keep the repository skill concise.")
+        XCTAssertLessThan(lines.count, 440, "Keep the repository skill concise.")
 
         for forbidden in [
             "/Users/",
@@ -41,23 +41,32 @@ final class SQLSkillDocumentationTests: XCTestCase {
         for required in [
             "https://github.com/lukevanin/swiftql.git",
             "`SwiftQLCore` only when implementing a dialect or database adapter",
-            "fresh immutable `XLInvocationBindings<XLSQLiteValue>` packet",
+            "fresh immutable `XLInvocationBindings<XLSQLiteValue>` packet per call",
             "`XLStaticQueryDescriptor`",
             "runtime Swift values are not inferred from bare variables",
             "`XLValueCodec`",
             "`XLInvocationBindingError` and `XLRequestBindingError`",
-            "Do not invent a high-level `GRDBDatabase.transaction` API",
+            "`withTransaction(_:)` is the shipped typed transaction contract",
             "`sqlCreate` is not a migration engine",
             "SwiftQL exposes no general raw-fragment API",
             "`XLRequest` across tasks; it is not `Sendable`",
             "checked-out public v1 contract",
-            "1.5.3 is the latest published package, adding `@SQLCodec` property-level codec selection plus built-in Date TEXT/numeric, JSON `Codable`, and UUID codec presets on top of v1.5.1's declared-query macros (@SQLQuery/@SQLQueries) and typed transaction scopes on the v1 surface",
-            "`1.5.3` is the latest published package",
+            "1.5.5 is the latest published package, adding async live-query streams, `@Observable` query wrappers, and lazy result sets on top of v1.5.4 method-style scalar functions and observers, v1.5.3 contextual codec presets and `@SQLCodec`, v1.5.2 build-time query validation, and v1.5.1 declared-query macros (`@SQLQuery`/`@SQLQueries`) and typed transaction scopes",
+            "`1.5.5` is the latest published package",
             "Keep those five statuses distinct",
             "recorded SQLite version, source ID, compile options, capabilities",
-            "#132 remains package-private research",
-            "neither persists prepared statements nor removes runtime preparation",
             "Swift 5.9 and Swift 6.0-6.3 evidence",
+            // v1.5 surfaces the skill must present as the preferred path.
+            "`@SQLQueries` (the recommended packaging)",
+            "Only one `@SQLQueries` extension is supported per database type",
+            "`stream()` and `streamOne()` are the canonical live-query API",
+            // Version-specific limitations and deprecations.
+            "Only `SELECT`-shaped specifications are supported",
+            "The frozen-literal guard rejects, at the declaration site",
+            "v1.5.4 deprecated them in favor of `all().count()`",
+            "`XLObservableQueryRow` require iOS 17 or macOS 14",
+            "`SQLRow6`) require Swift 6.1 or later",
+            "fails to build under Xcode 26.5 before validation runs",
         ] {
             XCTAssertTrue(
                 normalizedContents.contains(required),
@@ -66,7 +75,7 @@ final class SQLSkillDocumentationTests: XCTestCase {
         }
     }
 
-    func testV13GuidanceMatchesCanonicalConformanceInventory() throws {
+    func testConformanceCensusGuidanceMatchesCanonicalInventory() throws {
         let inventory = try JSONDecoder().decode(
             SkillConformanceInventory.self,
             from: Data(
@@ -173,7 +182,6 @@ final class SQLSkillDocumentationTests: XCTestCase {
                 + "#288. #254 adds \(northwindSuite.caseIDs.count) Northwind and "
                 + "#255 adds \(observationSuite.caseIDs.count) "
                 + "observation-stress cases",
-            "It ships no public validator, build plugin, query macro, schema system, or new v1.3 API. It neither persists prepared statements nor removes runtime preparation on a physical connection.",
         ] {
             XCTAssertTrue(
                 normalizedContents.contains(required),
@@ -184,28 +192,46 @@ final class SQLSkillDocumentationTests: XCTestCase {
 
     func testEverySwiftSnippetIsTheCompiledConsumerFixture() throws {
         let skill = try skillContents()
-        let sourceURL = repositoryRootURL().appendingPathComponent(
+        let fixturePath =
             "IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift"
+        let source = try String(
+            contentsOf: repositoryRootURL().appendingPathComponent(fixturePath),
+            encoding: .utf8
         )
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
-        let expected = try text(
-            between: "// swiftql-skill-example-begin\n",
-            and: "\n// swiftql-skill-example-end",
-            in: source
-        )
+        let regions = ["schema", "lifecycle", "live"]
 
         XCTAssertEqual(
             skill.components(separatedBy: "```swift\n").count - 1,
-            1,
-            "Every added Swift fence needs an explicit compiled fixture."
+            regions.count,
+            "Every Swift fence needs an explicit compiled fixture region."
         )
-        let actual = try text(between: "```swift\n", and: "\n```", in: skill)
-        XCTAssertEqual(actual, expected)
-        XCTAssertTrue(
-            skill.contains(
-                "<!-- compile-test: IntegrationTests/Swift5Client/Sources/SwiftQLSwift5Client/SkillQuickStart.swift -->"
+
+        var remainder = Substring(skill)
+        for region in regions {
+            let marker = "<!-- compile-test: \(fixturePath)#\(region) -->\n```swift\n"
+            guard
+                let start = remainder.range(of: marker)?.upperBound,
+                let end = remainder.range(
+                    of: "\n```",
+                    range: start ..< remainder.endIndex
+                )?.lowerBound
+            else {
+                return XCTFail(
+                    "SKILL.md must embed the compiled '\(region)' fixture region."
+                )
+            }
+            let expected = try text(
+                between: "// swiftql-skill-example-begin: \(region)\n",
+                and: "\n// swiftql-skill-example-end: \(region)",
+                in: source
             )
-        )
+            XCTAssertEqual(
+                String(remainder[start ..< end]),
+                expected,
+                "SKILL.md's '\(region)' snippet drifted from the compiled fixture."
+            )
+            remainder = remainder[end...]
+        }
     }
 
     func testSkillLinksResolveAndCommandsStayRepositoryRelative() throws {
@@ -227,8 +253,32 @@ final class SQLSkillDocumentationTests: XCTestCase {
             "https://lukevanin.github.io/swiftql/documentation/swiftql/customtypes/",
             "https://lukevanin.github.io/swiftql/documentation/swiftql/gettingstarted/",
             "https://lukevanin.github.io/swiftql/documentation/swiftql/advancedusage/",
+            "https://lukevanin.github.io/swiftql/documentation/swiftql/declaredqueries/",
+            "https://lukevanin.github.io/swiftql/documentation/swiftql/livequeries/",
+            "https://lukevanin.github.io/swiftql/documentation/swiftql/queries/",
+            "https://lukevanin.github.io/swiftql/documentation/swiftql/expressions/",
         ] {
-            XCTAssertTrue(contents.contains(canonicalURL))
+            XCTAssertTrue(contents.contains(canonicalURL), "SKILL.md must link \(canonicalURL).")
+        }
+        // Each linked DocC page must still exist in the catalog.
+        for article in [
+            "StaticQueries",
+            "CustomTypes",
+            "GettingStarted",
+            "AdvancedUsage",
+            "DeclaredQueries",
+            "LiveQueries",
+            "Queries",
+            "Expressions",
+        ] {
+            XCTAssertTrue(
+                FileManager.default.fileExists(
+                    atPath: root.appendingPathComponent(
+                        "Sources/SwiftQL/SwiftQL.docc/\(article).md"
+                    ).path
+                ),
+                "SKILL.md links a missing DocC article: \(article)."
+            )
         }
         XCTAssertTrue(
             contents.contains(
@@ -240,10 +290,12 @@ final class SQLSkillDocumentationTests: XCTestCase {
         XCTAssertEqual(
             shell.components(separatedBy: .newlines),
             [
+                "swift build",
                 "swift test --filter SQLSkillDocumentationTests",
+                "swift test --filter SQLDocumentationCatalogTests",
+                "swift test",
                 "python3 scripts/ci/sqlite-conformance-inventory.py check",
                 "scripts/ci/check-downstream-swift5-client.sh committed",
-                "swift test",
                 "./make-docs.sh docs",
                 "scripts/ci/check-first-party-warnings.sh",
                 "scripts/ci/check-strict-concurrency.sh",


### PR DESCRIPTION
Closes #231

## Summary

`SKILL.md` was written for v1.2/v1.3 and never caught up. Two of its section headers literally read "Use the v1.2 reusable-query boundary retained in v1.3" and "Report v1.3 support from canonical evidence"; it named `1.5.3` as the latest release; and its one worked example was a hand-built `XLRequest` with a manually assembled binding packet, presented as *the* way to run a query.

An agent reading that file would not learn that `@SQLQuery`/`@SQLQueries`, `withTransaction(_:)`, `stream()`/`streamOne()`, build-time validation, the v1.5.3 codec presets, `XLResultSet`, or the observable query wrappers exist — and would reach for the deprecated free functions `count(_:)`/`min(_:)`/`max(_:)`/`iif`/`printf` because nothing said not to.

## Changes

**`SKILL.md`** — rewritten around the preferred v1.5 path, same location, same Codex frontmatter (`name` + `description` only).

- Leads with the declared-query workflow: `@SQLTable`/`@SQLResult` → `@SQLQueries` → `withTransaction { scope in }` → `stream()`/`streamOne()`. `makeRequest(with:)`, mutating `set`, raw prepared handles, and direct GRDB are explicitly framed as what you reach for when the high-level path does not cover the case, not as first choice.
- Adds the surfaces the old file predated: build-time validation (`swiftql-build-validate` + the SwiftPM plugin), `XLDateTextCodec` / numeric `Date` codecs / `XLJSONValueCodec` / `XLUUIDValueCodec` / `@SQLCodec`, `XLResultSet`, and `XLObservableQuery` / `XLQueryObserver`.
- Warnings and version-specific limits an agent will otherwise trip over: `SELECT`-only declarations (writes stay on `makeRequest`), collection parameters rejected, the frozen-literal guard's full list of rejected reference shapes, one `@SQLQueries` extension per database type, the v1.5.4 free-function deprecations, `#row`'s Swift 6.1 floor, `XLObservableQuery`'s iOS 17 / macOS 14 floor, and the build plugin's Xcode 26.5 failure (#492).
- Exact platform and toolchain numbers pulled from `COMPATIBILITY.md`; `1.5.5` as the published version, matching `README.md` and `CHANGELOG.md`.
- Links out to `DeclaredQueries`, `LiveQueries`, `Queries`, and `Expressions` alongside the four DocC pages it already referenced, rather than restating contracts that will drift.
- Drops the stale `#132` paragraph, which claimed no public validator or build plugin ships — true of that research issue, actively misleading now that #292–#294 shipped one. The conformance census numbers are unchanged and still derived from the canonical inventory by test.

**Compile-tested snippets.** The fixture's single `swiftql-skill-example` region becomes three named regions (`schema`, `lifecycle`, `live`), and `SQLSkillDocumentationTests` now matches each fence against its own region instead of assuming exactly one fence exists. Every fence in the file is still verbatim fixture source; there is no untested code block.

- The `@SQLQueries` container moves from `DeclaredQueriesFixture.swift` into `SkillQuickStart.swift` — only one such extension is supported per database type, and the skill needs to show it. `DeclaredQueriesFixture.swift` keeps the `@SQLQuery` peer form.
- `main.swift` drives the lifecycle through `runSkillLifecycle`, so create → insert-in-a-transaction → declared-query read → update → delete runs against real SQLite rather than only compiling.

**`SQLSkillDocumentationTests`** — required-phrase list updated to the v1.5 content, with new assertions for the preferred-API framing (`@SQLQueries` recommended, `stream()`/`streamOne()` canonical) and for each documented limitation. Linked DocC articles are now checked for existence on disk, not just as strings. `testV13GuidanceMatchesCanonicalConformanceInventory` renamed to `testConformanceCensusGuidanceMatchesCanonicalInventory`. The line-count bound moves from 220 to 440: the file's compiled code grew from 37 lines to 136, and its prose from 183 to ~280.

## Validation

| Command | Result |
| --- | --- |
| `swift build` | Build complete |
| `swift test` | 1186 passed, 0 failures |
| `swift test --filter SQLSkillDocumentationTests` | 4 passed |
| `swift test --filter SQLDocumentationCatalogTests` | 8 passed |
| `swift test --filter XLDocumentationTests` | 39 passed |
| `python3 scripts/ci/sqlite-conformance-inventory.py check` | report current |
| `scripts/ci/check-downstream-swift5-client.sh committed` | exit 0, one success marker |

The downstream check is the one that matters here: it compiles and executes all three skill snippets from a real separate package under the Swift 5 language-mode floor.

Not run locally: `./make-docs.sh docs`, `check-first-party-warnings.sh`, `check-strict-concurrency.sh`. No `Sources/` file changed, so there is nothing new for the warning and concurrency gates to see, and no DocC content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)