### PR TITLE
Scope SKILL.md's Xcode build-validation warning to 1.5.2-1.5.5

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -339,10 +339,10 @@ opened, or a raw-value handle that can cross tasks.
   against a checked-in schema snapshot during `swift build`. They prove the SQL
   parses and that schema, parameter, and capability metadata agree, and prove
   nothing about result values, row counts, or behavior. No macro emits a
-  manifest from a `@SQLQuery` declaration yet. On the published 1.5.2 through
-  1.5.5 packages a plugin-adopting target also fails to build under Xcode 26.5
-  before validation runs (#492), so drive it with `swift build` there; the
-  unreleased v1.5.6 fixes that and builds under both.
+  manifest from a `@SQLQuery` declaration yet. On the published v1.5.2 through
+  v1.5.5 packages a plugin-adopting target also fails to build under Xcode 26.5
+  before validation runs, which is issue #492; drive it with `swift build`
+  there. The unreleased v1.5.6 fixes that and builds under both.
 
 Read the [static-query guide](https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/)
 for descriptor construction, captures, cardinality, preparation, and typed

--- a/SKILL.md
+++ b/SKILL.md
@@ -339,9 +339,10 @@ opened, or a raw-value handle that can cross tasks.
   against a checked-in schema snapshot during `swift build`. They prove the SQL
   parses and that schema, parameter, and capability metadata agree, and prove
   nothing about result values, row counts, or behavior. No macro emits a
-  manifest from a `@SQLQuery` declaration yet, and a plugin-adopting package
-  fails to build under Xcode 26.5 before validation runs, so drive it with
-  `swift build`.
+  manifest from a `@SQLQuery` declaration yet. On the published 1.5.2 through
+  1.5.5 packages a plugin-adopting target also fails to build under Xcode 26.5
+  before validation runs (#492), so drive it with `swift build` there; the
+  unreleased v1.5.6 fixes that and builds under both.
 
 Read the [static-query guide](https://lukevanin.github.io/swiftql/documentation/swiftql/staticqueries/)
 for descriptor construction, captures, cardinality, preparation, and typed


### PR DESCRIPTION
Follow-up to #502 (which closed #231).

## Summary

#502 was authored against `version/1.5.6` before #501 merged, so the refreshed `SKILL.md` states the build-validation plugin's Xcode failure in the present tense:

> a plugin-adopting package fails to build under Xcode 26.5 before validation runs, so drive it with `swift build`.

That is correct for the packages `SKILL.md` is scoped to — `1.5.5` is the latest published version, and #492 affects 1.5.2 through 1.5.5. It stops being correct the moment 1.5.6 ships, which is the exact drift #231 existed to fix.

## Changes

One sentence in `SKILL.md`'s build-validation bullet now names the affected range and the fix, so it reads true on both sides of the release instead of needing an edit at release time. `CHANGELOG.md` already frames it the same way ("Fixed in v1.5.6; on v1.5.2 through v1.5.5 the plugin is usable from `swift build` and CI only").

No test change: `SQLSkillDocumentationTests` asserts the phrase `fails to build under Xcode 26.5 before validation runs`, which the new wording keeps.

## Test plan

- [x] `swift test --filter "SQLSkillDocumentationTests|SQLDocumentationCatalogTests"` — 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)