### PR TITLE
Cancel the observation when cancellation lands between next() calls

### DIFF
--- a/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
+++ b/Tests/SQLTests/GRDBLiveQueryAsyncStreamTests.swift
@@ -639,6 +639,59 @@ final class GRDBLiveQueryAsyncStreamTests: XCTestCase {
         )
     }
 
+    /// Cancellation that lands *between* two `next()` calls must still tear the observation down.
+    ///
+    /// The sibling test above cancels while the consumer is suspended inside `next()`, where
+    /// `GRDBLiveQueryAsyncBridge`'s own `withTaskCancellationHandler(onCancel:)` fires. This one
+    /// parks the consumer in the loop *body* instead, which is the case `AsyncThrowingStream`'s
+    /// `unfolding` wrapper short-circuits: the next iteration resolves to `nil` without ever
+    /// calling the bridge, so that handler never runs. What stops the observation instead is the
+    /// wrapper releasing the unfolding closure -- the stream is the bridge's only owner, so the
+    /// bridge deinits and its `AnyDatabaseCancellable` cancels on deinit, which is exactly why
+    /// `stream()` captures `self` strongly.
+    ///
+    /// Added by #541, where the same cancellation path left a prototype bridge fetching because it
+    /// captured `self` weakly. The production bridge was checked and found safe; this test is what
+    /// keeps it that way. `withExtendedLifetime(stream)` holds the stream past the assertion, so a
+    /// regression cannot hide behind the test's own scope ending.
+    func testCancellationBetweenNextCallsTearsDownObservation() async throws {
+        try createRecordTable()
+        let stream = database.makeRequest(with: orderedStatement()).stream()
+        let firstValue = XLAwaitableValue<Bool>()
+        let resumeLoopBody = XLAwaitableValue<Bool>()
+        let loopEnded = XLAwaitableValue<Bool>()
+
+        let task = Task {
+            do {
+                for try await _ in stream {
+                    firstValue.fulfill(true)
+                    // Parking here, rather than inside `next()`, is the whole point of this test.
+                    _ = await resumeLoopBody.wait()
+                }
+            }
+            catch {
+                XCTFail("Unexpected stream error: \(error)")
+            }
+            loopEnded.fulfill(true)
+        }
+
+        _ = await firstValue.wait()
+        task.cancel()
+        resumeLoopBody.fulfill(true)
+        _ = await loopEnded.wait()
+
+        let fetchCountAtCancel = logger.count(containing: "stream:")
+        try insertDirect(AsyncStreamRecord(id: "after-cancel-between-next", value: 1))
+        await drainMainQueue()
+        XCTAssertEqual(
+            logger.count(containing: "stream:"),
+            fetchCountAtCancel,
+            "A write after cancellation must not fetch, even when the cancellation landed between "
+                + "two next() calls."
+        )
+        withExtendedLifetime(stream) {}
+    }
+
     func testCancellationBeforeFirstNextPreventsAnyFetch() async throws {
         try createRecordTable()
         let stream = database.makeRequest(with: orderedStatement()).stream()

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -477,9 +477,22 @@ private final class LazyBufferedGRDBBridge<Value>: @unchecked Sendable {
     /// value performs no database work: only the first `next()` call (i.e.
     /// the first iteration attempt, whether via `for try await` or a manual
     /// `makeAsyncIterator().next()`) starts the GRDB observation.
+    ///
+    /// The closure captures `self` strongly, matching `GRDBLiveQueryAsyncBridge.stream()`. That is
+    /// not incidental: `AsyncThrowingStream`'s own `unfolding` wrapper resolves to `nil` *without
+    /// calling this closure* when the consuming task is already cancelled, and it releases the
+    /// closure at the same time. For the production bridge that release is what tears the
+    /// observation down -- the stream is the bridge's only owner, so the bridge deinits and its
+    /// `AnyDatabaseCancellable` cancels on deinit. A `[weak self]` capture here broke that model:
+    /// a cancellation landing *between* two `next()` calls never reached the bridge (the closure
+    /// was never entered) and never released it either, so the observation kept fetching. That is
+    /// issue #541, seen first as a 1-in-50 failure of
+    /// `testCancellingTheConsumingTaskCancelsTheUnderlyingObservation`.
+    ///
+    /// No retain cycle: the bridge holds no reference back to the stream.
     func stream() -> AsyncThrowingStream<Value, Error> {
-        AsyncThrowingStream(unfolding: { [weak self] in
-            try await self?.next()
+        AsyncThrowingStream(unfolding: {
+            try await self.next()
         })
     }
 }
@@ -812,10 +825,62 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
         )
     }
 
+    /// Cancellation that lands *between* two `next()` calls must still stop the observation.
+    ///
+    /// The consumer parks in the loop body rather than inside `next()`, so this is the case
+    /// `AsyncThrowingStream`'s `unfolding` wrapper short-circuits: it resolves the next iteration to
+    /// `nil` without ever calling the bridge, so the bridge's own
+    /// `withTaskCancellationHandler(onCancel:)` never fires. What stops the observation instead is
+    /// the release of the unfolding closure -- the stream is the bridge's only owner, so the bridge
+    /// deinits and its `AnyDatabaseCancellable` cancels. Issue #541: while the prototype's
+    /// `stream()` captured `self` weakly, nothing tore it down on this path and the observation
+    /// kept fetching, which is what made
+    /// `testCancellingTheConsumingTaskCancelsTheUnderlyingObservation` fail roughly 1 run in 50.
+    func testCancellationBetweenNextCallsStillCancelsTheObservation() async throws {
+        let fetchCounter = LockedCounter()
+        // The stream is deliberately the bridge's only owner, exactly as in production
+        // (`GRDBRequest.stream()` hands its bridge straight to the returned stream).
+        let stream = makeBridge(fetchProbe: { fetchCounter.increment() }).stream()
+        let firstValue = XLAwaitableValue<Bool>()
+        let resumeLoopBody = XLAwaitableValue<Bool>()
+        let loopEnded = XLAwaitableValue<Bool>()
+
+        let task = Task {
+            do {
+                for try await _ in stream {
+                    firstValue.fulfill(true)
+                    // Parking here, rather than inside `next()`, is the whole point of this test.
+                    _ = await resumeLoopBody.wait()
+                }
+            }
+            catch {
+                XCTFail("Unexpected stream error: \(error)")
+            }
+            loopEnded.fulfill(true)
+        }
+
+        _ = await firstValue.wait()
+        task.cancel()
+        resumeLoopBody.fulfill(true)
+        _ = await loopEnded.wait()
+
+        let fetchCountAtCancel = fetchCounter.read()
+        try insert("after-cancel-between-next", 99)
+        await xlDrainMainQueue()
+        XCTAssertEqual(
+            fetchCounter.read(),
+            fetchCountAtCancel,
+            "A write after cancellation must not fetch, even when the cancellation landed between "
+                + "two next() calls."
+        )
+    }
+
     func testCancellingTheConsumingTaskCancelsTheUnderlyingObservation() async throws {
         let fetchCounter = LockedCounter()
-        let bridge = makeBridge(fetchProbe: { fetchCounter.increment() })
-        let stream = bridge.stream()
+        // As in production, the stream owns the bridge (see `stream()`'s note): holding a separate
+        // strong reference here would keep the observation alive past a cancellation that landed
+        // between two `next()` calls, which is issue #541.
+        let stream = makeBridge(fetchProbe: { fetchCounter.increment() }).stream()
         let seen = LockedArray<Int>()
         let loopExpectation = expectation(description: "loop ends after task cancellation")
 

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -879,6 +879,62 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
         withExtendedLifetime(stream) {}
     }
 
+    /// Negative control for the test above: it must be able to fail.
+    ///
+    /// The teardown that test relies on is deallocation-driven -- the stream releases the unfolding
+    /// closure when the consuming task is cancelled, the bridge is then unreferenced, and its
+    /// `AnyDatabaseCancellable` cancels on deinit. So the way to reach the broken world is to break
+    /// the ownership rule rather than to break the code: this control keeps its own strong
+    /// reference to the bridge, which production has no way to do (`GRDBRequest.stream()` hands its
+    /// bridge straight to the stream and keeps nothing), and the observation then survives the
+    /// cancellation and fetches again.
+    ///
+    /// Reverting `stream()`'s capture to `[weak self]` is *not* a usable control here: with the
+    /// production ownership shape nothing would retain the bridge past `stream()` at all, so the
+    /// stream would vend nothing and the test would hang instead of failing -- the other failure
+    /// mode that capture's comment warns about.
+    ///
+    /// Constants are decoupled from the paired test's: a different row id and a different value.
+    func testNegativeControlARetainedBridgeKeepsObservingAfterCancellation() async throws {
+        let fetchCounter = LockedCounter()
+        let bridge = makeBridge(fetchProbe: { fetchCounter.increment() })
+        let stream = bridge.stream()
+        let firstValue = XLAwaitableValue<Bool>()
+        let resumeLoopBody = XLAwaitableValue<Bool>()
+        let loopEnded = XLAwaitableValue<Bool>()
+
+        let task = Task {
+            do {
+                for try await _ in stream {
+                    firstValue.fulfill(true)
+                    _ = await resumeLoopBody.wait()
+                }
+            }
+            catch {
+                XCTFail("Unexpected stream error: \(error)")
+            }
+            loopEnded.fulfill(true)
+        }
+
+        _ = await firstValue.wait()
+        task.cancel()
+        resumeLoopBody.fulfill(true)
+        _ = await loopEnded.wait()
+
+        let fetchCountAtCancel = fetchCounter.read()
+        try insert("retained-bridge-after-cancel", 77)
+        await xlDrainMainQueue()
+
+        XCTAssertNotEqual(
+            fetchCounter.read(),
+            fetchCountAtCancel,
+            "Negative control: with an extra strong reference keeping the bridge alive, the "
+                + "observation must still be fetching -- otherwise the paired test's assertion "
+                + "cannot fail and proves nothing."
+        )
+        withExtendedLifetime((bridge, stream)) {}
+    }
+
     func testCancellingTheConsumingTaskCancelsTheUnderlyingObservation() async throws {
         let fetchCounter = LockedCounter()
         // As in production, the stream owns the bridge (see `stream()`'s note): holding a separate

--- a/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
+++ b/Tests/SQLTests/LiveQueryBufferingSemanticsTests.swift
@@ -873,6 +873,10 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
             "A write after cancellation must not fetch, even when the cancellation landed between "
                 + "two next() calls."
         )
+        // Holds the stream -- and so the bridge -- past the assertion. Without this, ARC is free to
+        // release it once the consuming task has ended, and the test would pass because the bridge
+        // deallocated rather than because cancellation tore the observation down.
+        withExtendedLifetime(stream) {}
     }
 
     func testCancellingTheConsumingTaskCancelsTheUnderlyingObservation() async throws {
@@ -909,6 +913,9 @@ final class LiveQueryBufferingSemanticsTests: XCTestCase {
             fetchCountAtCancel,
             "Cancelling the consuming task must cancel the underlying GRDB observation."
         )
+        // See the note in testCancellationBetweenNextCallsStillCancelsTheObservation: the stream
+        // must outlive the assertion, or a pass proves deallocation rather than cancellation.
+        withExtendedLifetime(stream) {}
     }
 
     // MARK: - Terminal error (edge case: terminal error)


