### PR TITLE
Publish a DocC tutorial for an end-to-end SwiftQL query

### DIFF
--- a/Coverage/README.md
+++ b/Coverage/README.md
@@ -47,6 +47,14 @@ generated macro expansion files therefore cannot contribute to the reported
 first-party totals. Fixture tests inject each excluded category and verify that
 the totals and manifest remain unchanged.
 
+Swift files inside a `.docc` catalog are excluded as well, even though they sit
+under a configured target root. SwiftPM copies a documentation catalog as a
+resource bundle rather than compiling what is in it, so those files are the code
+snapshots the DocC tutorial displays through `@Code(file:)` and LLVM never
+reports a region for one. `Tests/SQLTests/SQLDocumentationCatalogTests.swift`
+checks each snapshot against the compiled walkthrough it was cut from, which is
+where their type checking comes from.
+
 LLVM does not currently report executable regions for `Sources/SwiftQL/SQL.swift`,
 `Sources/SwiftQL/SQLScalarResult.swift`, or the import-only
 `Sources/SwiftQL/SwiftQLCore.swift` compatibility shim. They are explicit

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -33,7 +33,9 @@ to the style and conventions of the Swift language.
 SwiftQL targets SQLite's SQL dialect. If you already know SQLite syntax, the
 corresponding SwiftQL statements should feel familiar.
 
