### PR TITLE
Fix blocking strict-concurrency warnings on Swift 6.0 committed/clean resolution

### DIFF
--- a/Examples/Sources/SwiftQLExamples/ExampleSchema.swift
+++ b/Examples/Sources/SwiftQLExamples/ExampleSchema.swift
@@ -15,7 +15,7 @@ import SwiftQL
 /// `String` maps to SQLite `TEXT`, `Int` to `INTEGER`, and an optional
 /// property is the one column allowed to hold `NULL`.
 @SQLTable
-public struct Person {
+public struct Person: Sendable {
     public var id: String
     public var occupationId: String?
     public var name: String
@@ -27,7 +27,7 @@ public struct Person {
 /// The playground uses this second table for the joins and lookups that need
 /// more than one table in scope.
 @SQLTable
-public struct Occupation {
+public struct Occupation: Sendable {
     public var id: String
     public var title: String
 }

--- a/Tests/SQLTests/XLLiveQueryWaitSupport.swift
+++ b/Tests/SQLTests/XLLiveQueryWaitSupport.swift
@@ -122,7 +122,7 @@ extension XLAwaitableState {
 /// particular queue -- rather than evolving state. Awaiting the callback *itself* and then asserting
 /// on what it carried keeps the wrong outcome a test failure rather than a hang, which is not true
 /// of waiting for a flag that is only set when the outcome is already the expected one.
-final class XLAwaitableValue<Value>: @unchecked Sendable {
+final class XLAwaitableValue<Value: Sendable>: @unchecked Sendable {
 
     private let lock = NSLock()
 


### PR DESCRIPTION
## Summary

- `Swift 6.0 / committed resolution` and `Swift 6.0 / clean resolution` fail on the pinned Swift 6.0.3 cell at the "complete strict-concurrency checking" step, with `check-strict-concurrency.sh` treating first-party warnings as blocking.
- **Warning 1** — `XLAwaitableValue.fulfill(_:)` ([Tests/SQLTests/XLLiveQueryWaitSupport.swift:146](Tests/SQLTests/XLLiveQueryWaitSupport.swift#L146)) resumes every waiter's continuation with the same `newValue`. Because `Value` was an unconstrained generic, the compiler can't statically prove repeated `sending` transfers of a task-isolated value are safe, and flags `sending 'newValue' risks causing data races`. Fix: constrain `Value: Sendable` on `XLAwaitableValue`. All current callers already pass `Bool` or `Void`, so this doesn't change behavior.
- **Warning 2** — once warning 1 stopped masking the rest of the step, CI surfaced a second, pre-existing blocking warning: `Examples/Sources/SwiftQLExamples/ExampleDatabase.swift`'s `seedOccupations`/`seedPeople` statics aren't concurrency-safe because `Person`/`Occupation` ([Examples/Sources/SwiftQLExamples/ExampleSchema.swift](Examples/Sources/SwiftQLExamples/ExampleSchema.swift)) don't conform to `Sendable`. Both are plain value types (`String`/`Int`/`String?` properties only), so conforming is a correctness statement the compiler couldn't previously verify, not a behavior change.
- This was never caught before because the same job was already failing earlier (a `swift-frontend` segfault in the Getting Started playground step, [issue #530](https://github.com/lukevanin/swiftql/issues/530) / fixed by [PR #538](https://github.com/lukevanin/swiftql/pull/538)), so the strict-concurrency step's output was never reached/reported.
- **`Swift 6.0 / committed resolution` still fails on this PR** — the SILGen segfault #538 fixes is not yet merged into `version/1.5.6`, so that job never reaches the strict-concurrency step at all (confirmed: `check-strict-concurrency.sh` doesn't appear anywhere in its log). `Swift 6.0 / clean resolution` happened not to hit the segfault on this run and got all the way through the strict-concurrency step clean, confirming both fixes above are correct. Once #538 lands on `version/1.5.6` and this branch is rebased, `committed resolution` should go green too.
- Newer compilers in the CI matrix don't emit either warning, and the local toolchain here is Swift 6.3.2 (also quiet), so this can only be confirmed via the pinned Swift 6.0 CI cell.

## Test plan

- [x] `swift build --build-tests -Xswiftc -strict-concurrency=complete` succeeds locally (Swift 6.3.2 — does not reproduce the pinned-cell warnings, included for basic sanity only)
- [x] `Swift 6.0 / clean resolution` passes on this PR, strict-concurrency step included
- [ ] `Swift 6.0 / committed resolution` — blocked on #538 landing on `version/1.5.6` (unrelated segfault, not this PR's diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
