### PR TITLE
Wait on named events instead of durations in XLAsyncStreamPublisherTests

### DIFF
--- a/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
+++ b/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
@@ -108,12 +108,34 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
     /// either been cancelled mid-`next()` or exited and dropped its iterator, so it can never
     /// deliver another value. Suspends via a continuation, so waiting costs no polling and no
     /// wall-clock deadline decides the outcome.
-    func waitForTermination(ofStream streamIndex: Int = 0) async -> StreamTermination {
+    ///
+    /// An index no `makeStream()` call has reached yet fails the test immediately, naming the index,
+    /// rather than parking forever on a stream that may never exist -- the same "a harness misuse
+    /// must fail where it happened" rule `yield`/`finish` follow. The value it returns in that case
+    /// is meaningless; the `XCTFail` is the outcome.
+    func waitForTermination(
+        ofStream streamIndex: Int = 0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async -> StreamTermination {
         await withCheckedContinuation { continuation in
             lock.lock()
             if let termination = terminations[streamIndex] {
                 lock.unlock()
                 continuation.resume(returning: termination)
+                return
+            }
+            guard streamIndex >= 0, streamIndex < continuations.count else {
+                let createdCount = continuations.count
+                lock.unlock()
+                XCTFail(
+                    "ControllableStreamSource.waitForTermination(ofStream: \(streamIndex)) called "
+                        + "with an out-of-range stream index (only \(createdCount) stream(s) created "
+                        + "so far). Wait for callCount to reach \(streamIndex + 1) first.",
+                    file: file,
+                    line: line
+                )
+                continuation.resume(returning: .finished)
                 return
             }
             terminationWaiters[streamIndex, default: []].append(continuation)
@@ -224,9 +246,10 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
 /// There is deliberately no timeout: a bounded wait is a wall-clock deadline wearing a different
 /// hat, and the failure it produces under load is exactly the one this suite is being fixed for.
 ///
-/// Events are consumed one at a time and in order. A `wait(for:)` that finds no match parks on a
-/// continuation until the matching event arrives; events that do not match stay buffered, so a
-/// later wait can still consume them.
+/// Each wait consumes the earliest *matching* buffered event, and parks on a continuation if none
+/// has arrived yet. Non-matching events are not skipped past and discarded: they stay buffered in
+/// arrival order, so a later wait for one of them still finds it. A wait therefore never has to
+/// step over -- or block on -- an event the test does not care about.
 private final class SubscriptionEventRecorder: @unchecked Sendable {
 
     private struct RecordedEvent {
@@ -1222,6 +1245,19 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         XCTExpectFailure("Finishing a stream index that was never created must fail loudly.") {
             source.finish()
         }
+
+        XCTAssertEqual(source.callCount, 0)
+    }
+
+    /// Same rule for the termination signal this PR adds: a stream index nothing ever created fails
+    /// where the mistake was made, instead of parking the caller forever.
+    func testWaitingForTerminationOfAStreamThatWasNeverCreatedFailsInsteadOfHanging() async {
+        let source = ControllableStreamSource<Int>()
+
+        // The block form of `XCTExpectFailure` takes a synchronous closure, so the whole-test form
+        // is used here: the awaited call is what must record the failure.
+        XCTExpectFailure("Awaiting termination of a stream that was never created must fail loudly.")
+        _ = await source.waitForTermination()
 
         XCTAssertEqual(source.callCount, 0)
     }

--- a/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
+++ b/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
@@ -15,6 +15,15 @@ import XCTest
 
 // MARK: - Deterministic, GRDB-independent stream source
 
+/// How a stream created by ``ControllableStreamSource`` ended.
+private enum StreamTermination: Equatable {
+    /// The consumer `Task` was cancelled, or the consumer loop exited and dropped its iterator.
+    case cancelled
+    /// This source finished the stream itself, with or without an error.
+    case finished
+}
+
+
 /// A hand-controlled `AsyncThrowingStream` factory used to drive
 /// ``XLAsyncStreamPublisher`` deterministically, without a real GRDB database. Every call to
 /// ``makeStream()`` produces one fresh, independent stream and records its own continuation, so a
@@ -25,14 +34,20 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
 
     private let lock = NSLock()
 
-    /// One entry per `makeStream()` call, in order. `AsyncThrowingStream`'s `build` closure runs
-    /// synchronously inside `init`, so the continuation for index `n` is always populated before
-    /// `makeStream()` returns -- no caller can observe a `nil` entry it just created.
+    /// One entry per `makeStream()` call, in order. A slot is appended as `nil` and filled in by
+    /// `AsyncThrowingStream`'s `build` closure; `makeStreamCallCount` is published only once the
+    /// slot holds its continuation, so a `nil` slot is never reachable through `callCount` (#464).
     private var continuations: [AsyncThrowingStream<Value, Error>.Continuation?] = []
 
     private var makeStreamCallCount = 0
 
     private var cancelledContinuationCount = 0
+
+    /// How each stream ended, by index, once its `onTermination` has fired.
+    private var terminations: [Int: StreamTermination] = [:]
+
+    /// Callers parked in ``waitForTermination(ofStream:)`` for a stream that has not ended yet.
+    private var terminationWaiters: [Int: [CheckedContinuation<StreamTermination, Never>]] = [:]
 
     func makeStream() -> AsyncThrowingStream<Value, Error> {
         lock.lock()
@@ -45,16 +60,30 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
             self.continuations[index] = continuation
             // Only becomes visible to `callCount` once the continuation this index needs is
             // actually stored -- issue #464's "publish race": incrementing before the continuation
-            // was stored let a concurrent `waitUntil { callCount == 1 }` observer race ahead of
-            // this closure and call `yield`/`finish` against a still-`nil` slot, which silently
-            // dropped the value instead of failing.
+            // was stored let a concurrent observer of `callCount` race ahead of this closure and
+            // call `yield`/`finish` against a still-`nil` slot, which silently dropped the value
+            // instead of failing.
             self.makeStreamCallCount += 1
             self.lock.unlock()
             continuation.onTermination = { [weak self] termination in
-                guard let self, case .cancelled = termination else { return }
+                guard let self else { return }
+                let kind: StreamTermination
+                if case .cancelled = termination {
+                    kind = .cancelled
+                }
+                else {
+                    kind = .finished
+                }
                 self.lock.lock()
-                self.cancelledContinuationCount += 1
+                if kind == .cancelled {
+                    self.cancelledContinuationCount += 1
+                }
+                self.terminations[index] = kind
+                let waiters = self.terminationWaiters.removeValue(forKey: index) ?? []
                 self.lock.unlock()
+                for waiter in waiters {
+                    waiter.resume(returning: kind)
+                }
             }
         }
     }
@@ -69,6 +98,27 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return cancelledContinuationCount
+    }
+
+    /// Suspends until the `streamIndex`-th stream has ended, and reports how.
+    ///
+    /// This is the harness-side counterpart of ``XLAsyncStreamSubscriptionTestHooks``' subscription
+    /// events, and the thing that makes "nothing else was delivered" provable rather than a race
+    /// against a sleep: once a stream reports `.cancelled`, the consumer loop that owned it has
+    /// either been cancelled mid-`next()` or exited and dropped its iterator, so it can never
+    /// deliver another value. Suspends via a continuation, so waiting costs no polling and no
+    /// wall-clock deadline decides the outcome.
+    func waitForTermination(ofStream streamIndex: Int = 0) async -> StreamTermination {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if let termination = terminations[streamIndex] {
+                lock.unlock()
+                continuation.resume(returning: termination)
+                return
+            }
+            terminationWaiters[streamIndex, default: []].append(continuation)
+            lock.unlock()
+        }
     }
 
     /// Yields `value` on the stream constructed by the `streamIndex`-th `makeStream()` call
@@ -162,6 +212,188 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
 }
 
 
+// MARK: - Deterministic waits on the subscription's own lifecycle
+
+/// Buffers every `XLAsyncStreamSubscription` lifecycle event the `#if DEBUG` seam from issue #465
+/// emits, and lets a test await a *named* one instead of polling a predicate against a wall-clock
+/// deadline (issue #466).
+///
+/// Waiting this way is what makes runner load unable to change a verdict: every wait here resumes
+/// because the subscription reached a specific point in its own control flow, so load can only make
+/// a test take longer, never make it assert against a state the subscription has not reached yet.
+/// There is deliberately no timeout: a bounded wait is a wall-clock deadline wearing a different
+/// hat, and the failure it produces under load is exactly the one this suite is being fixed for.
+///
+/// Events are consumed one at a time and in order. A `wait(for:)` that finds no match parks on a
+/// continuation until the matching event arrives; events that do not match stay buffered, so a
+/// later wait can still consume them.
+private final class SubscriptionEventRecorder: @unchecked Sendable {
+
+    private struct RecordedEvent {
+        let sequence: Int
+        let event: XLAsyncStreamSubscriptionEvent
+    }
+
+    private struct Waiter {
+        let matches: (XLAsyncStreamSubscriptionEvent) -> Bool
+        let continuation: CheckedContinuation<RecordedEvent, Never>
+    }
+
+    private let lock = NSLock()
+
+    private var buffered: [RecordedEvent] = []
+
+    private var waiter: Waiter?
+
+    private var nextSequence = 0
+
+    private var pump: Task<Void, Never>?
+
+    init() {
+        // `events()` registers its observer synchronously inside `AsyncStream`'s build closure, and
+        // that stream buffers without bound, so no event emitted after this line can be missed --
+        // including events emitted before `pump` gets its first chance to run.
+        let stream = XLAsyncStreamSubscriptionTestHooks.shared.events()
+        pump = Task { [weak self] in
+            for await event in stream {
+                self?.ingest(event)
+            }
+        }
+    }
+
+    func stop() {
+        pump?.cancel()
+        pump = nil
+    }
+
+    private func ingest(_ event: XLAsyncStreamSubscriptionEvent) {
+        lock.lock()
+        let recorded = RecordedEvent(sequence: nextSequence, event: event)
+        nextSequence += 1
+        if let waiter, waiter.matches(event) {
+            self.waiter = nil
+            lock.unlock()
+            // Resumed outside the lock: the resumed test task goes on to call into the subscription
+            // (cancel, request more demand), which takes the subscription's own lock.
+            waiter.continuation.resume(returning: recorded)
+            return
+        }
+        buffered.append(recorded)
+        lock.unlock()
+    }
+
+    private func wait(
+        matching matches: @escaping (XLAsyncStreamSubscriptionEvent) -> Bool
+    ) async -> RecordedEvent {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if let index = buffered.firstIndex(where: { matches($0.event) }) {
+                let match = buffered.remove(at: index)
+                lock.unlock()
+                continuation.resume(returning: match)
+                return
+            }
+            precondition(
+                waiter == nil,
+                "SubscriptionEventRecorder serves one wait at a time: a test that awaits two events "
+                    + "concurrently would silently overwrite and hang the first waiter."
+            )
+            waiter = Waiter(matches: matches, continuation: continuation)
+            lock.unlock()
+        }
+    }
+
+    /// Awaits (and consumes) the next occurrence of `event`.
+    func wait(for event: XLAsyncStreamSubscriptionEvent) async {
+        _ = await wait(matching: { $0 == event })
+    }
+
+    /// Awaits `finish(error:)` running and reports whether it forwarded the completion downstream or
+    /// suppressed it as self-inflicted.
+    ///
+    /// Matching *either* outcome is deliberate. A test that waited only for the outcome it expects
+    /// would hang -- rather than fail -- in the world where the subscription made the opposite
+    /// decision, which is the world the test exists to detect.
+    func waitForFinish() async -> Bool {
+        let match = await wait(matching: { event in
+            if case .finished = event {
+                return true
+            }
+            return false
+        })
+        guard case .finished(let forwarded) = match.event else {
+            preconditionFailure("wait(matching:) resumed with a non-`.finished` event.")
+        }
+        return forwarded
+    }
+
+    /// Awaits the next consumer task starting, and forgets everything emitted before it.
+    ///
+    /// The seam is process-global -- `Publisher.receive(subscriber:)` erases the concrete
+    /// `XLAsyncStreamSubscription` behind Combine's `Subscription` existential the moment it is
+    /// vended, so no test ever holds a handle to hook per-instance. That means a previous test's
+    /// (or previous round's) still-unwinding subscription can in principle emit one last event into
+    /// this recorder. `.consumerTaskStarted` can only come from a consumer task starting *now*, so
+    /// fencing on it and dropping everything with a lower sequence number gives each test a clean
+    /// epoch, without polling for quiescence.
+    func fenceOnConsumerTaskStart() async {
+        let match = await wait(matching: { $0 == .consumerTaskStarted })
+        discardEvents(before: match.sequence)
+    }
+
+    /// Locked, non-`async` half of ``fenceOnConsumerTaskStart()``: recent Foundation marks
+    /// `NSLock.lock()`/`unlock()` unavailable directly inside an asynchronous context (an error in
+    /// the Swift 6 language mode), the same split `XLAsyncStreamSubscription` itself uses.
+    private func discardEvents(before sequence: Int) {
+        lock.lock()
+        buffered.removeAll { $0.sequence < sequence }
+        lock.unlock()
+    }
+}
+
+
+/// A one-shot value a test can await, used where the thing being observed is a downstream callback
+/// rather than a subscription lifecycle event (`sink`'s delivery on the main queue).
+private final class AsyncValue<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var value: Value?
+
+    private var waiters: [CheckedContinuation<Value, Never>] = []
+
+    /// Records the first value only: later calls are ignored, so a test asserting on "the delivery"
+    /// cannot be confused by a second one arriving while it is being read.
+    func fulfill(_ newValue: Value) {
+        lock.lock()
+        guard value == nil else {
+            lock.unlock()
+            return
+        }
+        value = newValue
+        let pending = waiters
+        waiters = []
+        lock.unlock()
+        for waiter in pending {
+            waiter.resume(returning: newValue)
+        }
+    }
+
+    func wait() async -> Value {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if let value {
+                lock.unlock()
+                continuation.resume(returning: value)
+                return
+            }
+            waiters.append(continuation)
+            lock.unlock()
+        }
+    }
+}
+
+
 private enum XLAsyncStreamPublisherTestError: Error, Equatable {
     case terminal
 }
