### PR TITLE
Bring the public docs into agreement with what v1.5 ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [1.5.6] - Unreleased
 
+### Added
+
+- Added a `SwiftQLExamples` library product (issue #480), holding the
+  pre-expanded schema and declared queries the Getting Started playground
+  imports. A classic Xcode playground has no `Package.swift` of its own and
+  cannot reliably load a Swift macro compiler plugin, so the example schema is
+  built during the ordinary package build and the playground calls
+  already-expanded API. It is example code rather than a supported API, and
+  nothing in `SwiftQL` or `SwiftQLCore` depends on it.
+
+### Changed
+
+- `SQLiteBuildValidator` now reports the schema checks it could not run, and
+  stops preparing queries once the snapshot's schema identity is already known
+  not to match the manifest (issue #440). When
+  `SQLiteBuildValidationRuntime.capture` fails, the row-count and fingerprint
+  checks used to vanish from the report; they now appear as `.unsupported`
+  `schema.row-count` and `schema.fingerprint` diagnostics, so a reader can tell
+  a check that could not run apart from one that was never in the report. When
+  a schema identity mismatch is already recorded, every manifest entry gets one
+  deterministic `schema.mismatch-skipped` outcome instead of a preparation
+  whose result is already meaningless. `overallVerdict` resolution, the
+  manifest format, the CLI surface, and every existing pass/fail outcome are
+  unchanged, and canonical reports remain byte-identical across repeated runs.
+
 ### Fixed
 
 - Fixed `SwiftQLSQLiteBuildValidationPlugin` failing every Xcode build of a

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -18,8 +18,21 @@ have separate responsibilities:
 - `SwiftQL` is the application-facing library. It includes `SwiftQLCore`, the
   macros and typed SQL DSL, contextual value codecs, and the current
   GRDB-backed SQLite driver.
-- `swiftql-benchmark` is a repository performance diagnostic executable, not an
-  application runtime dependency or a database adapter.
+- `SwiftQLSQLiteBuildValidationManifest` and
+  `SwiftQLSQLiteBuildValidationValidator` are the build-time query validator's
+  manifest format and validation engine, added in v1.5.2. The
+  `swiftql-build-validate` executable and the
+  `SwiftQLSQLiteBuildValidationPlugin` build-tool plugin drive them from a
+  build; see "Build-validation plugin build systems" below for the build
+  systems they are verified under. None of them is required to use `SwiftQL`
+  at runtime.
+- `SwiftQLExamples` holds the pre-expanded schema and declared queries the
+  Getting Started playground imports, added in v1.5.6. A classic Xcode
+  playground cannot expand SwiftQL's macros itself, so the module is built as
+  part of the package instead. It is example code, not a supported API.
+- `swiftql-benchmark` and `swiftql-construction-profile` are repository
+  performance diagnostic executables, not application runtime dependencies or
+  database adapters.
 
 The manifest's dependency bounds are SwiftSyntax 509.0.0, GRDB 6.29.3 or later,
 Swift-DocC plugin 1.0.0 or later, and exact OpenCombine 0.14.0. SwiftSyntax also
@@ -433,10 +446,11 @@ single non-mutating command:
 ```
 
 The command treats first-party DocC diagnostics as errors, writes the static
-site to the ignored `docs/` directory, and validates the SwiftQL landing page
-and all twelve source articles. Pass an existing external destination when a
-separate output is useful, for example `./make-docs.sh /tmp/swiftql-docs`.
-The command never stages or commits files.
+site to the ignored `docs/` directory, and validates the SwiftQL landing page,
+all sixteen source articles, and the tutorial routes together with every code
+snapshot and image the tutorial catalog names. Pass an existing external
+destination when a separate output is useful, for example
+`./make-docs.sh /tmp/swiftql-docs`. The command never stages or commits files.
 
 The site also carries the blog under `Website/blog`, generated with
 [Hugo](https://gohugo.io). `make-docs.sh` requires Hugo 0.164.x on `PATH` and

--- a/README.md
+++ b/README.md
@@ -264,10 +264,17 @@ explicit list of the places the correspondence is not exact.
   Define database-independent SQL, parameter, result, identity, and cardinality
   metadata before opening a database, then prepare it against a compatible
   driver.
+- **[Declared queries](https://lukevanin.github.io/swiftql/documentation/swiftql/declaredqueries/).**
+  Write a query as an ordinary Swift function with `@SQLQuery`, or a whole
+  container of them with `@SQLQueries`, and call it like any other function.
+  A SwiftPM build-tool plugin can prepare every declared query against a
+  schema snapshot at build time; see
+  [COMPATIBILITY.md](COMPATIBILITY.md) for the build systems it runs under.
 - **[Live data](https://lukevanin.github.io/swiftql/documentation/swiftql/livequeries/).**
-  Observe typed query results through GRDB-backed Combine publishers that track
-  the database region a query reads, or adopt `XLQueryObserver`/
-  `XLQueryRowObserver` directly with SwiftUI's `@StateObject`/`@ObservedObject`.
+  Observe typed query results with `for try await` over `stream()` and
+  `streamOne()`, the canonical live-query API. GRDB-backed Combine publishers
+  track the same database region a query reads, and `XLObservableQuery` or
+  `XLQueryObserver` adopt either one from SwiftUI.
 - **Your domain.** Extend SQLite with Swift enums, custom value types, and
   type-safe custom SQL functions.
 
@@ -293,8 +300,8 @@ SQLite coverage without blurring that line.
   toolchains and reproducible CI matrix.
 - [SQLite conformance](COMPATIBILITY.md#sqlite-conformance-inventory) records
   the evidence boundary for SwiftQL's currently supported public subset.
-- [Changelog](CHANGELOG.md) records released behavior and the unreleased v1.3
-  evidence milestone.
+- [Changelog](CHANGELOG.md) records released behavior, and the unreleased
+  section records what has landed since the latest published version.
 - [Performance benchmarks](BENCHMARKS.md) measure query construction,
   preparation, caching, binding, execution, and decoding.
 - [First-party source coverage](Coverage/README.md) preserves the reproducible

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -208,7 +208,16 @@ the milestone actually shipped, and correct:
 - **"Where the correspondence is not exact" in PortingFromSQL.** This restates
   the conformance inventory's gaps and must agree with it exactly. Update it
   from the inventory, not from recollection.
-- **Version numbers** in the installation instructions.
+- **Version numbers** in the installation instructions. The claim about which
+  version is published lives in six places, and every one of them ships stale
+  if it is missed: README.md, `Sources/SwiftQL/SwiftQL.docc/GettingStarted.md`,
+  `Sources/SwiftQL/SwiftQL.docc/SwiftQL.md`, SKILL.md's front-matter
+  description and its body, and Website/index.html. Bump them together.
+  `SQLDocumentationCatalogTests.testV13PublicDocumentsShareReleaseAndBoundaryContract`
+  and `SQLSkillDocumentationTests` pin the exact strings, so the pins move in
+  the same change — a bump that updates the prose but not the test fails the
+  suite, and one that updates neither passes it while shipping the wrong
+  number.
 
 The landing page at [Website/index.html](Website/index.html) restates the
 tagline, the comparison table, the "Choose something else when" list, and the

--- a/Sources/SwiftQL/SwiftQL.docc/AdvancedUsage.md
+++ b/Sources/SwiftQL/SwiftQL.docc/AdvancedUsage.md
@@ -30,6 +30,13 @@ research-only schema-snapshot preparation prototype. Applications still own
 their schema lifecycle and perform physical preparation on the runtime
 connection that executes each statement.
 
+The build-time validator v1.5.2 shipped from that research does not change
+either point. It prepares a manifest of declared queries against a checked-in
+schema snapshot during the build and finalizes each statement immediately, so
+runtime preparation on the executing connection still happens exactly as
+described here. See <doc:StaticQueries> for what a successful validation does
+and does not prove.
+
 ## Requests, layouts, and packets
 
 Requests retain the generated SQL and an immutable `XLParameterLayout`. The

--- a/Sources/SwiftQL/SwiftQL.docc/BuiltinFunctions.md
+++ b/Sources/SwiftQL/SwiftQL.docc/BuiltinFunctions.md
@@ -44,6 +44,12 @@ This statement returns the person's name in the `person` column, and the word
 `Unemployed` in the `occupation` column if the person's occupation is `NULL`,
 or `Employed` if the person's occupation is not `NULL`.
 
+> Note: `condition.iif(then:else:)` is the method-style spelling v1.5.4
+> introduced. The free function `iif(_:then:else:)` still compiles with a
+> deprecation warning and will be removed in SwiftQL 2. Migrate by moving the
+> condition in front of the call: `iif(c, then: a, else: b)` becomes
+> `c.iif(then: a, else: b)`.
+
 ### switchCase(), when(), and else()
 
 The `switchCase-when-then-else` APIs create conditional expressions matching
@@ -164,6 +170,14 @@ let smallest = x.min(0, 10)
 let largest = x.max(0, 10)
 ```
 
+> Note: these method-style spellings arrived in v1.5.4 and require at least one
+> further expression, because SQLite's scalar `MIN`/`MAX` is meaningless with
+> fewer. The free functions `min(_:)` and `max(_:)` still compile with a
+> deprecation warning and will be removed in SwiftQL 2. A multi-argument
+> `min(x, 0, 10)` becomes `x.min(0, 10)`. A *single*-argument `min(x)` was
+> never the scalar function — SQLite parses `MIN(expr)` as the aggregate — so
+> migrate that spelling to `minOrNull()` or `maxOrNull()` instead.
+
 ## String functions
 
 ### collate()
@@ -235,6 +249,11 @@ let formatted = "%s is %d years old".printf(name, age)
 
 Refer to the [SQLite printf](https://sqlite.org/printf.html) documentation for
 more information.
+
+> Note: calling `printf` on the format expression is the v1.5.4 spelling. The
+> free function `printf(format:_:)` still compiles with a deprecation warning
+> and will be removed in SwiftQL 2. Migrate by moving the format string in
+> front of the call: `printf(format: f, a, b)` becomes `f.printf(a, b)`.
 
 ## Type conversion
 

--- a/Sources/SwiftQL/SwiftQL.docc/Queries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/Queries.md
@@ -282,7 +282,10 @@ It always returns a `Double`, ignores individual NULL values, and returns `0.0`
 for empty or all-NULL input. Existing `sum()` and `sumOrNull()` behavior is
 unchanged.
 
-Use `all().count()` when NULL values must still contribute to the row count.
+Use `all().count()` when NULL values must still contribute to the row count. It
+is the method-style spelling v1.5.4 introduced, and it replaces the free
+function `count(_:)`: `count(all())` becomes `all().count()`. The free function
+still compiles with a deprecation warning and will be removed in SwiftQL 2.
 
 <!-- test: XLDocumentationTests.testDocumentationQueriesJoinsAggregatesPaginationSubqueriesCompoundsAndCTEs -->
 ```swift

--- a/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
+++ b/Sources/SwiftQL/SwiftQL.docc/StaticQueries.md
@@ -38,8 +38,18 @@ Successful prototype validation applies only to the recorded snapshot, SQLite
 build, and registered capabilities. It does not prove result values,
 cardinality, dynamic storage classes, codec behavior, or application semantics.
 The inspected statement is finalized immediately; runtime execution still
-prepares or retrieves a cached physical statement on its own connection. A
-standalone validator and SwiftPM plugin remain separate v1.5 follow-up work.
+prepares or retrieves a cached physical statement on its own connection.
+
+The standalone validator and SwiftPM plugin that research led to shipped in
+v1.5.2: the `swiftql-build-validate` executable and the
+`SwiftQLSQLiteBuildValidationPlugin` build-tool plugin prepare a manifest of
+declared queries against a checked-in schema snapshot and fail the build when
+one no longer prepares. v1.5.6 makes the plugin work under Xcode's build system
+as well as SwiftPM's. The limits above still hold for what a successful
+validation proves. The
+[compatibility matrix](https://github.com/lukevanin/swiftql/blob/main/COMPATIBILITY.md)
+records the verified build systems, and the demo application in
+<doc:TodoDemo> adopts the plugin.
 
 ## Construct a descriptor
 

--- a/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
+++ b/Sources/SwiftQL/SwiftQL.docc/SwiftQL.md
@@ -108,6 +108,15 @@ validator, build plugin, query macro, schema system, or new query-declaration
 API. It neither persists prepared statements nor removes runtime preparation
 on each physical connection. Version 1.5.5 is the latest published package.
 
+Two of those did ship later in the v1.5 line, and this page's boundary
+statement is about v1.3 rather than about SwiftQL today. v1.5.1 added the
+`@SQLQuery` and `@SQLQueries` query-declaration macros, described in
+<doc:DeclaredQueries>; v1.5.2 added the `swiftql-build-validate` executable and
+the `SwiftQLSQLiteBuildValidationPlugin` build-tool plugin, described in
+<doc:StaticQueries>. Neither persists prepared statements or removes runtime
+preparation, so the sentence above still holds for that part. SwiftQL still
+ships no schema system; migrations remain GRDB's `DatabaseMigrator`.
+
 ## When to use SwiftQL
 
 SwiftQL provides a safer way to write SQL to interact with an SQLite database, 

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -813,6 +813,162 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         XCTAssertEqual(firstReleaseHeading, "## [1.5.6] - Unreleased")
     }
 
+    /// `check-docc-output.sh` proves one built page per catalog article. An
+    /// article missing from its list is published without ever being checked,
+    /// so a broken route or a renamed page 404s on the site with nothing
+    /// failing first. That is how `TodoDemo.md` shipped unvalidated, found by
+    /// issue #230. Deriving the expected list from the catalog itself, titles
+    /// included, means the next article cannot repeat it.
+    func testEveryCatalogArticleIsCheckedInTheBuiltDocCOutput() throws {
+        let catalog = documentationCatalogURL()
+        var expectedPages: [String: String] = [:]
+        for articleURL in try FileManager.default.contentsOfDirectory(
+            at: catalog,
+            includingPropertiesForKeys: nil
+        ) where articleURL.pathExtension == "md" {
+            let name = articleURL.deletingPathExtension().lastPathComponent
+            // The landing page is checked by its own `documentation/swiftql`
+            // route above the article list, not as an article.
+            guard name != "SwiftQL" else {
+                continue
+            }
+            let heading = try String(contentsOf: articleURL, encoding: .utf8)
+                .components(separatedBy: .newlines)
+                .first { $0.hasPrefix("# ") }
+            expectedPages[name.lowercased()] = try XCTUnwrap(
+                heading,
+                "\(articleURL.lastPathComponent) has no level-one heading to publish as its title."
+            ).dropFirst(2).trimmingCharacters(in: .whitespaces)
+        }
+
+        let script = try String(
+            contentsOf: repositoryRootURL().appendingPathComponent(
+                "scripts/ci/check-docc-output.sh"
+            ),
+            encoding: .utf8
+        )
+        let lines = script.components(separatedBy: .newlines)
+        let start = try XCTUnwrap(
+            lines.firstIndex(where: { $0.hasSuffix("<<'ARTICLES'") }),
+            "check-docc-output.sh no longer opens an ARTICLES heredoc."
+        )
+        let end = try XCTUnwrap(
+            lines[start...].dropFirst().firstIndex(of: "ARTICLES"),
+            "check-docc-output.sh no longer terminates its ARTICLES heredoc."
+        )
+        var checkedPages: [String: String] = [:]
+        for line in lines[(start + 1) ..< end] {
+            let fields = line.split(separator: "|", maxSplits: 1)
+            XCTAssertEqual(
+                fields.count,
+                2,
+                "ARTICLES entries are `slug|title`, but found: \(line)"
+            )
+            guard fields.count == 2 else {
+                continue
+            }
+            checkedPages[String(fields[0])] = String(fields[1])
+        }
+
+        XCTAssertEqual(
+            checkedPages,
+            expectedPages,
+            """
+            Every DocC article must have a `slug|title` line in \
+            check-docc-output.sh, with the slug lowercased from its file name \
+            and the title matching its level-one heading exactly.
+            """
+        )
+    }
+
+    /// The v1.3 contract above pins statements the v1.3 milestone made. Some
+    /// of them are boundary claims the v1.5 line then crossed, and a reader of
+    /// the current site has no way to tell a historical scope note from a
+    /// present-tense limitation. These pins hold the correction next to each
+    /// one, and hold the published-version claim consistent across every
+    /// document that restates it (issue #230).
+    func testPublicDocumentsAgreeOnTheShippedV15Surface() throws {
+        let repositoryRoot = repositoryRootURL()
+        let requiredPhrasesByPath = [
+            "README.md": [
+                "Write a query as an ordinary Swift function with `@SQLQuery`",
+                "Observe typed query results with `for try await` over `stream()`",
+            ],
+            // Nothing generated restates the landing page, so its Swift
+            // Package Manager version drifts silently; it was still on 1.5.4
+            // two releases later when #230 found it.
+            "Website/index.html": [
+                #".package(url: "https://github.com/lukevanin/swiftql.git", from: "1.5.5")"#,
+            ],
+            "COMPATIBILITY.md": [
+                "`SwiftQLSQLiteBuildValidationManifest` and",
+                "`SwiftQLExamples` holds the pre-expanded schema",
+            ],
+            "CHANGELOG.md": [
+                "Added a `SwiftQLExamples` library product",
+                "`SQLiteBuildValidator` now reports the schema checks it could not run",
+            ],
+            "RELEASING.md": [
+                "The claim about which",
+                "version is published lives in six places",
+            ],
+            "Sources/SwiftQL/SwiftQL.docc/SwiftQL.md": [
+                "v1.5.2 added the `swiftql-build-validate` executable",
+                "SwiftQL still",
+                "ships no schema system",
+            ],
+            "Sources/SwiftQL/SwiftQL.docc/StaticQueries.md": [
+                "The standalone validator and SwiftPM plugin that research led to shipped in",
+            ],
+            "Sources/SwiftQL/SwiftQL.docc/AdvancedUsage.md": [
+                "The build-time validator v1.5.2 shipped from that research",
+            ],
+            "Sources/SwiftQL/SwiftQL.docc/BuiltinFunctions.md": [
+                "The free function `iif(_:then:else:)` still compiles with a",
+                "The free functions `min(_:)` and `max(_:)` still compile with a",
+                "free function `printf(format:_:)` still compiles with a",
+            ],
+            "Sources/SwiftQL/SwiftQL.docc/Queries.md": [
+                "`count(_:)`: `count(all())` becomes `all().count()`",
+            ],
+        ]
+        // Claims the v1.5 line falsified. Each one read as a present-tense
+        // statement about SwiftQL on the published site.
+        let forbiddenPhrasesByPath = [
+            "Sources/SwiftQL/SwiftQL.docc/StaticQueries.md": [
+                "remain separate v1.5 follow-up work",
+            ],
+            "README.md": [
+                "the unreleased v1.3",
+            ],
+        ]
+
+        for (path, requiredPhrases) in requiredPhrasesByPath {
+            let contents = try String(
+                contentsOf: repositoryRoot.appendingPathComponent(path),
+                encoding: .utf8
+            )
+            for phrase in requiredPhrases {
+                XCTAssertTrue(
+                    contents.contains(phrase),
+                    "\(path) is missing the v1.5 currency phrase '\(phrase)'."
+                )
+            }
+        }
+        for (path, forbiddenPhrases) in forbiddenPhrasesByPath {
+            let contents = try String(
+                contentsOf: repositoryRoot.appendingPathComponent(path),
+                encoding: .utf8
+            )
+            for phrase in forbiddenPhrases {
+                XCTAssertFalse(
+                    contents.contains(phrase),
+                    "\(path) still makes the superseded claim '\(phrase)'."
+                )
+            }
+        }
+    }
+
     func testREADMERepositoryLinksResolveWithExactCase() throws {
         let repositoryRoot = repositoryRootURL()
         let readme = try String(

--- a/Website/index.html
+++ b/Website/index.html
@@ -419,7 +419,7 @@ footer {
       <a class="btn" href="https://github.com/lukevanin/swiftql/blob/main/Documentation/PortingFromSQL.md">Port a query</a>
       <a class="btn" href="https://github.com/lukevanin/swiftql">GitHub</a>
     </div>
-    <div class="install"><code>.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.5.4")</code></div>
+    <div class="install"><code>.package(url: "https://github.com/lukevanin/swiftql.git", from: "1.5.5")</code></div>
   </div>
 </header>
 
@@ -532,7 +532,7 @@ footer {
       </div>
       <div class="card">
         <h3>Live data</h3>
-        <p>Observe typed results through GRDB-backed Combine publishers, or adopt <code>XLQueryObserver</code> directly from SwiftUI.</p>
+        <p>Observe typed results with <code>for try await</code> over <code>stream()</code>, through GRDB-backed Combine publishers, or by adopting <code>XLObservableQuery</code> directly from SwiftUI.</p>
       </div>
       <div class="card">
         <h3>Your domain</h3>

--- a/scripts/ci/check-docc-output.sh
+++ b/scripts/ci/check-docc-output.sh
@@ -40,6 +40,7 @@ numericdatecodecs|Numeric Date Codecs
 queries|Select Queries
 realvalues|Real Values
 staticqueries|Static queries
+tododemo|The to-do demo
 ARTICLES
 
     check_tutorials "$output"


### PR DESCRIPTION
Closes #230.

Most of what #230 asks for is already true. #431/#432 restructured the README, #439 and #476 and #478 added the badge and the demo and playground links, #231 rewrote SKILL.md, #27 and #477 published the tutorial and the demo article, and WHATSNEW covers every release through 1.5.5. This is the residue: what those changes did not touch, plus what the v1.5 line falsified in documents nobody had reason to reopen.

## What was actually stale

### Three boundary claims the v1.5 line crossed

`StaticQueries.md` ended its build-validation section with "A standalone validator and SwiftPM plugin remain separate v1.5 follow-up work." Both shipped in v1.5.2 — `swiftql-build-validate` and `SwiftQLSQLiteBuildValidationPlugin` — and v1.5.6 made the plugin work under Xcode's build system. COMPATIBILITY.md documents them two sections apart from a page still calling them follow-up work.

`SwiftQL.md` closes its v1.3 section with "v1.3 does not ship a public validator, build plugin, query macro, schema system, or new query-declaration API." That is true of v1.3 and false of SwiftQL. On the published site it is the last sentence before the topic list, and a reader has no way to tell a historical scope note from a present-tense limitation. `AdvancedUsage.md` makes the same claim about a validation API.

None of the three is wrong about v1.3, so none of them is rewritten. Each keeps its statement and gains the correction next to it, naming the version that shipped and linking the article that documents it. The one part of `SwiftQL.md`'s list that is still accurate — no schema system — now says so explicitly, and points at `DatabaseMigrator` the way the README's "Choose something else when" does.

### Live queries described as Combine-only

The README's "Live data" bullet and the landing page's card both offered Combine publishers and `XLQueryObserver` as the way to observe a query. `stream()`/`streamOne()` have been the canonical API since 1.5.5, with Combine explicitly a leaf adapter over them (`LiveQueries.md` says so, SKILL.md says so, the 1.5.5 changelog says so). Both now lead with `for try await` and mention `XLObservableQuery`.

"What becomes first-class" had no entry for declared queries at all — the v1.5.1 headline feature, and the thing RELEASING.md's documentation-currency gate names first as the list to re-check. Added, with the build-time validator alongside it.

### An unreleased-section reference two minor versions behind

> [Changelog](CHANGELOG.md) records released behavior and the unreleased v1.3 evidence milestone.

The unreleased section is 1.5.6. Reworded version-neutrally so it cannot go stale again.

### The landing page was installing 1.5.4

`Website/index.html` still said `from: "1.5.4"` while the README, `GettingStarted.md`, `SwiftQL.md`, and SKILL.md all said 1.5.5. RELEASING.md predicted exactly this: "It carries no generated content, so nothing warns you when it drifts." It drifted, for two releases. Fixed, and now pinned by a test — see below.

### CHANGELOG's 1.5.6 section was missing two merged changes

- **#440** changed the build validator's report. Capture failure used to make the row-count and fingerprint checks vanish rather than appear as skipped; they now emit `.unsupported` `schema.row-count` and `schema.fingerprint` diagnostics. A recorded schema identity mismatch now short-circuits per-query preparation and emits one `schema.mismatch-skipped` outcome per manifest entry. That is a visible change to the report format's contents for anyone consuming it.
- **#480** added a `SwiftQLExamples` library product. A new product appears in `swift package describe`, in Xcode's product picker, and in any downstream target list.

Both are now in the section, with #440 under Changed and #480 under Added.

### COMPATIBILITY's product list and article count

"Its public products have separate responsibilities" listed three products. The package vends nine plus a macro target: the five build-validation products from v1.5.2, `SwiftQLExamples` from v1.5.6, and `swiftql-construction-profile`, which was never listed. Added, grouped by what they are for rather than enumerated one per bullet, with each group saying plainly that it is not needed at runtime.

The DocC section claimed `make-docs.sh` "validates the SwiftQL landing page and all twelve source articles". It checked fifteen — sixteen once this PR adds the to-do demo route below — and, since #27, the tutorial routes plus every code snapshot and image the tutorial catalog names.

### Deprecated functions with no migration line where a reader looks

The v1.5.4 deprecations (`count(_:)`, `min(_:)`/`max(_:)`, `iif(_:then:else:)`, `printf(format:_:)`) all carry a replacement in their `@available` message, and every guide already uses the new method-style spelling. What was missing is the connection: a reader with `printf(format:)` in their code who opens `BuiltinFunctions.md` § printf() saw only the new spelling and nothing telling them the old one was going away or how to move. Each of the four sections now carries a note with the mechanical rewrite.

The `min(_:)` note is the one that matters most, because the migration is not uniform: `min(x, 0, 10)` becomes `x.min(0, 10)`, but a single-argument `min(x)` was never the scalar function — SQLite parses `MIN(expr)` as the aggregate — so that spelling migrates to `minOrNull()` instead. The deprecation message says this; nothing in the guides did.

## `TodoDemo.md` was published without a route check

`check-docc-output.sh` proves one built page per catalog article, and `TodoDemo.md` was not in its list. The article renders today, so nothing was broken — but a rename, a case-only change, or a DocC routing change would have 404d on Pages with the whole gate green. #528 shipped a verbatim-excerpt drift contract for the article's *code* and correctly did not touch the route list; nothing covered the route.

Adding one line fixes today. `testEveryCatalogArticleIsCheckedInTheBuiltDocCOutput` fixes the class of problem: it enumerates the catalog's `.md` files, derives each expected slug from the file name and each expected title from the level-one heading, parses the `ARTICLES` heredoc out of the shell script, and asserts the two are equal. A new article that skips the script fails here, and so does a heading edit that leaves the script's title behind.

**Demonstrated.** Deleting the `tododemo|The to-do demo` line fails it with both dictionaries in the message; restoring it passes.

## Pinning what this PR corrected

`testV13PublicDocumentsShareReleaseAndBoundaryContract` pins the v1.3 statements *as made*, which is why the three boundary claims survived the v1.5 line intact — the pin was doing its job, and there was nothing pinning the correction beside them. Rather than loosen it, `testPublicDocumentsAgreeOnTheShippedV15Surface` sits alongside: required phrases for each correction, plus forbidden phrases for the two claims the v1.5 line falsified, so re-introducing "remain separate v1.5 follow-up work" fails rather than reads plausibly.

It also pins `Website/index.html`'s SPM version. That is the drift this PR found, and the only reason it went two releases is that no check existed. RELEASING.md's "Version numbers" bullet now names all six places the published-version claim lives — README, two DocC articles, SKILL.md's front matter and body, and the landing page — and names the two tests that pin them, so a bump that updates prose without the pins fails the suite instead of half-landing.

## Validation

| Check | Result |
| --- | --- |
| `swift build` | Exit 0 |
| `swift build --build-tests` | Exit 0, `Build complete!`, no first-party warnings |
| `swift test --filter "SQLDocumentationCatalogTests\|XLDocumentationTests\|SQLSkillDocumentationTests"` | 57 tests, 0 failures |
| — `SQLDocumentationCatalogTests` alone | 12 tests, 0 failures (was 10; +2 here) |
| — `XLDocumentationTests` alone | 41 tests, 0 failures |
| — `SQLSkillDocumentationTests` alone | 4 tests, 0 failures |
| `swift test` (full suite) | 1193 tests, 0 failures |
| `testEveryCatalogArticleIsCheckedInTheBuiltDocCOutput` with the `tododemo` line deleted | Fails, both dictionaries in the message |
| Same, restored | Passes |
| `python3 scripts/ci/sqlite-conformance-inventory.py check` | Exit 0, "report is current" |
| `./make-docs.sh /tmp/swiftql-docs-230` | Exit 0, `--warnings-as-errors`, zero DocC warnings |
| `./scripts/ci/check-docc-output.sh /tmp/swiftql-docs-230` | Exit 0, `SWIFTQL_DOCC_OUTPUT ok` — including the new `tododemo` route |

The conformance inventory needed no change: COMPATIBILITY.md's 114 features / 180 evidence records / 110 supported / 2 capability-gated / 1 intentionally unsupported / 1 unimplemented already match the canonical JSON exactly, and `testV13PublicDocumentsShareReleaseAndBoundaryContract` derives those phrases from the inventory rather than trusting the prose.

The DocC build is what proves the new cross-references (`<doc:TodoDemo>` from `StaticQueries.md`, `<doc:DeclaredQueries>` and `<doc:StaticQueries>` from `SwiftQL.md`, `<doc:StaticQueries>` from `AdvancedUsage.md`). `make-docs.sh` runs with `--warnings-as-errors`, and an unresolvable `<doc:>` link is a DocC warning.

Validated against Xcode 26.5 (17F42), Swift 6.3.2, macOS 26 / arm64.

## On changed code samples

No runnable sample changed. Every Swift fence in the README and the catalog is byte-identical to what merged before this PR — `testEverySwiftExampleMapsToACompiledDocumentationScenario` and `testSourceExcerptArticlesQuoteTheirSourcesVerbatim` both still pass, which is the proof. The additions are prose and Markdown `> Note:` callouts; the deprecation notes deliberately name the rewrite inline (``count(all())`` becomes ``all().count()``) rather than adding a fence, so nothing new needs a marker and nothing enters the catalog unexercised.

## Effect on the rest of the package

Documentation, one CI shell script, and one test file. No source changes and no public API change. `SQLTests` gains two tests and no fixtures.

## Deliberately not folded in

Per #230's non-goals, one thing found and left alone: the DocC landing page's section headings are still versioned (`## v1.2 boundaries`, `## v1.3 conformance evidence`), so a first-time reader meets two version numbers before the topic list. Reorganising the landing page is a structural change to a page under a phrase-level pin, not a currency fix, and it belongs with whoever next revisits the site's information architecture. The claims inside those sections are correct as of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