-New here? Start with <doc:GettingStarted>. Upgrading? The repository's
+New here? Follow <doc:/tutorials/SwiftQL> to build one query from an empty
+file, then read <doc:GettingStarted> for the rest of the everyday API.
+Upgrading? The repository's
 [what's new](https://github.com/lukevanin/swiftql/blob/main/WHATSNEW.md)
 summarizes each release in plain language, and the
 [changelog](https://github.com/lukevanin/swiftql/blob/main/CHANGELOG.md)
@@ -130,6 +132,10 @@ This type information reduces construction and result-decoding mistakes without
 replacing SQLite's runtime type rules.
 
 ## Topics
+
+### Tutorials
+
+- <doc:/tutorials/SwiftQL>
 
 ### Essentials
 

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/EndToEndQuery.tutorial
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/EndToEndQuery.tutorial
@@ -1,0 +1,261 @@
+@Tutorial(time: 15) {
+    @Intro(title: "Query a SQLite database end to end") {
+        Build one complete SwiftQL program. It describes two tables in Swift,
+        opens a scratch SQLite database, writes a few rows inside a
+        transaction, joins the tables behind a named binding, and decodes the
+        matching rows into a Swift array.
+
+        The finished program is about seventy lines and uses only APIs that
+        ship in SwiftQL 1.5. Each step adds to the same file, so the code panel
+        highlights exactly what changed.
+    }
+
+    @Section(title: "Describe the tables") {
+        @ContentAndMedia {
+            A SwiftQL table is a Swift `struct` annotated with `@SQLTable`.
+            The property names become column names and the property types
+            decide how values are bound and decoded, so the schema and the
+            Swift model stay the same declaration.
+
+            A query that reads columns from more than one table needs a
+            projection type as well. That is a `struct` annotated with
+            `@SQLResult`, and it carries only the columns you asked for.
+        }
+
+        @Steps {
+            @Step {
+                Create a Swift file and import SwiftQL. `Foundation` comes
+                along for `URL`.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-01-01.swift)
+            }
+
+            @Step {
+                Add a `Studio` table. Each property is non-optional, so
+                SwiftQL emits every column with a `NOT NULL` constraint.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-01-02.swift)
+            }
+
+            @Step {
+                Add an `Album` table whose `studioId` refers to a studio's
+                `id`. SwiftQL does not generate foreign keys, so the
+                relationship lives in the join you write later.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-01-03.swift)
+            }
+
+            @Step {
+                Declare `AlbumCredit` with `@SQLResult`. It holds the three
+                columns the query returns rather than either whole table.
+                `@SQLResult` generates a `columns(...)` factory that you use
+                to build the projection inside a query.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-01-04.swift)
+            }
+        }
+    }
+
+    @Section(title: "Open a database and create the tables") {
+        @ContentAndMedia {
+            `GRDBDatabase` is the SQLite adapter that ships with SwiftQL. It
+            opens a database file and hands out requests, which are rendered
+            SQL statements you can execute more than once.
+
+            Passing a temporary file URL gives you a database you can delete
+            afterwards, which is what the test suite does when it runs this
+            program.
+        }
+
+        @Steps {
+            @Step {
+                Write a function that takes the country to search for and the
+                database file to use, then open the database. Passing `nil`
+                for `logger` turns off statement logging.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-02-01.swift)
+            }
+
+            @Step {
+                Create both tables. `sqlCreate` renders
+                `CREATE TABLE IF NOT EXISTS`, so running it against a database
+                that already has the tables does nothing.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-02-02.swift)
+            }
+        }
+    }
+
+    @Section(title: "Insert the records") {
+        @ContentAndMedia {
+            Rows are ordinary Swift values. `sqlInsert` turns one value into an
+            insert statement with the value's properties already bound, which
+            means you never write the column list by hand.
+
+            Wrapping the inserts in `withTransaction(_:)` commits them
+            together. If the closure throws, every write inside it rolls back.
+        }
+
+        @Steps {
+            @Step {
+                Build the studios and albums you want in the database. Two of
+                the three albums were recorded at the British studio, which is
+                what the query will select later.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-03-01.swift)
+            }
+
+            @Step {
+                Insert them inside a transaction. The `scope` the closure
+                receives works like the database itself, so you call
+                `makeRequest(with:)` on it the same way.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-03-02.swift)
+            }
+        }
+    }
+
+    @Section(title: "Build the query") {
+        @ContentAndMedia {
+            The `sql` builder describes a statement without running it. Inside
+            the closure you ask the schema for the tables you need, build the
+            projection, and write the clauses in the order SQLite expects.
+
+            An `XLNamedBindingReference` stands in for a value you supply at
+            call time. The rendered SQL contains `:country` rather than a
+            literal, so one request serves every country you ask about.
+        }
+
+        @Steps {
+            @Step {
+                Declare the named binding for the country. The generic
+                parameter is the Swift type the placeholder accepts, and the
+                name is written without a leading colon.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-04-01.swift)
+            }
+
+            @Step {
+                Write the query. `AlbumCredit.columns(...)` maps each result
+                property to a column expression, `Join.Inner` matches albums to
+                their studio, and `Where` compares the studio's country against
+                the binding.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-04-02.swift)
+            }
+
+            @Step {
+                Turn the query into a request and build the values for this
+                call. `parameterLayout` describes the placeholders the request
+                rendered, and `validatingComplete()` rejects a packet that
+                misses one or carries a value the layout does not know about.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-04-03.swift)
+            }
+        }
+    }
+
+    @Section(title: "Fetch and check the results") {
+        @ContentAndMedia {
+            `fetchAll(bindings:)` runs the request with the packet you built
+            and decodes every matching row into `AlbumCredit`. The rows arrive
+            in the order the `OrderBy` clause asked for.
+
+            Once this runs, <doc:GettingStarted> covers updates, deletes and
+            the rest of the everyday API, <doc:Queries> covers grouping,
+            subqueries and common table expressions, <doc:Expressions> covers
+            operators and typed conditions, and <doc:DeclaredQueries> shows how
+            to declare a query as a function with the `@SQLQuery` macro instead
+            of building it inline.
+        }
+
+        @Steps {
+            @Step {
+                Fetch the rows and return them.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-05-01.swift)
+            }
+
+            @Step {
+                Print each credit so you can see the decoded values. Calling
+                `albumCredits(recordedIn: "GB", databaseURL: url)` writes
+                `1966  Revolver (Abbey Road)` and
+                `1969  Abbey Road (Abbey Road)`, and leaves out the album
+                recorded in the US.
+
+                @Code(name: "AlbumCredits.swift", file: EndToEndQuery-05-02.swift)
+            }
+        }
+    }
+
+    @Assessments {
+        @MultipleChoice {
+            Where does the value `"GB"` end up in the SQL that SwiftQL renders
+            for `creditsQuery`?
+
+            @Choice(isCorrect: false) {
+                Inlined as a string literal in the `WHERE` clause.
+
+                @Justification(reaction: "Try again") {
+                    A literal would force a new statement for every country.
+                    The query refers to a named binding instead.
+                }
+            }
+
+            @Choice(isCorrect: true) {
+                Nowhere. The SQL contains `:country`, and the value travels in
+                the bindings packet.
+
+                @Justification(reaction: "That's right") {
+                    The request holds rendered SQL and a description of its
+                    parameters. Values for one call live in a separate
+                    `XLInvocationBindings` packet.
+                }
+            }
+
+            @Choice(isCorrect: false) {
+                In the `Studio` table's `country` column.
+
+                @Justification(reaction: "Try again") {
+                    The column already holds each studio's country. `"GB"` is
+                    the value the query compares against.
+                }
+            }
+        }
+
+        @MultipleChoice {
+            Why does the query need `AlbumCredit` rather than selecting
+            `Album` or `Studio`?
+
+            @Choice(isCorrect: true) {
+                The result mixes columns from both tables, so it needs a type
+                that describes that combination.
+
+                @Justification(reaction: "That's right") {
+                    `@SQLResult` declares an arbitrary set of columns and
+                    generates the `columns(...)` factory the query uses to
+                    build it.
+                }
+            }
+
+            @Choice(isCorrect: false) {
+                `@SQLTable` types cannot be used in a join.
+
+                @Justification(reaction: "Try again") {
+                    Joining `@SQLTable` types is exactly what `Join.Inner`
+                    does here. The projection type only decides which columns
+                    come back.
+                }
+            }
+
+            @Choice(isCorrect: false) {
+                `fetchAll(bindings:)` only decodes `@SQLResult` types.
+
+                @Justification(reaction: "Try again") {
+                    `fetchAll()` decodes whatever row type the query selects,
+                    including a whole `@SQLTable` value.
+                }
+            }
+        }
+    }
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-01-01.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-01-01.swift
@@ -1,0 +1,2 @@
+import Foundation
+import SwiftQL

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-01-02.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-01-02.swift
@@ -1,0 +1,8 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-01-03.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-01-03.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-01-04.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-01-04.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-02-01.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-02-01.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-02-02.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-02-02.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+    try database.makeRequest(with: sqlCreate(Studio.self)).execute()
+    try database.makeRequest(with: sqlCreate(Album.self)).execute()
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-03-01.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-03-01.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+    try database.makeRequest(with: sqlCreate(Studio.self)).execute()
+    try database.makeRequest(with: sqlCreate(Album.self)).execute()
+
+    let studios = [
+        Studio(id: "abbey-road", name: "Abbey Road", country: "GB"),
+        Studio(id: "sun", name: "Sun", country: "US"),
+    ]
+    let albums = [
+        Album(id: "revolver", studioId: "abbey-road", title: "Revolver", year: 1966),
+        Album(id: "abbey-road", studioId: "abbey-road", title: "Abbey Road", year: 1969),
+        Album(id: "sun-sessions", studioId: "sun", title: "The Sun Sessions", year: 1976),
+    ]
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-03-02.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-03-02.swift
@@ -1,0 +1,47 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+    try database.makeRequest(with: sqlCreate(Studio.self)).execute()
+    try database.makeRequest(with: sqlCreate(Album.self)).execute()
+
+    let studios = [
+        Studio(id: "abbey-road", name: "Abbey Road", country: "GB"),
+        Studio(id: "sun", name: "Sun", country: "US"),
+    ]
+    let albums = [
+        Album(id: "revolver", studioId: "abbey-road", title: "Revolver", year: 1966),
+        Album(id: "abbey-road", studioId: "abbey-road", title: "Abbey Road", year: 1969),
+        Album(id: "sun-sessions", studioId: "sun", title: "The Sun Sessions", year: 1976),
+    ]
+
+    try database.withTransaction { scope in
+        for studio in studios {
+            try scope.makeRequest(with: sqlInsert(studio)).execute()
+        }
+        for album in albums {
+            try scope.makeRequest(with: sqlInsert(album)).execute()
+        }
+    }
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-04-01.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-04-01.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+    try database.makeRequest(with: sqlCreate(Studio.self)).execute()
+    try database.makeRequest(with: sqlCreate(Album.self)).execute()
+
+    let studios = [
+        Studio(id: "abbey-road", name: "Abbey Road", country: "GB"),
+        Studio(id: "sun", name: "Sun", country: "US"),
+    ]
+    let albums = [
+        Album(id: "revolver", studioId: "abbey-road", title: "Revolver", year: 1966),
+        Album(id: "abbey-road", studioId: "abbey-road", title: "Abbey Road", year: 1969),
+        Album(id: "sun-sessions", studioId: "sun", title: "The Sun Sessions", year: 1976),
+    ]
+
+    try database.withTransaction { scope in
+        for studio in studios {
+            try scope.makeRequest(with: sqlInsert(studio)).execute()
+        }
+        for album in albums {
+            try scope.makeRequest(with: sqlInsert(album)).execute()
+        }
+    }
+
+    let countryParameter = XLNamedBindingReference<String>(name: "country")
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-04-02.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-04-02.swift
@@ -1,0 +1,63 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+    try database.makeRequest(with: sqlCreate(Studio.self)).execute()
+    try database.makeRequest(with: sqlCreate(Album.self)).execute()
+
+    let studios = [
+        Studio(id: "abbey-road", name: "Abbey Road", country: "GB"),
+        Studio(id: "sun", name: "Sun", country: "US"),
+    ]
+    let albums = [
+        Album(id: "revolver", studioId: "abbey-road", title: "Revolver", year: 1966),
+        Album(id: "abbey-road", studioId: "abbey-road", title: "Abbey Road", year: 1969),
+        Album(id: "sun-sessions", studioId: "sun", title: "The Sun Sessions", year: 1976),
+    ]
+
+    try database.withTransaction { scope in
+        for studio in studios {
+            try scope.makeRequest(with: sqlInsert(studio)).execute()
+        }
+        for album in albums {
+            try scope.makeRequest(with: sqlInsert(album)).execute()
+        }
+    }
+
+    let countryParameter = XLNamedBindingReference<String>(name: "country")
+    let creditsQuery = sql { schema in
+        let album = schema.table(Album.self)
+        let studio = schema.table(Studio.self)
+        let credit = AlbumCredit.columns(
+            title: album.title,
+            year: album.year,
+            studioName: studio.name
+        )
+        Select(credit)
+        From(album)
+        Join.Inner(studio, on: studio.id == album.studioId)
+        Where(studio.country == countryParameter)
+        OrderBy(album.year.ascending())
+    }
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-04-03.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-04-03.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+    try database.makeRequest(with: sqlCreate(Studio.self)).execute()
+    try database.makeRequest(with: sqlCreate(Album.self)).execute()
+
+    let studios = [
+        Studio(id: "abbey-road", name: "Abbey Road", country: "GB"),
+        Studio(id: "sun", name: "Sun", country: "US"),
+    ]
+    let albums = [
+        Album(id: "revolver", studioId: "abbey-road", title: "Revolver", year: 1966),
+        Album(id: "abbey-road", studioId: "abbey-road", title: "Abbey Road", year: 1969),
+        Album(id: "sun-sessions", studioId: "sun", title: "The Sun Sessions", year: 1976),
+    ]
+
+    try database.withTransaction { scope in
+        for studio in studios {
+            try scope.makeRequest(with: sqlInsert(studio)).execute()
+        }
+        for album in albums {
+            try scope.makeRequest(with: sqlInsert(album)).execute()
+        }
+    }
+
+    let countryParameter = XLNamedBindingReference<String>(name: "country")
+    let creditsQuery = sql { schema in
+        let album = schema.table(Album.self)
+        let studio = schema.table(Studio.self)
+        let credit = AlbumCredit.columns(
+            title: album.title,
+            year: album.year,
+            studioName: studio.name
+        )
+        Select(credit)
+        From(album)
+        Join.Inner(studio, on: studio.id == album.studioId)
+        Where(studio.country == countryParameter)
+        OrderBy(album.year.ascending())
+    }
+
+    let creditsRequest = database.makeRequest(with: creditsQuery)
+    let countrySlot = creditsRequest.parameterLayout.slot(for: .named("country"))!
+    let creditsBindings = try XLInvocationBindings<XLSQLiteValue>(
+        layout: creditsRequest.parameterLayout,
+        bindings: [
+            try XLInvocationBinding(slot: countrySlot, value: .text(country))
+        ]
+    ).validatingComplete()
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-05-01.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-05-01.swift
@@ -1,0 +1,75 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+    try database.makeRequest(with: sqlCreate(Studio.self)).execute()
+    try database.makeRequest(with: sqlCreate(Album.self)).execute()
+
+    let studios = [
+        Studio(id: "abbey-road", name: "Abbey Road", country: "GB"),
+        Studio(id: "sun", name: "Sun", country: "US"),
+    ]
+    let albums = [
+        Album(id: "revolver", studioId: "abbey-road", title: "Revolver", year: 1966),
+        Album(id: "abbey-road", studioId: "abbey-road", title: "Abbey Road", year: 1969),
+        Album(id: "sun-sessions", studioId: "sun", title: "The Sun Sessions", year: 1976),
+    ]
+
+    try database.withTransaction { scope in
+        for studio in studios {
+            try scope.makeRequest(with: sqlInsert(studio)).execute()
+        }
+        for album in albums {
+            try scope.makeRequest(with: sqlInsert(album)).execute()
+        }
+    }
+
+    let countryParameter = XLNamedBindingReference<String>(name: "country")
+    let creditsQuery = sql { schema in
+        let album = schema.table(Album.self)
+        let studio = schema.table(Studio.self)
+        let credit = AlbumCredit.columns(
+            title: album.title,
+            year: album.year,
+            studioName: studio.name
+        )
+        Select(credit)
+        From(album)
+        Join.Inner(studio, on: studio.id == album.studioId)
+        Where(studio.country == countryParameter)
+        OrderBy(album.year.ascending())
+    }
+
+    let creditsRequest = database.makeRequest(with: creditsQuery)
+    let countrySlot = creditsRequest.parameterLayout.slot(for: .named("country"))!
+    let creditsBindings = try XLInvocationBindings<XLSQLiteValue>(
+        layout: creditsRequest.parameterLayout,
+        bindings: [
+            try XLInvocationBinding(slot: countrySlot, value: .text(country))
+        ]
+    ).validatingComplete()
+
+    let credits = try creditsRequest.fetchAll(bindings: creditsBindings)
+    return credits
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-05-02.swift
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/EndToEndQuery-05-02.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+    try database.makeRequest(with: sqlCreate(Studio.self)).execute()
+    try database.makeRequest(with: sqlCreate(Album.self)).execute()
+
+    let studios = [
+        Studio(id: "abbey-road", name: "Abbey Road", country: "GB"),
+        Studio(id: "sun", name: "Sun", country: "US"),
+    ]
+    let albums = [
+        Album(id: "revolver", studioId: "abbey-road", title: "Revolver", year: 1966),
+        Album(id: "abbey-road", studioId: "abbey-road", title: "Abbey Road", year: 1969),
+        Album(id: "sun-sessions", studioId: "sun", title: "The Sun Sessions", year: 1976),
+    ]
+
+    try database.withTransaction { scope in
+        for studio in studios {
+            try scope.makeRequest(with: sqlInsert(studio)).execute()
+        }
+        for album in albums {
+            try scope.makeRequest(with: sqlInsert(album)).execute()
+        }
+    }
+
+    let countryParameter = XLNamedBindingReference<String>(name: "country")
+    let creditsQuery = sql { schema in
+        let album = schema.table(Album.self)
+        let studio = schema.table(Studio.self)
+        let credit = AlbumCredit.columns(
+            title: album.title,
+            year: album.year,
+            studioName: studio.name
+        )
+        Select(credit)
+        From(album)
+        Join.Inner(studio, on: studio.id == album.studioId)
+        Where(studio.country == countryParameter)
+        OrderBy(album.year.ascending())
+    }
+
+    let creditsRequest = database.makeRequest(with: creditsQuery)
+    let countrySlot = creditsRequest.parameterLayout.slot(for: .named("country"))!
+    let creditsBindings = try XLInvocationBindings<XLSQLiteValue>(
+        layout: creditsRequest.parameterLayout,
+        bindings: [
+            try XLInvocationBinding(slot: countrySlot, value: .text(country))
+        ]
+    ).validatingComplete()
+
+    let credits = try creditsRequest.fetchAll(bindings: creditsBindings)
+    for credit in credits {
+        print("\(credit.year)  \(credit.title) (\(credit.studioName))")
+    }
+    return credits
+}

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/swiftql-tutorial-chapter.svg
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/swiftql-tutorial-chapter.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 260" width="640" height="260" role="img">
+  <style>
+    .card { fill: none; stroke: #8E8E93; stroke-width: 2; rx: 10; }
+    .label { fill: #8E8E93; font-family: -apple-system, "SF Pro Text", Helvetica, Arial, sans-serif; font-size: 17px; font-weight: 600; }
+    .detail { fill: #8E8E93; font-family: "SF Mono", Menlo, Consolas, monospace; font-size: 13px; }
+    .arrow { fill: none; stroke: #F05138; stroke-width: 2.5; }
+    .head { fill: #F05138; }
+  </style>
+  <rect class="card" x="12" y="60" width="176" height="140" rx="10"/>
+  <text class="label" x="100" y="98" text-anchor="middle">Swift types</text>
+  <text class="detail" x="100" y="130" text-anchor="middle">@SQLTable Studio</text>
+  <text class="detail" x="100" y="152" text-anchor="middle">@SQLTable Album</text>
+  <text class="detail" x="100" y="174" text-anchor="middle">@SQLResult AlbumCredit</text>
+
+  <rect class="card" x="232" y="60" width="176" height="140" rx="10"/>
+  <text class="label" x="320" y="98" text-anchor="middle">Rendered SQL</text>
+  <text class="detail" x="320" y="130" text-anchor="middle">SELECT ... FROM Album</text>
+  <text class="detail" x="320" y="152" text-anchor="middle">JOIN Studio ON ...</text>
+  <text class="detail" x="320" y="174" text-anchor="middle">WHERE country = :country</text>
+
+  <rect class="card" x="452" y="60" width="176" height="140" rx="10"/>
+  <text class="label" x="540" y="98" text-anchor="middle">Decoded rows</text>
+  <text class="detail" x="540" y="130" text-anchor="middle">1966 Revolver</text>
+  <text class="detail" x="540" y="152" text-anchor="middle">1969 Abbey Road</text>
+
+  <path class="arrow" d="M196 130 h24"/>
+  <path class="head" d="M220 124 l12 6 -12 6 z"/>
+  <path class="arrow" d="M416 130 h24"/>
+  <path class="head" d="M440 124 l12 6 -12 6 z"/>
+</svg>

--- a/Sources/SwiftQL/SwiftQL.docc/Tutorials/SwiftQL.tutorial
+++ b/Sources/SwiftQL/SwiftQL.docc/Tutorials/SwiftQL.tutorial
@@ -1,0 +1,20 @@
+@Tutorials(name: "SwiftQL") {
+    @Intro(title: "Build a query with SwiftQL") {
+        Work through one SwiftQL query from an empty file to decoded Swift
+        values. You define two tables, open a database, insert rows, join the
+        tables behind a named binding, and read the results back.
+
+        Every code snapshot in these tutorials is a snapshot of source that the
+        package compiles, and the finished program runs against a real SQLite
+        database in the test suite on every commit.
+    }
+
+    @Chapter(name: "Your first query") {
+        Define tables with `@SQLTable`, project a join with `@SQLResult`, and
+        bind a value at call time.
+
+        @Image(source: swiftql-tutorial-chapter.svg, alt: "Three panels connected by arrows. The first lists the Swift declarations Studio, Album and AlbumCredit. The second shows the SQL SwiftQL renders from them, a SELECT over Album joined to Studio and filtered on a named country binding. The third shows the two rows the query decodes, Revolver from 1966 and Abbey Road from 1969.")
+
+        @TutorialReference(tutorial: "doc:EndToEndQuery")
+    }
+}

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -119,6 +119,10 @@ private let documentationTests = [
         "XLDocumentationTests.testDocumentationNumericDateCodecs",
         XLDocumentationTests.testDocumentationNumericDateCodecs
     ),
+    DocumentationTestReference(
+        "XLDocumentationTests.testDocumentationTutorialEndToEndQuery",
+        XLDocumentationTests.testDocumentationTutorialEndToEndQuery
+    ),
 ]
 
 
@@ -143,6 +147,27 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         "SwiftQL.md": "XLDocumentationTests.testDocumentationQuickStart",
     ]
 
+    /// Tutorial pages carry no Markdown fences, so instead of a `<!-- test:
+    /// -->` marker each one names the compiled walkthrough its `@Code(file:)`
+    /// snapshots are cut from, and the scenario that runs the last snapshot.
+    private let expectedTutorialWalkthroughByFile = [
+        "EndToEndQuery.tutorial": TutorialWalkthrough(
+            source: "Tests/SQLTests/SQLTutorialWalkthrough.swift",
+            marker: "swiftql-tutorial-walkthrough",
+            expectedTest: "XLDocumentationTests.testDocumentationTutorialEndToEndQuery"
+        ),
+    ]
+
+    /// A tutorial page with no code of its own. It only lists the tutorials
+    /// that do have code, so there is nothing to check against a walkthrough.
+    private let tableOfContentsTutorialFiles: Set<String> = ["SwiftQL.tutorial"]
+
+    struct TutorialWalkthrough {
+        let source: String
+        let marker: String
+        let expectedTest: String
+    }
+
     func testEverySwiftExampleMapsToACompiledDocumentationScenario() throws {
         let catalog = documentationCatalogURL()
         let articleURLs = try FileManager.default.contentsOfDirectory(
@@ -157,9 +182,11 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         )
         XCTAssertEqual(
             Set(documentationTests.map(\.name)),
-            Set(expectedMarkerByFile.values).union([
-                "XLDocumentationTests.testDocumentationREADME",
-            ]),
+            Set(expectedMarkerByFile.values)
+                .union(expectedTutorialWalkthroughByFile.values.map(\.expectedTest))
+                .union([
+                    "XLDocumentationTests.testDocumentationREADME",
+                ]),
             "Every marker must target a compile-time-checked documentation scenario."
         )
 
@@ -178,6 +205,137 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             file: readme.lastPathComponent,
             expectedTest: "XLDocumentationTests.testDocumentationREADME"
         )
+    }
+
+    /// The Markdown coverage check above cannot see tutorials, because a
+    /// `.tutorial` page shows code through `@Code(file:)` resources instead of
+    /// fenced examples. This is the same contract for those resources: every
+    /// snapshot a reader sees is cut from source the package compiles, the
+    /// snapshots only ever grow, and the last one is the compiled walkthrough
+    /// in full.
+    func testEveryTutorialCodeSnapshotIsCutFromCompiledSource() throws {
+        let catalog = documentationCatalogURL()
+        let tutorialURLs = try tutorialFileURLs(in: catalog)
+        XCTAssertEqual(
+            Set(tutorialURLs.map(\.lastPathComponent)),
+            Set(expectedTutorialWalkthroughByFile.keys)
+                .union(tableOfContentsTutorialFiles),
+            "Update the tutorial registry when the source catalog changes."
+        )
+
+        var referencedResources: Set<String> = []
+        for tutorialURL in tutorialURLs {
+            let file = tutorialURL.lastPathComponent
+            let contents = try String(contentsOf: tutorialURL, encoding: .utf8)
+
+            for image in imageDirectives(in: contents) {
+                referencedResources.insert(image.source)
+                XCTAssertFalse(
+                    image.alt.trimmingCharacters(in: .whitespaces).isEmpty,
+                    "\(file) references \(image.source) without alternative text."
+                )
+                XCTAssertGreaterThan(
+                    image.alt.split(separator: " ").count,
+                    5,
+                    "\(file) gives \(image.source) alternative text too short to describe it."
+                )
+            }
+
+            let codeSnapshots = codeDirectives(in: contents)
+            guard let walkthrough = expectedTutorialWalkthroughByFile[file] else {
+                XCTAssertTrue(
+                    codeSnapshots.isEmpty,
+                    "\(file) shows code but is registered as a table of contents."
+                )
+                continue
+            }
+
+            XCTAssertFalse(
+                codeSnapshots.isEmpty,
+                "\(file) must show at least one code snapshot."
+            )
+            XCTAssertEqual(
+                Set(codeSnapshots.map(\.file)).count,
+                codeSnapshots.count,
+                "\(file) shows the same snapshot more than once."
+            )
+            XCTAssertEqual(
+                codeSnapshots.map(\.file),
+                codeSnapshots.map(\.file).sorted(),
+                "\(file) shows its snapshots out of order."
+            )
+            referencedResources.formUnion(codeSnapshots.map(\.file))
+
+            let walkthroughSource = try String(
+                contentsOf: repositoryRootURL()
+                    .appendingPathComponent(walkthrough.source),
+                encoding: .utf8
+            )
+            XCTAssertTrue(
+                walkthroughSource.contains(file),
+                "\(walkthrough.source) must name the tutorial it feeds."
+            )
+            XCTAssertTrue(
+                walkthroughSource.contains(walkthrough.expectedTest),
+                "\(walkthrough.source) must name \(walkthrough.expectedTest)."
+            )
+
+            let compiled = try markedRegion(
+                named: walkthrough.marker,
+                in: walkthroughSource,
+                source: walkthrough.source
+            )
+            var previous: [String] = []
+            var previousName = ""
+            for snapshot in codeSnapshots {
+                let resourceURL = try resourceURL(named: snapshot.file, in: catalog)
+                let lines = try String(contentsOf: resourceURL, encoding: .utf8)
+                    .components(separatedBy: "\n")
+                    .dropLast()
+                XCTAssertFalse(lines.isEmpty, "\(snapshot.file) is empty.")
+                XCTAssertTrue(
+                    isOrderedSubsequence(Array(lines), of: compiled),
+                    "\(snapshot.file) contains lines that are not in \(walkthrough.source)."
+                )
+                XCTAssertTrue(
+                    isOrderedSubsequence(previous, of: Array(lines)),
+                    "\(snapshot.file) drops lines that \(previousName) already showed."
+                )
+                if !previousName.isEmpty {
+                    XCTAssertGreaterThan(
+                        lines.count,
+                        previous.count,
+                        "\(snapshot.file) adds nothing to \(previousName)."
+                    )
+                }
+                previous = Array(lines)
+                previousName = snapshot.file
+            }
+            XCTAssertEqual(
+                previous,
+                compiled,
+                "\(previousName) must be the whole \(walkthrough.marker) region of \(walkthrough.source)."
+            )
+        }
+
+        let resources = try FileManager.default.contentsOfDirectory(
+            at: catalog.appendingPathComponent("Tutorials/Resources", isDirectory: true),
+            includingPropertiesForKeys: nil
+        ).map(\.lastPathComponent)
+        XCTAssertEqual(
+            Set(resources),
+            referencedResources,
+            "Every tutorial resource must be referenced by exactly the tutorials that ship it."
+        )
+        for resource in resources {
+            XCTAssertTrue(
+                try pathExistsWithExactCase(
+                    "Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/\(resource)",
+                    below: repositoryRootURL()
+                ),
+                "Tutorial resource does not resolve with exact case: \(resource)"
+            )
+        }
     }
 
     /// The execution-model contract moved out of `GettingStarted.md` so the
@@ -690,6 +848,94 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             "SQLNamedBindingReference",
         ] {
             XCTAssertFalse(contents.contains(staleName), "\(file) uses stale API name \(staleName).")
+        }
+    }
+
+    private func tutorialFileURLs(in catalog: URL) throws -> [URL] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: catalog,
+            includingPropertiesForKeys: nil
+        ) else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        return enumerator
+            .compactMap { $0 as? URL }
+            .filter { $0.pathExtension == "tutorial" }
+            .sorted { $0.path < $1.path }
+    }
+
+    private func resourceURL(named name: String, in catalog: URL) throws -> URL {
+        guard let enumerator = FileManager.default.enumerator(
+            at: catalog,
+            includingPropertiesForKeys: nil
+        ) else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        let matches = enumerator
+            .compactMap { $0 as? URL }
+            .filter { $0.lastPathComponent == name }
+        // DocC resolves `@Code(file:)` and `@Image(source:)` by file name
+        // alone, so a name that matches twice is ambiguous in the built site
+        // even though both files exist.
+        XCTAssertEqual(matches.count, 1, "\(name) does not resolve to one catalog resource.")
+        return try XCTUnwrap(matches.first)
+    }
+
+    private func markedRegion(
+        named marker: String,
+        in contents: String,
+        source: String
+    ) throws -> [String] {
+        let lines = contents.components(separatedBy: "\n")
+        let begin = lines.firstIndex(of: "// \(marker)-begin")
+        let end = lines.firstIndex(of: "// \(marker)-end")
+        let start = try XCTUnwrap(begin, "\(source) is missing // \(marker)-begin.")
+        let finish = try XCTUnwrap(end, "\(source) is missing // \(marker)-end.")
+        XCTAssertLessThan(start, finish, "\(source) closes \(marker) before it opens it.")
+        return Array(lines[(start + 1) ..< finish])
+    }
+
+    private func isOrderedSubsequence(_ candidate: [String], of whole: [String]) -> Bool {
+        var index = whole.startIndex
+        for line in candidate {
+            guard let match = whole[index...].firstIndex(of: line) else {
+                return false
+            }
+            index = whole.index(after: match)
+        }
+        return true
+    }
+
+    private func codeDirectives(in contents: String) -> [(name: String, file: String)] {
+        let expression = try? NSRegularExpression(
+            pattern: #"@Code\(name: "([^"]+)", file: ([^)\s]+)\)"#
+        )
+        return matches(of: expression, in: contents).map {
+            (name: $0[0], file: $0[1])
+        }
+    }
+
+    private func imageDirectives(in contents: String) -> [(source: String, alt: String)] {
+        let expression = try? NSRegularExpression(
+            pattern: #"@Image\(source: ([^,\s]+), alt: "([^"]*)"\)"#
+        )
+        return matches(of: expression, in: contents).map {
+            (source: $0[0], alt: $0[1])
+        }
+    }
+
+    private func matches(
+        of expression: NSRegularExpression?,
+        in contents: String
+    ) -> [[String]] {
+        guard let expression else {
+            return []
+        }
+        let range = NSRange(contents.startIndex ..< contents.endIndex, in: contents)
+        return expression.matches(in: contents, range: range).map { match in
+            (1 ..< match.numberOfRanges).compactMap { group in
+                Range(match.range(at: group), in: contents).map { String(contents[$0]) }
+            }
         }
     }
 

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -3176,4 +3176,55 @@ extension XLDocumentationTests {
         ]
         XCTAssertEqual(interoperabilityDates, Array(repeating: "2023-11-14 22:13:20", count: 3))
     }
