### PR TITLE
Publish a DocC article walking through the to-do demo

### DIFF
--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -136,6 +136,7 @@ replacing SQLite's runtime type rules.
 ### Tutorials
 
 - <doc:/tutorials/SwiftQL>
+- <doc:TodoDemo>
 
 ### Essentials
 

--- a/Sources/SwiftQL/SwiftQL.docc/TodoDemo.md
+++ b/Sources/SwiftQL/SwiftQL.docc/TodoDemo.md
@@ -1,0 +1,217 @@
+# The to-do demo
+
+Read a whole application built on SwiftQL, one layer at a time.
+
+## Overview
+
+The other articles cover one topic each. This one walks through an application
+where those topics have to work together: a to-do app for iOS 17 and macOS 14
+whose entire data layer is SwiftQL, living in the repository at
+[`Examples/TodoApp`](https://github.com/lukevanin/swiftql/tree/main/Examples/TodoApp).
+
+Open `Examples/TodoApp/TodoApp.xcodeproj` and run the **TodoApp** scheme. There
+is nothing to configure — the app creates its database and seeds it the first
+time it launches. SwiftQL is a local path dependency on the repository, so the
+demo always builds the working tree, and CI builds and tests it on every pull
+request.
+
+Every excerpt below is cut verbatim from the demo's sources, and a test in this
+package fails if one of them stops matching.
+
+Where the tutorial in <doc:/tutorials/SwiftQL> has you type a query from an
+empty file, this article explains one that already exists. Read the tutorial to
+learn the API; read this to see what it looks like at application scale.
+
+## The schema
+
+Four tables: lists, to-dos, tags, and the many-to-many join between to-dos and
+tags. Each is an ordinary Swift struct.
+
+<!-- source: Examples/TodoApp/TodoKit/Sources/TodoKit/Schema.swift -->
+```swift
+@SQLTable
+public struct TodoList: Equatable, Identifiable, Sendable {
+
+    public var id: TodoUUID
+
+    public var name: String
+
+    /// Where the list sits in the sidebar. Renumbered when a list moves.
+    public var position: Int
+
+    public var createdAt: TodoDate
+}
+```
+
+`TodoUUID` and `TodoDate` are not intrinsic SwiftQL types. SwiftQL binds
+`Bool`, `Int`, `Double`, `String`, and `Data`; anything else reaches SQLite
+through a type that says how to read it, bind it, and render it. That is
+`XLCustomType`, and conforming to `XLComparable` alongside it is what makes
+`==` and `<` available in a `Where` clause. See <doc:CustomTypes> for the full
+contract and <doc:NumericDateCodecs> for the codecs the demo's stored forms
+match. Priority is an `XLEnum` — see <doc:Enums>.
+
+## Declared reads
+
+The demo's reads are functions. One `@SQLQueries` extension holds all of them,
+which is the form <doc:DeclaredQueries> recommends for product code.
+
+This is the aggregate behind the sidebar's counts. Open and total per list, in
+one grouped query rather than a count per list:
+
+<!-- source: Examples/TodoApp/TodoKit/Sources/TodoKit/TodoReads.swift -->
+```swift
+        func listCounts() -> [TodoListCounts] {
+            sqlResult { schema in
+                let todo = schema.table(Todo.self)
+                Select(TodoListCounts.columns(
+                    listID: todo.listID,
+                    openCount: when(todo.isCompleted == false, then: 1)
+                        .else(0)
+                        .sumOrNull() ?? 0,
+                    totalCount: all().count()
+                ))
+                From(todo)
+                GroupBy(todo.listID)
+            }
+        }
+```
+
+The demo also joins across the link table to fetch a to-do's tags, and does it
+once for a whole list rather than once per row.
+
+## One query, every combination
+
+The list view offers four filters, three sort orders, and a search box. That is
+not twelve queries plus a search variant. It is one statement.
+
+The filter arrives as three booleans the `Where` clause reads, rather than as a
+mode the query branches on:
+
+<!-- source: Examples/TodoApp/TodoKit/Sources/TodoKit/TodoQuery.swift -->
+```swift
+    var flags: (includesCompleted: Bool, includesActive: Bool, overdueOnly: Bool) {
+        switch self {
+        case .all:
+            return (true, true, false)
+        case .active:
+            return (false, true, false)
+        case .completed:
+            return (true, false, false)
+        case .overdue:
+            return (false, true, true)
+        }
+    }
+```
+
+Search is always applied, with `%` standing in for an empty box, so the clause
+is never added or removed — only sometimes vacuous. Sort works the same way:
+each `OrderBy` term is a conditional on the sort parameter, and a term whose
+condition is false collapses to a constant that orders every row equally, so it
+contributes nothing and the next term decides.
+
+This is the one read in the demo that is not a declared query. A declared
+query's frozen-literal guard rejects a parameter passed as an argument to a
+call, and `like(_:)` is a method — so text search cannot appear in a
+declaration. The demo uses named bindings for that statement instead, and says
+so where it does.
+
+## Writes that return their row
+
+Create, update, toggle, and delete all use `RETURNING`, so a caller gets the
+row the database holds without fetching again:
+
+<!-- source: Examples/TodoApp/TodoKit/Sources/TodoKit/TodoStore.swift -->
+```swift
+    @discardableResult
+    public func setCompleted(_ isCompleted: Bool, todoID id: TodoUUID) throws -> Todo {
+        let schema = XLSchema()
+        let table = schema.into(Todo.self)
+        return try written(
+            database.makeRequest(
+                with: update(table)
+                    .set { row in row.isCompleted = isCompleted }
+                    .where(table.id == id)
+                    .returning(schema.table(Todo.self))
+            ).fetchAll(),
+            or: id
+        )
+    }
+```
+
+Writes are not declarations. Declared queries are `SELECT`-only in v1.5, so the
+demo's writes use the functional statement syntax from <doc:FunctionalSyntax>.
+Still typed, still no SQL strings.
+
+## A transaction that has to be all or nothing
+
+Moving a to-do to another list renumbers the list it left and appends it to the
+one it joined. Those writes only make sense together, so they run in one
+`withTransaction` scope — see <doc:AdvancedUsage> for the full contract.
+
+The demo's test suite forces a failure part-way through and checks that both
+lists are exactly as they were. That case is the reason the operation takes an
+injectable failure point at all.
+
+## An interface that never refetches
+
+Every view is fed by a live query. The models are thin: they own an
+``XLObservableQuery`` and nothing else.
+
+<!-- source: Examples/TodoApp/TodoKit/Sources/TodoKit/TodoModels.swift -->
+```swift
+@available(iOS 17, macOS 14, *)
+@Observable
+@MainActor
+public final class TodoSidebarModel {
+
+    public let lists: XLObservableQuery<TodoList>
+
+    public let counts: XLObservableQuery<TodoListCounts>
+
+    public init(database: TodoDatabase) {
+        lists = XLObservableQuery(database.listsRequest)
+        counts = XLObservableQuery(database.listCountsRequest)
+    }
+```
+
+Completing a to-do in the detail pane updates the detail, the row in the list,
+and the sidebar's open count. Three independent observations of the same
+commit, none of which knows about the others, and no reload call anywhere. See
+<doc:LiveQueries> for the observation, buffering, and cancellation contracts
+these inherit.
+
+Changing the filter, sort, or search text does not filter rows already in
+memory. It builds a new binding packet and replaces the observation, because a
+live query captures its packet once.
+
+One thing to know before reaching for a declaration here: ``XLObservableQuery``
+observes an ``XLRequest``, and `@SQLQueries` does not produce one. The three
+reads the demo observes therefore exist twice — once as a declaration, once as
+a statement.
+
+## Queries checked before the app runs
+
+The demo carries a checked-in schema snapshot and a manifest of every query it
+runs. SwiftQL's build-tool plugin prepares each query against that snapshot on
+every build, so a query that no longer matches the schema fails the build
+rather than the app.
+
+Regenerate both after changing the schema or a query:
+
+```text
+Examples/TodoApp/Tools/regenerate-validation-manifest.sh
+```
+
+CI regenerates them and fails on any diff, so a query edited without
+regenerating cannot keep validating the old shape.
+
+## Where to go next
+
+- The demo's own
+  [README](https://github.com/lukevanin/swiftql/blob/main/Examples/TodoApp/README.md)
+  maps every file to the feature it exercises, and lists the places building it
+  found the API resisting.
+- <doc:/tutorials/SwiftQL> builds one query from an empty file.
+- <doc:DeclaredQueries>, <doc:LiveQueries>, and <doc:NumericDateCodecs> are the
+  reference topics this article draws on most.

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -278,11 +278,27 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                     let path = String(
                         line.dropFirst("<!-- source: ".count).dropLast(" -->".count)
                     )
+                    // The contract says repository-relative. Enforce it,
+                    // rather than letting an absolute path or a `..` hop
+                    // quietly read something outside the repository and
+                    // still pass.
+                    XCTAssertFalse(
+                        path.hasPrefix("/"),
+                        "\(article):\(lineNumber) source path must be repository-relative: \(path)"
+                    )
+                    XCTAssertFalse(
+                        path.components(separatedBy: "/").contains(".."),
+                        "\(article):\(lineNumber) source path must not traverse upwards: \(path)"
+                    )
                     XCTAssertTrue(
                         FileManager.default.fileExists(
                             atPath: repositoryRoot.appendingPathComponent(path).path
                         ),
                         "\(article):\(lineNumber) points at a file that does not exist: \(path)"
+                    )
+                    XCTAssertNil(
+                        pendingSource,
+                        "\(article):\(lineNumber) follows a source marker that never reached a Swift fence."
                     )
                     pendingSource = (path, lineNumber)
                     continue
@@ -299,6 +315,13 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             }
 
             XCTAssertNil(fence, "\(article) has an unterminated code fence.")
+            // A marker that never reached a Swift fence -- a typo, or one
+            // left above a sql or text block -- would otherwise be silently
+            // ignored, and the excerpt it was meant to guard unchecked.
+            XCTAssertNil(
+                pendingSource,
+                "\(article) has a source marker with no Swift example after it."
+            )
             XCTAssertGreaterThan(
                 checkedExcerpts,
                 0,

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -251,6 +251,24 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                             )
                             let sourceURL = repositoryRoot
                                 .appendingPathComponent(source.path)
+                            // A relative path can still leave the repository
+                            // through a symlink, so check where it actually
+                            // lands rather than only how it is spelled.
+                            let resolvedRoot = repositoryRoot
+                                .resolvingSymlinksInPath().standardizedFileURL.path
+                            let resolvedSource = sourceURL
+                                .resolvingSymlinksInPath().standardizedFileURL.path
+                            XCTAssertTrue(
+                                resolvedSource.hasPrefix(resolvedRoot + "/"),
+                                "\(article):\(source.line) resolves outside the repository: \(source.path)"
+                            )
+                            // An empty fence would satisfy `contains` for any
+                            // file, since every string contains the empty
+                            // one, and count as a checked excerpt.
+                            XCTAssertFalse(
+                                open.body.allSatisfy { $0.trimmingCharacters(in: .whitespaces).isEmpty },
+                                "\(article):\(open.line) is an empty Swift example."
+                            )
                             let sourceText = try String(
                                 contentsOf: sourceURL,
                                 encoding: .utf8

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -177,7 +177,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
 
         XCTAssertEqual(
             Set(articleURLs.map(\.lastPathComponent)),
-            Set(expectedMarkerByFile.keys),
+            Set(expectedMarkerByFile.keys).union(sourceExcerptArticles),
             "Update the documentation example registry when the source catalog changes."
         )
         XCTAssertEqual(
@@ -190,7 +190,8 @@ final class SQLDocumentationCatalogTests: XCTestCase {
             "Every marker must target a compile-time-checked documentation scenario."
         )
 
-        for articleURL in articleURLs.sorted(by: { $0.path < $1.path }) {
+        for articleURL in articleURLs.sorted(by: { $0.path < $1.path })
+        where !sourceExcerptArticles.contains(articleURL.lastPathComponent) {
             let contents = try String(contentsOf: articleURL, encoding: .utf8)
             try assertExampleCoverage(
                 in: contents,
@@ -213,6 +214,99 @@ final class SQLDocumentationCatalogTests: XCTestCase {
     /// snapshot a reader sees is cut from source the package compiles, the
     /// snapshots only ever grow, and the last one is the compiled walkthrough
     /// in full.
+    /// Articles whose Swift examples are cut from a source file rather than
+    /// compiled by `XLDocumentationTests`.
+    ///
+    /// `TodoDemo.md` describes the demo application in `Examples/TodoApp`,
+    /// which is a separate package this test target cannot import. Compiling
+    /// its excerpts here is impossible, so they carry a `source:` marker and
+    /// are checked verbatim against the file they came from instead --
+    /// a drift check with the same job as the `test:` markers, enforced
+    /// differently because the code lives somewhere this target cannot reach.
+    private var sourceExcerptArticles: Set<String> {
+        ["TodoDemo.md"]
+    }
+
+    func testSourceExcerptArticlesQuoteTheirSourcesVerbatim() throws {
+        let repositoryRoot = repositoryRootURL()
+
+        for article in sourceExcerptArticles.sorted() {
+            let articleURL = documentationCatalogURL().appendingPathComponent(article)
+            let contents = try String(contentsOf: articleURL, encoding: .utf8)
+            let lines = contents.components(separatedBy: .newlines)
+
+            var pendingSource: (path: String, line: Int)?
+            var fence: (language: String, body: [String], line: Int)?
+            var checkedExcerpts = 0
+
+            for (offset, line) in lines.enumerated() {
+                let lineNumber = offset + 1
+
+                if var open = fence {
+                    if line == "```" {
+                        if open.language == "swift" {
+                            let source = try XCTUnwrap(
+                                pendingSource,
+                                "\(article):\(open.line) is a Swift example with no source marker."
+                            )
+                            let sourceURL = repositoryRoot
+                                .appendingPathComponent(source.path)
+                            let sourceText = try String(
+                                contentsOf: sourceURL,
+                                encoding: .utf8
+                            )
+                            XCTAssertTrue(
+                                sourceText.contains(open.body.joined(separator: "\n")),
+                                """
+                                \(article):\(open.line) no longer matches \(source.path).
+                                Re-cut the excerpt from the source file.
+                                """
+                            )
+                            checkedExcerpts += 1
+                            pendingSource = nil
+                        }
+                        fence = nil
+                    }
+                    else {
+                        open.body.append(line)
+                        fence = open
+                    }
+                    continue
+                }
+
+                if line.hasPrefix("<!-- source: "), line.hasSuffix(" -->") {
+                    let path = String(
+                        line.dropFirst("<!-- source: ".count).dropLast(" -->".count)
+                    )
+                    XCTAssertTrue(
+                        FileManager.default.fileExists(
+                            atPath: repositoryRoot.appendingPathComponent(path).path
+                        ),
+                        "\(article):\(lineNumber) points at a file that does not exist: \(path)"
+                    )
+                    pendingSource = (path, lineNumber)
+                    continue
+                }
+
+                if line.hasPrefix("```") {
+                    let language = String(line.dropFirst(3))
+                    XCTAssertTrue(
+                        ["swift", "sql", "text"].contains(language),
+                        "\(article):\(lineNumber) has unsupported code-fence language '\(language)'."
+                    )
+                    fence = (language, [], lineNumber)
+                }
+            }
+
+            XCTAssertNil(fence, "\(article) has an unterminated code fence.")
+            XCTAssertGreaterThan(
+                checkedExcerpts,
+                0,
+                "\(article) must quote at least one excerpt from the demo."
+            )
+        }
+    }
+
     func testEveryTutorialCodeSnapshotIsCutFromCompiledSource() throws {
         let catalog = documentationCatalogURL()
         let tutorialURLs = try tutorialFileURLs(in: catalog)
@@ -710,6 +804,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
                 "Documentation/DESIGN.md",
                 "Documentation/PortingFromSQL.md",
                 "Examples/README.md",
+                "Examples/TodoApp/README.md",
                 "LICENSE.md",
                 "RELEASING.md",
                 "ROADMAP.md",


### PR DESCRIPTION
Closes #477. Last of the eight sub-issues under #469, on top of #527.

## What changed

- `Sources/SwiftQL/SwiftQL.docc/TodoDemo.md` — the article.
- `SwiftQL.md` — `<doc:TodoDemo>` listed under **Tutorials**, beside the interactive walkthrough.
- `SQLDocumentationCatalogTests.swift` — a second drift contract for articles that quote source, and one registry fix.

## The drift check needed a second shape

#477 asks for excerpts drawn from the real demo sources, enforced by the drift checker rather than by review. The existing checker cannot do that. `testEverySwiftExampleMapsToACompiledDocumentationScenario` requires every Swift fence in every catalog article to carry a `<!-- test: XLDocumentationTests.… -->` marker naming a scenario the package compiles — and the demo lives in `Examples/TodoApp/TodoKit`, a separate package `SQLTests` cannot import. There is no way to compile `TodoUUID` or `TodoSidebarModel` from there.

The choice was between excerpts that compile but are not the demo's code, and excerpts that are the demo's code but nothing checks. Neither is what the issue wants, so the checker gained a second contract instead:

- `sourceExcerptArticles` names articles exempt from the compiled-scenario rule.
- Each of their Swift fences must carry `<!-- source: <repository-relative path> -->`.
- `testSourceExcerptArticlesQuoteTheirSourcesVerbatim` asserts the file exists and contains the fence body verbatim, and that the article quotes at least one excerpt.

Same job as the `test:` markers — the article cannot drift from the code — enforced differently because the code is somewhere this target cannot reach.

**Demonstrated.** Changing one line of one excerpt (`public var name: String` to `public var title: String`) fails it:

```
TodoDemo.md:31 no longer matches Examples/TodoApp/TodoKit/Sources/TodoKit/Schema.swift.
Re-cut the excerpt from the source file.
```

Reverting it passes.

## A pre-existing failure this found

`testREADMERepositoryLinksResolveWithExactCase` enumerates the root README's repository links against a registry. #525 added `Examples/TodoApp/README.md` to the README and not to the registry, so that test has been failing on `version/1.5.6` since it merged. Fixed here.

Worth noting how it went unnoticed: PRs into `version/**` did not run CI until #527 landed the trigger change two PRs ago. This is the first thing that change would have caught, and now will.

## Cross-linking with the tutorial

The article links to `<doc:/tutorials/SwiftQL>` twice — once in the overview framing the difference (the tutorial has you type a query from an empty file; this explains one that exists), once in "Where to go next" — and both are now listed together under **Tutorials** on the landing page.

**The reverse link is pending.** Adding one from the tutorial means editing a `.tutorial` file whose code snapshots are themselves under a drift contract (`testEveryTutorialCodeSnapshotIsCutFromCompiledSource`), and doing that carefully is a change to #27's artifact rather than to this one. Recording it here as the issue allows.

## Validation

| Check | Result |
| --- | --- |
| `swift test --filter SQLDocumentationCatalogTests` | 10 tests, 0 failures |
| Same, with one excerpt line altered | Fails, naming the file and line |
| Same, reverted | Passes |
| `./make-docs.sh` | Exit 0, zero warnings or errors in the log |
| `./scripts/ci/check-docc-output.sh docs` | Exit 0, `SWIFTQL_DOCC_OUTPUT ok docs` |
| `docs/documentation/swiftql/tododemo` | Present in the rendered site |

Validated against Xcode 26.5 (17F42), Swift 6.3.2, macOS 26 / arm64.

## Effect on the rest of the package

Documentation and one test file. No source changes, no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)