### PR TITLE
Derive Sendable for public @SQLTable and @SQLResult models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@
   conformance they need cannot be written by an extension macro without the
   compiler reporting `circular reference expanding extension macros`;
   `SQLScalarResult` and `SQLRow2`...`SQLRow6`, the shapes behind `#row`, are
-  the affected types and they were not `Sendable` before this either.
+  the affected types and they were not `Sendable` before this either. The
+  conformance requires Swift 6.0 or later, since Swift 5.9 treats a
+  macro-expanded extension as a separate source file for the rule that a
+  `Sendable` conformance must be declared alongside its type and warns on every
+  model; the 5.9 support point keeps the behaviour it had. See COMPATIBILITY.md.
 - Added a `SwiftQLExamples` library product (issue #480), holding the
   pre-expanded schema and declared queries the Getting Started playground
   imports. A classic Xcode playground has no `Package.swift` of its own and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 ### Added
 
+- `@SQLTable` and `@SQLResult` now declare a `Sendable` conformance for the
+  models they expand, so a value built entirely from column values can be
+  shared across isolation domains without the conformance being written out at
+  every declaration (issue #531). Swift already infers `Sendable` for a struct
+  whose stored properties are all `Sendable`, but withholds that inference from
+  a type other modules can see, which is why a `public` model used to warn
+  under complete strict-concurrency checking and left callers reaching for
+  `nonisolated(unsafe)` to silence it. The macros fill in exactly that gap:
+  a `public` or `package` model gets the conformance, and a model that is
+  `internal` or narrower keeps the compiler's own inferred one and gets nothing
+  generated. This is a public API addition. A model that already states
+  `Sendable`, or `@unchecked Sendable`, keeps its own declaration and gets no
+  second one, so existing declarations such as the `TodoKit` schema still
+  compile unchanged. The generated conformance is checked rather than asserted,
+  so a `public` model holding a non-`Sendable` stored property is now diagnosed
+  on the generated extension where it previously compiled silently; declaring
+  `@unchecked Sendable` on such a model takes responsibility for it and turns
+  the generation off. Generic models are left alone, because the conditional
+  conformance they need cannot be written by an extension macro without the
+  compiler reporting `circular reference expanding extension macros`;
+  `SQLScalarResult` and `SQLRow2`...`SQLRow6`, the shapes behind `#row`, are
+  the affected types and they were not `Sendable` before this either.
 - Added a `SwiftQLExamples` library product (issue #480), holding the
   pre-expanded schema and declared queries the Getting Started playground
   imports. A classic Xcode playground has no `Package.swift` of its own and

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -227,6 +227,24 @@ including 5.9 and 6.0. This is the package's first source-level API
 divergence across compiler cells; see `Sources/SwiftQL/SQLRowMacro.swift` and
 `Sources/SwiftQL/SQLRowResult.swift` for the gated declarations.
 
+The `Sendable` conformance `@SQLTable` and `@SQLResult` declare for a `public`
+or `package` model (issue #531) requires Swift 6.0 or later. Swift 5.9 treats a
+macro-expanded extension as a separate source file for the rule that a
+`Sendable` conformance must be declared alongside its type, so every model there
+draws `conformance to 'Sendable' must occur in the same source file as struct
+'X'; use '@unchecked Sendable' for retroactive conformance`, which the
+first-party warnings-as-errors gate turns into a build failure. The spelling the
+compiler suggests is the one the conformance exists to avoid, so the 5.9 support
+point keeps the behaviour it had: nothing is generated, and a model that should
+be `Sendable` states it on the declaration. Swift 6.0 accepts the generated
+conformance without a diagnostic, verified on the pinned 6.0 cell. The gate is
+`#if compiler(>=6.0)` in `makeSendableExtension` in
+`Sources/SQLMacros/SQLMacro.swift`; because SwiftPM builds a macro plugin with
+the same toolchain that compiles the client, it resolves per compilation rather
+than per plugin build. The macro-expansion tests in
+`Tests/SQLMacrosTests/SQLTests.swift` and the conformance tests in
+`Tests/SQLTests/SQLModelSendableConformanceTests.swift` carry the same gate.
+
 ## Swift 6 series coverage
 
 | Swift series | GitHub runner | Xcode | Swift | macOS SDK |

--- a/Sources/SQLMacros/SQLMacro.swift
+++ b/Sources/SQLMacros/SQLMacro.swift
@@ -94,11 +94,20 @@ private let sendableInferenceWithheldModifiers: Set<String> = ["public", "open",
 ///   this is not hypothetical. They are left as they were: a generic model that should be
 ///   `Sendable` says so itself, `extension MyRow: Sendable where T: Sendable {}`, and the macro
 ///   then defers to it like any other stated conformance.
+/// - **Swift 6.0 and later only.** Swift 5.9 treats a macro-expanded extension as a separate
+///   source file for the rule that a `Sendable` conformance must be declared alongside its type,
+///   and warns `conformance to 'Sendable' must occur in the same source file as struct 'X'; use
+///   '@unchecked Sendable' for retroactive conformance` on every model. The suggested spelling is
+///   the one thing this change exists to avoid, so the 5.9 support point keeps the behaviour it
+///   had and models there state the conformance themselves if they want it. The plugin is built
+///   by the same toolchain that compiles the client, so `#if compiler(>=6.0)` below decides this
+///   per compilation rather than per plugin build. See COMPATIBILITY.md.
 ///
 private func makeSendableExtension(
     builder: MetaBuilder,
     conformingTo protocols: [TypeSyntax]
 ) throws -> ExtensionDeclSyntax? {
+#if compiler(>=6.0)
     let requested = protocols.contains { type in
         // Matched by spelling because the syntax the compiler hands back carries no resolved
         // type. Both the bare and module-qualified spellings are accepted, and nothing else is,
@@ -119,6 +128,9 @@ private func makeSendableExtension(
         return nil
     }
     return try makeExtensionDecl("extension \(builder.structName): Sendable {\n}")
+#else
+    return nil
+#endif
 }
 
 

--- a/Sources/SQLMacros/SQLMacro.swift
+++ b/Sources/SQLMacros/SQLMacro.swift
@@ -44,6 +44,84 @@ private func makeExtensionDecl(_ source: String) throws -> ExtensionDeclSyntax {
 }
 
 
+/// Access-level modifiers whose types Swift refuses to infer `Sendable` for.
+///
+/// A conformance a *different* module can see is an API promise, and Swift makes the declaring
+/// module state such a promise on purpose rather than inferring it. Everything narrower than this
+/// is inferred, so the macro has nothing to add there -- see `makeSendableExtension`.
+private let sendableInferenceWithheldModifiers: Set<String> = ["public", "open", "package"]
+
+
+///
+/// Builds the `Sendable` conformance both `SQLTableMacro` and `SQLResultMacro` declare (issue
+/// #531), or returns `nil` if the model does not need one.
+///
+/// A generated model is a struct whose stored properties are column values, so it is a value type
+/// built from value types and is `Sendable` in every ordinary case. Swift infers exactly that for
+/// such a struct on its own -- but not for one another module can see. The inference is withheld
+/// from `public` (and `package`) types on purpose, because a conformance visible outside the
+/// module is an API promise the declaring module has to make deliberately. Model types are exactly
+/// the types users declare `public` and read on one task to use on another, so before this the
+/// promise had to be written out by hand at every public declaration -- or the caller had to reach
+/// for `nonisolated(unsafe)`, which switches the checking off rather than satisfying it.
+///
+/// So the macro fills in precisely the gap the inference leaves, and nothing more:
+///
+/// - **Only where inference is withheld.** An `internal`, `fileprivate`, or `private` model
+///   already gets a compiler-inferred conformance, derived from its actual stored properties and
+///   therefore strictly more precise than anything spelled here. Generating a second, redundant
+///   one buys nothing and can only take something away: an internal model with a non-`Sendable`
+///   stored property is diagnosed under an explicit conformance where the inference simply
+///   declines to apply.
+/// - **Checked, not asserted.** `extension Model: Sendable {}` is an ordinary conformance, so a
+///   stored property whose type is not `Sendable` is diagnosed by the compiler on the generated
+///   extension. The macro never writes `@unchecked`, so no model silently claims to be `Sendable`
+///   when it is not.
+/// - **Deferring to the declaration.** `protocols` holds only the conformances from the macro's
+///   `conformances:` list that the type does not already have, so a model declared `: Sendable` --
+///   or `: @unchecked Sendable`, the escape hatch for a property whose safety its author vouches
+///   for -- yields an empty list here and no generated extension. That keeps the change
+///   source-compatible with models that already state the conformance, such as the `TodoKit`
+///   schema in `Examples/TodoApp`.
+/// - **Non-generic models only.** A generic model would need a *conditional* conformance, one
+///   `Sendable` requirement per generic parameter, the way the compiler's own inference produces
+///   one. An extension macro cannot write that: resolving the `where` clause needs the type's
+///   generic signature, resolving that needs every extension of the type, and expanding those
+///   extension macros is where the requirement came from, so the compiler stops with `circular
+///   reference expanding extension macros`. It is a real cycle, not a diagnostic quirk, and it
+///   fires on `public` and `private` generic models alike. SwiftQL ships generic models itself --
+///   `SQLScalarResult<T>` and `SQLRow2<C0, C1>`...`SQLRow6`, the row shapes behind `#row` -- so
+///   this is not hypothetical. They are left as they were: a generic model that should be
+///   `Sendable` says so itself, `extension MyRow: Sendable where T: Sendable {}`, and the macro
+///   then defers to it like any other stated conformance.
+///
+private func makeSendableExtension(
+    builder: MetaBuilder,
+    conformingTo protocols: [TypeSyntax]
+) throws -> ExtensionDeclSyntax? {
+    let requested = protocols.contains { type in
+        // Matched by spelling because the syntax the compiler hands back carries no resolved
+        // type. Both the bare and module-qualified spellings are accepted, and nothing else is,
+        // so some other protocol whose name merely ends in "Sendable" cannot be mistaken for it.
+        let name = type.trimmedDescription
+        return name == "Sendable" || name == "Swift.Sendable"
+    }
+    guard requested else {
+        return nil
+    }
+    let visibleOutsideModule = builder.declaration.modifiers.contains { modifier in
+        sendableInferenceWithheldModifiers.contains(modifier.name.text)
+    }
+    guard visibleOutsideModule else {
+        return nil
+    }
+    guard builder.declaration.genericParameterClause == nil else {
+        return nil
+    }
+    return try makeExtensionDecl("extension \(builder.structName): Sendable {\n}")
+}
+
+
 ///
 /// Shared member list for `SQLTableMacro` and `SQLResultMacro`: the memberwise initializer,
 /// projection factory, static row-layout factory, and (issue #66) the declaration-level codec
@@ -141,10 +219,14 @@ extension SQLTableMacro: ExtensionMacro {
             // errors are not reported again here to avoid emitting duplicate diagnostics.
             return []
         }
-        return [
+        var extensions = [
             try makeExtensionDecl(builder.makeMetaResultExtension(table: true)),
             try makeExtensionDecl(builder.makeMetaTableExtension()),
         ]
+        if let sendable = try makeSendableExtension(builder: builder, conformingTo: protocols) {
+            extensions.append(sendable)
+        }
+        return extensions
     }
 }
 
@@ -188,9 +270,13 @@ extension SQLResultMacro: ExtensionMacro {
             // errors are not reported again here to avoid emitting duplicate diagnostics.
             return []
         }
-        return [
+        var extensions = [
             try makeExtensionDecl(builder.makeMetaResultExtension(table: false)),
         ]
+        if let sendable = try makeSendableExtension(builder: builder, conformingTo: protocols) {
+            extensions.append(sendable)
+        }
+        return extensions
     }
 }
 

--- a/Sources/SwiftQL/SQL.swift
+++ b/Sources/SwiftQL/SQL.swift
@@ -1,15 +1,44 @@
 ///
 /// Defines the `@SQLTable` macro.
 ///
+/// ## Concurrency
+///
+/// The macro declares the `Sendable` conformance of a `public` (or `package`) model (issue #531).
+/// A table model is a struct whose stored properties are column values, so it is a value type
+/// built from value types, and it is the kind of value that gets read on one task and used on
+/// another. Swift infers `Sendable` for such a struct on its own, but withholds the inference from
+/// a type other modules can see, so a public model used to need the conformance written by hand at
+/// every declaration. A model that is `internal` or narrower keeps the compiler's own inferred
+/// conformance and gets nothing generated, since the inference is already exact.
+///
+/// The conformance is checked, not asserted. If a stored property's type is not `Sendable`, the
+/// compiler diagnoses that on the generated extension instead of the model quietly claiming
+/// something untrue. To take responsibility for such a property yourself, state the conformance
+/// on the declaration -- `@unchecked Sendable` included. The macro generates nothing when the
+/// declaration already conforms to `Sendable`.
+///
+/// A *generic* model is left alone. It would need a conditional conformance -- one `Sendable`
+/// requirement per generic parameter -- and an extension macro cannot write one: resolving the
+/// `where` clause needs the type's generic signature, which needs the type's extensions, which is
+/// what the macro is producing, and the compiler stops with `circular reference expanding
+/// extension macros`. Declare it yourself if you want it, `extension MyRow: Sendable where
+/// T: Sendable {}`, and the macro defers to that like any other stated conformance.
+///
 @attached(member, names: arbitrary)
-@attached(extension, conformances: XLResult, XLTable, names: arbitrary)
+@attached(extension, conformances: XLResult, XLTable, Sendable, names: arbitrary)
 public macro SQLTable(name: String? = nil) = #externalMacro(module: "SQLMacros", type: "SQLTableMacro")
 
 ///
 /// Defines the `@SQLResult` macro.
 ///
+/// ## Concurrency
+///
+/// As with `@SQLTable`, the macro declares the result type's `Sendable` conformance (issue #531)
+/// unless the declaration already states it. See ``SQLTable(name:)`` for the reasoning and the
+/// opt-out.
+///
 @attached(member, names: arbitrary)
-@attached(extension, conformances: XLResult, names: arbitrary)
+@attached(extension, conformances: XLResult, Sendable, names: arbitrary)
 public macro SQLResult() = #externalMacro(module: "SQLMacros", type: "SQLResultMacro")
 
 ///

--- a/Sources/SwiftQL/SQL.swift
+++ b/Sources/SwiftQL/SQL.swift
@@ -24,6 +24,10 @@
 /// extension macros`. Declare it yourself if you want it, `extension MyRow: Sendable where
 /// T: Sendable {}`, and the macro defers to that like any other stated conformance.
 ///
+/// Requires Swift 6.0 or later. Swift 5.9 treats a macro-expanded extension as a separate source
+/// file for the rule that a `Sendable` conformance must be declared alongside its type, and warns
+/// on every model, so nothing is generated on that support point. See COMPATIBILITY.md.
+///
 @attached(member, names: arbitrary)
 @attached(extension, conformances: XLResult, XLTable, Sendable, names: arbitrary)
 public macro SQLTable(name: String? = nil) = #externalMacro(module: "SQLMacros", type: "SQLTableMacro")

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -69,6 +69,16 @@ These mappings provide type safety for Swift expressions, bindings, and decoded
 results. Optional properties can store `NULL`; non-optional properties are
 emitted with a `NOT NULL` constraint.
 
+A table declared `public` or `package` also conforms to `Sendable`, so rows can
+be passed between tasks and held in `static` properties without tripping
+strict-concurrency checking. Swift infers the same conformance for a table that
+is `internal` or narrower, so those are left alone. Should a table hold a stored
+property that is not itself `Sendable`, the compiler says so on the generated
+conformance; declaring the table `@unchecked Sendable` takes responsibility for
+that property and turns the generation off. A generic table gets nothing
+generated either, because the conditional conformance it would need cannot be
+written by a macro, so declare that one yourself if you want it.
+
 ### Creating tables
 
 Use `sqlCreate` to create a basic table:

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -70,8 +70,9 @@ results. Optional properties can store `NULL`; non-optional properties are
 emitted with a `NOT NULL` constraint.
 
 On Swift 6.0 and later, a table declared `public` or `package` also conforms to
-`Sendable`, so rows can be passed between tasks and held in `static` properties
-without tripping strict-concurrency checking. Swift infers the same conformance
+`Sendable`, so rows can be passed between tasks and held in `static let`
+constants without tripping strict-concurrency checking. A `static var` is
+shared mutable state whatever it holds, and still needs isolating. Swift infers the same conformance
 for a table that is `internal` or narrower, so those are left alone. Should a
 table hold a stored property that is not itself `Sendable`, the compiler says so
 on the generated conformance; declaring the table `@unchecked Sendable` takes

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -69,15 +69,15 @@ These mappings provide type safety for Swift expressions, bindings, and decoded
 results. Optional properties can store `NULL`; non-optional properties are
 emitted with a `NOT NULL` constraint.
 
-A table declared `public` or `package` also conforms to `Sendable`, so rows can
-be passed between tasks and held in `static` properties without tripping
-strict-concurrency checking. Swift infers the same conformance for a table that
-is `internal` or narrower, so those are left alone. Should a table hold a stored
-property that is not itself `Sendable`, the compiler says so on the generated
-conformance; declaring the table `@unchecked Sendable` takes responsibility for
-that property and turns the generation off. A generic table gets nothing
-generated either, because the conditional conformance it would need cannot be
-written by a macro, so declare that one yourself if you want it.
+On Swift 6.0 and later, a table declared `public` or `package` also conforms to
+`Sendable`, so rows can be passed between tasks and held in `static` properties
+without tripping strict-concurrency checking. Swift infers the same conformance
+for a table that is `internal` or narrower, so those are left alone. Should a
+table hold a stored property that is not itself `Sendable`, the compiler says so
+on the generated conformance; declaring the table `@unchecked Sendable` takes
+responsibility for that property and turns the generation off. A generic table
+gets nothing generated either, because the conditional conformance it would need
+cannot be written by a macro, so declare that one yourself if you want it.
 
 ### Creating tables
 

--- a/Tests/SQLMacrosTests/SQLTests.swift
+++ b/Tests/SQLMacrosTests/SQLTests.swift
@@ -79,6 +79,11 @@ private func makeColumnsMemberTestMacros() -> [String: Macro.Type] {
 
 // MARK: - Sendable conformance (issue #531)
 
+// Gated to match the macro (see `makeSendableExtension`): Swift 5.9 treats a macro-expanded
+// extension as a separate source file for the rule that a `Sendable` conformance must be declared
+// alongside its type, so the conformance is generated on Swift 6.0 and later only.
+#if compiler(>=6.0)
+
 
 ///
 /// Reduces each generated extension to its signature -- extended type, conformances, and generic
@@ -216,6 +221,8 @@ private func makeAlreadySendableTestMacros() -> [String: Macro.Type] {
         "SQLResult": SQLResultSatisfyingSendableMacro.self,
     ]
 }
+
+#endif
 
 
 final class SQLMacroDiagnosticTests: XCTestCase {
@@ -1635,6 +1642,7 @@ final class MetaBuilderTests: XCTestCase {
 }
 
 
+#if compiler(>=6.0)
 // Issue #531: the model macros declare the model's `Sendable` conformance, so a value type built
 // from column values does not need it written out by hand at every public declaration.
 //
@@ -1863,3 +1871,4 @@ final class SQLMacroSendableConformanceTests: XCTestCase {
     }
 
 }
+#endif

--- a/Tests/SQLMacrosTests/SQLTests.swift
+++ b/Tests/SQLMacrosTests/SQLTests.swift
@@ -77,6 +77,147 @@ private func makeColumnsMemberTestMacros() -> [String: Macro.Type] {
 }
 
 
+// MARK: - Sendable conformance (issue #531)
+
+
+///
+/// Reduces each generated extension to its signature -- extended type, conformances, and generic
+/// `where` clause -- discarding the member block.
+///
+/// The `Sendable` extension is one of several the macros return, and the other two carry the
+/// entire generated metadata surface. Asserting on signatures keeps a conformance test about
+/// conformances while still showing that the new extension is *added to* the existing ones rather
+/// than replacing or reordering them.
+///
+private func extensionSignatures(
+    _ extensions: [ExtensionDeclSyntax]
+) throws -> [ExtensionDeclSyntax] {
+    try extensions.map { declaration in
+        let inheritance = declaration.inheritanceClause?.trimmedDescription ?? ""
+        let whereClause = declaration.genericWhereClause.map { " \($0.trimmedDescription)" } ?? ""
+        let source = "extension \(declaration.extendedType.trimmedDescription)\(inheritance)\(whereClause) {\n}"
+        guard let signature = ExtensionDeclSyntax(DeclSyntax(stringLiteral: source)) else {
+            throw SQLMacroError.invalidGeneratedCode
+        }
+        return signature
+    }
+}
+
+
+///
+/// Stands in for the compiler when the attached type does *not* already conform to `Sendable`.
+///
+/// `assertMacroExpansion` has no macro *declaration* to read a `conformances:` list from, so it
+/// always passes an empty protocol list. These wrappers supply the list the compiler would, which
+/// is the whole input the conformance decision turns on.
+///
+private struct SQLTableRequestingSendableMacro: ExtensionMacro {
+
+    static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        try extensionSignatures(
+            SQLTableMacro.expansion(
+                of: node,
+                attachedTo: declaration,
+                providingExtensionsOf: type,
+                conformingTo: [TypeSyntax(stringLiteral: "Sendable")],
+                in: context
+            )
+        )
+    }
+}
+
+
+/// Stands in for the compiler when the attached type already conforms to `Sendable`, which is how
+/// the compiler reports a declaration written `: Sendable` or `: @unchecked Sendable`.
+private struct SQLTableSatisfyingSendableMacro: ExtensionMacro {
+
+    static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        try extensionSignatures(
+            SQLTableMacro.expansion(
+                of: node,
+                attachedTo: declaration,
+                providingExtensionsOf: type,
+                conformingTo: [],
+                in: context
+            )
+        )
+    }
+}
+
+
+/// `@SQLResult`'s counterpart to `SQLTableRequestingSendableMacro`.
+private struct SQLResultRequestingSendableMacro: ExtensionMacro {
+
+    static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        try extensionSignatures(
+            SQLResultMacro.expansion(
+                of: node,
+                attachedTo: declaration,
+                providingExtensionsOf: type,
+                conformingTo: [TypeSyntax(stringLiteral: "Sendable")],
+                in: context
+            )
+        )
+    }
+}
+
+
+/// `@SQLResult`'s counterpart to `SQLTableSatisfyingSendableMacro`.
+private struct SQLResultSatisfyingSendableMacro: ExtensionMacro {
+
+    static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        try extensionSignatures(
+            SQLResultMacro.expansion(
+                of: node,
+                attachedTo: declaration,
+                providingExtensionsOf: type,
+                conformingTo: [],
+                in: context
+            )
+        )
+    }
+}
+
+
+private func makeSendableTestMacros() -> [String: Macro.Type] {
+    [
+        "SQLTable": SQLTableRequestingSendableMacro.self,
+        "SQLResult": SQLResultRequestingSendableMacro.self,
+    ]
+}
+
+private func makeAlreadySendableTestMacros() -> [String: Macro.Type] {
+    [
+        "SQLTable": SQLTableSatisfyingSendableMacro.self,
+        "SQLResult": SQLResultSatisfyingSendableMacro.self,
+    ]
+}
+
+
 final class SQLMacroDiagnosticTests: XCTestCase {
 
     func test_missingTypeAnnotation_emitsError() {
@@ -1491,4 +1632,234 @@ final class MetaBuilderTests: XCTestCase {
             .joined(separator: ", ")
         XCTAssertTrue(source.contains("fields: [\(expectedFieldsExpression)].flatMap { $0 },"))
     }
+}
+
+
+// Issue #531: the model macros declare the model's `Sendable` conformance, so a value type built
+// from column values does not need it written out by hand at every public declaration.
+//
+// The assertions below run against extension *signatures* (see `extensionSignatures`), so they
+// read as a statement about conformances rather than about the metadata surface that happens to
+// travel in the same extensions.
+final class SQLMacroSendableConformanceTests: XCTestCase {
+
+    // The ordinary case: a public model of plain column types. The `Sendable` extension is added
+    // after the metadata extensions, which are themselves unchanged.
+    func test_sendableConformanceIsGeneratedWhenTheCompilerRequestsIt() {
+        assertMacroExpansion(
+            """
+            @SQLTable
+            public struct Person {
+                public var id: String
+                public var occupationId: String?
+                public var name: String
+                public var age: Int
+            }
+            """,
+            expandedSource: """
+            public struct Person {
+                public var id: String
+                public var occupationId: String?
+                public var name: String
+                public var age: Int
+            }
+
+            extension Person: XLResult {
+            }
+
+            extension Person: XLTable {
+            }
+
+            extension Person: Sendable {
+            }
+            """,
+            macros: makeSendableTestMacros()
+        )
+    }
+
+    // The compiler drops a conformance the declaration already states from the requested list, so
+    // a model written `: Sendable` (or `: @unchecked Sendable`, for a property whose safety its
+    // author vouches for) keeps its own conformance and gets no second, conflicting one.
+    func test_sendableConformanceIsOmittedWhenTheDeclarationAlreadyStatesIt() {
+        assertMacroExpansion(
+            """
+            @SQLTable
+            public struct Person: Sendable {
+                public var id: String
+                public var name: String
+            }
+            """,
+            expandedSource: """
+            public struct Person: Sendable {
+                public var id: String
+                public var name: String
+            }
+
+            extension Person: XLResult {
+            }
+
+            extension Person: XLTable {
+            }
+            """,
+            macros: makeAlreadySendableTestMacros()
+        )
+    }
+
+    // `@SQLResult` derives the conformance on the same terms as `@SQLTable`: a projection decoded
+    // from a row is as much a value type as the table row it came from.
+    func test_sendableConformanceIsGeneratedForResultTypes() {
+        assertMacroExpansion(
+            """
+            @SQLResult
+            public struct Projection {
+                public var id: Int
+                public var name: String?
+            }
+            """,
+            expandedSource: """
+            public struct Projection {
+                public var id: Int
+                public var name: String?
+            }
+
+            extension Projection: XLResult {
+            }
+
+            extension Projection: Sendable {
+            }
+            """,
+            macros: makeSendableTestMacros()
+        )
+    }
+
+    func test_sendableConformanceIsOmittedForResultTypesThatAlreadyStateIt() {
+        assertMacroExpansion(
+            """
+            @SQLResult
+            public struct Projection: Sendable {
+                public var id: Int
+            }
+            """,
+            expandedSource: """
+            public struct Projection: Sendable {
+                public var id: Int
+            }
+
+            extension Projection: XLResult {
+            }
+            """,
+            macros: makeAlreadySendableTestMacros()
+        )
+    }
+
+    // A generic model would need a *conditional* conformance, and an extension macro cannot write
+    // one: the compiler reports `circular reference expanding extension macros` because resolving
+    // the `where` clause needs the generic signature, which needs the type's extensions, which is
+    // what the macro is producing. So generic models are left as they were -- including SwiftQL's
+    // own public `#row` shapes, `SQLScalarResult<T>` and `SQLRow2<C0, C1>`...`SQLRow6`, whose
+    // parameters are constrained to `XLLiteral & XLExpression` and are not `Sendable` on their own
+    // account. This pins the exclusion, because the failure it prevents is a build error in the
+    // library itself rather than a warning anyone could overlook.
+    func test_sendableConformanceIsNotGeneratedForGenericResultTypes() {
+        assertMacroExpansion(
+            """
+            @SQLResult
+            public struct Pair<C0, C1> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression {
+                public var first: C0
+                public var second: C1
+            }
+            """,
+            expandedSource: """
+            public struct Pair<C0, C1> where C0: XLLiteral & XLExpression, C1: XLLiteral & XLExpression {
+                public var first: C0
+                public var second: C1
+            }
+
+            extension Pair: XLResult {
+            }
+            """,
+            macros: makeSendableTestMacros()
+        )
+    }
+
+    func test_sendableConformanceIsNotGeneratedForGenericTables() {
+        assertMacroExpansion(
+            """
+            @SQLTable
+            public struct Box<Value> where Value: XLLiteral & XLExpression {
+                public var id: Int
+                public var value: Value
+            }
+            """,
+            expandedSource: """
+            public struct Box<Value> where Value: XLLiteral & XLExpression {
+                public var id: Int
+                public var value: Value
+            }
+
+            extension Box: XLResult {
+            }
+
+            extension Box: XLTable {
+            }
+            """,
+            macros: makeSendableTestMacros()
+        )
+    }
+
+    // A `package` model is visible outside its module on the same terms as a `public` one, so the
+    // inference is withheld from it too and the macro supplies the conformance.
+    func test_sendableConformanceIsGeneratedForPackageModels() {
+        assertMacroExpansion(
+            """
+            @SQLResult
+            package struct Projection {
+                package var id: Int
+            }
+            """,
+            expandedSource: """
+            package struct Projection {
+                package var id: Int
+            }
+
+            extension Projection: XLResult {
+            }
+
+            extension Projection: Sendable {
+            }
+            """,
+            macros: makeSendableTestMacros()
+        )
+    }
+
+    // An `internal` model -- the default, and what most declarations in an app are -- already has
+    // a compiler-inferred conformance derived from its actual stored properties. Generating a
+    // second one adds nothing and can only take something away: an internal model holding a
+    // non-`Sendable` property would start being diagnosed where the inference simply declines to
+    // apply.
+    func test_sendableConformanceIsNotGeneratedForInternalModels() {
+        assertMacroExpansion(
+            """
+            @SQLTable
+            struct Person {
+                var id: String
+                var name: String
+            }
+            """,
+            expandedSource: """
+            struct Person {
+                var id: String
+                var name: String
+            }
+
+            extension Person: XLResult {
+            }
+
+            extension Person: XLTable {
+            }
+            """,
+            macros: makeSendableTestMacros()
+        )
+    }
+
 }

--- a/Tests/SQLTests/SQLModelSendableConformanceTests.swift
+++ b/Tests/SQLTests/SQLModelSendableConformanceTests.swift
@@ -17,6 +17,11 @@ import Foundation
 import SwiftQL
 import XCTest
 
+// Gated to match the macro: Swift 5.9 treats a macro-expanded extension as a separate source file
+// for the rule that a `Sendable` conformance must be declared alongside its type, so the
+// conformance is generated on Swift 6.0 and later only. See COMPATIBILITY.md.
+#if compiler(>=6.0)
+
 
 /// A public table model of plain column types, the shape `SwiftQLExamples.Person` has.
 @SQLTable(name: "SendableConformancePerson")
@@ -105,3 +110,5 @@ final class SQLModelSendableConformanceTests: XCTestCase {
         XCTAssertEqual(Self.seedPeople.count, 2)
     }
 }