+
+    /// Runs the finished program from the DocC tutorial at
+    /// `Sources/SwiftQL/SwiftQL.docc/Tutorials/EndToEndQuery.tutorial` against
+    /// a temporary SQLite file, so the last code snapshot the tutorial shows is
+    /// executed rather than only compiled. `SQLDocumentationCatalogTests` ties
+    /// the earlier snapshots back to the same compiled source.
+    func testDocumentationTutorialEndToEndQuery() throws {
+        let tutorialDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tutorialDirectory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: tutorialDirectory) }
+
+        // Each call builds its own database, because the walkthrough creates
+        // the tables and inserts the rows itself.
+        XCTAssertEqual(
+            try albumCredits(
+                recordedIn: "GB",
+                databaseURL: tutorialDirectory
+                    .appendingPathComponent("british-credits.sqlite")
+            ),
+            [
+                AlbumCredit(title: "Revolver", year: 1966, studioName: "Abbey Road"),
+                AlbumCredit(title: "Abbey Road", year: 1969, studioName: "Abbey Road"),
+            ]
+        )
+        XCTAssertEqual(
+            try albumCredits(
+                recordedIn: "US",
+                databaseURL: tutorialDirectory
+                    .appendingPathComponent("american-credits.sqlite")
+            ),
+            [
+                AlbumCredit(
+                    title: "The Sun Sessions",
+                    year: 1976,
+                    studioName: "Sun"
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            try albumCredits(
+                recordedIn: "ZA",
+                databaseURL: tutorialDirectory
+                    .appendingPathComponent("unmatched-credits.sqlite")
+            ),
+            []
+        )
+    }
 }

