### PR TITLE
Build and test the demo app in CI on macOS

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -307,8 +307,14 @@ jobs:
       - name: Check out exact source commit
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # github.sha, matching release-tooling: on a pull request that is
+          # the merge commit, so the demo is built against the base branch it
+          # would actually land on rather than against its own head.
+          ref: ${{ github.sha }}
           persist-credentials: false
+
+      - name: Verify exact source commit
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - name: Validate and report compiler environment
         env:
@@ -331,7 +337,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ always() && !cancelled() }}
         with:
-          name: swiftql-todo-demo-${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
+          name: swiftql-todo-demo-${{ github.sha }}-${{ github.run_attempt }}
           path: |
             ${{ runner.temp }}/swiftql-todo-demo-*.log
             ${{ runner.temp }}/simulator-runtimes.txt

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,7 +5,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Milestone branches get the same pull-request signal main does. Without
+    # this, work merged into version/x.y.z reaches main having never been
+    # built by CI.
+    branches: [main, 'version/**']
 
 permissions:
   contents: read
@@ -287,6 +290,56 @@ jobs:
         run: |
           set -euo pipefail
           cd "$GITHUB_WORKSPACE"
+          git diff --exit-code
+          test -z "$(git status --porcelain)"
+
+  todo-demo:
+    name: To-do demo app
+    # macOS-only: the demo is a SwiftUI app for iOS and macOS, so it cannot
+    # run on the Linux cells. A separate job rather than a matrix entry, for
+    # the same reason.
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+
+    steps:
+      - name: Check out exact source commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Validate and report compiler environment
+        env:
+          EXPECTED_XCODE_VERSION: "16.2"
+          EXPECTED_XCODE_BUILD: 16C5032a
+          EXPECTED_SWIFT_SERIES: "6.0"
+          EXPECTED_SDK_VERSION: "15.2"
+          EXPECTED_DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+        run: scripts/ci/check-compatibility-environment.sh
+
+      - name: Report the pinned iOS simulator runtime
+        run: |
+          set -euo pipefail
+          xcrun simctl list runtimes | tee "$RUNNER_TEMP/simulator-runtimes.txt"
+
+      - name: Build and test the to-do demo
+        run: scripts/ci/check-todo-demo.sh "$RUNNER_TEMP"
+
+      - name: Upload demo build logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ always() && !cancelled() }}
+        with:
+          name: swiftql-todo-demo-${{ github.sha }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/swiftql-todo-demo-*.log
+            ${{ runner.temp }}/simulator-runtimes.txt
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Verify checkout remains clean
+        run: |
           git diff --exit-code
           test -z "$(git status --porcelain)"
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -331,7 +331,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ always() && !cancelled() }}
         with:
-          name: swiftql-todo-demo-${{ github.sha }}-${{ github.run_attempt }}
+          name: swiftql-todo-demo-${{ github.event.pull_request.head.sha || github.sha }}-${{ github.run_attempt }}
           path: |
             ${{ runner.temp }}/swiftql-todo-demo-*.log
             ${{ runner.temp }}/simulator-runtimes.txt

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -350,6 +350,52 @@ marker, and keeps build products outside the source tree. The compatibility
 matrix runs both fixture resolution paths only in its pinned Swift 6.0 cells;
 the ordinary package matrix continues to prove Swift 5.9 compiler support.
 
