### PR TITLE
Route MetaUpdate columns through key-path lookup so every spelling assigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,26 @@
   manifest format, the CLI surface, and every existing pass/fail outcome are
   unchanged, and canonical reports remain byte-identical across repeated runs.
 
+- Nullable columns are now assigned in a `Setting` closure the way any Swift
+  optional is: `row.occupationId = "occ-1"` sets the column and
+  `row.occupationId = nil` sets it to SQL `NULL`. Previously the generated
+  setter's type was `Optional<any XLExpression<T?>>`, where the outer
+  `Optional` meant "leave this column out of the `SET` clause" — that collided
+  with the column's own optionality, and no assignment of a value or of `nil`
+  compiled at all. A nullable column's setter now takes an expression of the
+  column's *wrapped* type, and whether the column takes part in the `SET`
+  clause is tracked separately by the new `@XLNullableColumnUpdate` wrapper, so
+  the two meanings no longer share one `Optional`. A column the closure never
+  assigns still stays out of the statement.
+
+  **Source break, nullable columns only.** An expression that is itself
+  optional-typed — a `XLNamedBindingReference<T?>` whose bound value may be
+  `NULL` at runtime, or another nullable column — no longer assigns to the
+  setter directly; assign it to the projected value instead
+  (`row.$occupationId = parameter`). Non-optional columns are unchanged, as is
+  `MetaUpdate`'s initializer, where a `nil` argument still means "omit this
+  column".
+
 ### Fixed
 
 - Fixed `SwiftQLSQLiteBuildValidationPlugin` failing every Xcode build of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,27 +53,25 @@
   manifest format, the CLI surface, and every existing pass/fail outcome are
   unchanged, and canonical reports remain byte-identical across repeated runs.
 
-- Nullable columns are now assigned in a `Setting` closure the way any Swift
-  optional is: `row.occupationId = "occ-1"` sets the column and
-  `row.occupationId = nil` sets it to SQL `NULL`. Previously the generated
-  setter's type was `Optional<any XLExpression<T?>>`, where the outer
-  `Optional` meant "leave this column out of the `SET` clause" — that collided
-  with the column's own optionality, and no assignment of a value or of `nil`
-  compiled at all. A nullable column's setter now takes an expression of the
-  column's *wrapped* type, and whether the column takes part in the `SET`
-  clause is tracked separately by the new `@XLNullableColumnUpdate` wrapper, so
-  the two meanings no longer share one `Optional`. A column the closure never
-  assigns still stays out of the statement.
-
-  **Source break, nullable columns only.** An expression that is itself
-  optional-typed — a `XLNamedBindingReference<T?>` whose bound value may be
-  `NULL` at runtime, or another nullable column — no longer assigns to the
-  setter directly; assign it to the projected value instead
-  (`row.$occupationId = parameter`). Non-optional columns are unchanged, as is
-  `MetaUpdate`'s initializer, where a `nil` argument still means "omit this
-  column".
-
 ### Fixed