@@ -245,6 +477,23 @@ private final class RecordingSubscriber<Input>: Subscriber, @unchecked Sendable 
 
 final class XLAsyncStreamPublisherTests: XCTestCase {
 
+    /// Observes the subscription seam for the duration of one test. Recreated per test, and the
+    /// shared hooks are reset on both sides of the test so no observer leaks into the next one.
+    private var events: SubscriptionEventRecorder!
+
+    override func setUp() {
+        super.setUp()
+        XLAsyncStreamSubscriptionTestHooks.shared.reset()
+        events = SubscriptionEventRecorder()
+    }
+
+    override func tearDown() {
+        events?.stop()
+        events = nil
+        XLAsyncStreamSubscriptionTestHooks.shared.reset()
+        super.tearDown()
+    }
+
     // MARK: - Lazy start
 
     func testConstructingThePublisherPerformsNoWork() throws {
@@ -260,9 +509,14 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let subscriber = RecordingSubscriber<Int>(initialDemand: .none)
 
         publisher.receive(subscriber: subscriber)
-        await drainCurrentThread()
+        // Nothing to await on the subject itself -- the claim is that it never starts a consumer
+        // task at all. A canary subscription created *after* it runs a full start-to-delivery round
+        // trip, so the assertion below is made at a point where the runtime demonstrably got around
+        // to starting consumer tasks and delivering values, rather than after a fixed sleep.
+        await runCanaryRoundTrip(value: 61)
 
         XCTAssertEqual(source.callCount, 0, "Zero demand must not start the consumer task.")
+        XCTAssertTrue(subscriber.recordedValues.isEmpty)
         subscriber.cancel()
     }
 
@@ -271,11 +525,14 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
         let subscriber = RecordingSubscriber<Int>(initialDemand: .max(1))
 
-        publisher.receive(subscriber: subscriber)
-        try await waitUntil { source.callCount == 1 }
+        await startConsuming(publisher, with: subscriber)
+        XCTAssertEqual(source.callCount, 1, "One subscriber must produce exactly one stream.")
 
         source.yield(1)
-        try await waitUntil { subscriber.recordedValues == [1] }
+        await events.wait(for: .delivered)
+
+        XCTAssertEqual(subscriber.recordedValues, [1])
+        XCTAssertEqual(source.callCount, 1)
         subscriber.cancel()
     }
 
