### PR TITLE
Fire a scheduled retry only once the bridge has subscribed

### DIFF
--- a/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
+++ b/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
@@ -176,8 +176,13 @@ private final class AsyncStreamInjectedBusyFunctionState: @unchecked Sendable {
 private final class AsyncStreamManualRetryScheduler: @unchecked Sendable {
 
     private struct PendingDelay {
+        let id: UUID
         let delay: TimeInterval
         let subject: PassthroughSubject<Void, Never>
+        /// `true` once the bridge has actually subscribed to `subject`. Firing before that point
+        /// sends into a `PassthroughSubject` with no subscriber, which drops the value -- and the
+        /// retry then never starts. See ``scheduler`` and ``waitForPendingDelays(_:)``.
+        var isSubscribed = false
     }
 
     /// Awaitable, so a test waits for "the backoff for attempt N has been scheduled" and is resumed
@@ -186,16 +191,42 @@ private final class AsyncStreamManualRetryScheduler: @unchecked Sendable {
 
     private let recorded = XLAwaitableState<[TimeInterval]>([])
 
+    /// The scheduling seam handed to the bridge.
+    ///
+    /// `GRDBLiveQueryAsyncBridge.scheduleRetry(after:)` subscribes to this publisher only *after*
+    /// this closure returns, while a test can see the delay in `pending` as soon as it is appended
+    /// -- from inside the closure. Firing in that window sends into a subject with no subscriber,
+    /// the value is dropped, and the retry never starts, which hangs the consumer. Recording the
+    /// subscription here is what lets ``waitForPendingDelays(_:)`` wait for a delay that is
+    /// genuinely safe to fire.
+    ///
+    /// The window was always open; polling for `pendingDelays` merely hid it by waiting out a 10ms
+    /// poll interval before firing. Awaiting the append directly (#467) closed that accidental gap
+    /// and made it reachable -- roughly 1 run in 8 under CPU-saturating load.
     var scheduler: GRDBLiveQueryRetryScheduler {
         GRDBLiveQueryRetryScheduler { [weak self] delay in
             guard let self else {
                 return Empty(completeImmediately: false).eraseToAnyPublisher()
             }
             let subject = PassthroughSubject<Void, Never>()
+            let id = UUID()
             self.recorded.withValue { $0.append(delay) }
             // Appended last, so a test resumed by this write already sees the delay recorded.
-            self.pending.withValue { $0.append(PendingDelay(delay: delay, subject: subject)) }
-            return subject.eraseToAnyPublisher()
+            self.pending.withValue {
+                $0.append(PendingDelay(id: id, delay: delay, subject: subject))
+            }
+            return subject
+                .handleEvents(receiveSubscription: { [weak self] _ in
+                    self?.markSubscribed(id)
+                })
+                .eraseToAnyPublisher()
+        }
+    }
+
+    private func markSubscribed(_ id: UUID) {
+        pending.withValue { pending in
+            guard let index = pending.firstIndex(where: { $0.id == id }) else { return }
+            pending[index].isSubscribed = true
         }
     }
 
@@ -207,10 +238,13 @@ private final class AsyncStreamManualRetryScheduler: @unchecked Sendable {
         recorded.read()
     }
 
-    /// Suspends until exactly `expected` is outstanding -- the deterministic replacement for polling
-    /// `pendingDelays` until it matches.
+    /// Suspends until exactly `expected` is outstanding *and every outstanding delay has been
+    /// subscribed to*, which is the point from which ``runNext()`` is guaranteed to be delivered.
+    /// The deterministic replacement for polling `pendingDelays` until it matches.
     func waitForPendingDelays(_ expected: [TimeInterval]) async {
-        await pending.wait(until: { $0.map(\.delay) == expected })
+        await pending.wait(until: { pending in
+            pending.map(\.delay) == expected && pending.allSatisfy(\.isSubscribed)
+        })
     }
 
     @discardableResult


### PR DESCRIPTION
Refs #463 (found by #468's repeat run; write-up: https://github.com/lukevanin/swiftql/issues/463#issuecomment-5158544713)

## Summary

The first attempt at #468's 50-run sequence **hung** on run 5. Not an assertion failure -- `GRDBLiveQueryAsyncStreamTests.testDeliveredValueResetsRetryBudget` started and never finished, with the process completely idle: main thread parked in `XCTWaiter`, every cooperative-pool thread idle, no runnable Swift task. Killed after 340s.

Reproduced in isolation, one CPU spinner per core, killing any run over 25s:

```
head:     pass=35 fail=0 hang=5  of 40      # version/1.5.6 at 445ddd4c, after #467
baseline: pass=40 fail=0 hang=0  of 40      # c36bf8fc, before this chain
```

## Mechanism

Instrumenting the test showed the wait completing normally and the retry never starting:

```
PROBE: waiting for pending delays
PROBE: got pending delays
PROBE: ran next, awaiting value
PROBE-TIMEOUT pending=[] recorded=[0.1] invocations=1
```

`AsyncStreamManualRetryScheduler`'s scheduling closure appends the delay to `pending` and returns a `PassthroughSubject`. `GRDBLiveQueryAsyncBridge.scheduleRetry(after:)` subscribes to that publisher only *after* the closure returns. A test that observes `pending` and fires in the window between those two points sends into a subject with no subscriber, the value is dropped, and the retry never starts -- so `next()` stays suspended forever.

The window was always open. Polling for `pendingDelays` hid it: `waitUntil` slept out its own 10ms poll interval before firing, which was always long enough. #467 replaced that poll with an await resumed by the append itself, which fires immediately -- correct in itself, and it made the harness's race reachable.

This is a test-harness defect, not a production one. A real timer-backed scheduler cannot fire before its own subscription exists.

## Fix

The harness records the subscription via `handleEvents(receiveSubscription:)`, and `waitForPendingDelays(_:)` now waits for every outstanding delay to be **subscribed** as well as scheduled -- the point from which `runNext()` is guaranteed to be delivered. Firing stays asynchronous and post-subscription, so the production path runs exactly as it did before.

**A replaying subject was tried first and rejected.** Swapping `PassthroughSubject` for a `CurrentValueSubject` that replays to a late subscriber still hung, 3 times in 40: replaying delivers the value synchronously inside the bridge's own `sink(...)` call, re-entering its state machine before `scheduleRetry` has finished storing the cancellable. Waiting for the subscription is the fix that does not change *when* production code runs.

## Related, deliberately not changed

`GRDBLiveQueryRetryTests`' own `ManualRetryScheduler` has the same shape and the same latent window. It has no reported flake, is expectation-driven (its `wait(for:)` round trip closes the window in practice), and is explicitly out of #467's scope. Worth knowing about if that suite ever starts hanging.

## Test plan

- [x] `swift build --build-tests` -- no warnings
- [x] `GRDBLiveQueryAsyncStreamTests` + `GRDBLiveQueryRetryTests` -- 27/27
- [x] **100 runs of `GRDBLiveQueryAsyncStreamTests` under one spinner per core (40 + 60 in two passes): 0 hangs, 0 failures**, against 5 hangs in 40 before the fix
- [x] Full `swift test` -- green (and #468's restarted 50-run sequence runs on top of this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)