--- a/Tests/SQLTests/SQLTutorialWalkthrough.swift
+++ b/Tests/SQLTests/SQLTutorialWalkthrough.swift
@@ -1,0 +1,96 @@
+//
+//  SQLTutorialWalkthrough.swift
+//
+//  The compiled source of record for the DocC tutorial at
+//  Sources/SwiftQL/SwiftQL.docc/Tutorials/EndToEndQuery.tutorial.
+//
+//  Every `@Code(file:)` snapshot the tutorial displays is checked against the
+//  marked region below by SQLDocumentationCatalogTests: each snapshot must be
+//  an ordered subsequence of this region, each snapshot must contain the one
+//  before it, and the last snapshot must match the region line for line. So
+//  every line a reader sees in the tutorial is a line the compiler checked.
+//
+//  XLDocumentationTests.testDocumentationTutorialEndToEndQuery runs the final
+//  scenario against a real temporary SQLite database and asserts its rows.
+//
+
+// swiftql-tutorial-walkthrough-begin
+import Foundation
+import SwiftQL
+
+@SQLTable struct Studio {
+    var id: String
+    var name: String
+    var country: String
+}
+
+@SQLTable struct Album {
+    var id: String
+    var studioId: String
+    var title: String
+    var year: Int
+}
+
+@SQLResult struct AlbumCredit: Equatable {
+    let title: String
+    let year: Int
+    let studioName: String
+}
+
+func albumCredits(recordedIn country: String, databaseURL: URL) throws -> [AlbumCredit] {
+    let database = try GRDBDatabase(url: databaseURL, logger: nil)
+
+    try database.makeRequest(with: sqlCreate(Studio.self)).execute()
+    try database.makeRequest(with: sqlCreate(Album.self)).execute()
+
+    let studios = [
+        Studio(id: "abbey-road", name: "Abbey Road", country: "GB"),
+        Studio(id: "sun", name: "Sun", country: "US"),
+    ]
+    let albums = [
+        Album(id: "revolver", studioId: "abbey-road", title: "Revolver", year: 1966),
+        Album(id: "abbey-road", studioId: "abbey-road", title: "Abbey Road", year: 1969),
+        Album(id: "sun-sessions", studioId: "sun", title: "The Sun Sessions", year: 1976),
+    ]
+
+    try database.withTransaction { scope in
+        for studio in studios {
+            try scope.makeRequest(with: sqlInsert(studio)).execute()
+        }
+        for album in albums {
+            try scope.makeRequest(with: sqlInsert(album)).execute()
+        }
+    }
+
+    let countryParameter = XLNamedBindingReference<String>(name: "country")
+    let creditsQuery = sql { schema in
+        let album = schema.table(Album.self)
+        let studio = schema.table(Studio.self)
+        let credit = AlbumCredit.columns(
+            title: album.title,
+            year: album.year,
+            studioName: studio.name
+        )
+        Select(credit)
+        From(album)
+        Join.Inner(studio, on: studio.id == album.studioId)
+        Where(studio.country == countryParameter)
+        OrderBy(album.year.ascending())
+    }
+
+    let creditsRequest = database.makeRequest(with: creditsQuery)
+    let countrySlot = creditsRequest.parameterLayout.slot(for: .named("country"))!
+    let creditsBindings = try XLInvocationBindings<XLSQLiteValue>(
+        layout: creditsRequest.parameterLayout,
+        bindings: [
+            try XLInvocationBinding(slot: countrySlot, value: .text(country))
+        ]
+    ).validatingComplete()
+
+    let credits = try creditsRequest.fetchAll(bindings: creditsBindings)
+    for credit in credits {
+        print("\(credit.year)  \(credit.title) (\(credit.studioName))")
+    }
+    return credits
+}
+// swiftql-tutorial-walkthrough-end

