### PR TITLE
Fix testTrackedSwiftFileHeadersMatchFilenames crashing on GRDB.swift checkout directory

### DIFF
--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -527,17 +527,33 @@ final class SQLDocumentationCatalogTests: XCTestCase {
 
     func testTrackedSwiftFileHeadersMatchFilenames() throws {
         let repositoryRoot = repositoryRootURL()
+        let skippedDirectoryNames: Set<String> = [".build", ".swiftpm", ".git"]
         for directoryName in ["IntegrationTests", "Sources", "Tests"] {
             let directory = repositoryRoot.appendingPathComponent(directoryName, isDirectory: true)
             guard let enumerator = FileManager.default.enumerator(
                 at: directory,
-                includingPropertiesForKeys: [.isRegularFileKey]
+                includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey]
             ) else {
                 XCTFail("Unable to enumerate \(directory.path)")
                 continue
             }
 
-            for case let fileURL as URL in enumerator where fileURL.pathExtension == "swift" {
+            for case let fileURL as URL in enumerator {
+                let resourceValues = try fileURL.resourceValues(
+                    forKeys: [.isRegularFileKey, .isDirectoryKey]
+                )
+                if resourceValues.isDirectory == true {
+                    if skippedDirectoryNames.contains(fileURL.lastPathComponent) {
+                        enumerator.skipDescendants()
+                    }
+                    continue
+                }
+                guard resourceValues.isRegularFile == true,
+                      fileURL.pathExtension == "swift"
+                else {
+                    continue
+                }
+
                 let lines = try String(contentsOf: fileURL, encoding: .utf8)
                     .components(separatedBy: .newlines)
                     .prefix(10)


### PR DESCRIPTION
## What changed

`testTrackedSwiftFileHeadersMatchFilenames` in [SQLDocumentationCatalogTests.swift](Tests/SQLTests/SQLDocumentationCatalogTests.swift) enumerated `IntegrationTests`, `Sources`, and `Tests` and matched any path with `pathExtension == "swift"`. That predicate also matches directories, and it never used the `.isRegularFileKey` it was already requesting.

## Why

After running `IntegrationTests/BuildValidationPluginFixture/verify.sh` (or a plain `swift build` in that fixture), SwiftPM checks out GRDB.swift into `IntegrationTests/BuildValidationPluginFixture/.build/checkouts/GRDB.swift` — a *directory*, not a file. The test then tried to open it with `String(contentsOf:)` and crashed with:

```
Error Domain=NSCocoaErrorDomain Code=256 "The file "GRDB.swift" couldn't be opened."
... NSUnderlyingError=... Code=21 "Is a directory"
```

The fixture's `.build`/`.swiftpm` are gitignored, so this never surfaces on a clean CI checkout — only locally, after exercising the fixture, and only fixable before by deleting `.build`.

## Fix

- Skip descendants of `.build`, `.swiftpm`, and `.git` directories during enumeration (`enumerator.skipDescendants()`).
- Check `resourceValues.isRegularFile == true` before treating a URL as a file to read.

The header-comment assertion itself is unchanged.

## Test plan

- [x] `IntegrationTests/BuildValidationPluginFixture/verify.sh` (creates the `GRDB.swift` checkout directory under `.build`)
- [x] `swift test --filter SQLDocumentationCatalogTests` — all 7 tests pass, including `testTrackedSwiftFileHeadersMatchFilenames`, without deleting `.build`
