### PR TITLE
Audit v1.5.6 release readiness (#232)

### DIFF
--- a/Documentation/ReleaseAudits/v1.5.md
+++ b/Documentation/ReleaseAudits/v1.5.md
@@ -49,12 +49,11 @@ produced at the sixth:
 | Public documentation and agent guidance | #230, #231, #431 | README, DocC, `COMPATIBILITY.md`, `SKILL.md`, `CONTRIBUTING.md` and a plain-language `WHATSNEW.md` refreshed and restructured onboarding-first |
 | Interactive DocC tutorial | #27 | Delivered under `Sources/SwiftQL/SwiftQL.docc/Tutorials` |
 | Getting Started playground | #478, #480, #481, #483 | Nine-page playground plus the `SwiftQLExamples` product it imports, verified by `check-playground-pages.sh` |
-| To-do demo application | #470–#477 | `Examples/TodoApp`, its query layer, live-query interface, unit tests, README link, DocC article, and a CI job |
+| To-do demo application | #470–#477 | `Examples/TodoApp`, its query layer, live-query interface, unit tests, README link, DocC article, and a CI job. #475 also corrected the workflow trigger so pull requests against `version/**` run the compatibility workflow at all |
 | Benchmarks | #257, #259 | Consumer compile-time scalability harness; cross-library workload research with contracts, an applicability matrix, and a three-family prototype |
 | Build validator | #440, #492 | Skipped-check reporting and schema-mismatch short-circuiting; the Xcode `Build input file cannot be found` failure fixed |
 | Coverage reporting | #438, #439 | LCOV uploaded to Codecov with a README badge |
 | Concurrency and toolchain fixes | #530, #531 | Swift 6.0 SILGen crash worked around in the demo and playground; `@SQLTable`/`@SQLResult` now derive `Sendable` on Swift 6.0 and later |
-| CI trigger correction | #475 | Pull requests against `version/**` now run the compatibility workflow |
 | Live-query test determinism | #463–#468, #533, #541 | Every wait in the four live-query suites is an await on a named event; the flaky-until-proven-otherwise rule is retired |
 | This audit | #232 | Delivered |
 | To-do demo tracking issue | #469 | Open by design; see below |
@@ -103,24 +102,24 @@ pass on the audited commit, and `sqlite-conformance-inventory.py validate` agree
 
 ### Planning reconciliation
 
-- The `v1.5.6` milestone has 32 closed issues and 2 open: #232, this audit, and
+- The `v1.5.6` milestone has 32 closed issues and 2 open: this audit (#232) and
   #469.
 - #469 is a standing tracker for the to-do demo whose eight remaining children
   (#479, #482, #484, #485, #486, #487, #488, #489) are milestoned across v1.6,
   v1.7, v1.8, v2, v2.1, v2.5, v2.6 and v2.8. It is **not** a v1.5.6 gap: every
   demo task the v1.5.6 milestone scoped (#470–#477) is closed and the demo builds
   and tests on both platforms. Its milestone assignment is the only thing that
-  stops #27's milestone closing, which the release preparation resolves the way
-  v1.4.6 resolved #115.
+  stops the v1.5.6 milestone closing once #232 is closed, which the release
+  preparation resolves the way v1.4.6 resolved #115.
 - #232's six recorded GitHub dependencies (#230, #231, #249, #256, #257, #259)
   are all closed, as are the issues its body names as coordinating work: #18,
   #26, #27, #291, #308 and #309. #116 and #117 are standing trackers that remain
   open by design.
-- Three v1.5-line follow-ups have their own issues but no milestone: #115 (the
-  standing conformance index, deliberately unmilestoned since the v1.4 audit),
-  #458 (a public `XLResultSet` initializer, from #249), and #495 (reinstating the
-  build-validation blog post, gated on #494). None is a v1.5.6 gap; each is
-  tracked and unscheduled.
+- Two v1.5-line follow-ups have their own issues but no milestone: #458 (a public
+  `XLResultSet` initializer, from #249) and #495 (reinstating the
+  build-validation blog post, gated on #494). Neither is a v1.5.6 gap; both are
+  tracked and unscheduled. #115 is also unmilestoned, deliberately so since the
+  v1.4 audit unlinked it to let v1.4.6 close.
 - `ROADMAP.md` does not agree with the live milestone set. That is #545.
 
 ### Open pull requests against `version/1.5.6`
@@ -150,13 +149,15 @@ so every compiler cell on it is red for reasons unrelated to its own diff.
 Recommended disposition: rebase onto the current tip and land it against #547 in
 v1.6, or close it in favour of reimplementing from #547.
 
-The audit's finding here is not about either pull request's code. It is that the
-underlying ergonomic gap had no issue at all, in either direction: #507 filed it
-as a follow-up inside a pull request, #526's description claims a fix that its
-merge commit `dcd20a51` does not contain (four files, none of them Swift source:
-the playground page, `Examples/README.md`, `GettingStarted.md` and
-`SQLExampleTests.swift`), and #539 exists without an issue behind it. #547 now tracks it. What v1.5.6 ships is correct and documented: the
-`toNullable()` and explicit-cast spelling in `GettingStarted.md`, covered by
+What the audit found here is that the underlying ergonomic gap had no issue
+behind it at any point. #507 filed it as a follow-up inside a pull request,
+#526's description claims a fix that its merge commit `dcd20a51` does not
+contain (four files, none of them Swift source: the playground page,
+`Examples/README.md`, `GettingStarted.md` and `SQLExampleTests.swift`), and #539
+exists on its own. Anyone reading #526 to work out what is on the branch should
+read `dcd20a51` instead. #547 now tracks the gap, and what v1.5.6 ships is
+correct and documented: the `toNullable()` and explicit-cast spelling in
+`GettingStarted.md`, covered by
 `XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings`.
 
 ### Validation evidence
@@ -219,10 +220,13 @@ listed so nothing is carried forward untracked.
 1. **Clear #469's milestone so `v1.5.6` can close.** `RELEASING.md` step 1
    requires the milestone to have no open issues. #469 is a standing tracker
    whose remaining children all live in later milestones, exactly the situation
-   the v1.4.6 release resolved by unlinking #115. Close #232 and unlink #469, and
-   the milestone reaches zero.
-2. **Date the changelog heading and write the `WHATSNEW.md` section**, per steps
-   4 and 5.
+   the v1.4.6 release resolved by unlinking #115. Unlinking it is the last thing
+   the milestone needs: #232 is closed when the pull request carrying this record
+   merges, which has to be done by hand because that pull request targets
+   `version/1.5.6` rather than the default branch and GitHub only auto-closes on
+   the default branch.
+2. **Date the changelog heading and write the `WHATSNEW.md` section**, per step
+   4.
 3. **Bump the "latest published" references** in README, `SKILL.md` and the DocC
    landing page from `1.5.5` to `1.5.6`.
 4. **Consider a `### Known limitations` entry in `CHANGELOG.md`'s `[1.5.6]`
@@ -238,8 +242,8 @@ swift test
 scripts/ci/check-first-party-warnings.sh
 scripts/ci/check-strict-concurrency.sh
 scripts/ci/check-downstream-swift5-client.sh committed
-scripts/ci/sqlite-conformance-inventory.py validate
-scripts/ci/check-core-contract-boundary.py
+python3 scripts/ci/sqlite-conformance-inventory.py validate
+python3 scripts/ci/check-core-contract-boundary.py
 scripts/ci/test-release-workflow.sh
 scripts/ci/check-playground-pages.sh
 scripts/ci/check-todo-demo.sh "$(mktemp -d)"

--- a/Documentation/ReleaseAudits/v1.5.md
+++ b/Documentation/ReleaseAudits/v1.5.md
@@ -1,0 +1,252 @@
+# SwiftQL v1.5 release-readiness audit
+
+The v1.5 line — "Query declarations, ergonomics, and v2 preview" — was delivered
+across the `v1.5.1`–`v1.5.6` patch milestones. Its closeout audit,
+[#232](https://github.com/lukevanin/swiftql/issues/232), is scheduled in the
+final `v1.5.6` milestone, so this single checked-in record covers the line and is
+produced at the `v1.5.6` release, as `RELEASING.md` requires. It is an
+evidence-backed record rather than an implementation task, and it does not
+weaken, skip, or relabel any validation to reach a verdict.
+
+Audited commit: `b3e75799` on `version/1.5.6`, the merge of
+[#542](https://github.com/lukevanin/swiftql/pull/542).
+
+## Verdict
+
+**Ready for `v1.5.6` and v1.5-line closure**, subject to the human-gated release
+process in `RELEASING.md`. No product, documentation, compatibility, packaging,
+security, or performance blocker remains. Every release-blocking compiler cell is
+green on the audited commit, the full first-party suite passes, and the
+documentation, compatibility, and conformance records agree with what the line
+shipped. Three gaps were found and each has its own issue: #545, #546 and #547.
+None of them blocks the release, for the reasons recorded against each below.
+
+Two things must happen in the release preparation itself and are listed under
+"Release-preparation actions": the `v1.5.6` milestone still holds two open issues
+and cannot close as `RELEASING.md` step 1 requires, and the audit found one
+`CHANGELOG.md` addition worth making while the heading still says `Unreleased`.
+
+## Verified facts
+
+### What the v1.5 line shipped
+
+No `v1.5.0` was ever published. The line released as five tags, and this audit is
+produced at the sixth:
+
+| Release | Published | Content |
+| --- | --- | --- |
+| [`v1.5.1`](https://github.com/lukevanin/swiftql/milestone/23) | 2026-07-26 | `@SQLQuery`/`@SQLQueries` declaration macros and callable prepared handles (#18, #26), typed multi-statement transaction scopes (#284), composite `@SQLResult` properties (#6), the `@SQLFunction` helper macro (#25), implicit function registration (#16), and the macro regression corpus (#256). `#row` (#20) was cut after it crashed the pinned Swift 5.9.2 compiler. |
+| [`v1.5.2`](https://github.com/lukevanin/swiftql/milestone/24) | 2026-07-27 | Build-time query validation: a versioned validation manifest (#292), the standalone `swiftql-build-validate` validator (#293), and the SwiftPM build-tool plugin wrapping it (#294). |
+| [`v1.5.3`](https://github.com/lukevanin/swiftql/milestone/25) | 2026-07-28 | Contextual value codecs: SQLite `Date` TEXT (#61) and numeric (#62) presets, JSON `Codable` codecs (#65), UUID TEXT/BLOB presets (#192), and `@SQLCodec` per-property selection (#66). |
+| [`v1.5.4`](https://github.com/lukevanin/swiftql/milestone/26) | 2026-07-29 | Query-syntax ergonomics: method-style scalar functions (#3), inferred `Setting` row generics (#96), flattened optional scalar subqueries (#162), the closed-out null-coalescing investigation (#7), SwiftUI observers (#28), and `#row`'s ad hoc projections in a Swift 5.9-safe form (#408). #69 was reverted before the release after it crashed the pinned Swift 5.9.2 and 6.0 cells, and is deferred. |
+| [`v1.5.5`](https://github.com/lukevanin/swiftql/milestone/22) | 2026-07-30 | Async live-query foundation: canonical `stream()`/`streamOne()` (#308), the buffering and resumed-demand contract (#291), Combine adapters rebuilt over the streams (#309), `@Observable` wrappers (#97), and the lazy `XLResultSet` (#249). |
+| [`v1.5.6`](https://github.com/lukevanin/swiftql/milestone/27) | unreleased | Benchmarks, documentation, and release closeout. Its 32 closed issues are broken down below. |
+
+### `v1.5.6` milestone deliverables
+
+| Area | Issues | Outcome |
+| --- | --- | --- |
+| Public documentation and agent guidance | #230, #231, #431 | README, DocC, `COMPATIBILITY.md`, `SKILL.md`, `CONTRIBUTING.md` and a plain-language `WHATSNEW.md` refreshed and restructured onboarding-first |
+| Interactive DocC tutorial | #27 | Delivered under `Sources/SwiftQL/SwiftQL.docc/Tutorials` |
+| Getting Started playground | #478, #480, #481, #483 | Nine-page playground plus the `SwiftQLExamples` product it imports, verified by `check-playground-pages.sh` |
+| To-do demo application | #470–#477 | `Examples/TodoApp`, its query layer, live-query interface, unit tests, README link, DocC article, and a CI job |
+| Benchmarks | #257, #259 | Consumer compile-time scalability harness; cross-library workload research with contracts, an applicability matrix, and a three-family prototype |
+| Build validator | #440, #492 | Skipped-check reporting and schema-mismatch short-circuiting; the Xcode `Build input file cannot be found` failure fixed |
+| Coverage reporting | #438, #439 | LCOV uploaded to Codecov with a README badge |
+| Concurrency and toolchain fixes | #530, #531 | Swift 6.0 SILGen crash worked around in the demo and playground; `@SQLTable`/`@SQLResult` now derive `Sendable` on Swift 6.0 and later |
+| CI trigger correction | #475 | Pull requests against `version/**` now run the compatibility workflow |
+| Live-query test determinism | #463–#468, #533, #541 | Every wait in the four live-query suites is an await on a named event; the flaky-until-proven-otherwise rule is retired |
+| This audit | #232 | Delivered |
+| To-do demo tracking issue | #469 | Open by design; see below |
+
+### Canonical live-query behaviour (#308, #309, #291)
+
+`Sources/SwiftQL/SwiftQL.docc/LiveQueries.md` documents the shipped contract in
+one place. `stream()`/`streamOne()` on `XLRequest` are the single canonical
+observation engine, built on `GRDBLiveQueryAsyncBridge` over
+`ValueObservation.start`. `publish()`/`publishOne()` are leaf Combine adapters
+that map `Subscribers.Demand` onto a pull loop over a fresh async stream per
+subscriber, with unchanged public signatures. The shared #291 decision is
+recorded under "Buffering and Resumed-Demand Semantics" with its snapshot
+lifecycle state machine, the rejected alternatives, the async-to-Combine demand
+mapping, and its remaining limitations: at most one undelivered snapshot per
+stream, newest wins, and resuming or replenishing demand surfaces whatever GRDB
+already produced rather than forcing a fresh fetch.
+
+`CONTRIBUTING.md` and `SKILL.md` both now state that
+`XLAsyncStreamPublisherTests`, `XLObservableLiveQueryTests`,
+`GRDBLiveQueryAsyncStreamTests` and `LiveQueryBufferingSemanticsTests` are
+deterministic, that every wait in them goes through
+`Tests/SQLTests/XLLiveQueryWaitSupport.swift`, and that a failure there is a
+regression to investigate. The repeat run backing that claim is one-off evidence
+on #468's pull request, and #468 deliberately added no new CI job.
+
+### Documentation, compatibility, and package metadata
+
+`COMPATIBILITY.md` carries the v1.5.6 facts: the `SwiftQLExamples` product and
+why it exists, the build-validation plugin's move to supported-under-both-build-systems
+with the v1.5.2–v1.5.5 `swift build`-only caveat and the #492 cause, the pinned
+compiler support points, the Swift 6 series coverage, the to-do demo, and the
+scope of the complete strict-concurrency check.
+
+README, `SKILL.md` and the DocC landing page all state that `1.5.5` is the latest
+published package, which is correct until the release bumps them. The DocC
+landing page's v1.3 boundary section carries an explicit reconciliation paragraph
+naming what the v1.5 line changed about it. `WHATSNEW.md` has no v1.5.6 section,
+which is expected: `RELEASING.md` step 4 puts it in the release-preparation
+change, alongside dating the changelog heading.
+
+The conformance counts in README, `COMPATIBILITY.md`, `CHANGELOG.md`,
+`Conformance/SQLite/REPORT.md` and `SKILL.md` are recomputed from the canonical
+JSON inventory by the documentation-catalog and skill regression suites, which
+pass on the audited commit, and `sqlite-conformance-inventory.py validate` agrees.
+
+### Planning reconciliation
+
+- The `v1.5.6` milestone has 32 closed issues and 2 open: #232, this audit, and
+  #469.
+- #469 is a standing tracker for the to-do demo whose eight remaining children
+  (#479, #482, #484, #485, #486, #487, #488, #489) are milestoned across v1.6,
+  v1.7, v1.8, v2, v2.1, v2.5, v2.6 and v2.8. It is **not** a v1.5.6 gap: every
+  demo task the v1.5.6 milestone scoped (#470–#477) is closed and the demo builds
+  and tests on both platforms. Its milestone assignment is the only thing that
+  stops #27's milestone closing, which the release preparation resolves the way
+  v1.4.6 resolved #115.
+- #232's six recorded GitHub dependencies (#230, #231, #249, #256, #257, #259)
+  are all closed, as are the issues its body names as coordinating work: #18,
+  #26, #27, #291, #308 and #309. #116 and #117 are standing trackers that remain
+  open by design.
+- Three v1.5-line follow-ups have their own issues but no milestone: #115 (the
+  standing conformance index, deliberately unmilestoned since the v1.4 audit),
+  #458 (a public `XLResultSet` initializer, from #249), and #495 (reinstating the
+  build-validation blog post, gated on #494). None is a v1.5.6 gap; each is
+  tracked and unscheduled.
+- `ROADMAP.md` does not agree with the live milestone set. That is #545.
+
+### Open pull requests against `version/1.5.6`
+
+Two pull requests target the milestone branch and neither is in scope for
+v1.5.6. Both are left open for a maintainer to dispose of; this audit does not
+merge or close them.
+
+**[#540](https://github.com/lukevanin/swiftql/pull/540), "Fix blocking
+strict-concurrency warnings on Swift 6.0" — superseded.** Both of its fixes are
+already on the branch, landed by #536 for #531. `Tests/SQLTests/XLLiveQueryWaitSupport.swift:132`
+declares `final class XLAwaitableValue<Value: Sendable>`, which commit `d67333a4`
+put there, and the `Examples` warning it describes is resolved by the
+macro-generated `Sendable` conformance from #531 rather than by the hand-written
+conformance #540 proposes. GitHub reports the pull request as `dirty`, which is
+consistent with the same lines having changed underneath it. Recommended
+disposition: close as superseded by #536, cross-linking #531.
+
+**[#539](https://github.com/lukevanin/swiftql/pull/539), "Route MetaUpdate
+columns through key-path lookup" — real work, wrong milestone.** It carries the
+`MetaUpdate` `@dynamicMemberLookup` implementation described in the body of the
+already-merged #526, which merged only its documentation commit. That work
+changes generated macro output and the shape of a public generated API, which is
+not what a "benchmarks, docs and release closeout" milestone is for, and its base
+`af00edaf` predates both the #530 SILGen fix and the #531 `Sendable` derivation,
+so every compiler cell on it is red for reasons unrelated to its own diff.
+Recommended disposition: rebase onto the current tip and land it against #547 in
+v1.6, or close it in favour of reimplementing from #547.
+
+The audit's finding here is not about either pull request's code. It is that the
+underlying ergonomic gap had no issue at all, in either direction: #507 filed it
+as a follow-up inside a pull request, #526's description claims a fix that its
+merge commit `dcd20a51` does not contain (four files, none of them Swift source:
+the playground page, `Examples/README.md`, `GettingStarted.md` and
+`SQLExampleTests.swift`), and #539 exists without an issue behind it. #547 now tracks it. What v1.5.6 ships is correct and documented: the
+`toNullable()` and explicit-cast spelling in `GettingStarted.md`, covered by
+`XLDocumentationTests.testDocumentationGettingStartedCRUDAndBindings`.
+
+### Validation evidence
+
+CI on the audited commit's pull request (#542, run
+[30792770752](https://github.com/lukevanin/swiftql/actions/runs/30792770752)):
+`Swift 5.9 / committed resolution`, `Swift 5.9 / clean resolution`,
+`Swift 6.0 / committed resolution`, `Swift 6.0 / clean resolution`,
+`To-do demo app` and `Release tooling fixtures` all succeeded. The Swift 6.1,
+6.2 and 6.3 sweep and the coverage job are skipped on pull requests by design and
+run on push to `main` and on the release workflow's `workflow_call`, which is
+where `RELEASING.md` step 2 requires all seven release-blocking cells.
+
+Run locally on `b3e75799` (Swift 6.3.2, Xcode 26.5 17F42, macOS 26.5 arm64), with
+each exit code checked directly rather than through a pipe:
+
+| Check | Result |
+| --- | --- |
+| `swift test` | 1225 tests, 0 failures, exit 0 |
+| `scripts/ci/check-first-party-warnings.sh` | `STATUS clean`, exit 0 |
+| `scripts/ci/check-downstream-swift5-client.sh committed` | exit 0 |
+| `scripts/ci/sqlite-conformance-inventory.py validate` | exit 0 |
+| `scripts/ci/check-core-contract-boundary.py` | exit 0 |
+| `scripts/ci/test-release-workflow.sh` | exit 0 |
+| `./make-docs.sh` | exit 0, `SWIFTQL_BLOG ok` |
+| `scripts/ci/check-playground-pages.sh` | all 9 pages compiled, ran and exited cleanly, exit 0 |
+| `scripts/ci/check-todo-demo.sh` | builds and tests on macOS and an iOS simulator, exit 0 |
+| `scripts/ci/check-strict-concurrency.sh` | **exit 1**, five first-party warnings; see #546 |
+
+The strict-concurrency result is the one local failure and it is not a release
+blocker. The gate is wired to the pinned Swift 6.0 cell by
+`if: matrix.swift_series == '6.0'` in `.github/workflows/swift.yml`, which passes
+on the audited commit, and `COMPATIBILITY.md` documents that pinning. The five
+`#SendableMetatypes` warnings come from a compiler three series newer than the
+gate, in Swift 5 language mode where they are warnings. They become errors when
+#133 turns on Swift 6 language mode, which is why #546 sits in v2.
+
+## Remaining work and disposition
+
+No release-blocking item remains. Three issues were filed:
+
+- **[#545](https://github.com/lukevanin/swiftql/issues/545)** (v1.6, P4) —
+  `ROADMAP.md` omits v1.6, v1.7, v1.8, v2.6, v2.7, v2.8 and the cross-library
+  benchmark milestone entirely, reads as though the cross-library benchmarks
+  shipped in v1.5, and links an empty milestone 1 for the v1.5 row.
+- **[#546](https://github.com/lukevanin/swiftql/issues/546)** (v2, P3) — five
+  first-party `#SendableMetatypes` warnings under complete strict-concurrency
+  checking on Swift 6.2 and later, in `JSONValueCodec.swift` and
+  `XLAsyncStreamPublisher.swift`, invisible to CI because the gate runs on the
+  Swift 6.0 cell only.
+- **[#547](https://github.com/lukevanin/swiftql/issues/547)** (v1.6, P3) —
+  assigning a nullable column in a `Setting` closure needs `toNullable()` or an
+  explicit `any XLExpression<Wrapped?>` cast.
+
+## Release-preparation actions
+
+These belong to `RELEASING.md`'s own flow rather than to this audit, and are
+listed so nothing is carried forward untracked.
+
+1. **Clear #469's milestone so `v1.5.6` can close.** `RELEASING.md` step 1
+   requires the milestone to have no open issues. #469 is a standing tracker
+   whose remaining children all live in later milestones, exactly the situation
+   the v1.4.6 release resolved by unlinking #115. Close #232 and unlink #469, and
+   the milestone reaches zero.
+2. **Date the changelog heading and write the `WHATSNEW.md` section**, per steps
+   4 and 5.
+3. **Bump the "latest published" references** in README, `SKILL.md` and the DocC
+   landing page from `1.5.5` to `1.5.6`.
+4. **Consider a `### Known limitations` entry in `CHANGELOG.md`'s `[1.5.6]`
+   section** for the nullable-column `Setting` spelling, matching how `[1.5.2]`
+   and `[1.5.3]` record theirs, and link #547. The section currently has
+   `Added`, `Changed` and `Fixed` only.
+
+## Reproduction commands
+
+```sh
+git checkout b3e75799
+swift test
+scripts/ci/check-first-party-warnings.sh
+scripts/ci/check-strict-concurrency.sh
+scripts/ci/check-downstream-swift5-client.sh committed
+scripts/ci/sqlite-conformance-inventory.py validate
+scripts/ci/check-core-contract-boundary.py
+scripts/ci/test-release-workflow.sh
+scripts/ci/check-playground-pages.sh
+scripts/ci/check-todo-demo.sh "$(mktemp -d)"
+docc_output="$(mktemp -d)"; ./make-docs.sh "$docc_output"
+git diff --check
+```
+
+Per-release local results and the release-run, asset, attestation, and ruleset
+evidence are recorded in the dedicated `v1.5.6` release issue, so this checked-in
+record does not imply that mutable CI runs are part of the source contract.


### PR DESCRIPTION
Closes #232.

Adds `Documentation/ReleaseAudits/v1.5.md`, the checked-in release-readiness
record `RELEASING.md` requires when a line's audit issue sits in the version
being released. #232 is scheduled in v1.5.6, the last milestone of the v1.5 line,
so this covers v1.5.1 through v1.5.6 the way `v1.4.md` covers the v1.4 line.

Audit-only. No product code, test, workflow or configuration file changes.

## Verdict

**Ready**, subject to the human-gated release process. Audited commit is
`b3e75799`.

## Evidence the verdict rests on

CI on #542, run [30792770752](https://github.com/lukevanin/swiftql/actions/runs/30792770752):
Swift 5.9 committed and clean, Swift 6.0 committed and clean, the to-do demo job
and the release tooling fixtures all succeeded.

Run locally on `b3e75799` (Swift 6.3.2, Xcode 26.5 17F42, macOS 26.5 arm64), exit
codes checked directly rather than through a pipe:

| Check | Result |
| --- | --- |
| `swift test` | 1225 tests, 0 failures, exit 0 |
| `check-first-party-warnings.sh` | `STATUS clean`, exit 0 |
| `check-downstream-swift5-client.sh committed` | exit 0 |
| `sqlite-conformance-inventory.py validate` | exit 0 |
| `check-core-contract-boundary.py` | exit 0 |
| `test-release-workflow.sh` | exit 0 |
| `./make-docs.sh` | exit 0, `SWIFTQL_BLOG ok` |
| `check-playground-pages.sh` | 9 pages compiled, ran and exited cleanly, exit 0 |
| `check-todo-demo.sh` | macOS and iOS simulator, exit 0 |
| `check-strict-concurrency.sh` | exit 1, five first-party warnings, tracked as #546 |

The strict-concurrency failure comes from a compiler three series newer than the
gate, which `.github/workflows/swift.yml` pins to the Swift 6.0 cell and
`COMPATIBILITY.md` documents as pinned. It is not a v1.5.6 blocker and the audit
says why.

## Follow-up issues filed

- #545 (v1.6, P4) — `ROADMAP.md` omits v1.6, v1.7, v1.8, v2.6, v2.7, v2.8 and
  the cross-library benchmark milestone, reads as though the cross-library
  benchmarks shipped in v1.5, and links an empty milestone 1 for its v1.5 row.
- #546 (v2, P3) — five `#SendableMetatypes` warnings in `JSONValueCodec.swift`
  and `XLAsyncStreamPublisher.swift` under complete strict-concurrency checking
  on Swift 6.2 and later, invisible to CI.
- #547 (v1.6, P3) — assigning a nullable column in a `Setting` closure needs
  `toNullable()` or an explicit `any XLExpression<Wrapped?>` cast.

## The two open pull requests, assessed but untouched

#540 is superseded: both of its fixes are already on `version/1.5.6` via #536 for
#531, and GitHub reports it `dirty`. #539 carries the `MetaUpdate` key-path
implementation that #526's description claims but its merge commit `dcd20a51`
does not contain; it is macro-codegen work on a base predating #530 and #531, so
it belongs in v1.6 behind #547 rather than in a closeout milestone. Neither is
merged or closed here.

## What reviewers should look at closely

The "Verified facts" section, since the whole document is a factual claim. Every
issue number, exit code and commit hash in it was checked against the live API or
a local run rather than recalled.

Two items in "Release-preparation actions" need a maintainer: #469's milestone
has to be cleared before v1.5.6 can close with no open issues, the way v1.4.6
unlinked #115, and `CHANGELOG.md`'s `[1.5.6]` section could carry a
`### Known limitations` entry for the nullable-`Setting` spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