@@ -286,8 +543,7 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
         let subscriber = RecordingSubscriber<Int>(initialDemand: .max(1))
 
-        publisher.receive(subscriber: subscriber)
-        try await waitUntil { source.callCount == 1 }
+        await startConsuming(publisher, with: subscriber)
 
         // Yield three values while only one unit of demand is outstanding: only the first may be
         // delivered; the rest must sit in the stream's own buffer, untouched, until more demand
@@ -295,17 +551,23 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         source.yield(1)
         source.yield(2)
         source.yield(3)
-        try await waitUntil { subscriber.recordedValues == [1] }
-        await drainCurrentThread()
+        await events.wait(for: .delivered)
+        // `.demandWaiterRegistered` is the proof that the consumer loop came back around, found no
+        // demand left, and parked. An adapter that drained eagerly would have delivered 2 and 3
+        // before reaching this same point, so the assertion below can fail rather than merely
+        // racing a sleep.
+        await events.wait(for: .demandWaiterRegistered)
         XCTAssertEqual(subscriber.recordedValues, [1], "Must not pull ahead of granted demand.")
 
         subscriber.requestMore(.max(1))
-        try await waitUntil { subscriber.recordedValues == [1, 2] }
-        await drainCurrentThread()
+        await events.wait(for: .delivered)
+        await events.wait(for: .demandWaiterRegistered)
         XCTAssertEqual(subscriber.recordedValues, [1, 2])
 
         subscriber.requestMore(.max(1))
-        try await waitUntil { subscriber.recordedValues == [1, 2, 3] }
+        await events.wait(for: .delivered)
+        await events.wait(for: .demandWaiterRegistered)
+        XCTAssertEqual(subscriber.recordedValues, [1, 2, 3])
         subscriber.cancel()
     }
 
@@ -314,13 +576,16 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
         let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
 
-        publisher.receive(subscriber: subscriber)
-        try await waitUntil { source.callCount == 1 }
+        await startConsuming(publisher, with: subscriber)
 
         for value in 1...5 {
             source.yield(value)
         }
-        try await waitUntil { subscriber.recordedValues == [1, 2, 3, 4, 5] }
+        for _ in 1...5 {
+            await events.wait(for: .delivered)
+        }
+
+        XCTAssertEqual(subscriber.recordedValues, [1, 2, 3, 4, 5])
         subscriber.cancel()
     }
 
@@ -334,13 +599,14 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
             additionalDemand: { _ in .max(1) }
         )
 
-        publisher.receive(subscriber: subscriber)
-        try await waitUntil { source.callCount == 1 }
+        await startConsuming(publisher, with: subscriber)
 
         for value in 1...3 {
             source.yield(value)
-            try await waitUntil { subscriber.recordedValues.last == value }
+            await events.wait(for: .delivered)
+            XCTAssertEqual(subscriber.recordedValues.last, value)
         }
+        XCTAssertEqual(subscriber.recordedValues, [1, 2, 3])
         subscriber.cancel()
     }
 
@@ -358,11 +624,14 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         // independently-scheduled `Task`, so there is no guarantee *which* of the two calls lands at
         // index 0 versus index 1 -- only that there are two distinct, independent streams. The
         // assertions below deliberately never assume a fixed index-to-subscriber mapping.
-        try await waitUntil { source.callCount == 2 }
+        await events.fenceOnConsumerTaskStart()
+        await events.wait(for: .consumerTaskStarted)
+        await events.wait(for: .streamCreated)
+        await events.wait(for: .streamCreated)
+        XCTAssertEqual(source.callCount, 2)
 
         source.yield(100, toStream: 0)
-        try await waitUntil { first.recordedValues == [100] || second.recordedValues == [100] }
-        await drainCurrentThread()
+        await events.wait(for: .delivered)
         let ownerOf100 = first.recordedValues == [100] ? first : second
         let otherSubscriber = ownerOf100 === first ? second : first
         XCTAssertTrue(
@@ -371,13 +640,13 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         )
 
         source.yield(200, toStream: 1)
-        try await waitUntil { otherSubscriber.recordedValues == [200] }
-        await drainCurrentThread()
+        await events.wait(for: .delivered)
         XCTAssertEqual(
             ownerOf100.recordedValues,
             [100],
             "A later value on the other stream must not leak into this subscription."
         )
+        XCTAssertEqual(otherSubscriber.recordedValues, [200])
 
         first.cancel()
         second.cancel()
@@ -393,7 +662,9 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         publisher.receive(subscriber: subscriber)
         subscriber.cancel()
         subscriber.requestMore(.unlimited)
-        await drainCurrentThread()
+        // As in the zero-demand test: the claim is that nothing starts, so the canary's full
+        // start-to-delivery round trip is what proves the runtime had the opportunity.
+        await runCanaryRoundTrip(value: 62)
 
         XCTAssertEqual(source.callCount, 0)
         XCTAssertTrue(subscriber.recordedValues.isEmpty)
@@ -405,13 +676,19 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
         let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
 
-        publisher.receive(subscriber: subscriber)
-        try await waitUntil { source.callCount == 1 }
+        await startConsuming(publisher, with: subscriber)
         source.yield(1)
-        try await waitUntil { subscriber.recordedValues == [1] }
+        await events.wait(for: .delivered)
 
         subscriber.cancel()