--- a/scripts/ci/check-docc-output.sh
+++ b/scripts/ci/check-docc-output.sh
@@ -40,7 +40,70 @@ realvalues|Real Values
 staticqueries|Static queries
 ARTICLES
 
+    check_tutorials "$output"
+
     printf 'SWIFTQL_DOCC_OUTPUT ok %s\n' "$output"
+}
+
+# Tutorials live on their own /tutorials route and pull their code from
+# `@Code(file:)` resources rather than from the page itself, so neither the
+# route nor the resources are covered by the article checks above. Both the
+# routes and every resource named by the catalog source are checked here, with
+# exact case, because a case-only rename survives a macOS build and 404s once
+# the site is served from GitHub Pages.
+check_tutorials() {
+    output="$1"
+    catalog="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd -P)/Sources/SwiftQL/SwiftQL.docc"
+    overview="$output/data/tutorials/swiftql.json"
+    tutorial="$output/data/tutorials/swiftql/endtoendquery.json"
+
+    require_exact_file "$output" "tutorials/swiftql/index.html"
+    require_exact_file "$output" "data/tutorials/swiftql.json"
+    require_page "$overview" "Build a query with SwiftQL"
+    require_exact_file "$output" "tutorials/swiftql/endtoendquery/index.html"
+    require_exact_file "$output" "data/tutorials/swiftql/endtoendquery.json"
+    require_page "$tutorial" "Query a SQLite database end to end"
+
+    if ! grep -Fq '"doc://SwiftQL/tutorials/SwiftQL"' \
+        "$output/data/documentation/swiftql.json"; then
+        printf 'error: the SwiftQL landing page no longer links the tutorial\n' >&2
+        return 1
+    fi
+
+    code_resources=0
+    for resource in $(list_directive_values '@Code' "$catalog"); do
+        code_resources=$((code_resources + 1))
+        if ! grep -Fq "\"$resource\"" "$tutorial"; then
+            printf 'error: built tutorial does not reference code snapshot: %s\n' \
+                "$resource" >&2
+            return 1
+        fi
+    done
+    if [ "$code_resources" -eq 0 ]; then
+        printf 'error: no @Code resources found in %s\n' "$catalog" >&2
+        return 1
+    fi
+
+    for resource in $(list_directive_values '@Image' "$catalog"); do
+        require_exact_file "$output" "images/SwiftQL/$resource"
+    done
+}
+
+# Prints the resource file name from every `@Code(name:file:)` or
+# `@Image(source:alt:)` directive in the catalog's tutorial sources.
+list_directive_values() {
+    directive="$1"
+    catalog="$2"
+    case "$directive" in
+        '@Code')
+            find "$catalog" -name '*.tutorial' -print0 | xargs -0 cat | sed -n \
+                's/.*@Code(name: "[^"]*", file: \([^)]*\)).*/\1/p'
+            ;;
+        '@Image')
+            find "$catalog" -name '*.tutorial' -print0 | xargs -0 cat | sed -n \
+                's/.*@Image(source: \([^,]*\),.*/\1/p'
+            ;;
+    esac
 }
 
 require_file() {
@@ -48,6 +111,28 @@ require_file() {
         printf 'error: missing or empty DocC output: %s\n' "$1" >&2
         return 1
     fi
+}
+
+# `[ -f ... ]` matches case-insensitively on the macOS runners that build the
+# site, so each path component is matched against the real directory listing.
+require_exact_file() {
+    root="$1"
+    remaining="$2"
+    current="$root"
+    while [ -n "$remaining" ]; do
+        component="${remaining%%/*}"
+        case "$remaining" in
+            */*) remaining="${remaining#*/}" ;;
+            *) remaining="" ;;
+        esac
+        if ! ls -1 -- "$current" 2>/dev/null | grep -Fxq -- "$component"; then
+            printf 'error: DocC output is missing %s (exact case) in %s\n' \
+                "$component" "$current" >&2
+            return 1
+        fi
+        current="$current/$component"
+    done
+    require_file "$current"
 }
 
 require_page() {

--- a/scripts/ci/check-docc-output.sh
+++ b/scripts/ci/check-docc-output.sh
@@ -52,55 +52,65 @@ ARTICLES
 # exact case, because a case-only rename survives a macOS build and 404s once
 # the site is served from GitHub Pages.
 check_tutorials() {
-    output="$1"
-    catalog="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd -P)/Sources/SwiftQL/SwiftQL.docc"
-    overview="$output/data/tutorials/swiftql.json"
-    tutorial="$output/data/tutorials/swiftql/endtoendquery.json"
+    tutorial_output="$1"
+    tutorial_catalog="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd -P)"
+    tutorial_catalog="$tutorial_catalog/Sources/SwiftQL/SwiftQL.docc"
+    tutorial_overview_page="$tutorial_output/data/tutorials/swiftql.json"
+    tutorial_page="$tutorial_output/data/tutorials/swiftql/endtoendquery.json"
 
-    require_exact_file "$output" "tutorials/swiftql/index.html"
-    require_exact_file "$output" "data/tutorials/swiftql.json"
-    require_page "$overview" "Build a query with SwiftQL"
-    require_exact_file "$output" "tutorials/swiftql/endtoendquery/index.html"
-    require_exact_file "$output" "data/tutorials/swiftql/endtoendquery.json"
-    require_page "$tutorial" "Query a SQLite database end to end"
+    require_exact_file "$tutorial_output" "tutorials/swiftql/index.html"
+    require_exact_file "$tutorial_output" "data/tutorials/swiftql.json"
+    require_page "$tutorial_overview_page" "Build a query with SwiftQL"
+    require_exact_file "$tutorial_output" "tutorials/swiftql/endtoendquery/index.html"
+    require_exact_file "$tutorial_output" "data/tutorials/swiftql/endtoendquery.json"
+    require_page "$tutorial_page" "Query a SQLite database end to end"
 
     if ! grep -Fq '"doc://SwiftQL/tutorials/SwiftQL"' \
-        "$output/data/documentation/swiftql.json"; then
+        "$tutorial_output/data/documentation/swiftql.json"; then
         printf 'error: the SwiftQL landing page no longer links the tutorial\n' >&2
         return 1
     fi
 
-    code_resources=0
-    for resource in $(list_directive_values '@Code' "$catalog"); do
-        code_resources=$((code_resources + 1))
-        if ! grep -Fq "\"$resource\"" "$tutorial"; then
+    tutorial_code_resources=0
+    while IFS= read -r tutorial_resource; do
+        [ -n "$tutorial_resource" ] || continue
+        tutorial_code_resources=$((tutorial_code_resources + 1))
+        if ! grep -Fq "\"$tutorial_resource\"" "$tutorial_page"; then
             printf 'error: built tutorial does not reference code snapshot: %s\n' \
-                "$resource" >&2
+                "$tutorial_resource" >&2
             return 1
         fi
-    done
-    if [ "$code_resources" -eq 0 ]; then
-        printf 'error: no @Code resources found in %s\n' "$catalog" >&2
+    done <<EOF
+$(list_directive_values '@Code' "$tutorial_catalog")
+EOF
+    if [ "$tutorial_code_resources" -eq 0 ]; then
+        printf 'error: no @Code resources found in %s\n' "$tutorial_catalog" >&2
         return 1
     fi
 
-    for resource in $(list_directive_values '@Image' "$catalog"); do
-        require_exact_file "$output" "images/SwiftQL/$resource"
-    done
+    while IFS= read -r tutorial_resource; do
+        [ -n "$tutorial_resource" ] || continue
+        require_exact_file "$tutorial_output" "images/SwiftQL/$tutorial_resource"
+    done <<EOF
+$(list_directive_values '@Image' "$tutorial_catalog")
+EOF
 }
 
 # Prints the resource file name from every `@Code(name:file:)` or
-# `@Image(source:alt:)` directive in the catalog's tutorial sources.
+# `@Image(source:alt:)` directive in the catalog's tutorial sources. `find
+# -exec ... +` rather than `xargs`, because GNU xargs runs its command once
+# with no arguments when the input is empty, and `cat` with no arguments would
+# then block on this script's stdin instead of reporting no tutorials.
 list_directive_values() {
-    directive="$1"
-    catalog="$2"
-    case "$directive" in
+    directive_name="$1"
+    directive_catalog="$2"
+    case "$directive_name" in
         '@Code')
-            find "$catalog" -name '*.tutorial' -print0 | xargs -0 cat | sed -n \
+            find "$directive_catalog" -name '*.tutorial' -exec cat {} + | sed -n \
                 's/.*@Code(name: "[^"]*", file: \([^)]*\)).*/\1/p'
             ;;
         '@Image')
