### PR TITLE
Retire the flaky-until-proven-otherwise rule for the live-query suites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,16 +38,18 @@ swift test
 fail intermittently under load, and the working rule was to re-run them before
 believing a failure. That is no longer true, and the rule is retired.
 
-Every wait in those suites is an await on a named event -- a subscription
-lifecycle transition, a harness state change, an Observation change -- through
-the shared helpers in `Tests/SQLTests/XLLiveQueryWaitSupport.swift`. None of
-them derives a verdict from elapsed wall-clock time, so a loaded machine can
-make one of these tests slower but cannot make it fail. **A failure there is a
-regression to investigate, not noise to re-run away.**
+Waits in those suites are awaits on a named event -- a subscription lifecycle
+transition, a harness state change, a change reported by Observation -- through
+the shared helpers in `Tests/SQLTests/XLLiveQueryWaitSupport.swift`. A loaded
+machine makes those tests slower; it does not change their verdict. **A failure
+there is a regression to investigate, not noise to re-run away.**
 
-When adding a test to those files, wait on an event rather than a duration. For
-the one condition nothing can signal -- an object being deallocated -- use
-`xlWaitUntil(describing:)`, whose failure names what it was waiting for.
+There is one deliberate exception. `xlWaitUntil(describing:)` is time-bounded,
+because the condition it exists for -- an object being deallocated -- has
+nothing to signal it. Only three tests use it, and its failure names what it was
+waiting for, so a timeout there says which unobservable condition never became
+true rather than leaving you to guess. Treat that one as the exception it is:
+everything else should wait on an event, not a duration.
 
 ### Test directory layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,24 @@ Run the full test suite:
 swift test
 ```
 
+### The live-query async suites are deterministic
+
+`XLAsyncStreamPublisherTests`, `XLObservableLiveQueryTests`,
+`GRDBLiveQueryAsyncStreamTests`, and `LiveQueryBufferingSemanticsTests` used to
+fail intermittently under load, and the working rule was to re-run them before
+believing a failure. That is no longer true, and the rule is retired.
+
+Every wait in those suites is an await on a named event -- a subscription
+lifecycle transition, a harness state change, an Observation change -- through
+the shared helpers in `Tests/SQLTests/XLLiveQueryWaitSupport.swift`. None of
+them derives a verdict from elapsed wall-clock time, so a loaded machine can
+make one of these tests slower but cannot make it fail. **A failure there is a
+regression to investigate, not noise to re-run away.**
+
+When adding a test to those files, wait on an event rather than a duration. For
+the one condition nothing can signal -- an object being deallocated -- use
+`xlWaitUntil(describing:)`, whose failure names what it was waiting for.
+
 ### Test directory layout
 
 The `Tests/` directory contains several distinct kinds of targets, and the split

--- a/SKILL.md
+++ b/SKILL.md
@@ -421,8 +421,9 @@ The live-query async suites -- `XLAsyncStreamPublisherTests`,
 `XLObservableLiveQueryTests`, `GRDBLiveQueryAsyncStreamTests`, and
 `LiveQueryBufferingSemanticsTests` -- were unreliable for a long time, and the
 standing advice was to treat any failure in them as flaky until proven
-otherwise. That advice is retired. No test in them derives a verdict from
-elapsed time any more: every wait is an await on a named event, through
-`Tests/SQLTests/XLLiveQueryWaitSupport.swift`. Load can delay one of these
-tests; it cannot change its outcome. Investigate a failure there as a
-regression rather than re-running it away.
+otherwise. That advice is retired. Waits there are awaits on named events,
+through `Tests/SQLTests/XLLiveQueryWaitSupport.swift`, so load delays these
+tests rather than changing their verdict. The one time-bounded helper,
+`xlWaitUntil(describing:)`, covers the only condition nothing can signal -- an
+object being deallocated -- and names that condition when it times out.
+Investigate a failure there as a regression rather than re-running it away.

--- a/SKILL.md
+++ b/SKILL.md
@@ -416,3 +416,13 @@ consumer fixture and checked by `SQLSkillDocumentationTests`; edit the fixture
 first, never the fence. Run the warnings and strict-concurrency gates with a
 supported Xcode, and use the required GitHub compatibility matrix for exact
 Swift 5.9 and Swift 6.0-6.3 evidence rather than substituting a local compiler.
+
+The live-query async suites -- `XLAsyncStreamPublisherTests`,
+`XLObservableLiveQueryTests`, `GRDBLiveQueryAsyncStreamTests`, and
+`LiveQueryBufferingSemanticsTests` -- were unreliable for a long time, and the
+standing advice was to treat any failure in them as flaky until proven
+otherwise. That advice is retired. No test in them derives a verdict from
+elapsed time any more: every wait is an await on a named event, through
+`Tests/SQLTests/XLLiveQueryWaitSupport.swift`. Load can delay one of these
+tests; it cannot change its outcome. Investigate a failure there as a
+regression rather than re-running it away.


### PR DESCRIPTION
Closes #468

## Summary

The rule for these suites was "treat any single failure as flaky until proven otherwise, verify via an isolated rerun before treating it as a regression." It existed because the suites were genuinely unreliable, and it meant a real regression in the live-query async engine could be dismissed as noise. #464 through #467, plus the three defects the repeat runs themselves turned up (#533, #537, #541, and the `stop()` race in #544), removed the reasons for it. This retires it on evidence.

## The evidence: 50 consecutive passing runs

```
commit=918786bc30f58fdfc8e1cec5c397dfffb2b18da3
cores=14 dedicated_spinners=4
command=swift test --skip-build
started=2026-08-03T06:15:11Z
finished=2026-08-03T07:07:27Z pass=50 fail=0
```

| | | |
|---|---|---|
| run 01 PASS 60s (load 5.08) | run 02 PASS 59s (6.32) | run 03 PASS 58s (6.28) |
| run 04 PASS 58s (6.63) | run 05 PASS 59s (6.64) | run 06 PASS 59s (7.88) |
| run 07 PASS 59s (6.96) | run 08 PASS 59s (9.03) | run 09 PASS 546s (8.37) |
| run 10 PASS 50s (8.39) | run 11 PASS 52s (7.75) | run 12 PASS 51s (7.69) |
| run 13 PASS 51s (7.29) | run 14 PASS 52s (7.15) | run 15 PASS 51s (7.50) |
| run 16 PASS 51s (7.23) | run 17 PASS 51s (7.87) | run 18 PASS 52s (7.23) |
| run 19 PASS 51s (7.59) | run 20 PASS 52s (7.73) | run 21 PASS 51s (7.82) |
| run 22 PASS 52s (7.91) | run 23 PASS 51s (8.30) | run 24 PASS 52s (7.43) |
| run 25 PASS 52s (7.55) | run 26 PASS 53s (7.86) | run 27 PASS 52s (7.96) |
| run 28 PASS 52s (7.51) | run 29 PASS 52s (7.69) | run 30 PASS 51s (7.15) |
| run 31 PASS 52s (7.29) | run 32 PASS 52s (8.18) | run 33 PASS 51s (7.09) |
| run 34 PASS 52s (6.97) | run 35 PASS 52s (7.72) | run 36 PASS 51s (8.18) |
| run 37 PASS 52s (8.72) | run 38 PASS 51s (7.63) | run 39 PASS 53s (8.22) |
| run 40 PASS 53s (9.70) | run 41 PASS 52s (8.26) | run 42 PASS 52s (7.36) |
| run 43 PASS 52s (7.05) | run 44 PASS 51s (7.74) | run 45 PASS 52s (7.80) |
| run 46 PASS 52s (7.90) | run 47 PASS 51s (8.33) | run 48 PASS 51s (7.99) |
| run 49 PASS 52s (8.30) | run 50 PASS 53s (8.52) | |

Load comes from two sources, both recorded per run: four dedicated CPU spinners for the whole sequence, and the machine's ambient load from other agent sessions building and testing this same repository throughout. Run 09 took 546s against a 52s median -- an unrelated build storm landing mid-run. It still passed, which is the point: **load changes how long these tests take, not whether they pass.**

## The command, recorded so it can be re-run

```sh
for i in $(seq 1 4); do yes > /dev/null & done
for run in $(seq 1 50); do
  swift test --skip-build > "run-$run.log" 2>&1
  printf 'run %02d exit=%s %s\n' "$run" "$?" "$(uptime | sed 's/.*load averages*: //')"