-        try await waitUntil { source.cancelledCount == 1 }
+        let termination = await source.waitForTermination()
+
+        XCTAssertEqual(
+            termination,
+            .cancelled,
+            "Cancelling the subscription must tear down the underlying stream, not leave it running."
+        )
+        XCTAssertEqual(source.cancelledCount, 1)
     }
 
     func testSelfInflictedCancellationDoesNotDeliverASpuriousCompletion() async throws {
@@ -419,18 +696,25 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
         let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
 
-        publisher.receive(subscriber: subscriber)
-        try await waitUntil { source.callCount == 1 }
+        await startConsuming(publisher, with: subscriber)
         source.yield(1)
-        try await waitUntil { subscriber.recordedValues == [1] }
+        await events.wait(for: .delivered)
+        // Waiting for the *next* demand unit to be consumed puts the consumer loop provably inside
+        // `next()` before cancelling, which is the case under test: cancellation resolves `next()`
+        // to nil, and a naive bridge would forward that as `.finished`.
+        await events.wait(for: .demandUnitConsumed)
 
         subscriber.cancel()
-        // Give the cancelled consumer task every opportunity to (incorrectly) resolve next() to
-        // nil and forward it as `.finished` before asserting it never did.
-        try await waitUntil { source.cancelledCount == 1 }
-        await drainCurrentThread()
-        try await Task.sleep(nanoseconds: 20_000_000)
+        // The positive event that proves the opposite outcome had its opportunity: `finish(error:)`
+        // ran and *decided*. `waitForFinish()` matches either decision, so the wrong one fails this
+        // test rather than hanging it.
+        let forwarded = await events.waitForFinish()
 
+        XCTAssertFalse(
+            forwarded,
+            "A completion produced by this subscription's own cancel() must be suppressed, not "
+                + "forwarded."
+        )
         XCTAssertTrue(
             subscriber.recordedCompletions.isEmpty,
             "Cancelling must never manifest as a completion, matching Combine's own contract that "
@@ -466,14 +750,19 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         )
         capturedSubscriber = subscriber
 
-        publisher.receive(subscriber: subscriber)
-        try await waitUntil { source.callCount == 1 }
+        await startConsuming(publisher, with: subscriber)
         source.yield(1)
         source.yield(2)
-        try await waitUntil { cancelledDuringReceive.isSet }
-        await drainCurrentThread()
-        try await Task.sleep(nanoseconds: 20_000_000)
+        await events.wait(for: .delivered)
+        XCTAssertTrue(cancelledDuringReceive.isSet)
 
+        // The positive event: the stream is torn down, which happens only once the consumer loop has
+        // either been cancelled inside `next()` or exited and dropped its iterator. Either way it
+        // has had -- and used up -- every opportunity to deliver the second value, so the assertion
+        // below no longer races a fixed sleep.
+        let termination = await source.waitForTermination()
+
+        XCTAssertEqual(termination, .cancelled)
         XCTAssertEqual(
             subscriber.recordedValues,
             [1],
@@ -490,13 +779,13 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
         let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
 
-        publisher.receive(subscriber: subscriber)
-        try await waitUntil { source.callCount == 1 }
+        await startConsuming(publisher, with: subscriber)
         source.finish(throwing: XLAsyncStreamPublisherTestError.terminal)
 
-        try await waitUntil { !subscriber.recordedCompletions.isEmpty }
-        await drainCurrentThread()
+        let forwarded = await events.waitForFinish()
+        _ = await source.waitForTermination()
 
+        XCTAssertTrue(forwarded, "A stream that failed on its own must forward its failure.")
         XCTAssertEqual(subscriber.recordedCompletions.count, 1)
         guard case .failure(let error) = subscriber.recordedCompletions[0] else {
             return XCTFail("Expected a failure completion.")
@@ -509,16 +798,17 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
         let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
 
-        publisher.receive(subscriber: subscriber)
-        try await waitUntil { source.callCount == 1 }
+        await startConsuming(publisher, with: subscriber)
         source.yield(1)
-        try await waitUntil { subscriber.recordedValues == [1] }
+        await events.wait(for: .delivered)
 
         // The stream ends on its own, with no cancel() ever called: this is NOT the self-inflicted
         // case, so it must be forwarded normally as `.finished`.
         source.finish()
 
-        try await waitUntil { !subscriber.recordedCompletions.isEmpty }
+        let forwarded = await events.waitForFinish()
+
+        XCTAssertTrue(forwarded, "A completion nobody cancelled for must be forwarded downstream.")
         XCTAssertEqual(subscriber.recordedCompletions.count, 1)
         guard case .finished = subscriber.recordedCompletions[0] else {
             return XCTFail("Expected a normal `.finished` completion, not a self-inflicted suppression.")
@@ -530,53 +820,384 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
     func testXlLiveQueryPublisherDeliversOnTheMainQueueByDefault() async throws {
         let source = ControllableStreamSource<Int>()
         let publisher = xlLiveQueryPublisher(makeStream: source.makeStream)
-        let deliveredOnMain = LockedFlag()
-        let completedOnMain = LockedFlag()
+        let deliveryOnMainQueue = AsyncValue<Bool>()
+        let completionOnMainQueue = AsyncValue<Bool>()
 
         let cancellable = publisher.sink(
             receiveCompletion: { _ in
-                if Thread.isMainThread { completedOnMain.set() }
+                completionOnMainQueue.fulfill(Thread.isMainThread)
             },
             receiveValue: { _ in
-                if Thread.isMainThread { deliveredOnMain.set() }
+                deliveryOnMainQueue.fulfill(Thread.isMainThread)
             }
         )
 
-        try await waitUntil { source.callCount == 1 }
+        await events.fenceOnConsumerTaskStart()
+        await events.wait(for: .streamCreated)
         // Yield from a background queue: the adapter itself is thread-agnostic, so this proves the
         // main-queue delivery comes from `.receive(on: DispatchQueue.main)`, not from whichever
         // thread produced the value.
         DispatchQueue.global().async {
             source.yield(1)
         }
-        try await waitUntil { deliveredOnMain.isSet }
+        // Awaiting the delivery itself -- rather than a flag that is only set on the main queue --
+        // means a delivery on the wrong thread fails this test instead of hanging it.
+        let deliveredOnMainQueue = await deliveryOnMainQueue.wait()
+        XCTAssertTrue(deliveredOnMainQueue, "Values must be delivered on the main queue by default.")
 
         source.finish()
-        try await waitUntil { completedOnMain.isSet }
+        let completedOnMainQueue = await completionOnMainQueue.wait()
+        XCTAssertTrue(completedOnMainQueue, "Completions must be delivered on the main queue too.")
         withExtendedLifetime(cancellable) {}
     }
 
     // MARK: - Deterministic repeated stress (no sleeps as synchronization)
 
     func testRepeatedSubscribeYieldCancelCycleLeavesNoDanglingState() async throws {
-        for round in 0 ..< 25 {
+        // 25 rounds by default; issue #466 asks for at least 250 during review, and #463's repeat-run
+        // evidence re-runs this file under load. Raise it in place with
+        // `SWIFTQL_PUBLISHER_CYCLE_ROUNDS=250 swift test --filter XLAsyncStreamPublisherTests`
+        // rather than editing the file, so the review run is reproducible from the command alone.
+        let rounds = ProcessInfo.processInfo.environment["SWIFTQL_PUBLISHER_CYCLE_ROUNDS"]
+            .flatMap(Int.init) ?? 25
+        for round in 0 ..< rounds {
             let source = ControllableStreamSource<Int>()
             let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
             let subscriber = RecordingSubscriber<Int>(initialDemand: .max(1))
 
-            publisher.receive(subscriber: subscriber)
-            try await waitUntil { source.callCount == 1 }
+            // `startConsuming` fences on this round's own `.consumerTaskStarted`, so a previous
+            // round's last event can never be mistaken for one of this round's.
+            await startConsuming(publisher, with: subscriber)
             source.yield(round)
-            try await waitUntil { subscriber.recordedValues == [round] }
-            subscriber.cancel()
-            try await waitUntil { source.cancelledCount == 1 }
+            await events.wait(for: .delivered)
+            XCTAssertEqual(subscriber.recordedValues, [round])
 
+            subscriber.cancel()
+            let termination = await source.waitForTermination()
+
+            XCTAssertEqual(termination, .cancelled, "Round \(round) left the stream running.")
             XCTAssertTrue(subscriber.recordedCompletions.isEmpty)
         }
     }
 
+    // MARK: - Negative controls
+    //
+    // One per rewritten test above. Each drives the same wait sequence in a scenario where the
+    // guarded behaviour does *not* hold, and asserts that the paired test's own predicate is false
+    // at exactly the point that test asserts it -- so a rewritten test cannot pass vacuously, and
+    // its waits are shown to resume early enough to see the wrong outcome.
+    //
+    // Every control uses values and demands decoupled from its paired test's constants (the 9xx
+    // range, and different demand counts), so it cannot pass merely by sharing them.
+    //
+    // The broken world is produced through legal use of the publisher -- granting different demand,
+    // finishing instead of cancelling, subscribing twice -- rather than by mutating the subscription
+    // under test, so these controls exercise the real adapter rather than a stub of it.
+
+    func testNegativeControlZeroDemandNoWorkAssertionCanFail() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        // The broken world: a subscription that *does* start a stream. If zero demand ever started
+        // one, this is the state the two "performs no work" tests would find.
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .max(1))
+
+        await startConsuming(publisher, with: subscriber)
+
+        assertGuardedPredicateFails(
+            source.callCount == 0,
+            "`callCount == 0` must be able to fail once a stream really is created."
+        )
+        subscriber.cancel()
+    }
+
+    func testNegativeControlFirstPositiveDemandStartsExactlyOneStreamAssertionCanFail() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        let first = RecordingSubscriber<Int>(initialDemand: .max(1))
+        let second = RecordingSubscriber<Int>(initialDemand: .max(1))
+
+        publisher.receive(subscriber: first)
+        publisher.receive(subscriber: second)
+        await events.fenceOnConsumerTaskStart()
+        await events.wait(for: .consumerTaskStarted)
+        await events.wait(for: .streamCreated)
+        await events.wait(for: .streamCreated)
+
+        assertGuardedPredicateFails(
+            source.callCount == 1,
+            "`callCount == 1` must be able to fail when more than one stream is created."
+        )
+        first.cancel()
+        second.cancel()
+    }
+
+    func testNegativeControlEagerDrainingWouldBeVisibleAtTheSameWaitPoint() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        // Three units of demand rather than one: the adapter legitimately delivers all three, which
+        // is exactly the observable state an eagerly-draining adapter would produce.
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .max(3))
+
+        await startConsuming(publisher, with: subscriber)
+        source.yield(901)
+        source.yield(902)
+        source.yield(903)
+        await events.wait(for: .delivered)
+        await events.wait(for: .demandWaiterRegistered)
+
+        assertGuardedPredicateFails(
+            subscriber.recordedValues == [901],
+            "The one-at-a-time assertion must be able to see values delivered beyond the first by "
+                + "the time the consumer loop parks."
+        )
+        XCTAssertEqual(subscriber.recordedValues, [901, 902, 903])
+        subscriber.cancel()
+    }
+
+    func testNegativeControlUnderDeliveryWouldBeVisibleAtTheSameWaitPoint() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        // Two units of demand for four values: the observable state an adapter that stopped pulling
+        // early under unlimited demand would produce.
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .max(2))
+
+        await startConsuming(publisher, with: subscriber)
+        for value in 911...914 {
+            source.yield(value)
+        }
+        await events.wait(for: .delivered)
+        await events.wait(for: .delivered)
+        await events.wait(for: .demandWaiterRegistered)
+
+        assertGuardedPredicateFails(
+            subscriber.recordedValues == [911, 912, 913, 914],
+            "The unlimited-demand assertion must be able to fail when values are missing."
+        )
+        XCTAssertEqual(subscriber.recordedValues, [911, 912])
+        subscriber.cancel()
+    }
+
+    func testNegativeControlAStalledPullStaysStalledWithoutAdditionalDemand() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        // The broken world for "additional demand from receive(_:) resumes the pull": a subscriber
+        // that grants none, so the second value must never arrive.
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .max(1))
+
+        await startConsuming(publisher, with: subscriber)
+        source.yield(921)
+        source.yield(922)
+        await events.wait(for: .delivered)
+        await events.wait(for: .demandWaiterRegistered)
+
+        assertGuardedPredicateFails(
+            subscriber.recordedValues.last == 922,
+            "The resumed-pull assertion must be able to fail when no additional demand is granted."
+        )
+        XCTAssertEqual(subscriber.recordedValues, [921])
+        subscriber.cancel()
+    }
+
+    func testNegativeControlCrossStreamLeakWouldBeVisible() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        let first = RecordingSubscriber<Int>(initialDemand: .unlimited)
+        let second = RecordingSubscriber<Int>(initialDemand: .unlimited)
+
+        publisher.receive(subscriber: first)
+        publisher.receive(subscriber: second)
+        await events.fenceOnConsumerTaskStart()
+        await events.wait(for: .consumerTaskStarted)
+        await events.wait(for: .streamCreated)
+        await events.wait(for: .streamCreated)
+
+        // Yield the same value to *both* streams: the observable state a leak between subscriptions
+        // would produce, reached here without one.
+        source.yield(931, toStream: 0)
+        await events.wait(for: .delivered)
+        source.yield(931, toStream: 1)
+        await events.wait(for: .delivered)
+
+        assertGuardedPredicateFails(
+            first.recordedValues.isEmpty || second.recordedValues.isEmpty,
+            "The independence assertion must be able to fail when both subscribers hold the value."
+        )
+        XCTAssertEqual(first.recordedValues, [931])
+        XCTAssertEqual(second.recordedValues, [931])
+        first.cancel()
+        second.cancel()
+    }
+
+    func testNegativeControlANormallyEndedStreamIsNotReportedAsCancelled() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
+
+        await startConsuming(publisher, with: subscriber)
+        source.yield(941)
+        await events.wait(for: .delivered)
+        // Ending the stream from the source rather than cancelling: the termination signal the
+        // cancellation test asserts on must discriminate between the two.
+        source.finish()
+        let termination = await source.waitForTermination()
+
+        assertGuardedPredicateFails(
+            termination == .cancelled && source.cancelledCount == 1,
+            "The cancellation-propagation assertion must be able to fail when nothing cancelled."
+        )
+        XCTAssertEqual(termination, .finished)
+        XCTAssertEqual(source.cancelledCount, 0)
+        subscriber.cancel()
+    }
+
+    func testNegativeControlAForwardedCompletionIsVisibleToTheSuppressionAssertion() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
+
+        await startConsuming(publisher, with: subscriber)
+        source.yield(951)
+        await events.wait(for: .delivered)
+        await events.wait(for: .demandUnitConsumed)
+        // No cancel: the stream ends on its own, so the completion *is* forwarded -- exactly what
+        // the self-inflicted-cancellation test claims never happens in its scenario.
+        source.finish()
+        let forwarded = await events.waitForFinish()
+
+        assertGuardedPredicateFails(
+            !forwarded && subscriber.recordedCompletions.isEmpty,
+            "The suppression assertion must be able to see a completion that really was forwarded."
+        )
+        XCTAssertTrue(forwarded)
+        XCTAssertEqual(subscriber.recordedCompletions.count, 1)
+        subscriber.cancel()
+    }
+
+    func testNegativeControlASecondBufferedValueIsVisibleWhenNothingCancels() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        // Same shape as the concurrent-cancellation test, minus the cancel inside receive(_:): both
+        // buffered values are delivered, which is what that test asserts must not happen.
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .max(2))
+
+        await startConsuming(publisher, with: subscriber)
+        source.yield(961)
+        source.yield(962)
+        await events.wait(for: .delivered)
+        await events.wait(for: .delivered)
+
+        subscriber.cancel()
+        let termination = await source.waitForTermination()
+
+        XCTAssertEqual(termination, .cancelled)
+        assertGuardedPredicateFails(
+            subscriber.recordedValues == [961],
+            "The post-cancel suppression assertion must be able to see a second delivered value at "
+                + "the same wait point."
+        )
+        XCTAssertEqual(subscriber.recordedValues, [961, 962])
+    }
+
+    func testNegativeControlANormalCompletionIsNotAFailure() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
+
+        await startConsuming(publisher, with: subscriber)
+        // Finishing without an error, where the terminal-error test finishes with one.
+        source.finish()
+        _ = await events.waitForFinish()
+
+        var carriesTheTerminalError = false
+        if let completion = subscriber.recordedCompletions.first,
+            case .failure(let error) = completion {
+            carriesTheTerminalError = (error as? XLAsyncStreamPublisherTestError) == .terminal
+        }
+        assertGuardedPredicateFails(
+            carriesTheTerminalError,
+            "The terminal-error assertion must be able to fail when the stream ended without one."
+        )
+        XCTAssertEqual(subscriber.recordedCompletions.count, 1)
+    }
+
+    func testNegativeControlASuppressedCompletionIsVisibleToTheForwardingAssertion() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
+
+        await startConsuming(publisher, with: subscriber)
+        source.yield(971)
+        await events.wait(for: .delivered)
+        await events.wait(for: .demandUnitConsumed)
+        // Cancelling first makes the completion self-inflicted, so it is suppressed -- the opposite
+        // of what the normal-completion test asserts.
+        subscriber.cancel()
+        let forwarded = await events.waitForFinish()
+
+        assertGuardedPredicateFails(
+            forwarded && !subscriber.recordedCompletions.isEmpty,
+            "The forwarding assertion must be able to fail when the completion was suppressed."
+        )
+        XCTAssertFalse(forwarded)
+        XCTAssertTrue(subscriber.recordedCompletions.isEmpty)
+    }
+
+    func testNegativeControlDeliveryOffTheMainQueueIsVisible() async throws {
+        let source = ControllableStreamSource<Int>()
+        // The raw publisher, without `xlLiveQueryPublisher`'s `.receive(on: DispatchQueue.main)`:
+        // its consumer `Task` runs on the cooperative pool, never the main thread.
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        let deliveryOnMainQueue = AsyncValue<Bool>()
+        let subscriber = RecordingSubscriber<Int>(
+            initialDemand: .unlimited,
+            additionalDemand: { _ in
+                deliveryOnMainQueue.fulfill(Thread.isMainThread)
+                return .none
+            }
+        )
+
+        await startConsuming(publisher, with: subscriber)
+        DispatchQueue.global().async {
+            source.yield(981)
+        }
+        let deliveredOnMainQueue = await deliveryOnMainQueue.wait()
+
+        assertGuardedPredicateFails(
+            deliveredOnMainQueue,
+            "The main-queue delivery assertion must be able to fail when delivery is off-main."
+        )
+        subscriber.cancel()
+    }
+
+    func testNegativeControlADanglingCompletionAfterCancelWouldBeVisible() async throws {
+        let source = ControllableStreamSource<Int>()
+        let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
+        // Unlimited demand, so the consumer loop is provably inside `next()` when the stream ends and
+        // the completion really is forwarded rather than left unobserved behind a demand wait.
+        let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
+
+        await startConsuming(publisher, with: subscriber)
+        source.yield(991)
+        await events.wait(for: .delivered)
+        await events.wait(for: .demandUnitConsumed)
+        // Ending the stream before cancelling leaves a completion recorded -- the dangling state the
+        // repeat-cycle test asserts each round never leaves behind.
+        source.finish()
+        _ = await events.waitForFinish()
+        subscriber.cancel()
+
+        assertGuardedPredicateFails(
+            subscriber.recordedCompletions.isEmpty,
+            "The repeat-cycle assertion must be able to see a completion left behind by a round."
+        )
+    }
+
     // MARK: - Harness self-test (negative controls for #464)
 
