### PR TITLE
Link the Getting Started playground from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ From there:
   whose examples are connected to executable test scenarios, so the API shown
   in the guides stays aligned with the library.
 
+### Run it instead
+
+[The Getting Started playground](Examples/README.md) is that same walkthrough
+with the code running beside the explanation: nine pages against a real SQLite
+file, from defining a table through inserting, selecting, updating, deleting,
+named bindings, lazy result sets, and transactions, to observing a live query.
+Open `Examples/SwiftQLExamples.xcworkspace`, build the `SwiftQLExamples` scheme
+for My Mac, and step through it.
+
+Each page prints its results and states the output it expects next to the code
+producing it, so you can change a query and see immediately what moved.
+
 ## What's new
 
 [WHATSNEW.md](WHATSNEW.md) describes each release in plain language — what you

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -706,6 +706,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "Coverage/README.md",
                 "Documentation/DESIGN.md",
                 "Documentation/PortingFromSQL.md",
+                "Examples/README.md",
                 "LICENSE.md",
                 "RELEASING.md",
                 "ROADMAP.md",


### PR DESCRIPTION
Closes #478. Third of three sub-issues under this issue's own remit (`Examples/README.md`/workspace scaffold via #480, content via #481 already merged as #507, CI verification via #483/#518 pending Copilot re-review) -- this is the final linking step so the playground is actually discoverable from the README rather than only existing under `Examples/`.

## What changed

Adds a "Run it instead" section right after README's "Read the guide", pointing at `Examples/README.md` and the `SwiftQLExamples.xcworkspace` -- the same onboarding walkthrough `GettingStarted.md` describes, but running against a real SQLite file as you read it: nine pages from defining a table through inserting, selecting, updating, deleting, named bindings, lazy result sets, and transactions, to observing a live query.

`SQLDocumentationCatalogTests.testREADMERepositoryLinksResolveWithExactCase` pins README's full link set; it now includes `Examples/README.md`.

## Test plan

- [x] `swift test --filter testREADMERepositoryLinksResolveWithExactCase` -- passes with the new link added to the pinned set
- [x] `swift test --filter XLDocumentationTests` -- 40/40 pass, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)