+## To-do demo application
+
+[`Examples/TodoApp`](Examples/TodoApp/README.md) is a SwiftUI application whose
+whole data layer is SwiftQL. It lives in this repository so that a library
+change breaks it immediately rather than silently, which only holds if CI
+builds it.
+
+The `To-do demo app` job runs on `macos-15` at the same pinned support point
+the Swift 6.0 macOS cells use, and it is macOS-only: the demo builds for iOS
+and macOS destinations, neither of which exists on the Linux cells, so it is a
+separate job rather than a matrix entry.
+
+| Pinned | Value |
+| --- | --- |
+| Runner image | `macos-15` |
+| Xcode | 16.2 (build 16C5032a) |
+| Swift series | 6.0 |
+| macOS SDK | 15.2 |
+| `DEVELOPER_DIR` | `/Applications/Xcode_16.2.app/Contents/Developer` |
+| iOS simulator destination | `generic/platform=iOS Simulator` |
+| Demo deployment floor | iOS 17.0, macOS 14.0 |
+
+The demo's floor is above the library's iOS 16 / macOS 13 floor because it uses
+`@Observable`. That does not change the library's floor.
+
+The iOS runtime is whichever the pinned Xcode ships, resolved through a generic
+simulator destination rather than a named device, so the job does not break
+when the runner image's device list changes. The job records
+`xcrun simctl list runtimes` on every run, so the runtime a given result was
+produced against is recoverable from the retained artifact rather than inferred
+from the image version.
+
+Reproduce the job with:
+
+```sh
+export DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer
+scripts/ci/check-todo-demo.sh
+```
+
+The checker builds the demo package from clean (which is what forces SwiftQL's
+build-time query validator to run over every declared query), runs its tests,
+regenerates the checked-in validation manifest and schema snapshot and fails on
+any diff, asserts that `SWIFT_TREAT_WARNINGS_AS_ERRORS` and
+`GCC_TREAT_WARNINGS_AS_ERRORS` are still `YES` rather than trusting them, and
+then builds the app for macOS and for an iOS simulator.
+
 ## First-party warnings as errors
 
 Every supported compiler and dependency-resolution cell performs a clean build