+    // `XCTExpectFailure` has no equivalent in swift-corelibs-xctest (the pinned Swift 5.9 Linux
+    // cell), and intercepting a recorded failure is the only way to prove `XCTFail` fired, so these
+    // two are Darwin-only. Every other control in this file is portable and runs on every cell.
+    #if canImport(Darwin)
     /// Proves `ControllableStreamSource` fails the test explicitly, rather than silently dropping
     /// the value and letting a caller time out somewhere unrelated, when driven ahead of a stream
     /// that does not exist yet.
@@ -604,6 +1225,7 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
 
         XCTAssertEqual(source.callCount, 0)
     }
+    #endif
 
     // MARK: - Helpers
 
@@ -624,39 +1246,54 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         }
     }
 
-    /// Lets any already-scheduled asynchronous work (Task hops, `DispatchQueue.main` blocks already
-    /// enqueued) finish before an assertion, without asserting anything about timing itself.
+    /// Subscribes `subscriber` and returns once its consumer task has started and its stream exists.
     ///
-    /// This suspends via a checked continuation rather than XCTest's synchronous `wait(for:timeout:)`
-    /// deliberately: every call site runs inside an `async throws` test method, which executes on
-    /// Swift concurrency's cooperative thread pool. Blocking one of those threads synchronously (as
-    /// `wait(for:timeout:)` does) can starve the pool of the thread this test's own consumer `Task`
-    /// needs to make progress, causing a self-inflicted hang -- exactly the failure mode this helper
-    /// exists to avoid.
-    private func drainCurrentThread() async {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.main.async {
-                continuation.resume()
-            }
-        }
+    /// Both waits are load-bearing. `fenceOnConsumerTaskStart()` gives this test its own event
+    /// epoch, and `.streamCreated` is the point from which `source.yield(_:)` is guaranteed to find
+    /// a stored continuation rather than fail (#464's ordering).
+    private func startConsuming<Value>(
+        _ publisher: XLAsyncStreamPublisher<Value>,
+        with subscriber: RecordingSubscriber<Value>
+    ) async {
+        publisher.receive(subscriber: subscriber)
+        await events.fenceOnConsumerTaskStart()
+        await events.wait(for: .streamCreated)
     }
 