-            find "$catalog" -name '*.tutorial' -print0 | xargs -0 cat | sed -n \
+            find "$directive_catalog" -name '*.tutorial' -exec cat {} + | sed -n \
                 's/.*@Image(source: \([^,]*\),.*/\1/p'
             ;;
     esac
@@ -116,23 +126,24 @@ require_file() {
 # `[ -f ... ]` matches case-insensitively on the macOS runners that build the
 # site, so each path component is matched against the real directory listing.
 require_exact_file() {
-    root="$1"
-    remaining="$2"
-    current="$root"
-    while [ -n "$remaining" ]; do
-        component="${remaining%%/*}"
-        case "$remaining" in
-            */*) remaining="${remaining#*/}" ;;
-            *) remaining="" ;;
+    exact_root="$1"
+    exact_remaining="$2"
+    exact_current="$exact_root"
+    while [ -n "$exact_remaining" ]; do
+        exact_component="${exact_remaining%%/*}"
+        case "$exact_remaining" in
+            */*) exact_remaining="${exact_remaining#*/}" ;;
+            *) exact_remaining="" ;;
         esac
-        if ! ls -1 -- "$current" 2>/dev/null | grep -Fxq -- "$component"; then
+        if ! ls -1 -- "$exact_current" 2>/dev/null \
+            | grep -Fxq -- "$exact_component"; then
             printf 'error: DocC output is missing %s (exact case) in %s\n' \
