### PR TITLE
Wait for the observation, not the main queue, in the buffering-semantics suite

### DIFF
--- a/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
+++ b/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
@@ -59,49 +59,61 @@ private enum AsyncStreamTestError: Error, Equatable {
 
 // MARK: - Locked helpers
 
+/// Backed by ``XLAwaitableState`` (`XLLiveQueryWaitSupport.swift`) so a test can *await* the value
+/// it needs -- resumed by the write that produces it -- instead of polling for it (#467).
 private final class AsyncStreamLockedValue<Value>: @unchecked Sendable {
 
-    private let lock = NSLock()
-
-    private var value: Value
+    private let state: XLAwaitableState<Value>
 
     init(_ value: Value) {
-        self.value = value
+        state = XLAwaitableState(value)
     }
 
     @discardableResult
     func withValue<Result>(_ body: (inout Value) -> Result) -> Result {
-        lock.lock()
-        defer { lock.unlock() }
-        return body(&value)
+        state.withValue(body)
     }
 
     func set(_ newValue: Value) {
-        withValue { $0 = newValue }
+        state.set(newValue)
     }
 
     func read() -> Value {
-        withValue { $0 }
+        state.read()
+    }
+
+    /// Suspends until the value satisfies `isSatisfied`.
+    func wait(until isSatisfied: @escaping (Value) -> Bool) async {
+        await state.wait(until: isSatisfied)
     }
 }
 
 
+extension AsyncStreamLockedValue where Value: Equatable {
+
+    /// Suspends until the value equals `expected`.
+    func wait(for expected: Value) async {
+        await state.wait(for: expected)
+    }
+}
+
+
+/// The array form of ``AsyncStreamLockedValue``, with the same awaitable semantics.
 private final class AsyncStreamLockedArray<Element>: @unchecked Sendable {
 
-    private let lock = NSLock()
-
-    private var values: [Element] = []
+    private let state = XLAwaitableState<[Element]>([])
 
     func append(_ value: Element) {
-        lock.lock()
-        defer { lock.unlock() }
-        values.append(value)
+        state.withValue { $0.append(value) }
     }
 
     func read() -> [Element] {
-        lock.lock()
-        defer { lock.unlock() }
-        return values
+        state.read()
+    }
+
+    /// Suspends until at least `count` elements have been appended.
+    func wait(untilCountIsAtLeast count: Int) async {
+        await state.wait(untilCountIsAtLeast: count)
     }
 }
 
@@ -114,26 +126,29 @@ private final class AsyncStreamInjectedBusyFunctionState: @unchecked Sendable {
         case failAlways
     }
 
-    private let lock = NSLock()
-
     private let behavior: Behavior
 
-    private var invocationCountValue = 0
+    /// Awaitable, so a test can wait for the attempt it cares about rather than polling for it.
+    private let invocations = XLAwaitableState(0)
 
     init(behavior: Behavior) {
         self.behavior = behavior
     }
 
     var invocationCount: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return invocationCountValue
+        invocations.read()
+    }
+
+    /// Suspends until this function has been invoked at least `count` times.
+    func waitForInvocationCount(atLeast count: Int) async {
+        await invocations.wait(until: { $0 >= count })
     }
 
     func invoke() throws -> Int {
-        lock.lock()
-        invocationCountValue += 1
-        let invocationCount = invocationCountValue
+        let invocationCount = invocations.withValue { value -> Int in
+            value += 1
+            return value
+        }
         let failsThisInvocation: Bool
         switch behavior {
         case .succeed:
@@ -143,7 +158,6 @@ private final class AsyncStreamInjectedBusyFunctionState: @unchecked Sendable {
         case .failAlways:
             failsThisInvocation = true
         }
-        lock.unlock()
 
         if failsThisInvocation {
             throw DatabaseError(
@@ -166,11 +180,11 @@ private final class AsyncStreamManualRetryScheduler: @unchecked Sendable {
         let subject: PassthroughSubject<Void, Never>
     }
 
-    private let lock = NSLock()
+    /// Awaitable, so a test waits for "the backoff for attempt N has been scheduled" and is resumed
+    /// by the scheduling itself, instead of polling `pendingDelays` against a deadline (#467).
+    private let pending = XLAwaitableState<[PendingDelay]>([])
 
-    private var pending: [PendingDelay] = []
-
-    private var recorded: [TimeInterval] = []
+    private let recorded = XLAwaitableState<[TimeInterval]>([])
 
     var scheduler: GRDBLiveQueryRetryScheduler {
         GRDBLiveQueryRetryScheduler { [weak self] delay in
@@ -178,38 +192,32 @@ private final class AsyncStreamManualRetryScheduler: @unchecked Sendable {
                 return Empty(completeImmediately: false).eraseToAnyPublisher()
             }
             let subject = PassthroughSubject<Void, Never>()
-            self.lock.lock()
-            self.pending.append(PendingDelay(delay: delay, subject: subject))
-            self.recorded.append(delay)
-            self.lock.unlock()
+            self.recorded.withValue { $0.append(delay) }
+            // Appended last, so a test resumed by this write already sees the delay recorded.
+            self.pending.withValue { $0.append(PendingDelay(delay: delay, subject: subject)) }
             return subject.eraseToAnyPublisher()
         }
     }
 
     var pendingDelays: [TimeInterval] {
-        lock.lock()
-        defer { lock.unlock() }
-        return pending.map(\.delay)
+        pending.read().map(\.delay)
     }
 
     var recordedDelays: [TimeInterval] {
-        lock.lock()
-        defer { lock.unlock() }
-        return recorded
+        recorded.read()
+    }
+
+    /// Suspends until exactly `expected` is outstanding -- the deterministic replacement for polling
+    /// `pendingDelays` until it matches.
+    func waitForPendingDelays(_ expected: [TimeInterval]) async {
+        await pending.wait(until: { $0.map(\.delay) == expected })
     }
 
     @discardableResult
     func runNext() -> Bool {
-        let next: PendingDelay?
-        lock.lock()
-        if pending.isEmpty {
-            next = nil
+        let next: PendingDelay? = pending.withValue { pending in
+            pending.isEmpty ? nil : pending.removeFirst()
         }
-        else {
-            next = pending.removeFirst()
-        }
-        lock.unlock()
-
         guard let next else { return false }
         next.subject.send(())
         next.subject.send(completion: .finished)
@@ -285,14 +293,14 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
 
     // MARK: - Lazy start / unused stream
 
-    func testUnusedStreamPerformsNoObservationOrFetch() throws {
+    func testUnusedStreamPerformsNoObservationOrFetch() async throws {
         try createRecordTable()
         let request = database.makeRequest(with: orderedStatement())
 
         _ = request.stream() // constructed, never iterated
         _ = request.streamOne() // constructed, never iterated
 
-        drainMainQueue()
+        await drainMainQueue()
         XCTAssertEqual(
             logger.count(containing: "stream:"),
             0,
@@ -582,14 +590,14 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
             loopEnded.set(true)
         }
 
-        try await waitUntil { !seen.read().isEmpty }
+        await seen.wait(untilCountIsAtLeast: 1)
         task.cancel()
-        try await waitUntil { loopEnded.read() }
+        await loopEnded.wait(for: true)
         XCTAssertEqual(seen.read(), [[]])
 
         let fetchCountAtCancel = logger.count(containing: "stream:")
         try insertDirect(AsyncStreamRecord(id: "after-cancel", value: 1))
-        drainMainQueue()
+        await drainMainQueue()
         XCTAssertEqual(
             logger.count(containing: "stream:"),
             fetchCountAtCancel,
@@ -719,7 +727,7 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
         XCTAssertEqual(refreshedA, [AsyncStreamRecord(id: "only-in-a", value: 1)])
 
         // The second, identically-named table in the other pool must remain empty.
-        drainMainQueue()
+        await drainMainQueue()
         let secondRows = try secondDatabase.makeRequest(with: orderedStatement()).fetchAll()
         XCTAssertEqual(secondRows, [])
     }
@@ -774,16 +782,16 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
             }
         }
 
-        try await waitUntil { scheduler.pendingDelays == [0.1] }
+        await scheduler.waitForPendingDelays([0.1])
         XCTAssertEqual(fixture.functionState.invocationCount, 1)
         scheduler.runNext()
-        try await waitUntil { scheduler.pendingDelays == [0.2] }
+        await scheduler.waitForPendingDelays([0.2])
         XCTAssertEqual(fixture.functionState.invocationCount, 2)
         scheduler.runNext()
-        try await waitUntil { scheduler.pendingDelays == [0.4] }
+        await scheduler.waitForPendingDelays([0.4])
         XCTAssertEqual(fixture.functionState.invocationCount, 3)
         scheduler.runNext()
-        try await waitUntil { fixture.functionState.invocationCount == 4 }
+        await fixture.functionState.waitForInvocationCount(atLeast: 4)
 
         switch await consumeTask.value {
         case .success:
@@ -838,7 +846,7 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
             try await iterator.next()
         }
 
-        try await waitUntil { scheduler.pendingDelays == [0.1] }
+        await scheduler.waitForPendingDelays([0.1])
         XCTAssertEqual(fixture.functionState.invocationCount, 1)
         task.cancel()
 
@@ -847,7 +855,7 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
 
         // Firing the pending delay after cancellation must not start a new attempt.
         scheduler.runNext()
-        drainMainQueue()
+        await drainMainQueue()
         XCTAssertEqual(
             fixture.functionState.invocationCount,
             1,
@@ -874,7 +882,7 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
             try await iterator.next()
         }
 
-        try await waitUntil { scheduler.pendingDelays == [0.1] }
+        await scheduler.waitForPendingDelays([0.1])
         scheduler.runNext()
         let delivered = try await consumeTask.value
         XCTAssertEqual(delivered, [AsyncStreamRetryRecord(id: "initial", value: 1)])
@@ -1026,31 +1034,13 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
         }
     }
 
-    private func drainMainQueue() {
-        let barrier = expectation(description: "main-queue barrier")
-        DispatchQueue.main.async {
-            barrier.fulfill()
-        }
-        wait(for: [barrier], timeout: 2)
-    }
-
-    /// Bounded, deterministic polling: sleeps in small increments up to `timeout`, checking
-    /// `condition` each time, rather than proving anything via one blind sleep.
-    private func waitUntil(
-        timeout: TimeInterval = 3,
-        pollInterval: UInt64 = 10_000_000,
-        file: StaticString = #filePath,
-        line: UInt = #line,
-        _ condition: () -> Bool
-    ) async throws {
-        let maxAttempts = max(Int((timeout * 1_000_000_000) / Double(pollInterval)), 1)
-        for _ in 0 ..< maxAttempts {
-            if condition() {
-                return
-            }
-            try await Task.sleep(nanoseconds: pollInterval)
-        }
-        XCTFail("Condition not met within \(timeout)s", file: file, line: line)
+    /// A barrier on the queue GRDB's `ValueObservation` actually delivers on, not a deadline: it
+    /// resumes when the main queue reaches the block it enqueued, however long that takes. Every
+    /// call site below uses it to let already-scheduled observation work run before asserting that
+    /// no *further* fetch happened. The suite's polling `waitUntil` is gone (#467): the conditions
+    /// it polled are now awaited directly on the harness state that produces them.
+    private func drainMainQueue() async {
+        await xlDrainMainQueue()
     }
 
     private struct InjectedBusyFixture {

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -109,8 +109,22 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
 
     private let state = OSAllocatedUnfairLock(uncheckedState: State())
 
+    /// The most recent value this mailbox has been handed, whether it was delivered straight to a
+    /// waiter or buffered. Separate from `State` and awaitable, so a test can wait for the
+    /// *observation* to have produced a particular snapshot -- rather than assuming, from a main-queue
+    /// barrier, that GRDB has already fetched it (#533).
+    private let newestYield = XLAwaitableState<Value?>(nil)
+
     var totalYieldCount: Int {
         state.withLock { $0.totalYieldCount }
+    }
+
+    /// Suspends until a value satisfying `isExpected` has been yielded into this mailbox.
+    func waitForYield(satisfying isExpected: @escaping (Value) -> Bool) async {
+        await newestYield.wait(until: { value in
+            guard let value else { return false }
+            return isExpected(value)
+        })
     }
 
     // `@unchecked Sendable`, matching `FastPathOutcome`/`RegistrationOutcome` below: a bare
@@ -159,7 +173,11 @@ private final class SingleSlotMailbox<Value>: @unchecked Sendable {
         // arbitrary downstream code, which must never happen while this
         // mailbox's own lock is held.
         if let delivery {
+            newestYield.set(delivery.value)
             delivery.waiter.resume(returning: delivery.value)
+        }
+        else {
+            newestYield.set(value)
         }
     }
 
@@ -378,6 +396,12 @@ private final class LazyBufferedGRDBBridge<Value>: @unchecked Sendable {
     }
 
     var totalYieldCount: Int { mailbox.totalYieldCount }
+
+    /// Suspends until the underlying observation has produced a value satisfying `isExpected`,
+    /// whether or not a consumer has pulled it yet.
+    func waitForYield(satisfying isExpected: @escaping (Value) -> Bool) async {
+        await mailbox.waitForYield(satisfying: isExpected)
+    }
 
     var startCount: Int { state.withLock { $0.startCount } }
 
@@ -614,28 +638,29 @@ private final class LockedCounter: @unchecked Sendable {
 }
 
 
+/// Backed by ``XLAwaitableState`` (`XLLiveQueryWaitSupport.swift`), so a test awaits the appends it
+/// needs and is resumed by the append itself.
+///
+/// The previous version was polled by a `waitForCount` helper that created one `XCTestExpectation`
+/// per attempt and waited on it with a 0.2s timeout, up to 200 times per call. Under load those
+/// waits time out while the value is merely late, and the `asyncAfter` block that fulfils an
+/// already-timed-out expectation is an XCTest API violation -- one of the two candidate mechanisms
+/// for the `Index out of range` crash recorded on #533.
 private final class LockedArray<Element>: @unchecked Sendable {
 
-    private let state = OSAllocatedUnfairLock(uncheckedState: [Element]())
+    private let state = XLAwaitableState<[Element]>([])
 
-    // See the `nonisolated(unsafe)` shadow note on `SingleSlotMailbox.yield(_:)` above -- identical
-    // reasoning.
     func append(_ value: Element) {
-        #if compiler(>=6.0)
-        nonisolated(unsafe) let value = value
-        #endif
-        state.withLock { $0.append(value) }
-    }
-
-    // `@unchecked Sendable` box, matching `Delivery`/`FastPathOutcome`/`RegistrationOutcome` above:
-    // returning a bare `[Element]` directly from this `@Sendable` closure is itself flagged, the same
-    // way those types were.
-    private struct ElementsBox: @unchecked Sendable {
-        let elements: [Element]
+        state.withValue { $0.append(value) }
     }
 
     func read() -> [Element] {
-        state.withLock { ElementsBox(elements: $0) }.elements
+        state.read()
+    }
+
+    /// Suspends until at least `count` elements have been appended.
+    func wait(untilCountIsAtLeast count: Int) async {
+        await state.wait(untilCountIsAtLeast: count)
     }
 }
 
@@ -787,7 +812,7 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
         )
     }
 
-    func testCancellingTheConsumingTaskCancelsTheUnderlyingObservation() throws {
+    func testCancellingTheConsumingTaskCancelsTheUnderlyingObservation() async throws {
         let fetchCounter = LockedCounter()
         let bridge = makeBridge(fetchProbe: { fetchCounter.increment() })
         let stream = bridge.stream()
@@ -806,14 +831,14 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
             loopExpectation.fulfill()
         }
 
-        waitForCount(seen, atLeast: 1)
+        await seen.wait(untilCountIsAtLeast: 1)
         task.cancel()
-        wait(for: [loopExpectation], timeout: 2)
+        await fulfillment(of: [loopExpectation], timeout: 2)
         XCTAssertEqual(seen.read(), [0])
 
         let fetchCountAtCancel = fetchCounter.read()
         try insert("after-task-cancel", 99)
-        drainMainQueue()
+        await xlDrainMainQueue()
         XCTAssertEqual(
             fetchCounter.read(),
             fetchCountAtCancel,
@@ -870,7 +895,7 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
     // MARK: - Demand mapping (edge cases: zero demand, incremental demand,
     // unlimited demand, demand added from receive)
 
-    func testDemandDrivenPullerConsumesExactlyDemandedCountWithoutEagerDraining() throws {
+    func testDemandDrivenPullerConsumesExactlyDemandedCountWithoutEagerDraining() async throws {
         let bridge = makeBridge()
         let delivered = LockedArray<Int>()
         let puller = DemandDrivenPuller(
@@ -880,13 +905,13 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
         )
 
         // Zero demand: the puller must not touch the bridge at all.
-        drainMainQueue()
+        await xlDrainMainQueue()
         XCTAssertEqual(bridge.startCount, 0, "Zero demand must not start the observation.")
         XCTAssertEqual(delivered.read(), [])
 
         // Grant demand for exactly one value.
         puller.requestDemand(1)
-        waitForCount(delivered, atLeast: 1)
+        await delivered.wait(untilCountIsAtLeast: 1)
         XCTAssertEqual(delivered.read(), [0])
 
         // Multiple rapid writes while demand is exhausted (zero outstanding):
@@ -896,7 +921,16 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
         // the observed count).
         try insert("a", 1)
         try insert("b", 2)
-        drainMainQueue()
+        // Wait for the observation to have actually produced the state after
+        // *both* commits. GRDB fetches on a reader queue and only then
+        // dispatches to main, so a main-queue barrier says nothing about
+        // whether the second commit has been fetched yet: under load it often
+        // has not, the mailbox still holds the snapshot for the first insert,
+        // and resuming demand correctly delivered `1` rather than `2` (#533).
+        // How many fetches those two commits coalesce into is GRDB's business
+        // and deliberately not asserted -- only that the newest value the
+        // mailbox holds is the final one before demand resumes.
+        await bridge.waitForYield(satisfying: { $0 == 2 })
         XCTAssertEqual(
             delivered.read(),
             [0],
@@ -907,13 +941,13 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
         // single buffered "newest" snapshot, not a backlog of every write
         // that occurred while paused.
         puller.requestDemand(1)
-        waitForCount(delivered, atLeast: 2)
+        await delivered.wait(untilCountIsAtLeast: 2)
         XCTAssertEqual(delivered.read(), [0, 2])
 
         puller.cancel()
     }
 
-    func testUnlimitedDemandDeliversAsValuesBecomeAvailableWithoutSpinningOrDoubleDelivery() throws {
+    func testUnlimitedDemandDeliversAsValuesBecomeAvailableWithoutSpinningOrDoubleDelivery() async throws {
         let bridge = makeBridge()
         let delivered = LockedArray<Int>()
         let finished = LockedValueBox<Error??>(nil)
@@ -925,19 +959,19 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
 
         // A very large demand simulates Combine's `.unlimited`.
         puller.requestDemand(1_000_000)
-        waitForCount(delivered, atLeast: 1)
+        await delivered.wait(untilCountIsAtLeast: 1)
         XCTAssertEqual(delivered.read(), [0])
 
         // The bridge observes `COUNT(*)`, so one insert into this fresh
         // table moves the row count from 0 to 1 (the inserted row's own
         // `value` column, 42, is unrelated to the observed count).
         try insert("x", 42)
-        waitForCount(delivered, atLeast: 2)
+        await delivered.wait(untilCountIsAtLeast: 2)
         XCTAssertEqual(delivered.read(), [0, 1])
 
         // No further writes: the puller must not spin, error, or duplicate
         // delivery while waiting for the next relevant commit.
-        drainMainQueue()
+        await xlDrainMainQueue()
         XCTAssertEqual(delivered.read(), [0, 1])
         XCTAssertNil(finished.get() ?? nil)
 
@@ -999,19 +1033,6 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
         wait(for: [barrier], timeout: 2)
     }
 
-    private func waitForCount<Element>(_ array: LockedArray<Element>, atLeast minimumCount: Int) {
-        for attempt in 1 ... 200 {
-            if array.read().count >= minimumCount {
-                return
-            }
-            let poll = expectation(description: "array poll \(attempt)")
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                poll.fulfill()
-            }
-            wait(for: [poll], timeout: 0.2)
-        }
-        XCTFail("Expected at least \(minimumCount) delivered values; received \(array.read().count).")
-    }
 }
 
 

--- a/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
+++ b/Tests/SQLTests/XLAsyncStreamPublisherTests.swift
@@ -256,187 +256,9 @@ private final class ControllableStreamSource<Value>: @unchecked Sendable {
 }
 
 
-// MARK: - Deterministic waits on the subscription's own lifecycle
-
-/// Buffers every `XLAsyncStreamSubscription` lifecycle event the `#if DEBUG` seam from issue #465
-/// emits, and lets a test await a *named* one instead of polling a predicate against a wall-clock
-/// deadline (issue #466).
-///
-/// Waiting this way is what makes runner load unable to change a verdict: every wait here resumes
-/// because the subscription reached a specific point in its own control flow, so load can only make
-/// a test take longer, never make it assert against a state the subscription has not reached yet.
-/// There is deliberately no timeout: a bounded wait is a wall-clock deadline wearing a different
-/// hat, and the failure it produces under load is exactly the one this suite is being fixed for.
-///
-/// Each wait consumes the earliest *matching* buffered event, and parks on a continuation if none
-/// has arrived yet. Non-matching events are not skipped past and discarded: they stay buffered in
-/// arrival order, so a later wait for one of them still finds it. A wait therefore never has to
-/// step over -- or block on -- an event the test does not care about.
-private final class SubscriptionEventRecorder: @unchecked Sendable {
-
-    private struct RecordedEvent {
-        let sequence: Int
-        let event: XLAsyncStreamSubscriptionEvent
-    }
-
-    private struct Waiter {
-        let matches: (XLAsyncStreamSubscriptionEvent) -> Bool
-        let continuation: CheckedContinuation<RecordedEvent, Never>
-    }
-
-    private let lock = NSLock()
-
-    private var buffered: [RecordedEvent] = []
-
-    private var waiter: Waiter?
-
-    private var nextSequence = 0
-
-    private var pump: Task<Void, Never>?
-
-    init() {
-        // `events()` registers its observer synchronously inside `AsyncStream`'s build closure, and
-        // that stream buffers without bound, so no event emitted after this line can be missed --
-        // including events emitted before `pump` gets its first chance to run.
-        let stream = XLAsyncStreamSubscriptionTestHooks.shared.events()
-        pump = Task { [weak self] in
-            for await event in stream {
-                self?.ingest(event)
-            }
-        }
-    }
-
-    func stop() {
-        pump?.cancel()
-        pump = nil
-    }
-
-    private func ingest(_ event: XLAsyncStreamSubscriptionEvent) {
-        lock.lock()
-        let recorded = RecordedEvent(sequence: nextSequence, event: event)
-        nextSequence += 1
-        if let waiter, waiter.matches(event) {
-            self.waiter = nil
-            lock.unlock()
-            // Resumed outside the lock: the resumed test task goes on to call into the subscription
-            // (cancel, request more demand), which takes the subscription's own lock.
-            waiter.continuation.resume(returning: recorded)
-            return
-        }
-        buffered.append(recorded)
-        lock.unlock()
-    }
-
-    private func wait(
-        matching matches: @escaping (XLAsyncStreamSubscriptionEvent) -> Bool
-    ) async -> RecordedEvent {
-        await withCheckedContinuation { continuation in
-            lock.lock()
-            if let index = buffered.firstIndex(where: { matches($0.event) }) {
-                let match = buffered.remove(at: index)
-                lock.unlock()
-                continuation.resume(returning: match)
-                return
-            }
-            precondition(
-                waiter == nil,
-                "SubscriptionEventRecorder serves one wait at a time: a test that awaits two events "
-                    + "concurrently would silently overwrite and hang the first waiter."
-            )
-            waiter = Waiter(matches: matches, continuation: continuation)
-            lock.unlock()
-        }
-    }
-
-    /// Awaits (and consumes) the next occurrence of `event`.
-    func wait(for event: XLAsyncStreamSubscriptionEvent) async {
-        _ = await wait(matching: { $0 == event })
-    }
-
-    /// Awaits `finish(error:)` running and reports whether it forwarded the completion downstream or
-    /// suppressed it as self-inflicted.
-    ///
-    /// Matching *either* outcome is deliberate. A test that waited only for the outcome it expects
-    /// would hang -- rather than fail -- in the world where the subscription made the opposite
-    /// decision, which is the world the test exists to detect.
-    func waitForFinish() async -> Bool {
-        let match = await wait(matching: { event in
-            if case .finished = event {
-                return true
-            }
-            return false
-        })
-        guard case .finished(let forwarded) = match.event else {
-            preconditionFailure("wait(matching:) resumed with a non-`.finished` event.")
-        }
-        return forwarded
-    }
-
-    /// Awaits the next consumer task starting, and forgets everything emitted before it.
-    ///
-    /// The seam is process-global -- `Publisher.receive(subscriber:)` erases the concrete
-    /// `XLAsyncStreamSubscription` behind Combine's `Subscription` existential the moment it is
-    /// vended, so no test ever holds a handle to hook per-instance. That means a previous test's
-    /// (or previous round's) still-unwinding subscription can in principle emit one last event into
-    /// this recorder. `.consumerTaskStarted` can only come from a consumer task starting *now*, so
-    /// fencing on it and dropping everything with a lower sequence number gives each test a clean
-    /// epoch, without polling for quiescence.
-    func fenceOnConsumerTaskStart() async {
-        let match = await wait(matching: { $0 == .consumerTaskStarted })
-        discardEvents(before: match.sequence)
-    }
-
-    /// Locked, non-`async` half of ``fenceOnConsumerTaskStart()``: recent Foundation marks
-    /// `NSLock.lock()`/`unlock()` unavailable directly inside an asynchronous context (an error in
-    /// the Swift 6 language mode), the same split `XLAsyncStreamSubscription` itself uses.
-    private func discardEvents(before sequence: Int) {
-        lock.lock()
-        buffered.removeAll { $0.sequence < sequence }
-        lock.unlock()
-    }
-}
-
-
-/// A one-shot value a test can await, used where the thing being observed is a downstream callback
-/// rather than a subscription lifecycle event (`sink`'s delivery on the main queue).
-private final class AsyncValue<Value>: @unchecked Sendable {
-
-    private let lock = NSLock()
-
-    private var value: Value?
-
-    private var waiters: [CheckedContinuation<Value, Never>] = []
-
-    /// Records the first value only: later calls are ignored, so a test asserting on "the delivery"
-    /// cannot be confused by a second one arriving while it is being read.
-    func fulfill(_ newValue: Value) {
-        lock.lock()
-        guard value == nil else {
-            lock.unlock()
-            return
-        }
-        value = newValue
-        let pending = waiters
-        waiters = []
-        lock.unlock()
-        for waiter in pending {
-            waiter.resume(returning: newValue)
-        }
-    }
-
-    func wait() async -> Value {
-        await withCheckedContinuation { continuation in
-            lock.lock()
-            if let value {
-                lock.unlock()
-                continuation.resume(returning: value)
-                return
-            }
-            waiters.append(continuation)
-            lock.unlock()
-        }
-    }
-}
+// The deterministic waiting primitives this suite runs on -- `XLSubscriptionEventRecorder` (the
+// #465 subscription seam) and `XLAwaitableValue` -- live in `XLLiveQueryWaitSupport.swift`, shared
+// with `XLObservableLiveQueryTests` and `GRDBLiveQueryAsyncStreamTests` (#467).
 
 
 private enum XLAsyncStreamPublisherTestError: Error, Equatable {
@@ -524,12 +346,12 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
 
     /// Observes the subscription seam for the duration of one test. Recreated per test, and the
     /// shared hooks are reset on both sides of the test so no observer leaks into the next one.
-    private var events: SubscriptionEventRecorder!
+    private var events: XLSubscriptionEventRecorder!
 
     override func setUp() {
         super.setUp()
         XLAsyncStreamSubscriptionTestHooks.shared.reset()
-        events = SubscriptionEventRecorder()
+        events = XLSubscriptionEventRecorder()
     }
 
     override func tearDown() {
@@ -868,8 +690,8 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
     func testXlLiveQueryPublisherDeliversOnTheMainQueueByDefault() async throws {
         let source = ControllableStreamSource<Int>()
         let publisher = xlLiveQueryPublisher(makeStream: source.makeStream)
-        let deliveryOnMainQueue = AsyncValue<Bool>()
-        let completionOnMainQueue = AsyncValue<Bool>()
+        let deliveryOnMainQueue = XLAwaitableValue<Bool>()
+        let completionOnMainQueue = XLAwaitableValue<Bool>()
 
         let cancellable = publisher.sink(
             receiveCompletion: { _ in
@@ -1197,7 +1019,7 @@ final class XLAsyncStreamPublisherTests: XCTestCase {
         // The raw publisher, without `xlLiveQueryPublisher`'s `.receive(on: DispatchQueue.main)`:
         // its consumer `Task` runs on the cooperative pool, never the main thread.
         let publisher = XLAsyncStreamPublisher(makeStream: source.makeStream)
-        let deliveryOnMainQueue = AsyncValue<Bool>()
+        let deliveryOnMainQueue = XLAwaitableValue<Bool>()
         let subscriber = RecordingSubscriber<Int>(
             initialDemand: .unlimited,
             additionalDemand: { _ in

--- a/Tests/SQLTests/XLLiveQueryWaitSupport.swift
+++ b/Tests/SQLTests/XLLiveQueryWaitSupport.swift
@@ -147,12 +147,6 @@ final class XLAwaitableValue<Value>: @unchecked Sendable {
         }
     }
 
-    var isFulfilled: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return value != nil
-    }
-
     func wait() async -> Value {
         await withCheckedContinuation { continuation in
             lock.lock()
@@ -317,26 +311,26 @@ final class XLSubscriptionEventRecorder: @unchecked Sendable {
 /// Suspends until `isSatisfied` holds for main-actor `@Observable` state, resumed by Observation's
 /// own change notification rather than by a poll.
 ///
-/// `withObservationTracking` fires `onChange` *before* the tracked property's new value is visible,
-/// so each round resumes on the notification and then re-reads on the next main-actor turn. That is
-/// an await on a scheduling hop, not on a duration: the loop cannot conclude anything early, and
-/// under load it simply takes more turns.
+/// Each round evaluates `isSatisfied` inside `withObservationTracking`, so the properties it reads
+/// are exactly the ones whose next mutation resumes the wait -- there is no window between checking
+/// and subscribing in which a change could be missed. `onChange` fires just *before* the new value
+/// is visible, so the loop yields the main actor once and re-evaluates afterwards. That is an await
+/// on a scheduling hop, not on a duration: under load the loop simply takes more turns, and it can
+/// never conclude anything early.
 @available(iOS 17, macOS 14, *)
 @MainActor
-func xlWaitForObservedState(
-    _ isSatisfied: @escaping @MainActor () -> Bool,
-    trackedBy track: @escaping @MainActor () -> Void
-) async {
-    while !isSatisfied() {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            withObservationTracking {
-                track()
-            } onChange: {
-                continuation.resume()
-            }
+func xlWaitForObservedState(_ isSatisfied: @escaping @MainActor () -> Bool) async {
+    while true {
+        let changed = XLAwaitableValue<Void>()
+        let isSatisfiedNow = withObservationTracking {
+            isSatisfied()
+        } onChange: {
+            changed.fulfill(())
         }
-        // `onChange` runs before the mutation lands, so yield the main actor once and re-read the
-        // state as it stands after the writer's turn completes.
+        if isSatisfiedNow {
+            return
+        }
+        await changed.wait()
         await Task.yield()
     }
 }
@@ -352,37 +346,12 @@ func xlWaitForObservedState(
 /// an unobservable condition that never becomes true would otherwise hang forever with no diagnosis
 /// at all. `describing` is mandatory, so the failure says what was being waited for instead of
 /// issue #463's anonymous `Condition not met within 3.0s`.
-func xlWaitUntil(
-    describing description: String,
-    timeout: TimeInterval = 3,
-    pollInterval: UInt64 = 10_000_000,
-    file: StaticString = #filePath,
-    line: UInt = #line,
-    _ condition: () -> Bool
-) async throws {
-    let maximumAttempts = max(Int((timeout * 1_000_000_000) / Double(pollInterval)), 1)
-    for _ in 0 ..< maximumAttempts {
-        if condition() {
-            return
-        }
-        try await Task.sleep(nanoseconds: pollInterval)
-    }
-    XCTFail(
-        "Timed out after \(timeout)s waiting for: \(description)",
-        file: file,
-        line: line
-    )
-}
-
-
-/// `@MainActor` overload of ``xlWaitUntil(describing:timeout:pollInterval:file:line:_:)``.
 ///
-/// Call sites inside `@MainActor` test methods form main-actor-isolated condition closures; a
-/// nonisolated helper would have to *send* the closure (and everything it captures) across an actor
-/// boundary just to receive it, which is the "sending risks causing data races" warning the sibling
-/// suites already document.
+/// `@MainActor`, matching its call sites: a condition closure formed inside a `@MainActor` test
+/// method is itself main-actor-isolated, and a nonisolated helper would have to *send* it (and
+/// everything it captures) across an actor boundary just to receive it as a parameter.
 @MainActor
-func xlWaitUntilOnMainActor(
+func xlWaitUntil(
     describing description: String,
     timeout: TimeInterval = 3,
     pollInterval: UInt64 = 10_000_000,

--- a/Tests/SQLTests/XLLiveQueryWaitSupport.swift
+++ b/Tests/SQLTests/XLLiveQueryWaitSupport.swift
@@ -1,0 +1,420 @@
+//
+//  XLLiveQueryWaitSupport.swift
+//
+//  Shared deterministic waiting for the live-query async suites (issue #467).
+//
+//  Before this file, three suites carried their own copy of the same `waitUntil` helper: a 5ms (or
+//  10ms) poll loop against a 3s wall-clock cap, failing with `Condition not met within 3.0s` --
+//  a message that named neither the condition nor the suite. Under load the cap expired while the
+//  code under test was merely slow, which is the failure class issue #463 exists to remove.
+//
+//  What replaces it:
+//
+//  - ``XLAwaitableState`` -- a lock-protected value whose *mutations* resume waiters. A test waits
+//    for the state it needs and is resumed by the write that produces it, so load can delay a test
+//    but cannot change its verdict.
+//  - ``XLAwaitableValue`` -- the one-shot form, for a callback that fires once.
+//  - ``XLSubscriptionEventRecorder`` -- buffers `XLAsyncStreamSubscription`'s own lifecycle events
+//    (the `#if DEBUG` seam from #465) so a test can await a named transition of the subject itself.
+//  - ``xlWaitUntil(describing:)`` -- the deliberately-bounded fallback, for the one class of
+//    condition nothing can signal: an object being deallocated. Its failure names the condition.
+//
+
+import Foundation
+import XCTest
+#if canImport(Observation) && canImport(Darwin)
+import Observation
+#endif
+@testable import SwiftQL
+
+
+// MARK: - Awaitable state
+
+/// A lock-protected value that callers await rather than poll.
+///
+/// `wait(until:)` suspends on a continuation and is resumed by the very mutation that satisfies its
+/// predicate, so nothing sleeps and nothing samples on a timer. Predicates are evaluated inside the
+/// lock, against the value as it stands at that instant, so a state that is reached and then left
+/// again between two polls -- the classic reason a polling wait misses an event -- cannot be missed
+/// here.
+final class XLAwaitableState<Value>: @unchecked Sendable {
+
+    private struct Waiter {
+        let id: UUID
+        let isSatisfied: (Value) -> Bool
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private let lock = NSLock()
+
+    private var value: Value
+
+    private var waiters: [Waiter] = []
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func read() -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    /// Mutates the value and resumes every waiter the new value satisfies.
+    @discardableResult
+    func withValue<Result>(_ body: (inout Value) -> Result) -> Result {
+        lock.lock()
+        let result = body(&value)
+        let satisfied = waiters.filter { $0.isSatisfied(value) }
+        let satisfiedIDs = Set(satisfied.map(\.id))
+        waiters.removeAll { satisfiedIDs.contains($0.id) }
+        lock.unlock()
+        // Resumed outside the lock: a resumed test task usually goes straight back into the code
+        // under test, which may take this same lock again through another mutation.
+        for waiter in satisfied {
+            waiter.continuation.resume()
+        }
+        return result
+    }
+
+    func set(_ newValue: Value) {
+        withValue { $0 = newValue }
+    }
+
+    /// Suspends until the value satisfies `isSatisfied`, returning immediately if it already does.
+    func wait(until isSatisfied: @escaping (Value) -> Bool) async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if isSatisfied(value) {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            waiters.append(Waiter(id: UUID(), isSatisfied: isSatisfied, continuation: continuation))
+            lock.unlock()
+        }
+    }
+}
+
+
+extension XLAwaitableState where Value: Equatable {
+
+    /// Suspends until the value equals `expected`.
+    func wait(for expected: Value) async {
+        await wait(until: { $0 == expected })
+    }
+}
+
+
+extension XLAwaitableState {
+
+    /// Suspends until the collection holds at least `count` elements.
+    func wait<Element>(untilCountIsAtLeast count: Int) async where Value == [Element] {
+        await wait(until: { $0.count >= count })
+    }
+}
+
+
+/// A value produced exactly once, which callers await.
+///
+/// Used where the observable thing is a single callback -- a completion handler, a delivery on a
+/// particular queue -- rather than evolving state. Awaiting the callback *itself* and then asserting
+/// on what it carried keeps the wrong outcome a test failure rather than a hang, which is not true
+/// of waiting for a flag that is only set when the outcome is already the expected one.
+final class XLAwaitableValue<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    private var value: Value?
+
+    private var waiters: [CheckedContinuation<Value, Never>] = []
+
+    /// Records the first value only. Later calls are ignored, so a test reading "the" value cannot be
+    /// confused by a second one arriving mid-assertion.
+    func fulfill(_ newValue: Value) {
+        lock.lock()
+        guard value == nil else {
+            lock.unlock()
+            return
+        }
+        value = newValue
+        let pending = waiters
+        waiters = []
+        lock.unlock()
+        for waiter in pending {
+            waiter.resume(returning: newValue)
+        }
+    }
+
+    var isFulfilled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value != nil
+    }
+
+    func wait() async -> Value {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if let value {
+                lock.unlock()
+                continuation.resume(returning: value)
+                return
+            }
+            waiters.append(continuation)
+            lock.unlock()
+        }
+    }
+}
+
+
+// MARK: - Subscription lifecycle events
+
+#if DEBUG
+/// Buffers every `XLAsyncStreamSubscription` lifecycle event the `#if DEBUG` seam from issue #465
+/// emits, and lets a test await a *named* one instead of polling a predicate against a wall-clock
+/// deadline.
+///
+/// Waiting this way is what makes runner load unable to change a verdict: every wait here resumes
+/// because the subscription reached a specific point in its own control flow, so load can only make
+/// a test take longer, never make it assert against a state the subscription has not reached yet.
+/// There is deliberately no timeout: a bounded wait is a wall-clock deadline wearing a different
+/// hat, and the failure it produces under load is exactly the one these suites are being fixed for.
+///
+/// Each wait consumes the earliest *matching* buffered event, and parks on a continuation if none
+/// has arrived yet. Non-matching events are not skipped past and discarded: they stay buffered in
+/// arrival order, so a later wait for one of them still finds it. A wait therefore never has to
+/// step over -- or block on -- an event the test does not care about.
+final class XLSubscriptionEventRecorder: @unchecked Sendable {
+
+    private struct RecordedEvent {
+        let sequence: Int
+        let event: XLAsyncStreamSubscriptionEvent
+    }
+
+    private struct Waiter {
+        let matches: (XLAsyncStreamSubscriptionEvent) -> Bool
+        let continuation: CheckedContinuation<RecordedEvent, Never>
+    }
+
+    private let lock = NSLock()
+
+    private var buffered: [RecordedEvent] = []
+
+    private var waiter: Waiter?
+
+    private var nextSequence = 0
+
+    private var pump: Task<Void, Never>?
+
+    init() {
+        // `events()` registers its observer synchronously inside `AsyncStream`'s build closure, and
+        // that stream buffers without bound, so no event emitted after this line can be missed --
+        // including events emitted before `pump` gets its first chance to run.
+        let stream = XLAsyncStreamSubscriptionTestHooks.shared.events()
+        pump = Task { [weak self] in
+            for await event in stream {
+                self?.ingest(event)
+            }
+        }
+    }
+
+    func stop() {
+        pump?.cancel()
+        pump = nil
+    }
+
+    private func ingest(_ event: XLAsyncStreamSubscriptionEvent) {
+        lock.lock()
+        let recorded = RecordedEvent(sequence: nextSequence, event: event)
+        nextSequence += 1
+        if let waiter, waiter.matches(event) {
+            self.waiter = nil
+            lock.unlock()
+            // Resumed outside the lock: the resumed test task goes on to call into the subscription
+            // (cancel, request more demand), which takes the subscription's own lock.
+            waiter.continuation.resume(returning: recorded)
+            return
+        }
+        buffered.append(recorded)
+        lock.unlock()
+    }
+
+    private func wait(
+        matching matches: @escaping (XLAsyncStreamSubscriptionEvent) -> Bool
+    ) async -> RecordedEvent {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if let index = buffered.firstIndex(where: { matches($0.event) }) {
+                let match = buffered.remove(at: index)
+                lock.unlock()
+                continuation.resume(returning: match)
+                return
+            }
+            precondition(
+                waiter == nil,
+                "XLSubscriptionEventRecorder serves one wait at a time: a test that awaits two events "
+                    + "concurrently would silently overwrite and hang the first waiter."
+            )
+            waiter = Waiter(matches: matches, continuation: continuation)
+            lock.unlock()
+        }
+    }
+
+    /// Awaits (and consumes) the next occurrence of `event`.
+    func wait(for event: XLAsyncStreamSubscriptionEvent) async {
+        _ = await wait(matching: { $0 == event })
+    }
+
+    /// Awaits `finish(error:)` running and reports whether it forwarded the completion downstream or
+    /// suppressed it as self-inflicted.
+    ///
+    /// Matching *either* outcome is deliberate. A test that waited only for the outcome it expects
+    /// would hang -- rather than fail -- in the world where the subscription made the opposite
+    /// decision, which is the world the test exists to detect.
+    func waitForFinish() async -> Bool {
+        let match = await wait(matching: { event in
+            if case .finished = event {
+                return true
+            }
+            return false
+        })
+        guard case .finished(let forwarded) = match.event else {
+            preconditionFailure("wait(matching:) resumed with a non-`.finished` event.")
+        }
+        return forwarded
+    }
+
+    /// Awaits the next consumer task starting, and forgets everything emitted before it.
+    ///
+    /// The seam is process-global -- `Publisher.receive(subscriber:)` erases the concrete
+    /// `XLAsyncStreamSubscription` behind Combine's `Subscription` existential the moment it is
+    /// vended, so no test ever holds a handle to hook per-instance. That means a previous test's
+    /// (or previous round's) still-unwinding subscription can in principle emit one last event into
+    /// this recorder. `.consumerTaskStarted` can only come from a consumer task starting *now*, so
+    /// fencing on it and dropping everything with a lower sequence number gives each test a clean
+    /// epoch, without polling for quiescence.
+    func fenceOnConsumerTaskStart() async {
+        let match = await wait(matching: { $0 == .consumerTaskStarted })
+        discardEvents(before: match.sequence)
+    }
+
+    /// Locked, non-`async` half of ``fenceOnConsumerTaskStart()``: recent Foundation marks
+    /// `NSLock.lock()`/`unlock()` unavailable directly inside an asynchronous context (an error in
+    /// the Swift 6 language mode), the same split `XLAsyncStreamSubscription` itself uses.
+    private func discardEvents(before sequence: Int) {
+        lock.lock()
+        buffered.removeAll { $0.sequence < sequence }
+        lock.unlock()
+    }
+}
+#endif
+
+
+// MARK: - Observation-native waiting
+
+#if canImport(Observation) && canImport(Darwin)
+/// Suspends until `isSatisfied` holds for main-actor `@Observable` state, resumed by Observation's
+/// own change notification rather than by a poll.
+///
+/// `withObservationTracking` fires `onChange` *before* the tracked property's new value is visible,
+/// so each round resumes on the notification and then re-reads on the next main-actor turn. That is
+/// an await on a scheduling hop, not on a duration: the loop cannot conclude anything early, and
+/// under load it simply takes more turns.
+@available(iOS 17, macOS 14, *)
+@MainActor
+func xlWaitForObservedState(
+    _ isSatisfied: @escaping @MainActor () -> Bool,
+    trackedBy track: @escaping @MainActor () -> Void
+) async {
+    while !isSatisfied() {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            withObservationTracking {
+                track()
+            } onChange: {
+                continuation.resume()
+            }
+        }
+        // `onChange` runs before the mutation lands, so yield the main actor once and re-read the
+        // state as it stands after the writer's turn completes.
+        await Task.yield()
+    }
+}
+#endif
+
+
+// MARK: - Bounded fallback
+
+/// Bounded wait for a condition nothing can signal -- in practice, only "this object has been
+/// deallocated," where no seam exists to be notified.
+///
+/// Every other wait in these suites is event-driven and unbounded. This one keeps a deadline because
+/// an unobservable condition that never becomes true would otherwise hang forever with no diagnosis
+/// at all. `describing` is mandatory, so the failure says what was being waited for instead of
+/// issue #463's anonymous `Condition not met within 3.0s`.
+func xlWaitUntil(
+    describing description: String,
+    timeout: TimeInterval = 3,
+    pollInterval: UInt64 = 10_000_000,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ condition: () -> Bool
+) async throws {
+    let maximumAttempts = max(Int((timeout * 1_000_000_000) / Double(pollInterval)), 1)
+    for _ in 0 ..< maximumAttempts {
+        if condition() {
+            return
+        }
+        try await Task.sleep(nanoseconds: pollInterval)
+    }
+    XCTFail(
+        "Timed out after \(timeout)s waiting for: \(description)",
+        file: file,
+        line: line
+    )
+}
+
+
+/// `@MainActor` overload of ``xlWaitUntil(describing:timeout:pollInterval:file:line:_:)``.
+///
+/// Call sites inside `@MainActor` test methods form main-actor-isolated condition closures; a
+/// nonisolated helper would have to *send* the closure (and everything it captures) across an actor
+/// boundary just to receive it, which is the "sending risks causing data races" warning the sibling
+/// suites already document.
+@MainActor
+func xlWaitUntilOnMainActor(
+    describing description: String,
+    timeout: TimeInterval = 3,
+    pollInterval: UInt64 = 10_000_000,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ condition: () -> Bool
+) async throws {
+    let maximumAttempts = max(Int((timeout * 1_000_000_000) / Double(pollInterval)), 1)
+    for _ in 0 ..< maximumAttempts {
+        if condition() {
+            return
+        }
+        try await Task.sleep(nanoseconds: pollInterval)
+    }
+    XCTFail(
+        "Timed out after \(timeout)s waiting for: \(description)",
+        file: file,
+        line: line
+    )
+}
+
+
+/// Suspends until every block already enqueued on the main queue has run.
+///
+/// A barrier, not a deadline: it resumes when the main queue reaches the block it enqueued, however
+/// long that takes. Valid only where the main queue genuinely is the delivery path being drained --
+/// GRDB's `ValueObservation` scheduling and Combine's `.receive(on: DispatchQueue.main)` -- and
+/// never as a stand-in for "let the cooperative pool settle," which it says nothing about.
+func xlDrainMainQueue() async {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.main.async {
+            continuation.resume()
+        }
+    }
+}

--- a/Tests/SQLTests/XLObservableLiveQueryTests.swift
+++ b/Tests/SQLTests/XLObservableLiveQueryTests.swift
@@ -80,7 +80,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
         let isLoadingInitially = model.isLoading
         XCTAssertTrue(isLoadingInitially)
 
-        try await waitUntil { !model.isLoading }
+        await xlWaitForObservedState { !model.isLoading }
         let rowsAfterInitialFetch = model.rows
         XCTAssertEqual(rowsAfterInitialFetch, [ObservableLiveQueryRecord(id: "a", value: 1)])
         let errorAfterInitialFetch = model.error
@@ -92,13 +92,13 @@ final class XLObservableLiveQueryTests: XCTestCase {
     func testRelevantWriteRefreshesRows() async throws {
         try createRecordTable()
         let model = XLObservableQuery(database.makeRequest(with: orderedStatement()))
-        try await waitUntil { !model.isLoading }
+        await xlWaitForObservedState { !model.isLoading }
         let rowsBeforeInsert = model.rows
         XCTAssertEqual(rowsBeforeInsert, [])
 
         try insertDirect(ObservableLiveQueryRecord(id: "a", value: 1))
 
-        try await waitUntil { model.rows == [ObservableLiveQueryRecord(id: "a", value: 1)] }
+        await xlWaitForObservedState { model.rows == [ObservableLiveQueryRecord(id: "a", value: 1)] }
         model.stop()
     }
 
@@ -114,7 +114,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
             .returning(table)
         let model = XLObservableQuery(database.makeRequest(with: statement))
 
-        try await waitUntil { !model.isLoading }
+        await xlWaitForObservedState { !model.isLoading }
         let error = model.error
         XCTAssertEqual(error as? XLReturningRequestError, .observationUnsupported)
         let rowsAfterFailure = model.rows
@@ -159,7 +159,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
         var model: XLObservableQuery<ObservableLiveQueryRecord>? = XLObservableQuery(
             database.makeRequest(with: orderedStatement())
         )
-        try await waitUntil { !(model?.isLoading ?? true) }
+        await xlWaitForObservedState { !(model?.isLoading ?? true) }
 
         // `weak let` needs Swift 6.2+: the pinned Swift 5.9/6.0 cells reject it ("'weak' must be
         // a mutable variable"), and Swift 6.1 (Xcode 16.4) does too, despite `#if compiler(>=6.1)`
@@ -173,7 +173,12 @@ final class XLObservableLiveQueryTests: XCTestCase {
         #endif
         model = nil // Drop the only strong reference; deinit must cancel the owned Task deterministically.
 
-        try await waitUntil { weakModel == nil }
+        // The one condition in this file nothing can signal: deallocation has no notification to
+        // await, so this stays a bounded wait -- now one whose failure names what it was waiting
+        // for. Everything else here is resumed by an Observation change.
+        try await xlWaitUntil(describing: "the released model to be deallocated") {
+            weakModel == nil
+        }
 
         let fetchCountAfterRelease = logger.count(containing: "stream:")
         try insertDirect(ObservableLiveQueryRecord(id: "b", value: 2))
@@ -189,7 +194,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
     func testExplicitStopPreventsFurtherWorkWithoutWaitingForDeallocation() async throws {
         try createRecordTable()
         let model = XLObservableQuery(database.makeRequest(with: orderedStatement()))
-        try await waitUntil { !model.isLoading }
+        await xlWaitForObservedState { !model.isLoading }
 
         model.stop()
         let fetchCountAtStop = logger.count(containing: "stream:")
@@ -208,13 +213,13 @@ final class XLObservableLiveQueryTests: XCTestCase {
     func testRapidUpdatesEventuallyReflectTheFinalDurableState() async throws {
         try createRecordTable()
         let model = XLObservableQuery(database.makeRequest(with: orderedStatement()))
-        try await waitUntil { !model.isLoading }
+        await xlWaitForObservedState { !model.isLoading }
 
         for index in 0 ..< 20 {
             try insertDirect(ObservableLiveQueryRecord(id: "row-\(index)", value: index))
         }
 
-        try await waitUntil(timeout: 5) { model.rows.count == 20 }
+        await xlWaitForObservedState { model.rows.count == 20 }
         model.stop()
     }
 
@@ -230,7 +235,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
         let bindings = try makeIDBindings(request: request, id: "per-1")
 
         let model = XLObservableQuery(request, bindings: bindings)
-        try await waitUntil { model.rows == [ObservableLiveQueryRecord(id: "per-1", value: 1)] }
+        await xlWaitForObservedState { model.rows == [ObservableLiveQueryRecord(id: "per-1", value: 1)] }
 
         try insertDirect(ObservableLiveQueryRecord(id: "per-3", value: 3))
         await drainMainQueue()
@@ -255,7 +260,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
             requestA,
             bindings: bindingsA
         )
-        try await waitUntil { modelA?.rows == [ObservableLiveQueryRecord(id: "per-1", value: 1)] }
+        await xlWaitForObservedState { modelA?.rows == [ObservableLiveQueryRecord(id: "per-1", value: 1)] }
 
         // Releasing the first model and constructing a second with a different packet is how binding
         // replacement happens for this Observation-native surface: each model owns one immutable
@@ -267,12 +272,15 @@ final class XLObservableLiveQueryTests: XCTestCase {
         weak var weakModelA = modelA
         #endif
         modelA = nil
-        try await waitUntil { weakModelA == nil }
+        // See the deallocation note in testReleasedModelPerformsNoFurtherWorkAfterRelease.
+        try await xlWaitUntil(describing: "the released model to be deallocated") {
+            weakModelA == nil
+        }
 
         let requestB = database.makeRequest(with: byIDStatement())
         let bindingsB = try makeIDBindings(request: requestB, id: "per-2")
         let modelB = XLObservableQuery(requestB, bindings: bindingsB)
-        try await waitUntil { modelB.rows == [ObservableLiveQueryRecord(id: "per-2", value: 2)] }
+        await xlWaitForObservedState { modelB.rows == [ObservableLiveQueryRecord(id: "per-2", value: 2)] }
         modelB.stop()
     }
 
@@ -307,7 +315,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
 
         let modelA = XLObservableQuery(database.makeRequest(with: orderedStatement()))
         let modelB = XLObservableQuery(secondDatabase.makeRequest(with: orderedStatement()))
-        try await waitUntil {
+        await xlWaitForObservedState {
             let isLoadingA = modelA.isLoading
             let isLoadingB = modelB.isLoading
             return !isLoadingA && !isLoadingB
@@ -318,7 +326,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
         XCTAssertEqual(initialRowsB, [])
 
         try insertDirect(ObservableLiveQueryRecord(id: "only-in-a", value: 1))
-        try await waitUntil { modelA.rows == [ObservableLiveQueryRecord(id: "only-in-a", value: 1)] }
+        await xlWaitForObservedState { modelA.rows == [ObservableLiveQueryRecord(id: "only-in-a", value: 1)] }
 
         await drainMainQueue()
         let finalRowsB = modelB.rows
@@ -335,13 +343,13 @@ final class XLObservableLiveQueryTests: XCTestCase {
         try insertDirect(ObservableLiveQueryRecord(id: "a", value: 1))
 
         let model = XLObservableQueryRow(database.makeRequest(with: orderedStatement()))
-        try await waitUntil { !model.isLoading }
+        await xlWaitForObservedState { !model.isLoading }
         let initialRow = model.row
         XCTAssertEqual(initialRow, ObservableLiveQueryRecord(id: "a", value: 1))
 
         // "A-earlier" sorts before "a", so the observed first row changes.
         try insertDirect(ObservableLiveQueryRecord(id: "A-earlier", value: 2))
-        try await waitUntil { model.row == ObservableLiveQueryRecord(id: "A-earlier", value: 2) }
+        await xlWaitForObservedState { model.row == ObservableLiveQueryRecord(id: "A-earlier", value: 2) }
         model.stop()
     }
 
@@ -353,7 +361,7 @@ final class XLObservableLiveQueryTests: XCTestCase {
         var model: XLObservableQueryRow<ObservableLiveQueryRecord>? = XLObservableQueryRow(
             database.makeRequest(with: orderedStatement())
         )
-        try await waitUntil { !(model?.isLoading ?? true) }
+        await xlWaitForObservedState { !(model?.isLoading ?? true) }
 
         // See the compiler(>=6.2) note in testReleasedModelPerformsNoFurtherWorkAfterRelease above.
         #if compiler(>=6.2)
@@ -362,7 +370,12 @@ final class XLObservableLiveQueryTests: XCTestCase {
         weak var weakModel = model
         #endif
         model = nil
-        try await waitUntil { weakModel == nil }
+        // The one condition in this file nothing can signal: deallocation has no notification to
+        // await, so this stays a bounded wait -- now one whose failure names what it was waiting
+        // for. Everything else here is resumed by an Observation change.
+        try await xlWaitUntil(describing: "the released model to be deallocated") {
+            weakModel == nil
+        }
 
         let fetchCountAfterRelease = logger.count(containing: "streamOne:")
         try insertDirect(ObservableLiveQueryRecord(id: "b", value: 2))
@@ -434,44 +447,14 @@ final class XLObservableLiveQueryTests: XCTestCase {
     // file's `@MainActor` test methods -- it needs to pump the run loop to let the `DispatchQueue.main
     // .async` block run, but that block competes with the same main-actor executor already suspended
     // resuming the calling test method's own async context, so it never gets a turn within the timeout.
-    // `@MainActor`, matching every caller and `waitUntil` above: calling a nonisolated async function
-    // from `@MainActor` code needs to send `self` (this non-Sendable XCTestCase instance) across that
-    // boundary, which this annotation avoids the same way it does for `waitUntil`.
+    //
+    // A barrier, not a deadline: it resumes when the main queue reaches the block it enqueued. Used
+    // only where the assertion is "no *further* work happened", after letting whatever was already
+    // scheduled on the delivery queue run. The suite's polling `waitUntil` is gone (#467): every
+    // other wait here is resumed by an Observation change through `xlWaitForObservedState`.
     @MainActor
     private func drainMainQueue() async {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.main.async {
-                continuation.resume()
-            }
-        }
-    }
-
-    /// Bounded, deterministic polling: sleeps in small increments up to `timeout`, checking `condition`
-    /// each time, rather than proving anything via one blind sleep. Mirrors
-    /// `GRDBLiveQueryAsyncStreamTests.waitUntil`, adapted to an `async` condition closure so it can read
-    /// this file's main-actor-isolated `@Observable` state.
-    ///
-    /// `@MainActor`, matching every caller: each call site is a closure literal formed inside one of
-    /// this file's `@MainActor` test methods, so it is itself `@MainActor`-isolated by inference. A
-    /// plain nonisolated `waitUntil` would need to *send* that closure (and the `self`/`model` it
-    /// captures) across an actor boundary just to receive it as a parameter, which is exactly the
-    /// "sending risks causing data races" warning this annotation avoids.
-    @MainActor
-    private func waitUntil(
-        timeout: TimeInterval = 3,
-        pollInterval: UInt64 = 10_000_000,
-        file: StaticString = #filePath,
-        line: UInt = #line,
-        _ condition: () async -> Bool
-    ) async throws {
-        let maxAttempts = max(Int((timeout * 1_000_000_000) / Double(pollInterval)), 1)
-        for _ in 0 ..< maxAttempts {
-            if await condition() {
-                return
-            }
-            try await Task.sleep(nanoseconds: pollInterval)
-        }
-        XCTFail("Condition not met within \(timeout)s", file: file, line: line)
+        await xlDrainMainQueue()
     }
 }
 #endif


### PR DESCRIPTION
Closes #533

## Summary

`testDemandDrivenPullerConsumesExactlyDemandedCountWithoutEagerDraining` fails under load:

```
LiveQueryBufferingSemanticsTests.swift:911: XCTAssertEqual failed: ("[0, 1]") is not equal to ("[0, 2]")
```

**3 failures in 20 runs** with 14 `yes > /dev/null` spinners on a 14-core machine.

The test pauses the puller at zero demand, commits two inserts, drains the main queue, then resumes demand expecting the bridge's single buffered "newest" snapshot to reflect both writes. GRDB fetches on a reader queue and only then dispatches to main, so a main-queue barrier says nothing about whether the second commit has been fetched yet. Under load it often has not: the mailbox still holds the snapshot for the first insert, and the puller correctly delivers the newest value it actually has.

Nothing was wrong with the buffering policy under test. The assertion was waiting on elapsed time -- the same root cause as #463, reached through a different helper.

## Changes

- `SingleSlotMailbox` records its newest yielded value in an `XLAwaitableState` (the shared helper #467 added), exposed through the bridge as `waitForYield(satisfying:)`. The test now awaits the observation having produced the state after both commits before resuming demand. How many fetches those two commits coalesce into stays GRDB's business and is still not asserted -- only that the newest value the mailbox holds is the final one when demand resumes.
- That also strengthens the "no demand outstanding, no delivery" assertion: it is now made at a point where the value provably exists in the mailbox and was not delivered, rather than after a main-queue round trip.
- `waitForCount` is deleted. It created one `XCTestExpectation` per poll attempt and waited on it with a 0.2s timeout, up to 200 times per call. Under load those waits time out while the value is merely late, and the `asyncAfter` block then fulfils an already-timed-out expectation -- an XCTest API violation, and one of the two candidate mechanisms recorded on #533 for the `Index out of range` crash reported in #463. `LockedArray` is awaitable instead, through the same `XLAwaitableState`.
- Three tests became `async` to await rather than pump the run loop; `wait(for:timeout:)` on the one genuine `XCTestExpectation` became `await fulfillment(of:timeout:)`.

## On the crash

Still not reproduced -- 25 runs of this suite before the fix (10 quiet, 15 under load) produced the assertion failure above and no crash. #533 records what was ruled out and both candidate mechanisms. Removing `waitForCount` closes the second candidate as a side effect; the first (a crash misattributed from the publisher suite's pre-#464 `continuations[streamIndex]` trap, in the same test process) was fixed by #464.

If it reappears after this, #533 should be reopened with the crash report attached.

## Test plan

- [x] `swift build --build-tests` -- no warnings
- [x] `LiveQueryBufferingSemanticsTests` 9/9, in 0.066s (0.464s before)
- [x] **25 consecutive runs under the same load that produced the original 3/20 failures: 0 failures**
- [x] Full `swift test` -- green
- [ ] Stacked on #534 (#467), which it uses `XLAwaitableState` from; merge that first. Its commits drop out of this diff once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)