-    /// Bounded, deterministic polling: checks `condition` repeatedly instead of sleeping blindly,
-    /// matching #308's own async test suite style (`GRDBLiveQueryAsyncStreamTests.waitUntil`).
-    private func waitUntil(
-        timeout: TimeInterval = 3,
-        pollInterval: UInt64 = 5_000_000,
+    /// Runs an independent subscription all the way from subscribing to a delivered value.
+    ///
+    /// Used by the two "performs no work" tests, whose claim is that a subscription never starts at
+    /// all: there is no event of their own to await, so this canary -- created *after* the subject,
+    /// and observed through the same seam -- is what proves the runtime reached the point of
+    /// starting consumer tasks and delivering values before those tests assert nothing happened.
+    private func runCanaryRoundTrip(
+        value: Int,
         file: StaticString = #filePath,
-        line: UInt = #line,
-        _ condition: () -> Bool
-    ) async throws {
-        let maxAttempts = max(Int((timeout * 1_000_000_000) / Double(pollInterval)), 1)
-        for _ in 0 ..< maxAttempts {
-            if condition() {
-                return
-            }
-            try await Task.sleep(nanoseconds: pollInterval)
-        }
-        XCTFail("Condition not met within \(timeout)s", file: file, line: line)
+        line: UInt = #line
+    ) async {
+        let canarySource = ControllableStreamSource<Int>()
+        let canaryPublisher = XLAsyncStreamPublisher(makeStream: canarySource.makeStream)
+        let canary = RecordingSubscriber<Int>(initialDemand: .max(1))
+
+        await startConsuming(canaryPublisher, with: canary)
+        canarySource.yield(value)
+        await events.wait(for: .delivered)
+
+        XCTAssertEqual(canary.recordedValues, [value], file: file, line: line)
+        canary.cancel()
+        _ = await canarySource.waitForTermination()
+    }
+
+    /// Asserts that `predicate` -- written to be the same predicate its paired test asserts -- does
+    /// *not* hold in a deliberately-broken scenario. That is what makes the paired test falsifiable:
+    /// its wait resumes early enough, and its assertion is specific enough, to catch the wrong
+    /// outcome rather than passing vacuously.
+    private func assertGuardedPredicateFails(
+        _ predicate: @autoclosure () -> Bool,
+        _ description: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertFalse(predicate(), "Negative control: \(description)", file: file, line: line)
     }
 }