--- a/scripts/ci/check-todo-demo.sh
+++ b/scripts/ci/check-todo-demo.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Builds and tests the to-do demo (Examples/TodoApp) against the working tree
+# of SwiftQL, so a library change that breaks the demo fails loudly here
+# rather than being discovered by someone cloning it later.
+#
+# Checks, in order:
+#   1. The demo package builds. This is also what runs SwiftQL's build-time
+#      query validator over every query the demo declares.
+#   2. Its tests pass.
+#   3. Regenerating the validation manifest and schema snapshot produces no
+#      diff, so a query edited without regenerating fails rather than
+#      validating the old shape.
+#   4. The app builds for macOS.
+#   5. The app builds for an iOS simulator destination.
+#
+# Warnings are errors throughout: the demo's Xcode project sets
+# SWIFT_TREAT_WARNINGS_AS_ERRORS and GCC_TREAT_WARNINGS_AS_ERRORS, and this
+# script verifies those settings are still in force rather than trusting them,
+# so silently dropping them cannot quietly weaken the gate.
+
+set -euo pipefail
+
+main() {
+    local source_root
+    local demo_root
+    local package_root
+    local derived_data
+    local log_directory
+    local ios_destination
+
+    source_root="$(cd "$(dirname "$0")/../.." && pwd -P)"
+    demo_root="$source_root/Examples/TodoApp"
+    package_root="$demo_root/TodoKit"
+    derived_data="${SWIFTQL_DEMO_DERIVED_DATA:-${TMPDIR:-/tmp}/swiftql-todo-demo-dd}"
+    log_directory="${1:-${TMPDIR:-/tmp}}"
+    ios_destination="${SWIFTQL_DEMO_IOS_DESTINATION:-generic/platform=iOS Simulator}"
+
+    test -d "$demo_root"
+    test -f "$demo_root/TodoApp.xcodeproj/project.pbxproj"
+    test -f "$package_root/Package.swift"
+
+    echo "== 1. Demo package builds, and the query validator runs =="
+    # Clean first: SwiftPM skips the validation command on an incremental
+    # build whose inputs have not changed, and "the validator ran" is only
+    # evidence if it had to.
+    xcrun swift package --package-path "$package_root" clean
+    xcrun swift build --package-path "$package_root" 2>&1 \
+        | tee "$log_directory/swiftql-todo-demo-build.log"
+    if ! grep -q "SwiftQL SQLite build validation" \
+        "$log_directory/swiftql-todo-demo-build.log"; then
+        echo "error: the build-time query validator did not run" >&2
+        return 1
+    fi
+
+    echo "== 2. Demo tests pass =="
+    xcrun swift test --package-path "$package_root" 2>&1 \
+        | tee "$log_directory/swiftql-todo-demo-test.log"
+
+    echo "== 3. The checked-in validation manifest is current =="
+    "$demo_root/Tools/regenerate-validation-manifest.sh" \
+        > "$log_directory/swiftql-todo-demo-manifest.log" 2>&1
+    if ! git -C "$source_root" diff --exit-code -- \
+        "Examples/TodoApp/TodoKit/Sources/TodoKitBuildValidation"; then
+        echo "error: the validation manifest or snapshot is stale." >&2
+        echo "Run Examples/TodoApp/Tools/regenerate-validation-manifest.sh and commit the result." >&2
+        return 1
+    fi
+
+    echo "== 4. Warnings are still errors =="
+    require_warning_setting "$demo_root" SWIFT_TREAT_WARNINGS_AS_ERRORS
+    require_warning_setting "$demo_root" GCC_TREAT_WARNINGS_AS_ERRORS
+
+    echo "== 5. The app builds for macOS =="
+    build_app "$demo_root" "$derived_data-macos" "platform=macOS" \
+        "$log_directory/swiftql-todo-demo-macos.log"
+
+    echo "== 6. The app builds for an iOS simulator =="
+    build_app "$demo_root" "$derived_data-ios" "$ios_destination" \
+        "$log_directory/swiftql-todo-demo-ios.log"
+
+    echo "OK: the to-do demo builds and tests cleanly on both platforms"
+}
+
+require_warning_setting() {
+    local demo_root="$1"
+    local setting="$2"
+    local value
+
+    value="$(
+        xcodebuild -project "$demo_root/TodoApp.xcodeproj" \
+            -scheme TodoApp \
+            -destination 'platform=macOS' \
+            -showBuildSettings 2>/dev/null \
+            | awk -v key="$setting" '$1 == key { print $3; exit }'
+    )"
+    if [[ "$value" != "YES" ]]; then
+        printf 'error: %s is %s, expected YES\n' "$setting" "${value:-unset}" >&2
+        return 1
+    fi
+}
+
+build_app() {
+    local demo_root="$1"
+    local derived_data="$2"
+    local destination="$3"
+    local log="$4"
+
+    rm -rf "$derived_data"
+    xcodebuild build \
+        -project "$demo_root/TodoApp.xcodeproj" \
+        -scheme TodoApp \
+        -destination "$destination" \
+        -derivedDataPath "$derived_data" \
+        CODE_SIGNING_ALLOWED=NO \
+        2>&1 | tee "$log" | grep -E '^(\*\*|.*(error|warning):)' || true
+
+    if ! grep -q "BUILD SUCCEEDED" "$log"; then
+        echo "error: the demo failed to build for $destination" >&2
+        tail -50 "$log" >&2
+        return 1
+    fi
+}
+
+main "$@"