-                "$component" "$current" >&2
+                "$exact_component" "$exact_current" >&2
             return 1
         fi
-        current="$current/$component"
+        exact_current="$exact_current/$exact_component"
     done
-    require_file "$current"
+    require_file "$exact_current"
 }
 
 require_page() {

--- a/scripts/ci/source-coverage-report.py
+++ b/scripts/ci/source-coverage-report.py
@@ -195,6 +195,15 @@ def aggregate(file_reports: Iterable[Mapping[str, Any]]) -> Dict[str, Any]:
     return result
 
 
+def in_documentation_catalog(relative_path: str) -> bool:
+    """A `.docc` catalog is a resource bundle, so SwiftPM copies the Swift
+    files inside it instead of compiling them. DocC tutorials use those files
+    as the code snapshots `@Code(file:)` displays. LLVM never reports a region
+    for one, so counting them would fail the report for a file the compiler was
+    never asked to build."""
+    return any(part.endswith(".docc") for part in relative_path.split("/")[:-1])
+
+
 def expected_sources(repository_root: Path, source_root: str) -> List[str]:
     directory = repository_root / source_root
     if not directory.is_dir():
@@ -223,7 +232,11 @@ def expected_sources(repository_root: Path, source_root: str) -> List[str]:
         tracked_paths = result.stdout.decode("utf-8").split("\0")
     except UnicodeDecodeError as error:
         raise CoverageError("tracked source paths are not valid UTF-8") from error
-    sources = sorted(path for path in tracked_paths if path.endswith(".swift"))
+    sources = sorted(
+        path
+        for path in tracked_paths
+        if path.endswith(".swift") and not in_documentation_catalog(path)
+    )
     if not sources:
         raise CoverageError(
             f"configured source root has no tracked Swift files: {source_root}"
@@ -252,6 +265,8 @@ def excluded_category(relative_path: Optional[str]) -> str:
         return "benchmarks"
     if ".derived/" in relative_path or "/DerivedSources/" in relative_path:
         return "generated"
+    if in_documentation_catalog(relative_path):
+        return "documentation_catalog"
     return "other_repository_sources"
 
 
@@ -325,7 +340,11 @@ def build_report(
                 raise CoverageError(f"duplicate first-party coverage entry: {relative}")
             selected[relative] = raw_file
             continue
-        if relative is not None and relative.startswith("Sources/"):
+        if (
+            relative is not None
+            and relative.startswith("Sources/")
+            and not in_documentation_catalog(relative)
+        ):
             unexpected_target_paths.append(relative)
         excluded[excluded_category(relative)] += 1
     if unexpected_target_paths:
@@ -403,7 +422,7 @@ def build_report(
             "file_entries": len(raw_files),
         },
         "filtering": {
-            "rule": "Only tracked .swift files under configured first-party target roots are included.",
+            "rule": "Only tracked .swift files under configured first-party target roots, outside any .docc documentation catalog, are included.",
             "included_source_files": len(included_manifest),
             "included_sources_sha256": sha256_text(included_manifest),
             "allowed_uninstrumented_source_files": len(uninstrumented_manifest),
@@ -433,8 +452,8 @@ def summary_markdown(report: Mapping[str, Any]) -> str:
         f"- LLVM coverage: `{report['toolchain']['llvm_cov'].replace(chr(10), ' / ')}`",
         f"- Source tree: `{report['source_tree_state']}`",
         f"- Filtering: only tracked `.swift` files under {source_roots}; "
-        "dependencies, tests, benchmarks, build products, and generated "
-        "expansion files are excluded.",
+        "dependencies, tests, benchmarks, build products, generated "
+        "expansion files, and `.docc` catalog resources are excluded.",
         "- This report is evidence only; it does not enforce a percentage threshold.",
         "",
         "| Target | Instrumented sources | Allowed uninstrumented | Lines | Functions |",

--- a/scripts/ci/test-source-coverage-report.py
+++ b/scripts/ci/test-source-coverage-report.py
@@ -293,6 +293,64 @@ class SourceCoverageReportTests(unittest.TestCase):
         self.assertNotIn("macro expansion", manifest)
         self.assertNotIn("@__swiftmacro_", manifest)
 
+    def track_documentation_catalog_snapshot(self) -> Path:
+        relative = "Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/Step-01-01.swift"
+        snapshot = self.make_source(relative)
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", "--", relative],
+            check=True,
+            capture_output=True,
+        )
+        return snapshot
+
+    def test_documentation_catalog_resources_are_not_production_sources(
+        self,
+    ) -> None:
+        snapshot = self.track_documentation_catalog_snapshot()
+        self.run_report(
+            [
+                file_entry(self.sql_macros, (8, 4), (4, 2)),
+                file_entry(self.swiftql, (10, 5), (2, 1)),
+            ],
+            "catalog",
+        )
+        report = json.loads(
+            (self.root / "catalog/first-party-coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        manifest = (self.root / "catalog/included-sources.txt").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(report["filtering"]["included_source_files"], 2)
+        self.assertNotIn("Step-01-01.swift", manifest)
+        self.assertTrue(snapshot.is_file())
+
+    def test_documentation_catalog_resource_with_coverage_data_is_ignored(
+        self,
+    ) -> None:
+        snapshot = self.track_documentation_catalog_snapshot()
+        self.run_report(
+            [
+                file_entry(self.sql_macros, (8, 4), (4, 2)),
+                file_entry(self.swiftql, (10, 5), (2, 1)),
+                file_entry(snapshot, (100, 100), (50, 50)),
+            ],
+            "catalog-covered",
+        )
+        report = json.loads(
+            (self.root / "catalog-covered/first-party-coverage.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(report["overall"]["lines"]["count"], 18)
+        self.assertEqual(report["overall"]["lines"]["covered"], 9)
+        self.assertEqual(report["filtering"]["included_source_files"], 2)
+        self.assertEqual(
+            report["filtering"]["excluded_raw_file_entries_by_category"],
+            {"documentation_catalog": 1},
+        )
+
     def test_large_dependency_input_cannot_change_first_party_totals(self) -> None:
         outside_root = Path(self.temporary_directory.name) / "dependencies"
         dependency_entries = [


### PR DESCRIPTION
Closes #27

## Summary

SwiftQL's documentation is fourteen reference articles and no guided path. This adds a native DocC tutorial that takes a reader from an empty Swift file to decoded rows in thirteen steps, using only v1.5 API: two `@SQLTable` declarations, an `@SQLResult` projection, a scratch SQLite database, inserts inside `withTransaction(_:)`, an inner join filtered by an `XLNamedBindingReference`, and `fetchAll(bindings:)`.

The interesting part is not the prose, it is that none of the displayed code is hand-written.

## Snapshots are cut from compiled source

`Tests/SQLTests/SQLTutorialWalkthrough.swift` holds the finished 78-line program between `// swiftql-tutorial-walkthrough-begin` / `-end` markers. It is an ordinary file in the test target, so the compiler type-checks it. The thirteen `@Code(file:)` resources under `Sources/SwiftQL/SwiftQL.docc/Tutorials/Resources/` are cumulative cuts of that region.

`SQLDocumentationCatalogTests.testEveryTutorialCodeSnapshotIsCutFromCompiledSource` holds that together:

- every snapshot's lines are an ordered subsequence of the compiled region, so no displayed line exists outside compiled source
- every snapshot contains the one before it, so the code panel only ever grows and DocC's diff highlighting is meaningful
- the last snapshot equals the region line for line
- every `@Code(file:)` and `@Image(source:)` name resolves to exactly one catalog resource, and no resource ships unreferenced
- the walkthrough file names both the tutorial it feeds and the test that runs it, so neither side can be renamed alone

`XLDocumentationTests.testDocumentationTutorialEndToEndQuery` then runs `albumCredits(recordedIn:databaseURL:)` against a real temporary SQLite file, asserting the two rows returned for `"GB"`, the one for `"US"`, and none for `"ZA"`.

I checked the checker catches drift: editing one string in `EndToEndQuery-03-01.swift` fails with `contains lines that are not in Tests/SQLTests/SQLTutorialWalkthrough.swift` plus `EndToEndQuery-03-02.swift drops lines that EndToEndQuery-03-01.swift already showed`.

## Route and asset checks

`scripts/ci/check-docc-output.sh` gains a `check_tutorials` step covering `/tutorials/swiftql` and `/tutorials/swiftql/endtoendquery` (HTML and JSON, with page titles), the landing page's link to the tutorial, every `@Code` resource appearing in the built tutorial JSON, and the chapter image on disk.

The resource names come from the catalog source rather than a hardcoded list, so adding a step without shipping its file fails the check. Path checks walk the real directory listing per component instead of using `[ -f ]`, because macOS matches case-insensitively and a case-only rename would build locally then 404 on Pages. Verified by renaming `endtoendquery` to `EndToEndQuery` and `swiftql-tutorial-chapter.svg` to `...-Chapter.svg` in a copy of the output; both fail.

## Coverage filtering

`scripts/ci/source-coverage-report.py` now skips tracked `.swift` files inside a `.docc` catalog. SwiftPM copies a documentation catalog as a resource bundle rather than compiling it, so LLVM never reports a region for a snapshot file. Without this, the `coverage` job would fail with `disappeared from LLVM coverage` for a file the compiler was never asked to build, and the alternative (thirteen entries in `allowed_uninstrumented_sources`) would claim they are production sources that happen to be uninstrumented.

The filtering rule string in the report and the summary line both changed, and the excluded-entry counter gains a `documentation_catalog` category. Two fixture tests in `test-source-coverage-report.py` cover it: one that a catalog snapshot never reaches the manifest, one that an entry LLVM reports anyway is categorised and excluded rather than failing the report. `Coverage/README.md` records the reasoning.

The pinned baseline in `Coverage/Baselines/` is unaffected. Its consistency test reads a historical commit's tree, which predates the catalog.

## Chapter image

`@Chapter` requires exactly one `@Image`, so there is a hand-written SVG rather than a screenshot. It is text, reviewable in the diff, deterministic, and uses a single neutral grey that reads on both the light and dark documentation themes. Its alt text describes the three panels and their contents; the test asserts alt text exists and is longer than five words on every tutorial image.

## Deliberately not here

No `CHANGELOG.md` entry. #501 introduces the `## [1.5.6] - Unreleased` heading and re-pins `testV13PublicDocumentsShareReleaseAndBoundaryContract` against it, so adding one here would conflict with that PR and break the pinned-heading assertion on this branch. Worth adding once #501 lands.

`declaredqueries` and `numericdatecodecs` are still missing from `check-docc-output.sh`'s article list. Pre-existing, unrelated to tutorials, left alone.

## Validation

| Command | Result |
| --- | --- |
| `swift build` | Build complete, no warnings, no unhandled-file diagnostics |
| `swift test` | exit 0, full suite |
| `swift test --filter "SQLDocumentationCatalogTests\|XLDocumentationTests"` | 49 passed, 0 failures |
| `swift test --filter SQLDocumentationCatalogTests` | 9 passed, including the new tutorial check |
| `python3 scripts/ci/test-source-coverage-report.py` | 28 passed (26 before, 2 new) |
| `./make-docs.sh` | DocC clean under `--warnings-as-errors`, then `SWIFTQL_DOCC_OUTPUT ok`, `SWIFTQL_LANDING_PAGE ok`, `SWIFTQL_BLOG ok` |
| `git status` after the doc build | clean, no source-tree mutations |

Served the built site under `/swiftql/` and checked it in a browser at 1280px and at 375px:

- `/swiftql/tutorials/swiftql/endtoendquery/` renders 31 code listings, the largest at 78 lines, with DocC's diff highlighting on the added lines of each step (6, 7, 7, ... highlighted lines per step)
- `/swiftql/tutorials/swiftql/` renders the chapter card, links the tutorial, and loads the SVG at its declared 640x260
- `/swiftql/documentation/swiftql/` carries four links to `/swiftql/tutorials/swiftql` (prose, Topics, navigation)
- at 375px the document's scroll width stays at 375px; only code lines exceed it, inside DocC's own scrollable code panel

Screenshots of the running pages are not attached: the browser pane this session had available rendered blank captures, so the evidence above is DOM measurement rather than pixels. Everything asserted is reproducible with `./make-docs.sh` and a static server.

Validated against Swift 6.3.2, Hugo 0.164.0, macOS 26.5 / arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)