### PR DESCRIPTION
Closes #541

## Summary

#468's repeat run failed on `LiveQueryBufferingSemanticsTests.testCancellingTheConsumingTaskCancelsTheUnderlyingObservation`: a fetch ran after the consuming task was cancelled and its loop had ended. The issue was filed with the mechanism as a hypothesis and an explicit question -- whether production is affected. **It is not**, and this PR proves that rather than assuming it.

## The mechanism, confirmed

`AsyncThrowingStream`'s own `unfolding` wrapper resolves the next iteration to `nil` **without calling the unfolding closure** when the consuming task is already cancelled, and releases that closure at the same time. So a cancellation landing *between* two `next()` calls -- while the consumer is in its loop body rather than suspended inside `next()` -- never reaches the bridge's `withTaskCancellationHandler(onCancel:)`.

What stops the observation on that path is the closure's release: the stream is the bridge's only owner, the bridge deinits, and GRDB's `AnyDatabaseCancellable` [cancels on deinit](https://github.com/groue/GRDB.swift/blob/master/GRDB/ValueObservation/DatabaseCancellable.swift).

## Production: checked, safe, and now covered

`GRDBLiveQueryAsyncBridge.stream()` captures `self` strongly, which its own doc comment already called out as deliberate. A new test parks the consumer in the loop body, cancels the task, lets the loop end, writes to the database, and asserts no fetch happened -- holding the stream alive past the assertion with `withExtendedLifetime` so a regression cannot hide behind the test's scope ending. **It passes against the production bridge unmodified**, 3/3 when first run as a probe.