--- a/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
+++ b/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
@@ -742,11 +742,14 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
 
         await startConsuming(publisher, with: subscriber)
+        await consumeStartupDemandUnit()
         source.yield(1)
         await events.wait(for: .delivered)
         // Waiting for the *next* demand unit to be consumed puts the consumer loop provably inside
         // `next()` before cancelling, which is the case under test: cancellation resolves `next()`
-        // to nil, and a naive bridge would forward that as `.finished`.
+        // to nil, and a naive bridge would forward that as `.finished`. The startup unit consumed
+        // above is what makes this wait refer to that second pull rather than resolving against the
+        // first one, still buffered in the recorder.
         await events.wait(for: .demandUnitConsumed)
 
         subscriber.cancel()
@@ -1101,6 +1104,7 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
 
         await startConsuming(publisher, with: subscriber)
+        await consumeStartupDemandUnit()
         source.yield(951)
         await events.wait(for: .delivered)
         await events.wait(for: .demandUnitConsumed)
@@ -1171,6 +1175,7 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
 
         await startConsuming(publisher, with: subscriber)
+        await consumeStartupDemandUnit()
         source.yield(971)
         await events.wait(for: .delivered)
         await events.wait(for: .demandUnitConsumed)
@@ -1222,6 +1227,7 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         let subscriber = RecordingSubscriber<Int>(initialDemand: .unlimited)
 
         await startConsuming(publisher, with: subscriber)
+        await consumeStartupDemandUnit()
         source.yield(991)
         await events.wait(for: .delivered)
         await events.wait(for: .demandUnitConsumed)
@@ -1316,6 +1322,16 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         publisher.receive(subscriber: subscriber)
         await events.fenceOnConsumerTaskStart()
         await events.wait(for: .streamCreated)
+    }
+
+    /// Consumes the demand unit the consumer loop takes at startup, before any value exists.
+    ///
+    /// A subscriber with demand outstanding at subscribe time makes the loop consume a unit and call
+    /// `next()` immediately, so `.demandUnitConsumed` is already in the recorder before the test
+    /// yields anything. Consuming it here is what lets a later `.demandUnitConsumed` wait mean "the
+    /// loop went back around and re-entered `next()`" rather than resolving against that first one.
+    private func consumeStartupDemandUnit() async {
+        await events.wait(for: .demandUnitConsumed)
     }
 
     /// Runs an independent subscription all the way from subscribing to a delivered value.

--- a/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
+++ b/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
@@ -125,12 +125,19 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
                 continuation.resume(returning: termination)
                 return
             }