+
+#endif

--- a/Tests/SQLTests/SQLModelSendableConformanceTests.swift
+++ b/Tests/SQLTests/SQLModelSendableConformanceTests.swift
@@ -1,0 +1,107 @@
+//
+//  SQLModelSendableConformanceTests.swift
+//  SwiftQL
+//
+//  Issue #531: a `public` model declared with `@SQLTable` or `@SQLResult` conforms to `Sendable`,
+//  so a value built entirely from column values can be shared across isolation domains without
+//  the conformance being written out by hand -- or, worse, without the checking being switched
+//  off with `nonisolated(unsafe)`.
+//
+//  These fixtures are `public` on purpose. Swift infers `Sendable` for an `internal` struct of
+//  `Sendable` stored properties on its own, so an internal fixture would pass whether or not the
+//  macro did anything; it withholds the inference from a type other modules can see, which is
+//  exactly the case the macro covers and exactly the case that warned in `SwiftQLExamples`.
+//
+
+import Foundation
+import SwiftQL
+import XCTest
+
+
+/// A public table model of plain column types, the shape `SwiftQLExamples.Person` has.
+@SQLTable(name: "SendableConformancePerson")
+public struct SendableConformancePersonTable {
+
+    public var id: String
+
+    public var occupationId: String?
+
+    public var name: String
+
+    public var age: Int
+}
+
+
+/// A second table with a different column mix -- `Double`, `Bool`, `Data`, `Date` -- so the
+/// conformance is shown to follow from the macro rather than from one fixture's property types.
+@SQLTable(name: "SendableConformanceMeasurement")
+public struct SendableConformanceMeasurementTable {
+
+    public var id: Int
+
+    public var value: Double
+
+    public var calibrated: Bool
+
+    public var payload: Data
+
+    public var recordedAt: Date
+}
+
+
+/// A public projection, to pin that `@SQLResult` derives the conformance on the same terms.
+@SQLResult
+public struct SendableConformanceProjection {
+
+    public var id: String
+
+    public var total: Int?
+}
+
+
+/// A model that states the conformance itself. The macro generates nothing here, and the
+/// declaration keeps its own conformance rather than colliding with a second one.
+@SQLTable(name: "SendableConformanceExplicit")
+public struct SendableConformanceExplicitTable: Sendable {
+
+    public var id: String
+
+    public var name: String
+}
+
+
+/// Compiles only if `T` conforms to `Sendable`. The requirement is an ordinary generic
+/// constraint, so it is checked in every language mode rather than only under strict concurrency.
+private func requireSendable<T: Sendable>(_: T.Type) {}
+
+
+final class SQLModelSendableConformanceTests: XCTestCase {
+
+    // The `static let` of models is the exact declaration that warned in
+    // `Examples/Sources/SwiftQLExamples/ExampleDatabase.swift`: a non-`Sendable` element type
+    // makes the array non-`Sendable`, which makes the static property unsafe to share.
+    static let seedPeople: [SendableConformancePersonTable] = [
+        SendableConformancePersonTable(id: "fred", occupationId: "eng", name: "Fred", age: 31),
+        SendableConformancePersonTable(id: "ida", occupationId: nil, name: "Ida", age: 68),
+    ]
+
+    func test_publicTableModelConformsToSendable() {
+        requireSendable(SendableConformancePersonTable.self)
+        requireSendable(SendableConformanceMeasurementTable.self)
+    }
+
+    func test_publicResultModelConformsToSendable() {
+        requireSendable(SendableConformanceProjection.self)
+    }
+
+    func test_modelStatingTheConformanceItselfKeepsIt() {
+        requireSendable(SendableConformanceExplicitTable.self)
+    }
+
+    // A collection of models is `Sendable` too, which is what the failing example needed.
+    func test_collectionsOfModelsAreSendable() {
+        requireSendable([SendableConformancePersonTable].self)
+        requireSendable([String: SendableConformanceProjection].self)
+        XCTAssertEqual(Self.seedPeople.count, 2)
+    }
+}

