### PR TITLE
Verify the coverage checkout before Codecov's diagnostic upload runs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -133,6 +133,16 @@ jobs:
           cat "$RUNNER_TEMP/swiftql-coverage-run-1/summary.md" \
             >> "$GITHUB_STEP_SUMMARY"
 
+      # Checked here, immediately after the captures that must not mutate the
+      # source tree, and before any diagnostic step below. The Codecov action
+      # in particular downloads its uploader into the checkout and leaves it
+      # behind as an untracked file, which is its own side effect, not
+      # evidence that a capture touched first-party source.
+      - name: Verify checkout remains clean
+        run: |
+          git diff --exit-code
+          test -z "$(git status --porcelain)"
+
       # Diagnostic evidence upload, not a release gate (Coverage/README.md) -- failure here
       # must never fail this job, hence fail_ci_if_error: false.
       - name: Upload coverage evidence to Codecov
@@ -187,11 +197,6 @@ jobs:
             "$ARTIFACT_URL" >> "$GITHUB_STEP_SUMMARY"
           printf -- '- Artifact SHA-256: `%s`\n' \
             "$ARTIFACT_DIGEST" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Verify checkout remains clean
-        run: |
-          git diff --exit-code
-          test -z "$(git status --porcelain)"
 
   swift-series:
     name: Swift ${{ matrix.swift_series }} / Apple clean resolution


### PR DESCRIPTION
## Why

The `Swift 6.0 / first-party source coverage` job's "Verify checkout remains clean" step ran last, after "Upload coverage evidence to Codecov". That action downloads its uploader into the checkout and leaves it behind as an untracked file, which the cleanliness check then reported as a dirty tree — failing a job whose Codecov step is explicitly documented in its own comment as a diagnostic upload that "must never fail this job".

Confirmed reproducible on two independent CI runs against `16509ef0` (the current `main` tip): the original post-merge push run, and a `release-test/v1.5.999` dry-run tag's compiler-matrix validation. Both failed at the same step, with `git diff --exit-code` passing (no tracked file changed) but `git status --porcelain` finding something — the untracked Codecov uploader.

This is currently release-blocking for v1.5.6: `release.yml`'s "Verify release dry run" and "Publish exact GitHub Release" jobs both `needs: [validate, compatibility, documentation]`, and the `compatibility` job is the entire reusable Swift compatibility workflow call — a failure in any of its jobs, including this non-release-blocking coverage job, fails that dependency and skips the actual publish steps.

## Fix

Move "Verify checkout remains clean" to run immediately after "Verify reproducible first-party source selection" (the last step that can legitimately leave the tree dirty) and before any diagnostic step. This restores the check's actual intent — proving the coverage captures themselves didn't mutate first-party source — without being tripped up by an unrelated step's incidental side effect.

## Scope

CI workflow only. No product source, test, or documentation change.