-            guard streamIndex >= 0, streamIndex < continuations.count else {
-                let createdCount = continuations.count
+            // Both "no such stream" and "that slot exists but its continuation is not stored yet"
+            // are the same harness mistake -- driving this source ahead of `callCount` -- and both
+            // would otherwise park the caller on a stream that has no `onTermination` to fire.
+            guard
+                streamIndex >= 0,
+                streamIndex < continuations.count,
+                continuations[streamIndex] != nil
+            else {
+                let readyCount = continuations.count
                 lock.unlock()
                 XCTFail(
                     "ControllableStreamSource.waitForTermination(ofStream: \(streamIndex)) called "
-                        + "with an out-of-range stream index (only \(createdCount) stream(s) created "
+                        + "before that stream was ready (only \(readyCount) stream slot(s) created "
                         + "so far). Wait for callCount to reach \(streamIndex + 1) first.",
                     file: file,
                     line: line

--- a/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
+++ b/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
@@ -208,18 +208,23 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
         file: StaticString,
         line: UInt
     ) -> AsyncThrowingStream<Value, Error>.Continuation? {
-        lock.lock()
-        defer { lock.unlock() }
-        guard streamIndex >= 0, streamIndex < continuations.count else {
+        // The lookup is resolved to a value under the lock and reported afterwards: `yield`/`finish`
+        // are called from background queues in this suite, and calling into XCTest (which takes its
+        // own locks, and can run arbitrary observer code) while holding this one is how test
+        // harnesses acquire deadlocks.
+        let lookup = lookUpContinuation(at: streamIndex)
+        switch lookup {
+        case .found(let continuation):
+            return continuation
+        case .outOfRange(let createdCount):
             XCTFail(
                 "ControllableStreamSource.\(caller)(toStream: \(streamIndex)) called with an "
-                    + "out-of-range stream index (only \(continuations.count) stream(s) created so far).",
+                    + "out-of-range stream index (only \(createdCount) stream(s) created so far).",
                 file: file,
                 line: line
             )
             return nil
-        }
-        guard let continuation = continuations[streamIndex] else {
+        case .notStoredYet:
             XCTFail(
                 "ControllableStreamSource.\(caller)(toStream: \(streamIndex)) called before that "
                     + "stream's continuation was stored. Wait for callCount to reach "
@@ -229,7 +234,24 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
             )
             return nil
         }
-        return continuation
+    }
+
+    private enum ContinuationLookup {
+        case found(AsyncThrowingStream<Value, Error>.Continuation)
+        case outOfRange(createdCount: Int)
+        case notStoredYet
+    }
+
+    private func lookUpContinuation(at streamIndex: Int) -> ContinuationLookup {
+        lock.lock()
+        defer { lock.unlock() }
+        guard streamIndex >= 0, streamIndex < continuations.count else {
+            return .outOfRange(createdCount: continuations.count)
+        }
+        guard let continuation = continuations[streamIndex] else {
+            return .notStoredYet
+        }
+        return .found(continuation)
     }
 }
 


### PR DESCRIPTION
Closes #466

## Summary

Every wait in `XLAsyncStreamPublisherTests` was a timing proxy. This replaces all of them with awaits on events the subscription actually emits, so runner load can delay a test but cannot change its verdict.

Three patterns are gone:

- **`waitUntil`** (34 call sites) -- polled a predicate every 5ms against a 3s wall-clock cap and failed with `Condition not met within 3.0s`, which named nothing. Removed entirely; the file has no polling helper left.
- **Two bare `Task.sleep(nanoseconds: 20_000_000)` calls proving a negative.** Both now wait for a positive event that proves the opposite outcome had its chance (details below).
- **`drainCurrentThread()`** -- drained `DispatchQueue.main` while the thing being waited on ran on the cooperative pool. Removed; nothing in the file needs it any more, including the main-queue delivery test.

## What the tests wait on now

Two seams, both event-driven and both suspending via checked continuations (never `wait(for:timeout:)`, which would block a cooperative thread the consumer `Task` may need):

1. `XLAsyncStreamSubscriptionTestHooks` from #465, consumed through a new `SubscriptionEventRecorder`. It buffers every event from construction onward, so nothing emitted between two waits is lost, and hands them out one at a time in order.
2. A new termination signal on `ControllableStreamSource`: `waitForTermination(ofStream:)` reports `.cancelled` or `.finished` for a given stream. Once a stream reports `.cancelled`, the consumer loop that owned it has either been cancelled inside `next()` or exited and dropped its iterator, so it can never deliver anything again. That is the harness-side "it had its chance and did not take it" proof.

The two negative tests specifically:

- `testSelfInflictedCancellationDoesNotDeliverASpuriousCompletion` first waits for `.demandUnitConsumed`, which puts the consumer loop provably inside `next()` -- the case under test, where cancellation resolves `next()` to nil and a naive bridge forwards `.finished`. It then cancels and waits for `finish(error:)` to *decide*. `waitForFinish()` deliberately matches either decision and returns which one it was, so a subscription that forwarded the completion fails the test instead of hanging it.
- `testValueDeliveredConcurrentlyWithCancellationIsNeverForwarded` waits for the stream to be torn down after the in-`receive(_:)` cancel, then asserts only the first value arrived. The second value is already buffered in the stream at that point, so if the adapter were going to deliver it, it had to do so before the loop exited.

## Negative controls

One per rewritten test, in their own `MARK` section. Each drives the same wait sequence in a scenario where the guarded behaviour does not hold, and asserts that the paired test's own predicate is false at exactly the point that test asserts it -- so a rewritten test cannot pass vacuously, and its waits are shown to resume early enough to see the wrong outcome. For example, the eager-draining control grants three units of demand instead of one, reaching the same `.delivered` + `.demandWaiterRegistered` wait point with all three values delivered, and asserts `recordedValues == [901]` is false there.

The broken world is always produced through legal use of the publisher -- different demand, finishing instead of cancelling, subscribing twice, subscribing to the raw publisher instead of `xlLiveQueryPublisher` -- rather than by stubbing out the subscription, so the controls exercise the real adapter.

Every control uses constants decoupled from its paired test's (the 9xx value range, different demand counts), so it cannot pass merely by sharing them.

## Assertions are unchanged in substance

The same Combine contract is verified: lazy start, one stream per subscriber, one-at-a-time and unlimited demand, demand granted from inside `receive(_:)`, subscription independence, cancellation propagation and suppression, terminal error and normal completion forwarding, main-queue delivery. Only the waiting changed. Two assertions were strengthened where the new signal made it free: cancellation now asserts the termination *reason* rather than a counter, and `finish`'s forward-or-suppress decision is asserted directly.

`testXlLiveQueryPublisherDeliversOnTheMainQueueByDefault` now awaits the delivery itself and asserts on `Thread.isMainThread` captured at delivery, instead of polling a flag that was only set when delivery happened to be on main. A delivery on the wrong thread now fails the test rather than timing out.

## No timeouts, by design

The waits are unbounded. A bounded wait is a wall-clock deadline wearing a different hat, and the failure it produces under load is exactly the one this suite is being fixed for. The trade-off is that a genuine regression which never emits the awaited event hangs rather than fails; the 45-minute job timeout in `swift.yml` is the backstop, and every wait is one line from a named event so the hang points at itself. This is what #466's "any remaining bounded wait exists only for a genuinely unobservable condition" asks for -- there are none left.

## Repeat-cycle rounds

`testRepeatedSubscribeYieldCancelCycleLeavesNoDanglingState` now reads its round count from `SWIFTQL_PUBLISHER_CYCLE_ROUNDS` (default 25), so the review run #466 asks for is reproducible from the command rather than from a temporary edit:

```
SWIFTQL_PUBLISHER_CYCLE_ROUNDS=250 swift test --filter XLAsyncStreamPublisherTests
```

Each round fences on its own `.consumerTaskStarted`, so no round can consume a previous round's trailing event.

## Linux compatibility fix carried in

The two harness self-tests added by #464 are now `#if canImport(Darwin)`-gated. `XCTExpectFailure` does not exist in swift-corelibs-xctest (verified against the `swift-5.9.2-RELEASE` tag's `Sources/XCTest/Public` listing -- there is no `XCTExpectFailure.swift`), and `SQLTests` builds and runs on the pinned Swift 5.9 / Ubuntu 22.04 cells, so as written they would not compile there. Intercepting a recorded failure is the only way to prove `XCTFail` fired, so those two stay Darwin-only; every other control in the file is portable and runs on every cell.

## Stacked on #496 and #497

#466 depends on #464 and #465, whose PRs (#496, #497) were still open when this branch was cut, so this branch merges both of their heads. Their commits will drop out of this diff once they merge into `version/1.5.6`; this PR should merge after them.

## Test plan

- [x] `swift build --build-tests` -- no warnings (the first draft's `NSLock` use inside an `async` function, an error under the Swift 6 language mode, is split into a non-`async` helper the same way `XLAsyncStreamSubscription` does it)
- [x] `swift test --filter XLAsyncStreamPublisherTests` -- 30/30 pass in 0.021s (the polling suite took seconds)
- [x] Every test also run individually, to prove no test depends on another's leftover state
- [x] `SWIFTQL_PUBLISHER_CYCLE_ROUNDS=250` and `=300` -- pass; runtime scales linearly with the count (25 rounds 0.002s, 250 rounds 0.012s, 2500 rounds 0.106s), confirming the override is really taking effect
- [x] 25 consecutive full-file runs at 250 rounds under 28 CPU spinners on a 14-core machine -- 25/25 green, 0 failures
- [x] Full `swift test` -- green

🤖 Generated with [Claude Code](https://claude.com/claude-code)