### PR TITLE
Cover the demo query layer with unit tests

### DIFF
--- a/Examples/TodoApp/TodoKit/Tests/TodoKitTests/TodoLiveQueryTests.swift
+++ b/Examples/TodoApp/TodoKit/Tests/TodoKitTests/TodoLiveQueryTests.swift
@@ -48,6 +48,15 @@ final class TodoLiveQueryTests: XCTestCase {
         XCTFail("timed out waiting for \(description)")
     }
 
+    /// Lets every main-actor continuation already scheduled run to
+    /// completion, so an assertion about something *not* happening cannot
+    /// pass merely because the work has not been dispatched yet.
+    private func quiesceMainActor(hops: Int = 50) async {
+        for _ in 0..<hops {
+            await Task.yield()
+        }
+    }
+
     private func query(
         _ listID: TodoUUID = TodoSeed.todayListID,
         filter: TodoFilter = .all,
@@ -240,6 +249,13 @@ final class TodoLiveQueryTests: XCTestCase {
         try await wait(for: "the probe to see the delete") {
             probe.counts(for: TodoSeed.todayListID).totalCount == 1
         }
+
+        // XLObservableQuery checks Task.isCancelled before awaiting its
+        // main-actor apply, so a snapshot already past that check can still
+        // be waiting to run. Drain the main actor before asserting, or a
+        // pass here would only mean "not yet applied".
+        await quiesceMainActor()
+
         XCTAssertEqual(
             model.todos.rows.count,
             2,

--- a/Examples/TodoApp/TodoKit/Tests/TodoKitTests/TodoLiveQueryTests.swift
+++ b/Examples/TodoApp/TodoKit/Tests/TodoKitTests/TodoLiveQueryTests.swift
@@ -225,11 +225,21 @@ final class TodoLiveQueryTests: XCTestCase {
         let model = try TodoListModel(database: database, query: query())
         try await wait(for: "the initial snapshot") { model.todos.rows.count == 2 }
 
+        // A probe on the same database, still observing. Waiting for it to
+        // see the delete is what bounds the window: once a live observation
+        // has delivered this commit, a stopped one has had its chance too.
+        // That is a condition to wait on, not a duration to guess at.
+        let probe = TodoSidebarModel(database: database)
+        try await wait(for: "the probe's initial counts") {
+            probe.counts(for: TodoSeed.todayListID).totalCount == 2
+        }
+
         model.stop()
         try database.deleteTodo(id: TodoSeed.renewPassportID)
 
-        // Give a snapshot every chance to arrive, then assert none did.
-        try await Task.sleep(nanoseconds: 200_000_000)
+        try await wait(for: "the probe to see the delete") {
+            probe.counts(for: TodoSeed.todayListID).totalCount == 1
+        }
         XCTAssertEqual(
             model.todos.rows.count,
             2,

--- a/Examples/TodoApp/TodoKit/Tests/TodoKitTests/TodoSuiteContractTests.swift
+++ b/Examples/TodoApp/TodoKit/Tests/TodoKitTests/TodoSuiteContractTests.swift
@@ -55,10 +55,15 @@ final class TodoSuiteContractTests: XCTestCase {
     }
 
     func testTemporaryDatabasesCleanUpAfterThemselves() throws {
-        let database = try makeDatabase()
-        let url = database.url
+        var database: TodoDatabase? = try makeDatabase()
+        let url = try XCTUnwrap(database?.url)
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
 
+        // Release the connection pool before removing the directory, which
+        // is the order the other suites tear down in. Deleting a file out
+        // from under an open pool is a different, less portable thing to be
+        // testing.
+        database = nil
         try FileManager.default.removeItem(at: url.deletingLastPathComponent())
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
@@ -144,11 +149,12 @@ final class TodoSuiteContractTests: XCTestCase {
     /// executes.
     func testEveryFilterAndSortCombinationExecutes() throws {
         let database = try makeDatabase()
+        let searches = ["", "a", "%", "_", "\\", "'"]
         var executed = 0
 
         for filter in TodoFilter.allCases {
             for sort in TodoSort.allCases {
-                for search in ["", "a", "%", "_", "\\", "'"] {
+                for search in searches {
                     _ = try database.todos(matching: TodoQuery(
                         listID: TodoSeed.todayListID,
                         filter: filter,
@@ -161,6 +167,9 @@ final class TodoSuiteContractTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(executed, 4 * 3 * 6)
+        XCTAssertEqual(
+            executed,
+            TodoFilter.allCases.count * TodoSort.allCases.count * searches.count
+        )
     }
 }

--- a/Examples/TodoApp/TodoKit/Tests/TodoKitTests/TodoSuiteContractTests.swift
+++ b/Examples/TodoApp/TodoKit/Tests/TodoKitTests/TodoSuiteContractTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+
+import SwiftQL
+import TodoKit
+
+/// Checks the suite's own promises, rather than the code under test.
+///
+/// The demo's tests are the thing that turns a library change from "the demo
+/// still compiles" into "the demo still behaves". That is only true if the
+/// tests are isolated from each other and deterministic, so those two
+/// properties are asserted rather than assumed.
+final class TodoSuiteContractTests: XCTestCase {
+
+    private let referenceDate = Date(timeIntervalSince1970: 1_800_000_000.25)
+
+    private var directories: [URL] = []
+
+    override func tearDownWithError() throws {
+        for directory in directories {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        directories = []
+    }
+
+    private func makeDatabase() throws -> TodoDatabase {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TodoContract-\(UUID().uuidString)", isDirectory: true)
+        directories.append(directory)
+        return try TodoDatabase(
+            url: directory.appendingPathComponent(TodoDatabase.fileName),
+            referenceDate: referenceDate
+        )
+    }
+
+    // MARK: - Isolation
+
+    func testEachDatabaseGetsItsOwnFile() throws {
+        let first = try makeDatabase()
+        let second = try makeDatabase()
+
+        XCTAssertNotEqual(first.url, second.url)
+    }
+
+    func testAWriteInOneDatabaseIsInvisibleInAnother() throws {
+        let first = try makeDatabase()
+        let second = try makeDatabase()
+
+        try first.deleteTodo(id: TodoSeed.renewPassportID)
+
+        XCTAssertNil(try first.todo(id: TodoSeed.renewPassportID))
+        XCTAssertNotNil(
+            try second.todo(id: TodoSeed.renewPassportID),
+            "a test's writes must not reach another test's database"
+        )
+    }
+
+    func testTemporaryDatabasesCleanUpAfterThemselves() throws {
+        let database = try makeDatabase()
+        let url = database.url
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+
+        try FileManager.default.removeItem(at: url.deletingLastPathComponent())
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    // MARK: - Determinism
+
+    func testTheSeedIsIdenticalForTheSameReferenceDate() throws {
+        let first = try makeDatabase()
+        let second = try makeDatabase()
+
+        XCTAssertEqual(
+            try first.todos(),
+            try second.todos(),
+            "two databases seeded at the same reference date must agree"
+        )
+    }
+
+    func testOverdueDependsOnTheReferenceDateAndNotTheClock() throws {
+        let database = try makeDatabase()
+
+        func overdueTitles(at date: Date) throws -> [String] {
+            try database.todos(matching: TodoQuery(
+                listID: TodoSeed.todayListID,
+                filter: .overdue,
+                referenceDate: TodoDate(date)
+            )).map(\.title)
+        }
+
+        // Two days before the reference date, nothing in this list is yet
+        // past due. Two days after, both open to-dos are.
+        XCTAssertEqual(
+            try overdueTitles(at: referenceDate.addingTimeInterval(-2 * 86_400)),
+            []
+        )
+        XCTAssertEqual(
+            try overdueTitles(at: referenceDate).sorted(),
+            ["Renew passport"]
+        )
+        XCTAssertEqual(
+            try overdueTitles(at: referenceDate.addingTimeInterval(2 * 86_400)).sorted(),
+            ["Book a dentist appointment", "Renew passport"]
+        )
+    }
+
+    func testEveryReadIsStableAcrossRepeatedRuns() throws {
+        let database = try makeDatabase()
+
+        let filters = TodoFilter.allCases
+        let sorts = TodoSort.allCases
+        let lists = [
+            TodoSeed.todayListID,
+            TodoSeed.homeListID,
+            TodoSeed.readingListID,
+        ]
+
+        for listID in lists {
+            for filter in filters {
+                for sort in sorts {
+                    let subject = TodoQuery(
+                        listID: listID,
+                        filter: filter,
+                        sort: sort,
+                        referenceDate: TodoDate(referenceDate)
+                    )
+                    let first = try database.todos(matching: subject).map(\.id)
+                    for _ in 0..<5 {
+                        XCTAssertEqual(
+                            try database.todos(matching: subject).map(\.id),
+                            first,
+                            "\(filter) / \(sort) is not stable"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /// Every combination the app can ask for prepares and runs.
+    ///
+    /// The build-time validator proves the SQL is valid against the schema;
+    /// this proves every binding packet the app can build is accepted and
+    /// executes.
+    func testEveryFilterAndSortCombinationExecutes() throws {
+        let database = try makeDatabase()
+        var executed = 0
+
+        for filter in TodoFilter.allCases {
+            for sort in TodoSort.allCases {
+                for search in ["", "a", "%", "_", "\\", "'"] {
+                    _ = try database.todos(matching: TodoQuery(
+                        listID: TodoSeed.todayListID,
+                        filter: filter,
+                        sort: sort,
+                        searchText: search,
+                        referenceDate: TodoDate(referenceDate)
+                    ))
+                    executed += 1
+                }
+            }
+        }
+
+        XCTAssertEqual(executed, 4 * 3 * 6)
+    }
+}


### PR DESCRIPTION
Closes #474. Fifth of the eight sub-issues under #469, on top of #523.

## Where the coverage already was

Most of #474's criteria were met as the features landed, because writing a query layer without tests and then adding them afterwards is the wrong order. #522 brought 33 tests with the query layer and #523 brought 22 with the live-query models. This PR is the audit and the gaps, not a second suite.

Criterion by criterion, with where each is covered:

| Criterion | Covered by |
| --- | --- |
| Fresh temporary database per test, cleaned up | Every suite's `setUpWithError`/`tearDownWithError`; now asserted by `testEachDatabaseGetsItsOwnFile`, `testAWriteInOneDatabaseIsInvisibleInAnother`, `testTemporaryDatabasesCleanUpAfterThemselves` |
| Every filter returns exactly the seeded rows | `TodoStoreTests` filters section (7 tests) |
| Overdue at a controlled reference date | `testOverdueDependsOnTheReferenceDateAndNotTheClock` — **new** |
| Search matches title and notes, excludes non-matches | `testSearchMatchesTitle`, `testSearchMatchesNotes`, `testSearchExcludesNonMatches`, plus the wildcard tests |
| Per-list counts match what the filters return | `testPerListCountsMatchWhatTheFiltersReturn` |
| Create/update/toggle/delete assert on `RETURNING` and state | `TodoStoreTests` writes section (8 tests) |
| Move tested for success and rollback | `testMovePlacesTheToDoAndClosesTheGapBehindIt`, `testAFailureMidMoveLeavesBothListsUntouched` |
| Deterministic, passes under repeat runs | `testEveryReadIsStableAcrossRepeatedRuns`, `testTheSeedIsIdenticalForTheSameReferenceDate` — **new** |

## What is new

`TodoSuiteContractTests` checks the suite's own promises rather than only the code under test. That matters here specifically: the demo's tests are the thing that turns a library change from "the demo still compiles" into "the demo still behaves", and that only holds if they are genuinely isolated and genuinely deterministic.

- **Isolation.** Each database gets its own file, a write in one is invisible in another, and a removed temporary directory takes the database with it.
- **Determinism.** Two databases seeded at the same reference date produce identical rows. Overdue is measured against the reference date, not the clock — asserted at three different dates, where the same list has zero, one, and two overdue to-dos. Every one of the 12 filter × sort combinations returns the same row order across six consecutive runs.
- **Coverage.** All 12 combinations execute against six search strings, including `%`, `_`, `\`, and a single quote. The build-time validator proves the SQL is valid against the schema; this proves every binding packet the app can construct is accepted and runs.

## The last fixed sleep is gone

`testStoppingAModelEndsItsObservation` asserted that nothing arrives after `stop()`, and previously waited 200 ms before checking. Proving a negative needs a window, but a guessed duration is exactly the flake the issue's "no sleeps" criterion is about.

The window is now a condition. A probe still observing the same database has to see the commit first; once a live observation has delivered it, a stopped one has had its chance too. The only remaining `Task.sleep` in the suite is the 5 ms tick inside the bounded-polling helper, which ends as soon as its condition holds.

## Validation

| Check | Result |
| --- | --- |
| `swift test` in `Examples/TodoApp/TodoKit` | 62 tests, 0 failures |
| Same, run three times in a row | 62 / 0 each time — 0.724s, 0.726s, 0.686s |
| `swift build` | Build complete, no warnings; validation runs over every query |

Validated against Xcode 26.5 (17F42), Swift 6.3.2, macOS 26 / arm64.

## Effect on the rest of the package

None. Test-only, inside the demo package. No public SwiftQL API changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)