--- a/Tests/SQLTests/XLLiveQueryWaitSupport.swift
+++ b/Tests/SQLTests/XLLiveQueryWaitSupport.swift
@@ -122,7 +122,14 @@ extension XLAwaitableState {
 /// particular queue -- rather than evolving state. Awaiting the callback *itself* and then asserting
 /// on what it carried keeps the wrong outcome a test failure rather than a hang, which is not true
 /// of waiting for a flag that is only set when the outcome is already the expected one.
-final class XLAwaitableValue<Value>: @unchecked Sendable {
+///
+/// `Value` is constrained to `Sendable` because `fulfill` hands it to a continuation that resumes
+/// on whichever task is waiting, and under complete strict-concurrency checking that crossing is
+/// `sending 'newValue' risks causing data races`. `XLAwaitableState` above needs no such
+/// constraint: its waiters resume with `Void` and read the value back through the lock. Every
+/// caller already passes a `Sendable` value (`Bool`, `Void`), so the constraint costs nothing and
+/// states what the type has always needed from them.
+final class XLAwaitableValue<Value: Sendable>: @unchecked Sendable {
 
     private let lock = NSLock()
 


### PR DESCRIPTION
Closes #531

## Summary

`SwiftQLExamples` fails the complete strict-concurrency gate on two warnings:

```
ExampleDatabase.swift:42:23: warning: static property 'seedOccupations' is not concurrency-safe
  because non-'Sendable' type '[Occupation]' may have shared mutable state
ExampleDatabase.swift:48:23: warning: static property 'seedPeople' is not concurrency-safe
  because non-'Sendable' type '[Person]' may have shared mutable state
```

#531 asked which of two fixes to take. The library change was chosen, so `@SQLTable` (and `@SQLResult`) now declare the model's `Sendable` conformance, which fixes every downstream user's identical warning rather than this one call site.

## Why the conformance was missing in the first place

`Occupation` and `Person` are structs of `String`/`Int`/`Int?`. Swift already infers `Sendable` for a struct whose stored properties are all `Sendable`, so the interesting question is why the inference did not apply. It is withheld from a type other modules can see: a conformance visible outside the module is an API promise the declaring module has to make on purpose, so `public` (and `package`) types are excluded. Model types are exactly the types users declare `public`, which is why the warning shows up the moment one is stored in a `static let`.

So the macro fills in that gap and nothing else:

| Model | Before | After |
|---|---|---|
| `public` / `package` | no conformance | `extension Model: Sendable {}` generated |
| `internal` or narrower | inferred by the compiler | unchanged, still inferred |
| states `Sendable` or `@unchecked Sendable` itself | its own conformance | unchanged, nothing generated |
| generic | no conformance | unchanged, nothing generated |
| any model, Swift 5.9 | no conformance | unchanged, nothing generated |

Four properties of the mechanism are worth a reviewer's attention.

**It is checked, not asserted.** `extension Model: Sendable {}` is an ordinary conformance, so a stored property whose type is not `Sendable` is diagnosed by the compiler on the generated extension. The macro never writes `@unchecked`, so no model can claim to be `Sendable` when it is not. This is the one behaviour change for existing code: a `public` model holding a non-`Sendable` property now gets a diagnostic where it previously compiled silently. Declaring that model `@unchecked Sendable` takes responsibility for the property and turns the generation off.

**It defers to the declaration.** `Sendable` was added to the `conformances:` list of the `@attached(extension, ...)` declarations, so the compiler hands the macro only the conformances the type does not already have. A model written `: Sendable` yields an empty list and gets nothing generated, which is why `Examples/TodoApp`'s `TodoKit` schema (six models, all already `: Sendable`) compiles unchanged.

**Generic models are excluded, and the reason is a hard compiler limit rather than caution.** A generic model needs a *conditional* conformance, one `Sendable` requirement per generic parameter, the way the inference produces one. An extension macro cannot write that: resolving the `where` clause needs the type's generic signature, resolving that needs every extension of the type, and expanding those extension macros is where the requirement came from. The first attempt at this PR did write it, and the compiler stopped with `circular reference expanding extension macros` on `SQLScalarResult`, `SQLRow2`...`SQLRow6` and on a `private` generic fixture in `StaticRowLayoutGRDBTests`. Those shapes were not `Sendable` before this either, so nothing regresses; a generic model that should be `Sendable` says so itself, `extension MyRow: Sendable where T: Sendable {}`, and the macro then defers to it like any other stated conformance.

**Swift 6.0 and later only**, which the first CI run on this PR established. Swift 5.9 treats a macro-expanded extension as a separate source file for the rule that a `Sendable` conformance must be declared alongside its type, so both 5.9 cells failed with one warning per model:

```
warning: conformance to 'Sendable' must occur in the same source file as struct 'Occupation';
  use '@unchecked Sendable' for retroactive conformance
```

The spelling the compiler suggests there is the one thing this change exists to avoid, so 5.9 keeps the behaviour it had, gated by `#if compiler(>=6.0)` in `makeSendableExtension`. SwiftPM builds a macro plugin with the same toolchain that compiles the client, so the gate resolves per compilation rather than per plugin build. COMPATIBILITY.md records the divergence next to the existing `#row` one, and both new test files carry the same gate.

The access-level restriction is worth its own line: generating a redundant conformance for an `internal` model would buy nothing, since the inference is derived from the model's actual stored properties and is therefore strictly more precise, and it could only take something away, since an internal model holding a non-`Sendable` property would start being diagnosed where the inference simply declines to apply.

## One fix outside the issue's scope

With the two example warnings gone, `Swift 6.0 / clean resolution` still failed the gate on one more first-party warning, in the wait helper #467 landed on `version/1.5.6` a few hours before this PR:

```
Tests/SQLTests/XLLiveQueryWaitSupport.swift:146:20: warning: sending 'newValue' risks causing
  data races; this is an error in the Swift 6 language mode
```

`XLAwaitableValue.fulfill` hands the value to a continuation that resumes on whichever task is waiting. `Value` is now constrained to `Sendable`; both callers already pass `Bool` or `Void`, so the constraint costs nothing. `XLAwaitableState` needs no equivalent, since its waiters resume with `Void` and read the value back through the lock.

Normally this would be filed separately, the way #531 itself was filed out of #230. It is fixed here because the gate is a single job, so #531's "done when" cannot be verified while that warning stands. Reverting it is one line if you would rather it went on its own issue.

## Changes

- `Sources/SwiftQL/SQL.swift` — `Sendable` added to the `conformances:` list of `@SQLTable` and `@SQLResult`, with the reasoning and the opt-out in the macro doc comments.
- `Sources/SQLMacros/SQLMacro.swift` — `makeSendableExtension(builder:conformingTo:)`, called from both extension expansions.
- `Sources/SwiftQL/SwiftQL.docc/GettingStarted.md` — one paragraph under "Defining tables", since this is the page where a reader meets `@SQLTable`.
- `COMPATIBILITY.md` — the Swift 5.9 divergence, under "Swift 5.9 and Swift 6.0 API surface gaps".
- `CHANGELOG.md` — recorded under `### Added` as a public API addition, including the behaviour change for a public model with a non-`Sendable` property.
- `Tests/SQLTests/XLLiveQueryWaitSupport.swift` — the out-of-scope fix above.

## Tests

`Tests/SQLMacrosTests/SQLTests.swift` gains `SQLMacroSendableConformanceTests`, eight expansion assertions covering every row of the table above for both macros. They run against extension *signatures* (an `extensionSignatures` helper strips the member blocks), so a conformance test reads as a statement about conformances while still showing the new extension is added to the existing `XLResult`/`XLTable` ones rather than replacing them. `assertMacroExpansion` has no macro declaration to read a `conformances:` list from, so the wrappers supply the protocol list the compiler would.

`Tests/SQLTests/SQLModelSendableConformanceTests.swift` is the end-to-end check: `public` `@SQLTable` and `@SQLResult` fixtures passed through `requireSendable<T: Sendable>`. The fixtures are `public` on purpose, because an `internal` one would pass whether or not the macro did anything. One of them holds `Double`/`Bool`/`Data`/`Date` rather than the example's `String`/`Int`, and one is a `static let` array, which is the exact declaration shape that warned. `requireSendable` is a plain generic constraint, so it fails to compile in any language mode if the conformance regresses.

## Test plan

- [x] `scripts/ci/check-strict-concurrency.sh` locally — both `ExampleDatabase.swift` warnings gone
- [x] Baseline run of the same script on `version/1.5.6` at `4904479`, for comparison. Five other first-party warnings appear in both runs (`JSONValueCodec.swift` x4, `XLAsyncStreamPublisher.swift`); they are pre-existing, unrelated, and only appear under the local Swift 6.2 toolchain, not under the Swift 6.0 cell the gate runs on.
- [x] `SWIFTQL_FIRST_PARTY_WARNING_GATE_FIRST_PARTY_WARNINGS: <none>` on Swift 6.0 clean resolution
- [x] Full `swift test` — 1221 tests green locally
- [x] Swift 5.9 committed resolution green; Swift 5.9 clean resolution's only failure is the known `XLPublisherTests.testDistinctDatabasePoolsDoNotCrossTrigger` flake
- [x] `Examples/TodoApp/TodoKit`'s six models already declare `Sendable`, so the macro generates nothing for them
- [x] `Swift 6.0 / clean resolution` green (run 30754796456) — the job that runs `Check complete strict concurrency`, and the one this issue is about
- [x] Both Swift 5.9 cells green on the same run
- [x] Remaining red jobs are "To-do demo app" and "Check the Getting Started playground", which fail identically on `version/1.5.6` itself (run 30750983869) and are not touched here. That run's third failure, `Swift 6.0 / clean resolution → Check complete strict concurrency`, is the one this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