That test is kept: it is the thing that will notice if the strong capture is ever "tidied" into a weak one.

## The prototype was the defect

`LiveQueryBufferingSemanticsTests`' `LazyBufferedGRDBBridge` captured `self` **weakly** -- a silent divergence from the type it exists to model. With the test also holding the bridge, nothing released it on this path, so the observation kept fetching. That is the whole failure.

- The prototype now captures strongly, with a comment explaining why the capture is load-bearing rather than incidental.
- The two cancellation tests let the stream own the bridge, exactly as `GRDBRequest.stream()` does.
- The 1-in-50 flake now has a deterministic sibling: `testCancellationBetweenNextCallsStillCancelsTheObservation` parks the consumer in the loop body instead of hoping the scheduler puts it there.

## Test plan

- [x] Deterministic reproduction **failed 3/3 before the fix** (`("2") is not equal to ("1")`, the same signature as the intermittent failure) and passes after
- [x] Production probe passes 3/3 against the unmodified bridge
- [x] `LiveQueryBufferingSemanticsTests` + `GRDBLiveQueryAsyncStreamTests` -- 33/33
- [x] **60 consecutive runs of both suites under one CPU spinner per core: 0 failures**
- [x] `swift build --build-tests` -- no warnings

Unblocks #468, whose 50-run sequence restarts on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)