--- a/scripts/ci/check-todo-demo.sh
+++ b/scripts/ci/check-todo-demo.sh
@@ -41,6 +41,7 @@ main() {
     log_directory="${1:-${TMPDIR:-/tmp}}"
     ios_destination="${SWIFTQL_DEMO_IOS_DESTINATION:-generic/platform=iOS Simulator}"
 
+    mkdir -p "$log_directory"
     test -d "$demo_root"
     test -f "$demo_root/TodoApp.xcodeproj/project.pbxproj"
     test -f "$package_root/Package.swift"

--- a/scripts/ci/check-todo-demo.sh
+++ b/scripts/ci/check-todo-demo.sh
@@ -4,20 +4,25 @@
 # of SwiftQL, so a library change that breaks the demo fails loudly here
 # rather than being discovered by someone cloning it later.
 #
-# Checks, in order:
-#   1. The demo package builds. This is also what runs SwiftQL's build-time
-#      query validator over every query the demo declares.
+# Checks, in the order the script prints them:
+#   1. The demo package builds from clean. This is also what runs SwiftQL's
+#      build-time query validator over every query the demo declares.
 #   2. Its tests pass.
-#   3. Regenerating the validation manifest and schema snapshot produces no
+#   3. The demo package built without warnings.
+#   4. Regenerating the validation manifest and schema snapshot produces no
 #      diff, so a query edited without regenerating fails rather than
 #      validating the old shape.
-#   4. The app builds for macOS.
-#   5. The app builds for an iOS simulator destination.
+#   5. The Xcode project's warnings-as-errors settings are still in force.
+#   6. The app builds for macOS.
+#   7. The app builds for an iOS simulator destination.
 #
-# Warnings are errors throughout: the demo's Xcode project sets
-# SWIFT_TREAT_WARNINGS_AS_ERRORS and GCC_TREAT_WARNINGS_AS_ERRORS, and this
-# script verifies those settings are still in force rather than trusting them,
-# so silently dropping them cannot quietly weaken the gate.
+# Warnings are errors on both sides of the demo, by two different mechanisms.
+# The Xcode project sets SWIFT_TREAT_WARNINGS_AS_ERRORS and
+# GCC_TREAT_WARNINGS_AS_ERRORS, and step 5 verifies those are still YES rather
+# than trusting them. The SwiftPM build does not inherit those settings, and
+# passing -warnings-as-errors there would fail on the dependencies' warnings
+# rather than the demo's, so step 3 instead rejects any warning whose source
+# path is inside the demo.
 
 set -euo pipefail
 
@@ -57,7 +62,12 @@ main() {
     xcrun swift test --package-path "$package_root" 2>&1 \
         | tee "$log_directory/swiftql-todo-demo-test.log"
 
-    echo "== 3. The checked-in validation manifest is current =="
+    echo "== 3. The demo package built without warnings =="
+    require_no_demo_warnings \
+        "$log_directory/swiftql-todo-demo-build.log" \
+        "$log_directory/swiftql-todo-demo-test.log"
+
+    echo "== 4. The checked-in validation manifest is current =="
     "$demo_root/Tools/regenerate-validation-manifest.sh" \
         > "$log_directory/swiftql-todo-demo-manifest.log" 2>&1
     if ! git -C "$source_root" diff --exit-code -- \
@@ -67,19 +77,37 @@ main() {
         return 1
     fi
 
-    echo "== 4. Warnings are still errors =="
+    echo "== 5. Warnings are still errors =="
     require_warning_setting "$demo_root" SWIFT_TREAT_WARNINGS_AS_ERRORS
     require_warning_setting "$demo_root" GCC_TREAT_WARNINGS_AS_ERRORS
 
-    echo "== 5. The app builds for macOS =="
+    echo "== 6. The app builds for macOS =="
     build_app "$demo_root" "$derived_data-macos" "platform=macOS" \
         "$log_directory/swiftql-todo-demo-macos.log"
 
-    echo "== 6. The app builds for an iOS simulator =="
+    echo "== 7. The app builds for an iOS simulator =="
     build_app "$demo_root" "$derived_data-ios" "$ios_destination" \
         "$log_directory/swiftql-todo-demo-ios.log"
 
     echo "OK: the to-do demo builds and tests cleanly on both platforms"
+}
+
+# Rejects any compiler warning originating in the demo's own sources.
+#
+# SwiftPM compiles the dependencies too, and their warnings are not this
+# gate's business -- matching on the demo's path is what keeps the gate about
+# the demo without silencing it.
+require_no_demo_warnings() {
+    local warnings
+
+    warnings="$(
+        grep -hE '^/.*Examples/TodoApp/.*: warning: ' "$@" | sort -u || true
+    )"
+    if [[ -n "$warnings" ]]; then
+        echo "error: the demo package emitted warnings:" >&2
+        printf '%s\n' "$warnings" >&2
+        return 1
+    fi
 }
 
 require_warning_setting() {


### PR DESCRIPTION
Closes #475. Seventh of the eight sub-issues under #469, on top of #525.

## What changed

- `scripts/ci/check-todo-demo.sh` — the checker.
- `.github/workflows/swift.yml` — a `To-do demo app` job, and `version/**` added to the pull-request trigger.
- `COMPATIBILITY.md` — a **To-do demo application** section recording the pinned toolchain and how to reproduce the job.

## What the checker does

Six steps, in order, failing closed at each:

1. **Clean build of the demo package.** Clean matters: SwiftPM skips the validation command on an incremental build whose inputs have not changed, so "the validator ran" is only evidence if it had to. The step greps for the plugin's own output and fails if it is absent.
2. **The 62 tests.**
3. **Regenerate the manifest and snapshot, then `git diff --exit-code`.** A query edited without regenerating would otherwise keep validating the old shape — the one drift risk in the generator design, now a hard failure with the fix in the message.
4. **Assert `SWIFT_TREAT_WARNINGS_AS_ERRORS` and `GCC_TREAT_WARNINGS_AS_ERRORS` are still `YES`**, read back from `xcodebuild -showBuildSettings`. The issue asks the job to fail on any warning; the project already does that, and this makes quietly dropping the setting fail rather than silently weakening the gate.
5. **Build for macOS.**
6. **Build for an iOS simulator.**

## The trigger change

`swift.yml` ran on `pull_request: branches: [main]` only. Every PR in this chain targets `version/1.5.6`, so none of them ran CI — and the same was true of every other milestone branch's work, which reached `main` having never been built.

Adding `version/**` fixes that. The cost is bounded: `coverage` and `swift-series` are already gated behind `github.event_name != 'pull_request'`, so a version-branch PR runs `release-tooling`, `compatibility`, and this new job — the same set a `main` PR runs.

This is broader than #475 strictly asked for, but the criterion says the job "runs on pull requests", and on a version branch it otherwise would not have.

## Demonstrated: a breaking change fails it

The criterion asks for this once, recorded. Renaming `fetchAll()` to `fetchEvery()` on `XLRequest`:

| Run | Exit code | Where |
| --- | --- | --- |
| With the rename | `1` | Step 1, 39 compiler errors |
| Reverted | `0` | `OK: the to-do demo builds and tests cleanly on both platforms` |

Recorded on the issue: https://github.com/lukevanin/swiftql/issues/475#issuecomment-5157537860

Worth being precise about what that proves. That rename breaks the library's own conformance, so it never reaches the demo's code — it is a build-error failure, not a behavioural one. A change that keeps the library compiling but alters what a query returns fails at step 2 instead, which is the reason the job runs the tests rather than only compiling.

## Validation

| Check | Result |
| --- | --- |
| `scripts/ci/check-todo-demo.sh` on a clean tree | Exit 0, all six steps pass |
| Same, with a public API renamed | Exit 1 at step 1 |
| Same, after reverting | Exit 0 |
| `bash -n scripts/ci/*.sh` | Clean |
| `ruby -e 'YAML.parse_file'` over every workflow | Clean |
| Local run's iOS runtimes | iOS 18.6 and iOS 26.5 present; the job uses a generic destination rather than naming one |

The iOS destination is `generic/platform=iOS Simulator` rather than a named device, so the job does not break when the runner image's device list changes. `xcrun simctl list runtimes` is captured on every run and retained with the build logs for 14 days, so the runtime behind a given result stays recoverable instead of being inferred from the image version.

**Not verified:** the job running on GitHub's runners. It cannot be, until this merges and the trigger change takes effect — which is itself the first thing the trigger change will demonstrate. Everything the job runs is the same script verified locally against Xcode 26.5; the pinned cell uses Xcode 16.2, and the environment check will fail loudly rather than silently drift if the runner image moves.

Validated against Xcode 26.5 (17F42), Swift 6.3.2, macOS 26 / arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)