+
+- Nullable columns can now be assigned in a `Setting` closure the way any
+  Swift optional is: `row.occupationId = "occ-1"` sets the column,
+  `row.occupationId = nil` sets it to SQL `NULL`, and an optional-typed
+  expression — a `XLNamedBindingReference<String?>` whose bound value may be
+  `NULL` at runtime, or another nullable column — assigns with the same
+  spelling. Previously the generated setter's type was
+  `Optional<any XLExpression<T?>>`, where the outer `Optional` meant "leave
+  this column out of the `SET` clause"; that collided with the column's own
+  optionality, and no assignment of a plain value or of `nil` compiled at
+  all. Generated `MetaUpdate` types now route column assignment through
+  key-path member lookup over typed per-column slots (`XLColumnUpdate` /
+  `XLNullableColumnUpdate`), so participation in the `SET` clause is tracked
+  separately from the value's own optionality and one column name resolves
+  against every assignment shape. A column the closure never assigns still
+  stays out of the statement, non-optional columns behave as before, and
+  `MetaUpdate`'s memberwise initializer keeps its v1 shape, where a `nil`
+  argument still means "omit this column".
 
 - Fixed `SwiftQLSQLiteBuildValidationPlugin` failing every Xcode build of a
   plugin-adopting target (issue #492). `context.tool(named:)` resolves a

--- a/Examples/GettingStarted.playground/Pages/4 Update statements.xcplaygroundpage/Contents.swift
+++ b/Examples/GettingStarted.playground/Pages/4 Update statements.xcplaygroundpage/Contents.swift
@@ -61,18 +61,15 @@ print("ida:", try database.fetchPersonByID(id: "ida")?.exampleSummary ?? "no mat
 /*:
  ## Setting a nullable column
 
- Both columns above are non-optional. `Person.occupationId` is `String?`, so
- its generated setter type is `Optional<any XLExpression<String?>>`. The outer
- `Optional` means "leave this column out of the `SET` clause" — a different
- thing from the column's own optionality, so assigning a plain `String` or
- `String?` value does not compile. `toNullable()` lifts a non-optional value
- expression into that slot:
+ Both columns above are non-optional. `Person.occupationId` is `String?`, and
+ it is assigned the way any Swift optional is — a value sets the column, and
+ `nil` sets it to SQL `NULL`.
  */
 let hireFred = sql { schema in
     let person = schema.into(Person.self)
     Update(person)
     Setting(person) { row in
-        row.occupationId = "chef".toNullable()
+        row.occupationId = "chef"
     }
     Where(person.id == "fred")
 }
@@ -81,17 +78,11 @@ try database.makeRequest(with: hireFred).execute()
 print("fred's occupation:", try database.fetchPersonByID(id: "fred")?.occupationId ?? "none")
 //: Prints `fred's occupation: chef`
 
-/*:
- Clearing the column back to `NULL` needs an already-*optional* value, so cast
- it to the existential explicitly instead of relying on `toNullable()`, which
- only accepts a non-optional expression:
- */
 let retireFred = sql { schema in
     let person = schema.into(Person.self)
     Update(person)
     Setting(person) { row in
-        let clearedOccupationId: String? = nil
-        row.occupationId = clearedOccupationId as any XLExpression<String?>
+        row.occupationId = nil
     }
     Where(person.id == "fred")
 }
@@ -99,6 +90,30 @@ try database.makeRequest(with: retireFred).execute()
 
 print("fred's occupation:", try database.fetchPersonByID(id: "fred")?.occupationId ?? "none")
 //: Prints `fred's occupation: none`
+
+/*:
+ Setting a column to `NULL` is not the same as leaving it out of the statement.
+ A column the closure never assigns takes no part in the `SET` clause and keeps
+ the value the row already held — which is why the `row.age = 42` update at the
+ top of this page left Fred's occupation untouched.
+
+ The value assigned is an expression of the column's *wrapped* type, so
+ literals and non-optional expressions assign directly. An expression that is
+ itself optional-typed — a binding whose value may be `NULL` at runtime — is
+ assigned through the projected value with `$`. The named bindings page covers
+ how the value reaches that placeholder.
+ */
+let occupationParameter = XLNamedBindingReference<String?>(name: "occupationId")
+
+let setOccupationFromBinding = sql { schema in
+    let person = schema.into(Person.self)
+    Update(person)
+    Setting(person) { row in
+        row.$occupationId = occupationParameter
+    }
+    Where(person.id == "fred")
+}
+_ = setOccupationFromBinding
 
 /*:
  ## Updating everything that matches

--- a/Examples/GettingStarted.playground/Pages/4 Update statements.xcplaygroundpage/Contents.swift
+++ b/Examples/GettingStarted.playground/Pages/4 Update statements.xcplaygroundpage/Contents.swift
@@ -97,11 +97,10 @@ print("fred's occupation:", try database.fetchPersonByID(id: "fred")?.occupation
  the value the row already held — which is why the `row.age = 42` update at the
  top of this page left Fred's occupation untouched.
 
- The value assigned is an expression of the column's *wrapped* type, so
- literals and non-optional expressions assign directly. An expression that is
- itself optional-typed — a binding whose value may be `NULL` at runtime — is
- assigned through the projected value with `$`. The named bindings page covers
- how the value reaches that placeholder.
+ Any expression of the column's wrapped type (`String`) or of its optional
+ type (`String?`) assigns the same way, so a named binding whose runtime value
+ may be `NULL` needs no special spelling. The named bindings page covers how
+ the value reaches that placeholder.
  */
 let occupationParameter = XLNamedBindingReference<String?>(name: "occupationId")
 
@@ -109,7 +108,7 @@ let setOccupationFromBinding = sql { schema in
     let person = schema.into(Person.self)
     Update(person)
     Setting(person) { row in
-        row.$occupationId = occupationParameter
+        row.occupationId = occupationParameter
     }
     Where(person.id == "fred")
 }

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -106,14 +106,6 @@ The live-queries page drives the main run loop instead, with
 there lives in a `Task` owned by a view model and nothing waits on the main
 thread.
 
-Assigning a nullable column in a `Setting` closure has a non-obvious spelling.
-The generated setter's type is `Optional<any XLExpression<T?>>`, where the
-outer `Optional` means "leave this column out of the `SET` clause", and that
-collides with the value's own optionality. `toNullable()` lifts a non-optional
-value expression into that slot, and an explicit `any XLExpression<T?>` cast
-assigns an already-optional value, including `nil` to clear the column back to
-`NULL`. The update page covers both.
-
 ## Keeping it working
 
 `SwiftQLExamples` is a first-party target, so `swift build` and the CI warning

--- a/Sources/SQLMacros/MetaBuilder.swift
+++ b/Sources/SQLMacros/MetaBuilder.swift
@@ -1061,33 +1061,75 @@ internal struct MetaBuilder {
             
             context.line("public typealias Row = \(structName)")
             
+            // A nullable column needs two independent pieces of state: whether
+            // it takes part in the SET clause, and whether the value it is set
+            // to is NULL. `Optional` alone cannot carry both -- reusing it for
+            // participation is what made `row.column = nil` and
+            // `row.column = value` unspellable -- so nullable columns go
+            // through a wrapper that tracks participation separately. The
+            // wrapped value is an expression of the column's *wrapped* type,
+            // which is what lets a literal or a non-optional expression assign
+            // directly.
             for property in properties {
-                context.line("public var \(property.name): Optional<any SwiftQL.XLExpression<\(property.qualifiedType)>>")
+                if property.optional {
+                    context.line("@SwiftQL.XLNullableColumnUpdate public var \(property.name): Optional<any SwiftQL.XLExpression<\(property.type)>>")
+                }
+                else {
+                    context.line("public var \(property.name): Optional<any SwiftQL.XLExpression<\(property.qualifiedType)>>")
+                }
             }
-            
+
             context.block("public init()") { context in
                 for property in properties {
-                    context.line("\(property.name) = nil")
-                }
-            }
-            
-            if !properties.isEmpty {
-                var parameters: [String] = []
-                for property in properties {
-                    parameters.append("\(property.name): Optional<any XLExpression<\(property.qualifiedType)>> = nil")
-                }
-                context.block("public init(\(parameters.joined(separator: ", ")))") { context in
-                    for property in properties {
-                        context.line("self.\(property.name) = \(property.name)")
+                    if property.optional {
+                        context.line("_\(property.name) = SwiftQL.XLNullableColumnUpdate()")
+                    }
+                    else {
+                        context.line("\(property.name) = nil")
                     }
                 }
             }
-            
+
+            if !properties.isEmpty {
+                var parameters: [String] = []
+                for property in properties {
+                    parameters.append("\(property.name): Optional<any XLExpression<\(property.type)>> = nil")
+                }
+                // A `nil` argument here means "leave this column out of the
+                // statement", matching every other column and this
+                // initializer's previous behaviour. That is deliberately not
+                // what `nil` means when assigned inside a `Setting` closure,
+                // where the column is already part of the statement and `nil`
+                // is the value it takes.
+                context.block("public init(\(parameters.joined(separator: ", ")))") { context in
+                    // Every stored property has to be initialized before any
+                    // of them can be assigned through an accessor, so the
+                    // wrapped columns are initialized first and only then
+                    // assigned.
+                    for property in properties {
+                        if property.optional {
+                            context.line("_\(property.name) = SwiftQL.XLNullableColumnUpdate()")
+                        }
+                        else {
+                            context.line("self.\(property.name) = \(property.name)")
+                        }
+                    }
+                    for property in properties where property.optional {
+                        context.block("if let \(property.name)") { context in
+                            context.line("self.\(property.name) = \(property.name)")
+                        }
+                    }
+                }
+            }
+
             context.block("public func makeSQL(context: inout XLBuilder)") { context in
                 context.block("context.unaryPrefix(\"SET\")") { context in
                     context.block("$0.list(separator: \",\")") { context in
                         for property in properties {
-                            context.block("if let \(property.name)") { context in
+                            let assigned = property.optional
+                                ? "let \(property.name) = _\(property.name)._xlAssignedExpression"
+                                : "let \(property.name)"
+                            context.block("if \(assigned)") { context in
                                 context.block("$0.listItem") { context in
                                     context.block("$0.binaryOperator(\"=\", left: XLName(\"\(property.alias)\").makeSQL)") { context in
                                         context.line("\(property.name).writeSQL(context: &$0)")
@@ -1147,14 +1189,12 @@ internal struct MetaBuilder {
                 }
                 else {
                     context.line("var output = MetaUpdate()")
+                    // A nullable column's setter now takes an expression of the
+                    // wrapped type, so the value no longer has to be lifted
+                    // with `toNullable()` before it is assigned.
                     for property in mutableProperties {
                         context.block("if let value = \(property.name)") { context in
-                            if property.optional {
-                                context.line("output.\(property.name) = SwiftQL._xlLegacyValueExpression(value).toNullable()")
-                            }
-                            else {
-                                context.line("output.\(property.name) = SwiftQL._xlLegacyValueExpression(value)")
-                            }
+                            context.line("output.\(property.name) = SwiftQL._xlLegacyValueExpression(value)")
                         }
                     }
                     context.line("return output")

--- a/Sources/SQLMacros/MetaBuilder.swift
+++ b/Sources/SQLMacros/MetaBuilder.swift
@@ -1057,66 +1057,94 @@ internal struct MetaBuilder {
             }
         }
             
-        context.block("public struct MetaUpdate: XLMetaUpdate") { context in
-            
+        // Column assignments route through key-path member lookup rather than
+        // stored properties, because a nullable column needs three assignment
+        // shapes on one name -- a wrapped-type expression, `nil` for SQL
+        // NULL, and an optional-typed expression -- and a stored property has
+        // exactly one setter type. Subscript overloads are the one place
+        // Swift resolves an assignment against more than one type, and
+        // @dynamicMemberLookup lets them keep the `row.column = value`
+        // spelling. Participation in the SET clause is tracked by the typed
+        // slots, separately from the value's own optionality.
+        context.block("@dynamicMemberLookup public struct MetaUpdate: XLMetaUpdate") { context in
+
             context.line("public typealias Row = \(structName)")
-            
-            // A nullable column needs two independent pieces of state: whether
-            // it takes part in the SET clause, and whether the value it is set
-            // to is NULL. `Optional` alone cannot carry both -- reusing it for
-            // participation is what made `row.column = nil` and
-            // `row.column = value` unspellable -- so nullable columns go
-            // through a wrapper that tracks participation separately. The
-            // wrapped value is an expression of the column's *wrapped* type,
-            // which is what lets a literal or a non-optional expression assign
-            // directly.
-            for property in properties {
-                if property.optional {
-                    context.line("@SwiftQL.XLNullableColumnUpdate public var \(property.name): Optional<any SwiftQL.XLExpression<\(property.type)>>")
+
+            context.block("public struct Columns") { context in
+                for property in properties {
+                    if property.optional {
+                        context.line("public var \(property.name) = SwiftQL.XLNullableColumnUpdate<\(property.type)>()")
+                    }
+                    else {
+                        context.line("public var \(property.name) = SwiftQL.XLColumnUpdate<\(property.qualifiedType)>()")
+                    }
                 }
-                else {
-                    context.line("public var \(property.name): Optional<any SwiftQL.XLExpression<\(property.qualifiedType)>>")
+                context.block("public init()") { _ in
+                }
+            }
+
+            context.line("public var _xlColumns: Columns")
+
+            context.block("public subscript<Wrapped>(dynamicMember keyPath: Swift.WritableKeyPath<Columns, SwiftQL.XLColumnUpdate<Wrapped>>) -> Optional<any SwiftQL.XLExpression<Wrapped>>") { context in
+                context.block("get") { context in
+                    context.line("_xlColumns[keyPath: keyPath].expression")
+                }
+                context.block("set") { context in
+                    context.line("_xlColumns[keyPath: keyPath].expression = newValue")
+                }
+            }
+
+            // For a nullable column, `nil` assigned through this overload
+            // means SQL NULL. Leaving the column out of the statement is what
+            // never assigning it does.
+            context.block("public subscript<Wrapped>(dynamicMember keyPath: Swift.WritableKeyPath<Columns, SwiftQL.XLNullableColumnUpdate<Wrapped>>) -> Optional<any SwiftQL.XLExpression<Wrapped>>") { context in
+                context.block("get") { context in
+                    context.line("_xlColumns[keyPath: keyPath].expression")
+                }
+                context.block("set") { context in
+                    context.line("_xlColumns[keyPath: keyPath].expression = newValue")
+                }
+            }
+
+            // Disfavored so a plain `Wrapped?` value, which both overloads
+            // accept with identical rendered SQL, resolves to the wrapped
+            // overload instead of being ambiguous. An expression whose type
+            // is `Wrapped?` only matches this overload, so it still applies.
+            context.line("@_disfavoredOverload")
+            context.block("public subscript<Wrapped>(dynamicMember keyPath: Swift.WritableKeyPath<Columns, SwiftQL.XLNullableColumnUpdate<Wrapped>>) -> any SwiftQL.XLExpression<Optional<Wrapped>>") { context in
+                context.block("get") { context in
+                    context.line("_xlColumns[keyPath: keyPath].optionalExpression ?? SwiftQL.XLNullExpression<Wrapped>()")
+                }
+                context.block("set") { context in
+                    context.line("_xlColumns[keyPath: keyPath].optionalExpression = newValue")
                 }
             }
 
             context.block("public init()") { context in
-                for property in properties {
-                    if property.optional {
-                        context.line("_\(property.name) = SwiftQL.XLNullableColumnUpdate()")
-                    }
-                    else {
-                        context.line("\(property.name) = nil")
-                    }
-                }
+                context.line("_xlColumns = Columns()")
             }
 
             if !properties.isEmpty {
                 var parameters: [String] = []
                 for property in properties {
-                    parameters.append("\(property.name): Optional<any XLExpression<\(property.type)>> = nil")
+                    parameters.append("\(property.name): Optional<any XLExpression<\(property.qualifiedType)>> = nil")
                 }
                 // A `nil` argument here means "leave this column out of the
                 // statement", matching every other column and this
-                // initializer's previous behaviour. That is deliberately not
-                // what `nil` means when assigned inside a `Setting` closure,
-                // where the column is already part of the statement and `nil`
-                // is the value it takes.
+                // initializer's v1 behaviour. That is deliberately not what
+                // `nil` means when assigned inside a `Setting` closure, where
+                // the column is already part of the statement and `nil` is
+                // the value it takes.
                 context.block("public init(\(parameters.joined(separator: ", ")))") { context in
-                    // Every stored property has to be initialized before any
-                    // of them can be assigned through an accessor, so the
-                    // wrapped columns are initialized first and only then
-                    // assigned.
+                    context.line("_xlColumns = Columns()")
                     for property in properties {
                         if property.optional {
-                            context.line("_\(property.name) = SwiftQL.XLNullableColumnUpdate()")
+                            context.block("if let \(property.name)") { context in
+                                context.line("_xlColumns.\(property.name).optionalExpression = \(property.name)")
+                            }
                         }
                         else {
-                            context.line("self.\(property.name) = \(property.name)")
-                        }
-                    }
-                    for property in properties where property.optional {
-                        context.block("if let \(property.name)") { context in
-                            context.line("self.\(property.name) = \(property.name)")
+                            context.line("_xlColumns.\(property.name).expression = \(property.name)")
                         }
                     }
                 }
@@ -1127,8 +1155,8 @@ internal struct MetaBuilder {
                     context.block("$0.list(separator: \",\")") { context in
                         for property in properties {
                             let assigned = property.optional
-                                ? "let \(property.name) = _\(property.name)._xlAssignedExpression"
-                                : "let \(property.name)"
+                                ? "let \(property.name) = _xlColumns.\(property.name)._xlAssignedExpression"
+                                : "let \(property.name) = _xlColumns.\(property.name).expression"
                             context.block("if \(assigned)") { context in
                                 context.block("$0.listItem") { context in
                                     context.block("$0.binaryOperator(\"=\", left: XLName(\"\(property.alias)\").makeSQL)") { context in
@@ -1189,9 +1217,10 @@ internal struct MetaBuilder {
                 }
                 else {
                     context.line("var output = MetaUpdate()")
-                    // A nullable column's setter now takes an expression of the
-                    // wrapped type, so the value no longer has to be lifted
-                    // with `toNullable()` before it is assigned.
+                    // The value here is always the column's wrapped type, so
+                    // it routes through MetaUpdate's wrapped-type assignment
+                    // for nullable and non-nullable columns alike -- no
+                    // `toNullable()` lift is needed.
                     for property in mutableProperties {
                         context.block("if let value = \(property.name)") { context in
                             context.line("output.\(property.name) = SwiftQL._xlLegacyValueExpression(value)")

--- a/Sources/SwiftQL/SQLNullableColumnUpdate.swift
+++ b/Sources/SwiftQL/SQLNullableColumnUpdate.swift
@@ -29,13 +29,38 @@ public struct XLNullExpression<Wrapped>: XLExpression {
 
 
 ///
-/// Records the value assigned to a nullable column in an update statement.
+/// The state of one non-nullable column in an update statement's `SET`
+/// clause.
+///
+/// Generated `MetaUpdate` types store one slot per column and route
+/// `row.column = expression` assignments to it through key-path member
+/// lookup. A slot whose `expression` is `nil` takes no part in the `SET`
+/// clause.
+///
+public struct XLColumnUpdate<Wrapped> {
+
+    /// The expression assigned to the column, or `nil` when the column is
+    /// left out of the `SET` clause.
+    public var expression: (any XLExpression<Wrapped>)?
+
+    /// Creates a slot that leaves the column out of the `SET` clause.
+    public init() {
+        self.expression = nil
+    }
+}
+
+
+///
+/// The state of one nullable column in an update statement's `SET` clause.
 ///
 /// A nullable column has two independent pieces of state: whether the column
-/// takes part in the `SET` clause at all, and — if it does — whether the value
-/// it is set to is `NULL`. Reusing `Optional` for both makes them collide, so
-/// this wrapper tracks participation separately from the value. That lets a
-/// nullable column be assigned the same way an ordinary Swift optional is:
+/// takes part in the `SET` clause at all, and — if it does — whether the
+/// value it is set to is `NULL`. Reusing `Optional` for both makes them
+/// collide, so this slot tracks participation separately from the value.
+/// Generated `MetaUpdate` types store one slot per nullable column and route
+/// assignments to it through overloaded key-path member subscripts, which is
+/// what lets a nullable column be assigned the same way an ordinary Swift
+/// optional is:
 ///
 /// ```swift
 /// Setting(person) { row in
@@ -44,67 +69,57 @@ public struct XLNullExpression<Wrapped>: XLExpression {
 /// }
 /// ```
 ///
-/// A column that is never assigned stays out of the statement entirely.
+/// An expression whose own type is already optional — a
+/// `XLNamedBindingReference<String?>` whose bound value may be `NULL` at
+/// runtime, or another nullable column — assigns the same way, through the
+/// slot's ``optionalExpression``. A column that is never assigned stays out
+/// of the statement entirely.
 ///
-/// The wrapped value is an expression of the column's *wrapped* type, so
-/// literals and non-optional expressions assign directly. To assign an
-/// expression that is itself optional-typed — a `XLNamedBindingReference<T?>`
-/// whose bound value may be `NULL` at runtime, or another nullable column —
-/// assign to the projected value instead:
-///
-/// ```swift
-/// let occupation = XLNamedBindingReference<String?>(name: "occupationId")
-/// Setting(person) { row in
-///     row.$occupationId = occupation
-/// }
-/// ```
-///
-@propertyWrapper
 public struct XLNullableColumnUpdate<Wrapped> {
 
     private var wrappedExpression: (any XLExpression<Wrapped>)?
 
-    private var optionalExpression: (any XLExpression<Optional<Wrapped>>)?
+    private var storedExpression: (any XLExpression<Optional<Wrapped>>)?
 
     private var isAssigned: Bool
 
-    /// Creates an assignment that leaves the column out of the `SET` clause.
+    /// Creates a slot that leaves the column out of the `SET` clause.
     public init() {
         self.wrappedExpression = nil
-        self.optionalExpression = nil
+        self.storedExpression = nil
         self.isAssigned = false
     }
 
-    /// The expression assigned to the column, as an expression of the column's
-    /// wrapped type.
+    /// The expression assigned to the column, as an expression of the
+    /// column's wrapped type.
     ///
     /// Assigning `nil` sets the column to SQL `NULL`; it does not remove the
-    /// column from the statement. Reading returns `nil` both for a column that
-    /// was never assigned and for one assigned an optional-typed expression
-    /// through ``projectedValue``.
-    public var wrappedValue: (any XLExpression<Wrapped>)? {
+    /// column from the statement. Reading returns `nil` both for a column
+    /// that was never assigned and for one assigned an optional-typed
+    /// expression through ``optionalExpression``.
+    public var expression: (any XLExpression<Wrapped>)? {
         get {
             wrappedExpression
         }
         set {
             wrappedExpression = newValue
-            optionalExpression = newValue?.toNullable()
+            storedExpression = newValue?.toNullable()
             isAssigned = true
         }
     }
 
-    /// The expression assigned to the column, as an optional-typed expression.
+    /// The expression assigned to the column, as an optional-typed
+    /// expression.
     ///
-    /// Use this to assign an expression whose own type is already optional,
-    /// which the wrapped value cannot accept. Assigning `nil` here sets the
-    /// column to SQL `NULL`, the same as assigning `nil` to the wrapped value.
-    public var projectedValue: (any XLExpression<Optional<Wrapped>>)? {
+    /// Assigning `nil` here sets the column to SQL `NULL`, the same as
+    /// assigning `nil` to ``expression``.
+    public var optionalExpression: (any XLExpression<Optional<Wrapped>>)? {
         get {
-            optionalExpression
+            storedExpression
         }
         set {
             wrappedExpression = nil
-            optionalExpression = newValue
+            storedExpression = newValue
             isAssigned = true
         }
     }
@@ -120,6 +135,6 @@ public struct XLNullableColumnUpdate<Wrapped> {
         guard isAssigned else {
             return nil
         }
-        return optionalExpression ?? XLNullExpression<Wrapped>()
+        return storedExpression ?? XLNullExpression<Wrapped>()
     }
 }

--- a/Sources/SwiftQL/SQLNullableColumnUpdate.swift
+++ b/Sources/SwiftQL/SQLNullableColumnUpdate.swift
@@ -103,7 +103,22 @@ public struct XLNullableColumnUpdate<Wrapped> {
         }
         set {
             wrappedExpression = newValue
-            storedExpression = newValue?.toNullable()
+            if let newValue {
+                // Built directly rather than through the generic
+                // `toNullable()` helper: calling a method with an opaque
+                // return type on a constrained existential
+                // (`any XLExpression<Wrapped>`) type-checks under Swift 6.0+
+                // but is ambiguous under the pinned Swift 5.9.2 compiler.
+                // `XLTypeAffinityExpression`'s own initializer takes an
+                // unconstrained `any XLExpression`, so widening to that
+                // sidesteps the limitation entirely.
+                storedExpression = XLTypeAffinityExpression<Optional<Wrapped>>(
+                    expression: newValue
+                )
+            }
+            else {
+                storedExpression = nil
+            }
             isAssigned = true
         }
     }

--- a/Sources/SwiftQL/SQLNullableColumnUpdate.swift
+++ b/Sources/SwiftQL/SQLNullableColumnUpdate.swift
@@ -1,0 +1,125 @@
+//
+//  SQLNullableColumnUpdate.swift
+//
+//
+//  Created by Luke Van In on 2026/08/02.
+//
+
+import Foundation
+
+
+///
+/// An expression that renders the SQL `NULL` literal.
+///
+/// Assigning `nil` to a nullable column inside a `Setting` closure stores this
+/// expression, so the column appears in the `SET` clause with an explicit
+/// `NULL` rather than being left out of the statement.
+///
+public struct XLNullExpression<Wrapped>: XLExpression {
+
+    public typealias T = Optional<Wrapped>
+
+    public init() {
+    }
+
+    public func makeSQL(context: inout XLBuilder) {
+        context.null()
+    }
+}
+
+
+///
+/// Records the value assigned to a nullable column in an update statement.
+///
+/// A nullable column has two independent pieces of state: whether the column
+/// takes part in the `SET` clause at all, and — if it does — whether the value
+/// it is set to is `NULL`. Reusing `Optional` for both makes them collide, so
+/// this wrapper tracks participation separately from the value. That lets a
+/// nullable column be assigned the same way an ordinary Swift optional is:
+///
+/// ```swift
+/// Setting(person) { row in
+///     row.occupationId = "occ-1"  // SET occupationId = 'occ-1'
+///     row.occupationId = nil      // SET occupationId = NULL
+/// }
+/// ```
+///
+/// A column that is never assigned stays out of the statement entirely.
+///
+/// The wrapped value is an expression of the column's *wrapped* type, so
+/// literals and non-optional expressions assign directly. To assign an
+/// expression that is itself optional-typed — a `XLNamedBindingReference<T?>`
+/// whose bound value may be `NULL` at runtime, or another nullable column —
+/// assign to the projected value instead:
+///
+/// ```swift
+/// let occupation = XLNamedBindingReference<String?>(name: "occupationId")
+/// Setting(person) { row in
+///     row.$occupationId = occupation
+/// }
+/// ```
+///
+@propertyWrapper
+public struct XLNullableColumnUpdate<Wrapped> {
+
+    private var wrappedExpression: (any XLExpression<Wrapped>)?
+
+    private var optionalExpression: (any XLExpression<Optional<Wrapped>>)?
+
+    private var isAssigned: Bool
+
+    /// Creates an assignment that leaves the column out of the `SET` clause.
+    public init() {
+        self.wrappedExpression = nil
+        self.optionalExpression = nil
+        self.isAssigned = false
+    }
+
+    /// The expression assigned to the column, as an expression of the column's
+    /// wrapped type.
+    ///
+    /// Assigning `nil` sets the column to SQL `NULL`; it does not remove the
+    /// column from the statement. Reading returns `nil` both for a column that
+    /// was never assigned and for one assigned an optional-typed expression
+    /// through ``projectedValue``.
+    public var wrappedValue: (any XLExpression<Wrapped>)? {
+        get {
+            wrappedExpression
+        }
+        set {
+            wrappedExpression = newValue
+            optionalExpression = newValue?.toNullable()
+            isAssigned = true
+        }
+    }
+
+    /// The expression assigned to the column, as an optional-typed expression.
+    ///
+    /// Use this to assign an expression whose own type is already optional,
+    /// which the wrapped value cannot accept. Assigning `nil` here sets the
+    /// column to SQL `NULL`, the same as assigning `nil` to the wrapped value.
+    public var projectedValue: (any XLExpression<Optional<Wrapped>>)? {
+        get {
+            optionalExpression
+        }
+        set {
+            wrappedExpression = nil
+            optionalExpression = newValue
+            isAssigned = true
+        }
+    }
+
+    ///
+    /// The expression this column contributes to the `SET` clause, or `nil`
+    /// when the column was never assigned and takes no part in the statement.
+    ///
+    /// Generated `makeSQL` implementations read this. It is not part of the
+    /// API a caller writes against.
+    ///
+    public var _xlAssignedExpression: (any XLExpression<Optional<Wrapped>>)? {
+        guard isAssigned else {
+            return nil
+        }
+        return optionalExpression ?? XLNullExpression<Wrapped>()
+    }
+}

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -444,11 +444,10 @@ statement. A column the closure never assigns takes no part in the `SET`
 clause and keeps whatever value the row already held, which is why an update
 that sets only `age` leaves `occupationId` alone.
 
-The value you assign is an expression of the column's *wrapped* type, so
-literals, column references, and `XLNamedBindingReference<String>` all assign
-directly. To assign an expression that is itself optional-typed — a binding
-whose bound value may be `NULL` at runtime, or another nullable column —
-assign to the projected value with `$` instead:
+Any expression of the column's wrapped type (`String`) or of its optional
+type (`String?`) assigns the same way — literals, plain values, column
+references, and named bindings included. A binding whose runtime value may be
+`NULL` needs no special spelling:
 
 <!-- test: XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings -->
 ```swift
@@ -458,7 +457,7 @@ let bindOccupationStatement = sql { schema in
     let person = schema.into(Person.self)
     Update(person)
     Setting(person) { row in
-        row.$occupationId = occupationParameter
+        row.occupationId = occupationParameter
     }
     Where(person.id == "fred")
 }

--- a/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
+++ b/Sources/SwiftQL/SwiftQL.docc/GettingStarted.md
@@ -413,14 +413,8 @@ try updateAgeRequest.execute(bindings: updateBindings)
 
 ### Setting a nullable column
 
-`Person.occupationId` is `String?`, so the generated setter's type is
-`Optional<any XLExpression<String?>>`. The outer `Optional` means "leave this
-column out of the `SET` clause" — a different thing from the column's own
-`String?` optionality, so assigning a plain `String` or `String?` value does
-not compile. Use `toNullable()` to lift a non-optional value expression into
-that slot, and an explicit `any XLExpression<String?>` cast to assign an
-already-optional value, including `nil` to clear the column back to SQL
-`NULL`:
+Assign a nullable column the way you would an ordinary Swift optional. A value
+sets the column, and `nil` sets it to SQL `NULL`:
 
 <!-- test: XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings -->
 ```swift
@@ -428,7 +422,7 @@ let setOccupationStatement = sql { schema in
     let person = schema.into(Person.self)
     Update(person)
     Setting(person) { row in
-        row.occupationId = "occ-1".toNullable()
+        row.occupationId = "occ-1"
     }
     Where(person.id == "fred")
 }
@@ -438,13 +432,40 @@ let clearOccupationStatement = sql { schema in
     let person = schema.into(Person.self)
     Update(person)
     Setting(person) { row in
-        let clearedOccupationId: String? = nil
-        row.occupationId = clearedOccupationId as any XLExpression<String?>
+        row.occupationId = nil
     }
     Where(person.id == "fred")
 }
 try database.makeRequest(with: clearOccupationStatement).execute()
 ```
+
+Setting a column to `NULL` is a different thing from leaving it out of the
+statement. A column the closure never assigns takes no part in the `SET`
+clause and keeps whatever value the row already held, which is why an update
+that sets only `age` leaves `occupationId` alone.
+
+The value you assign is an expression of the column's *wrapped* type, so
+literals, column references, and `XLNamedBindingReference<String>` all assign
+directly. To assign an expression that is itself optional-typed — a binding
+whose bound value may be `NULL` at runtime, or another nullable column —
+assign to the projected value with `$` instead:
+
+<!-- test: XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings -->
+```swift
+let occupationParameter = XLNamedBindingReference<String?>(name: "occupationId")
+
+let bindOccupationStatement = sql { schema in
+    let person = schema.into(Person.self)
+    Update(person)
+    Setting(person) { row in
+        row.$occupationId = occupationParameter
+    }
+    Where(person.id == "fred")
+}
+```
+
+That parameter's slot is nullable, so one prepared statement can bind either a
+value or `NULL` for each call.
 
 ## Delete statements
 

--- a/Tests/SQLMacrosTests/SQLTests.swift
+++ b/Tests/SQLMacrosTests/SQLTests.swift
@@ -1530,6 +1530,46 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains("output.id = SwiftQL._xlLegacyValueExpression(value)"))
     }
 
+    // A nullable column's update setter is keyed on the column's *wrapped*
+    // type and wrapped in `@XLNullableColumnUpdate`, which is what lets
+    // `row.nickname = "Ada"` and `row.nickname = nil` both compile and mean
+    // different things. A non-optional column keeps the plain optional
+    // existential, where `nil` still means "leave this column out".
+    func test_metaUpdateWrapsNullableColumnsOnly() throws {
+        let builder = try makeBuilder(
+            """
+            @SQLTable
+            struct NullableRow {
+                var id: Int
+                var nickname: String?
+            }
+            """
+        )
+        let source = builder.makeMetaTableExtension()
+
+        XCTAssertTrue(
+            source.contains(
+                "@SwiftQL.XLNullableColumnUpdate public var nickname: Optional<any SwiftQL.XLExpression<String>>"
+            )
+        )
+        XCTAssertTrue(
+            source.contains("public var id: Optional<any SwiftQL.XLExpression<Int>>")
+        )
+        XCTAssertFalse(source.contains("XLNullableColumnUpdate public var id"))
+
+        // The wrapper's backing storage is what carries "was this column
+        // assigned at all", so the SET clause reads it rather than the
+        // property.
+        XCTAssertTrue(
+            source.contains("if let nickname = _nickname._xlAssignedExpression")
+        )
+        XCTAssertTrue(source.contains("if let id"))
+
+        // A nullable column no longer needs `toNullable()` to bridge a value
+        // into the setter.
+        XCTAssertFalse(source.contains(".toNullable()"))
+    }
+
     // MARK: - #256 regression corpus: builder-level shape checks
     //
     // See `MacroRegressionCorpus.json` for the provenance record backing

--- a/Tests/SQLMacrosTests/SQLTests.swift
+++ b/Tests/SQLMacrosTests/SQLTests.swift
@@ -1171,10 +1171,11 @@ final class MetaBuilderTests: XCTestCase {
             """
         )
         let source = builder.makeMetaTableExtension()
-        // MetaInsert, MetaUpdate and UpdateRequest each declare exactly one parameterless
-        // initializer. Before the fix, MetaUpdate declared a duplicate `init()`.
+        // MetaInsert, MetaUpdate, MetaUpdate.Columns and UpdateRequest each declare exactly
+        // one parameterless initializer. Before the fix, MetaUpdate declared a duplicate
+        // `init()`.
         let count = source.components(separatedBy: "public init()").count - 1
-        XCTAssertEqual(count, 3)
+        XCTAssertEqual(count, 4)
     }
 
     func test_columnsBuildsResultWithoutDeprecatedHelper() throws {
@@ -1530,12 +1531,16 @@ final class MetaBuilderTests: XCTestCase {
         XCTAssertTrue(source.contains("output.id = SwiftQL._xlLegacyValueExpression(value)"))
     }
 
-    // A nullable column's update setter is keyed on the column's *wrapped*
-    // type and wrapped in `@XLNullableColumnUpdate`, which is what lets
-    // `row.nickname = "Ada"` and `row.nickname = nil` both compile and mean
-    // different things. A non-optional column keeps the plain optional
-    // existential, where `nil` still means "leave this column out".
-    func test_metaUpdateWrapsNullableColumnsOnly() throws {
+    // MetaUpdate routes column assignment through key-path member lookup over
+    // typed slots. A nullable column gets an `XLNullableColumnUpdate` slot and
+    // two subscript overloads -- one keyed on the column's *wrapped* type
+    // (which is what lets `row.nickname = "Ada"` and `row.nickname = nil`
+    // both compile and mean different things) and a disfavored one keyed on
+    // the optional type (which is what lets an optional-typed expression such
+    // as a `XLNamedBindingReference<String?>` assign with the same spelling).
+    // A non-optional column gets a plain `XLColumnUpdate` slot, where `nil`
+    // still means "leave this column out".
+    func test_metaUpdateRoutesColumnsThroughTypedSlots() throws {
         let builder = try makeBuilder(
             """
             @SQLTable
@@ -1548,25 +1553,55 @@ final class MetaBuilderTests: XCTestCase {
         let source = builder.makeMetaTableExtension()
 
         XCTAssertTrue(
+            source.contains("@dynamicMemberLookup public struct MetaUpdate: XLMetaUpdate")
+        )
+        XCTAssertTrue(
+            source.contains("public var nickname = SwiftQL.XLNullableColumnUpdate<String>()")
+        )
+        XCTAssertTrue(
+            source.contains("public var id = SwiftQL.XLColumnUpdate<Int>()")
+        )
+
+        // The three subscript overloads: wrapped-type for both slot kinds,
+        // and the disfavored optional-typed overload for nullable slots.
+        XCTAssertTrue(
             source.contains(
-                "@SwiftQL.XLNullableColumnUpdate public var nickname: Optional<any SwiftQL.XLExpression<String>>"
+                "public subscript<Wrapped>(dynamicMember keyPath: Swift.WritableKeyPath<Columns, SwiftQL.XLColumnUpdate<Wrapped>>) -> Optional<any SwiftQL.XLExpression<Wrapped>>"
             )
         )
         XCTAssertTrue(
-            source.contains("public var id: Optional<any SwiftQL.XLExpression<Int>>")
+            source.contains(
+                "public subscript<Wrapped>(dynamicMember keyPath: Swift.WritableKeyPath<Columns, SwiftQL.XLNullableColumnUpdate<Wrapped>>) -> Optional<any SwiftQL.XLExpression<Wrapped>>"
+            )
         )
-        XCTAssertFalse(source.contains("XLNullableColumnUpdate public var id"))
-
-        // The wrapper's backing storage is what carries "was this column
-        // assigned at all", so the SET clause reads it rather than the
-        // property.
+        XCTAssertTrue(source.contains("@_disfavoredOverload"))
         XCTAssertTrue(
-            source.contains("if let nickname = _nickname._xlAssignedExpression")
+            source.contains(
+                "public subscript<Wrapped>(dynamicMember keyPath: Swift.WritableKeyPath<Columns, SwiftQL.XLNullableColumnUpdate<Wrapped>>) -> any SwiftQL.XLExpression<Optional<Wrapped>>"
+            )
         )
-        XCTAssertTrue(source.contains("if let id"))
 
-        // A nullable column no longer needs `toNullable()` to bridge a value
-        // into the setter.
+        // The slots carry "was this column assigned at all", so the SET
+        // clause reads them rather than a stored property.
+        XCTAssertTrue(
+            source.contains("if let nickname = _xlColumns.nickname._xlAssignedExpression")
+        )
+        XCTAssertTrue(
+            source.contains("if let id = _xlColumns.id.expression")
+        )
+
+        // The memberwise initializer keeps its v1 shape: parameters are keyed
+        // on the column's declared (qualified) type, and `nil` means "omit
+        // this column from the statement".
+        XCTAssertTrue(
+            source.contains("nickname: Optional<any XLExpression<String?>> = nil")
+        )
+        XCTAssertTrue(
+            source.contains("id: Optional<any XLExpression<Int>> = nil")
+        )
+
+        // The generated expansion never needs `toNullable()` to bridge a
+        // value into a nullable column.
         XCTAssertFalse(source.contains(".toNullable()"))
     }
 

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1437,7 +1437,7 @@ extension XLDocumentationTests {
             let person = schema.into(Person.self)
             Update(person)
             Setting(person) { row in
-                row.$occupationId = occupationParameter
+                row.occupationId = occupationParameter
             }
             Where(person.id == "fred")
         }
@@ -1571,6 +1571,27 @@ extension XLDocumentationTests {
             try database.makeRequest(with: personByIDQuery).fetchOne(),
             Person(id: "per-3", occupationId: nil, name: "Yogi Bear", age: 68)
         )
+
+        // A plain optional value also assigns directly: a wrapped value
+        // renders the value, `nil` renders NULL.
+        let maybeOccupation: String? = "occ-4"
+        let setFromOptionalValueStatement = sql { schema in
+            let person = schema.into(Person.self)
+            Update(person)
+            Setting(person) { row in
+                row.occupationId = maybeOccupation
+            }
+            Where(person.id == "per-3")
+        }
+        XCTAssertEqual(
+            encoder.makeSQL(setFromOptionalValueStatement).sql,
+            "UPDATE Person AS t0 SET occupationId = 'occ-4' WHERE (t0.id == 'per-3')"
+        )
+        try database.makeRequest(with: setFromOptionalValueStatement).execute()
+        XCTAssertEqual(
+            try database.makeRequest(with: personByIDQuery).fetchOne(),
+            Person(id: "per-3", occupationId: "occ-4", name: "Yogi Bear", age: 68)
+        )
     }
 
     /// A column that is never assigned stays out of the `SET` clause, so an
@@ -1610,8 +1631,7 @@ extension XLDocumentationTests {
 
     /// An expression whose own type is already optional -- a binding reference
     /// whose bound value may be `NULL` at runtime, or another nullable column
-    /// -- is assigned through the projected value, which the wrapped value
-    /// cannot accept.
+    /// -- assigns with the same spelling as a wrapped-type expression.
     func testExample_Setting_NullableColumnFromOptionalExpression() throws {
         try database.makeRequest(with: sqlCreate(Person.self)).execute()
 
@@ -1623,7 +1643,7 @@ extension XLDocumentationTests {
             let person = schema.into(Person.self)
             Update(person)
             Setting(person) { row in
-                row.$occupationId = occupationParameter
+                row.occupationId = occupationParameter
             }
             Where(person.id == "per-1")
         }

--- a/Tests/SQLTests/SQLExampleTests.swift
+++ b/Tests/SQLTests/SQLExampleTests.swift
@@ -1411,7 +1411,7 @@ extension XLDocumentationTests {
             let person = schema.into(Person.self)
             Update(person)
             Setting(person) { row in
-                row.occupationId = "occ-1".toNullable()
+                row.occupationId = "occ-1"
             }
             Where(person.id == "fred")
         }
@@ -1426,12 +1426,25 @@ extension XLDocumentationTests {
             let person = schema.into(Person.self)
             Update(person)
             Setting(person) { row in
-                let clearedOccupationId: String? = nil
-                row.occupationId = clearedOccupationId as any XLExpression<String?>
+                row.occupationId = nil
             }
             Where(person.id == "fred")
         }
         try database.makeRequest(with: clearOccupationStatement).execute()
+
+        let occupationParameter = XLNamedBindingReference<String?>(name: "occupationId")
+        let bindOccupationStatement = sql { schema in
+            let person = schema.into(Person.self)
+            Update(person)
+            Setting(person) { row in
+                row.$occupationId = occupationParameter
+            }
+            Where(person.id == "fred")
+        }
+        XCTAssertEqual(
+            encoder.makeSQL(bindOccupationStatement).sql,
+            "UPDATE Person AS t0 SET occupationId = :occupationId WHERE (t0.id == 'fred')"
+        )
 
         XCTAssertEqual(
             try peopleByNameRequest.fetchOne(bindings: fredBindings),
@@ -1506,14 +1519,10 @@ extension XLDocumentationTests {
         )
     }
 
-    /// Regression test for the `Setting` closure not having an obvious
-    /// spelling for assigning a value to a nullable column. The generated
-    /// setter's type is `Optional<any XLExpression<T?>>`: the outer
-    /// `Optional` means "leave this column out of the `SET` clause", which
-    /// collides with the column's own optionality. `toNullable()` is the
-    /// supported way to bridge a non-optional value expression into that
-    /// slot; an explicit `any XLExpression<T?>` cast bridges a
-    /// already-optional value (including `nil`, to clear the column).
+    /// A nullable column is assigned in a `Setting` closure the same way an
+    /// ordinary Swift optional is: a value sets the column, and `nil` sets it
+    /// to SQL `NULL`. The two are distinct from leaving the column out of the
+    /// statement altogether, which is what an unassigned column does.
     func testExample_Setting_NullableColumn() throws {
         try database.makeRequest(with: sqlCreate(Person.self)).execute()
 
@@ -1524,7 +1533,7 @@ extension XLDocumentationTests {
             let person = schema.into(Person.self)
             Update(person)
             Setting(person) { row in
-                row.occupationId = "occ-1".toNullable()
+                row.occupationId = "occ-1"
             }
             Where(person.id == "per-3")
         }
@@ -1549,15 +1558,113 @@ extension XLDocumentationTests {
             let person = schema.into(Person.self)
             Update(person)
             Setting(person) { row in
-                let clearedOccupationId: String? = nil
-                row.occupationId = clearedOccupationId as any XLExpression<String?>
+                row.occupationId = nil
             }
             Where(person.id == "per-3")
         }
+        XCTAssertEqual(
+            encoder.makeSQL(clearOccupationStatement).sql,
+            "UPDATE Person AS t0 SET occupationId = NULL WHERE (t0.id == 'per-3')"
+        )
         try database.makeRequest(with: clearOccupationStatement).execute()
         XCTAssertEqual(
             try database.makeRequest(with: personByIDQuery).fetchOne(),
             Person(id: "per-3", occupationId: nil, name: "Yogi Bear", age: 68)
+        )
+    }
+
+    /// A column that is never assigned stays out of the `SET` clause, so an
+    /// update that touches one column leaves every other column alone --
+    /// including a nullable one holding a value.
+    func testExample_Setting_UnassignedNullableColumnIsNotCleared() throws {
+        try database.makeRequest(with: sqlCreate(Person.self)).execute()
+
+        let johnDoe = Person(id: "per-1", occupationId: "occ-1", name: "John Doe", age: 31)
+        try database.makeRequest(with: sqlInsert(johnDoe)).execute()
+
+        let updateAgeStatement = sql { schema in
+            let person = schema.into(Person.self)
+            Update(person)
+            Setting(person) { row in
+                row.age = 32
+            }
+            Where(person.id == "per-1")
+        }
+        XCTAssertEqual(
+            encoder.makeSQL(updateAgeStatement).sql,
+            "UPDATE Person AS t0 SET age = 32 WHERE (t0.id == 'per-1')"
+        )
+        try database.makeRequest(with: updateAgeStatement).execute()
+
+        let personByIDQuery = sql { schema in
+            let person = schema.table(Person.self)
+            Select(person)
+            From(person)
+            Where(person.id == "per-1")
+        }
+        XCTAssertEqual(
+            try database.makeRequest(with: personByIDQuery).fetchOne(),
+            Person(id: "per-1", occupationId: "occ-1", name: "John Doe", age: 32)
+        )
+    }
+
+    /// An expression whose own type is already optional -- a binding reference
+    /// whose bound value may be `NULL` at runtime, or another nullable column
+    /// -- is assigned through the projected value, which the wrapped value
+    /// cannot accept.
+    func testExample_Setting_NullableColumnFromOptionalExpression() throws {
+        try database.makeRequest(with: sqlCreate(Person.self)).execute()
+
+        let johnDoe = Person(id: "per-1", occupationId: "occ-1", name: "John Doe", age: 31)
+        try database.makeRequest(with: sqlInsert(johnDoe)).execute()
+
+        let occupationParameter = XLNamedBindingReference<String?>(name: "occupationId")
+        let setOccupationStatement = sql { schema in
+            let person = schema.into(Person.self)
+            Update(person)
+            Setting(person) { row in
+                row.$occupationId = occupationParameter
+            }
+            Where(person.id == "per-1")
+        }
+        XCTAssertEqual(
+            encoder.makeSQL(setOccupationStatement).sql,
+            "UPDATE Person AS t0 SET occupationId = :occupationId WHERE (t0.id == 'per-1')"
+        )
+
+        let request = database.makeRequest(with: setOccupationStatement)
+        let occupationSlot = try XCTUnwrap(
+            request.parameterLayout.slot(for: .named("occupationId"))
+        )
+
+        // The slot is nullable, so the same statement can bind a value or NULL.
+        try request.execute(
+            bindings: try XLInvocationBindings<XLSQLiteValue>(
+                layout: request.parameterLayout,
+                bindings: [try XLInvocationBinding(slot: occupationSlot, value: .text("occ-2"))]
+            ).validatingComplete()
+        )
+
+        let personByIDQuery = sql { schema in
+            let person = schema.table(Person.self)
+            Select(person)
+            From(person)
+            Where(person.id == "per-1")
+        }
+        XCTAssertEqual(
+            try database.makeRequest(with: personByIDQuery).fetchOne(),
+            Person(id: "per-1", occupationId: "occ-2", name: "John Doe", age: 31)
+        )
+
+        try request.execute(
+            bindings: try XLInvocationBindings<XLSQLiteValue>(
+                layout: request.parameterLayout,
+                bindings: [try XLInvocationBinding(slot: occupationSlot, value: .null)]
+            ).validatingComplete()
+        )
+        XCTAssertEqual(
+            try database.makeRequest(with: personByIDQuery).fetchOne(),
+            Person(id: "per-1", occupationId: nil, name: "John Doe", age: 31)
         )
     }
 

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -2174,7 +2174,10 @@ final class XLExecutionTests: XCTestCase {
             let table = $0.into(OptionalDateTest.self)
             Update(table)
             Setting<OptionalDateTest> { row in
-                row.date = dateParameter
+                // `dateParameter` is a `XLNamedBindingReference<Date?>`, an
+                // expression that is itself optional-typed, so it is assigned
+                // through the projected value rather than the wrapped one.
+                row.$date = dateParameter
             }
             Where(
                 table.id == entityId

--- a/Tests/SQLTests/SQLExecutionTests.swift
+++ b/Tests/SQLTests/SQLExecutionTests.swift
@@ -2174,10 +2174,7 @@ final class XLExecutionTests: XCTestCase {
             let table = $0.into(OptionalDateTest.self)
             Update(table)
             Setting<OptionalDateTest> { row in
-                // `dateParameter` is a `XLNamedBindingReference<Date?>`, an
-                // expression that is itself optional-typed, so it is assigned
-                // through the projected value rather than the wrapped one.
-                row.$date = dateParameter
+                row.date = dateParameter
             }
             Where(
                 table.id == entityId


### PR DESCRIPTION
[#526](https://github.com/lukevanin/swiftql/pull/526) fixed nullable-column assignment in a `Setting` closure with a property-wrapper setter: `row.occupationId = "occ-1"` and `row.occupationId = nil` both compiled and meant different things. But it only merged the first of what was meant to be a two-commit branch — the second commit, which removed that design's one remaining rough edge, was pushed after #526 had already closed and never made it into `version/1.5.6`. This PR carries that second commit forward as its own change.

## The rough edge #526 left

An expression that is itself optional-typed — a `XLNamedBindingReference<String?>` whose bound value may be `NULL` at runtime, or another nullable column — couldn't assign to the property-wrapper setter directly. It needed a separate spelling, `row.$occupationId = parameter`, because a property setter has exactly one type and the wrapped-type setter that made `= value` / `= nil` work couldn't also accept an optional-typed expression.

## What changed

Every assignment shape a Swift programmer expects now compiles on the *same* column name, with the meanings you'd guess:

```swift
Setting(person) { row in
    row.occupationId = "occ-1"                 // SET occupationId = 'occ-1'
    row.occupationId = nil                     // SET occupationId = NULL
    row.occupationId = optionalStringValue     // value or NULL
    row.occupationId = occupationParameter     // XLNamedBindingReference<String?>: binds value or NULL
}
```

A column the closure never assigns still stays out of the statement entirely.

### How

A property setter has exactly one type, Swift has no user-defined implicit conversions, and a type can conform to `XLExpression` only once — so no single setter type can absorb a wrapped value, `nil`, *and* an optional-typed expression while staying type-safe. Subscripts are the one place Swift resolves an assignment against more than one type. Generated `MetaUpdate` types are now `@dynamicMemberLookup` over a `Columns` struct of typed per-column slots (`XLColumnUpdate` for non-nullable, `XLNullableColumnUpdate` for nullable), with overloaded key-path subscripts:

- a wrapped-type overload — `(any XLExpression<Wrapped>)?`, where `nil` means SQL `NULL`;
- a `@_disfavoredOverload` optional-typed overload — `any XLExpression<Wrapped?>` — for expressions whose own type is already optional.

The attribute settles the one genuinely ambiguous case (a plain `Wrapped?` value, which both overloads accept with identical rendered SQL) in favour of the wrapped overload; verified empirically — without it, exactly that case failed to type-check and everything else resolved.

### Compatibility

No source break against v1.5.5, and this removes #526's source break too: the `$occupationId` projected-value spelling is gone, and `SQLExecutionTests`' `row.date = dateParameter` — which #526 had to migrate to `row.$date = dateParameter` — is back to its original spelling with no code change relative to what's on `version/1.5.6` today (confirmed with an empty diff on that file). The memberwise `MetaUpdate` initializer keeps its v1 shape (parameters keyed on the declared column type, `nil` means "omit").

## Files

- `Sources/SwiftQL/SQLNullableColumnUpdate.swift` — `XLNullExpression`, `XLColumnUpdate`, `XLNullableColumnUpdate` slots
- `Sources/SQLMacros/MetaBuilder.swift` — `MetaUpdate` codegen: `Columns`, `_xlColumns`, the three subscripts
- `Tests/SQLTests/SQLExampleTests.swift` — round trips against real SQLite for all four spellings, plus a test that an unassigned column is not cleared
- `Tests/SQLMacrosTests/SQLTests.swift` — pins the generated expansion's shape
- `Sources/SwiftQL/SwiftQL.docc/GettingStarted.md`, the playground's update page, `CHANGELOG.md`

## Validation (rebuilt against the current `version/1.5.6` tip)

| Check | Result |
| --- | --- |
| `swift test` (exit code checked directly) | 1212 tests, 0 failures |
| `swift build` (full package, warnings-as-errors) | Clean, 0 warnings |
| `scripts/ci/check-playground-pages.sh` (exit code checked) | All 9 pages compiled, ran, exited cleanly; page 4 prints `fred's occupation: chef` then `none` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)