done
pkill -x yes
```

The suite is run whole, not with `--filter`: the concurrency of the surrounding suites is part of the reproduction.

## What the earlier sequences found

Three sequences ran before this one, and each surfaced a real defect instead of converging. Every one was written up on #463 rather than retried away, which is what this issue asked for:

| Sequence | Result | Defect | Fix |
|---|---|---|---|
| 1 | 4 passed, run 5 **hung** | The manual retry scheduler dropped a fired delay before the bridge subscribed to it | #537 |
| 2 | 46 passed, run 25 **failed** | An observation still fetching after its consuming task was cancelled | #541 / #543 |
| 3 | 49 passed, run 41 **failed** | `testCancellationBeforeInitialValuePreventsAnyFetch` asserted a race it happened to win | #544 |
| 4 | **50 passed** | -- | -- |

Three defects, none of which ordinary CI had ever isolated, all found by looking rather than by re-running. That is the argument for the repeat gate.

## Guidance changes

- `CONTRIBUTING.md` gains "The live-query async suites are deterministic" under *Running the tests*: the four suites are named, the re-run rule is explicitly retired, and a failure there is called a regression to investigate. It also tells anyone adding a test to those files to wait on an event, and points at `xlWaitUntil(describing:)` for the one condition nothing can signal.
- `SKILL.md`'s *Validate repository changes* section carries the same statement for agents.

No other guidance in the repository described these suites as flaky. The wording that did -- an agent memory note carried between sessions -- has been rewritten to match.

## No new CI job

Nothing added to `.github/workflows/swift.yml`, per this issue.

## Where this deviates from the acceptance criteria

The criterion says "on a CI runner". These sequences ran on the development machine, and that is a real deviation rather than an equivalent:

- Dispatching a workflow needs the workflow file on the **default branch**, and this chain must not touch `main`.
- A job in `swift.yml` to carry it is exactly the recurring cost the same issue forbids.

What the local runs give up is a runner's specific core count and I/O profile. What they add is sustained CPU contention across the whole sequence -- which no CI cell has, and which is what surfaced all three defects above. The PR's own compatibility matrix still runs the full suite once on each pinned cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
