### PR TITLE
Add DeclaredQueries and NumericDateCodecs to the DocC output check

### DIFF
--- a/scripts/ci/check-docc-output.sh
+++ b/scripts/ci/check-docc-output.sh
@@ -29,12 +29,14 @@ advancedusage|Advanced usage
 builtinfunctions|Built-in Functions
 customfunctions|Custom Functions
 customtypes|Custom Types
+declaredqueries|Declared queries
 enums|Enum Values
 expressions|Expressions
 functionalsyntax|Functional Syntax
 generictableparameters|Generic Table Parameters
 gettingstarted|Getting started
 livequeries|Live Queries
+numericdatecodecs|Numeric Date Codecs
 queries|Select Queries
 realvalues|Real Values
 staticqueries|Static queries


### PR DESCRIPTION
## Summary
- `scripts/ci/check-docc-output.sh`'s `ARTICLES` list covered 13 of the 15 articles in `Sources/SwiftQL/SwiftQL.docc/`, missing `DeclaredQueries.md` (slug `declaredqueries`, title "Declared queries") and `NumericDateCodecs.md` (slug `numericdatecodecs`, title "Numeric Date Codecs")
- Both entries added in the same `slug|title` format so the check now fails if either page stops being generated

Titles were confirmed by building the site with `./make-docs.sh` and reading `metadata.title` from the generated `data/documentation/swiftql/<slug>.json` files.

## Test plan
- [x] `./make-docs.sh /tmp/swiftql-docs`
- [x] `sh scripts/ci/check-docc-output.sh /tmp/swiftql-docs` → exit 0, prints `SWIFTQL_DOCC_OUTPUT ok`
- [x] `swift test --filter SQLDocumentationCatalogTests` → all 9 tests pass
