### PR TITLE
ci: deliver CODECOV_TOKEN to the coverage upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/swift.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   documentation:
     name: Build exact documentation artifact

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,6 +2,13 @@ name: Swift compatibility
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        description: >-
+          Codecov upload token. Optional: the coverage upload is diagnostic
+          evidence, not a release gate, so a release run without it still
+          succeeds -- it just publishes no coverage report.
+        required: false
   push:
     branches: [main]
   pull_request:
@@ -136,10 +143,40 @@ jobs:
       # Diagnostic evidence upload, not a release gate (Coverage/README.md) -- failure here
       # must never fail this job, hence fail_ci_if_error: false.
       - name: Upload coverage evidence to Codecov
+        id: codecov-upload
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ runner.temp }}/swiftql-coverage-run-1/llvm-coverage.lcov
           fail_ci_if_error: false
+
+      # The upload above is intentionally non-fatal, which previously let a
+      # missing token rot the coverage badge to "unknown" without any signal.
+      # Record the token's presence and the step outcome so a silent upload
+      # failure is visible in the job summary instead of invisible.
+      - name: Report Codecov upload outcome
+        if: ${{ always() && !cancelled() }}
+        env:
+          UPLOAD_OUTCOME: ${{ steps.codecov-upload.outcome }}
+          UPLOAD_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$UPLOAD_TOKEN" ]]; then
+            token_state=present
+          else
+            token_state=missing
+          fi
+          {
+            printf '\n## Codecov upload\n\n'
+            printf -- '- Token: `%s`\n' "$token_state"
+            printf -- '- Outcome: `%s`\n' "$UPLOAD_OUTCOME"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$token_state" == missing ]]; then
+            printf '::warning::CODECOV_TOKEN is unavailable; coverage was not published.\n'
+          elif [[ "$UPLOAD_OUTCOME" != success ]]; then
+            printf '::warning::Codecov upload did not succeed (%s); coverage may be stale.\n' \
+              "$UPLOAD_OUTCOME"
+          fi
 
       - name: Prepare retained source coverage evidence
         if: ${{ always() && !cancelled() }}


### PR DESCRIPTION
## What changed

Wires the existing `CODECOV_TOKEN` repository secret through to the Codecov uploader, in the two places it was being dropped, and adds a guard so a broken upload can no longer fail silently.

- `.github/workflows/swift.yml` — declare `CODECOV_TOKEN` as an optional `workflow_call` secret; pass `token:` to the upload step; add a non-fatal `Report Codecov upload outcome` step.
- `.github/workflows/release.yml` — forward `CODECOV_TOKEN` into the reusable compatibility workflow.

## Why

The coverage badge has read **unknown** since the repo was created. Codecov reports the project as `activated: false` with **zero** commits ever uploaded (`/api/v2/.../commits/` returns `{"count": 0}`). The secret itself was fine — configured a month ago — it just never reached the uploader, in two independent places:

1. **The action was never given the token.** The upload step passed only `files:` and `fail_ci_if_error: false`. GitHub does not inject secrets into actions implicitly, and `codecov-action` reads its `token` input (or a `CODECOV_TOKEN` env var). Every upload was attempted unauthenticated and rejected — silently, because the step is deliberately non-fatal.

2. **Release runs would still have uploaded nothing.** `swift.yml` is a reusable workflow (`on: workflow_call`) invoked by `release.yml`. Reusable workflows receive no secrets unless forwarded explicitly, so `secrets.CODECOV_TOKEN` evaluated to an empty string in every release-triggered compatibility run. Fixing only (1) would have left this half broken.

## Notes for the reviewer

- `required: false` on the declared secret keeps the upload aligned with its existing contract — diagnostic evidence, not a release gate (see `Coverage/README.md`). A release run without the token still succeeds; it just publishes no coverage.
- The secret is forwarded explicitly rather than with `secrets: inherit`, matching the release pipeline's minimal-privilege style.
- **No fork-PR exposure:** the coverage job is already gated on `github.event_name != 'pull_request'`.
- The new reporting step is `always() && !cancelled()` and always exits 0 — it can never fail the job. It only annotates.

## Verification

- `ruby -ryaml` parses all four workflows
- `scripts/ci/test-swift-compatibility-workflow.py` — 12 tests OK
- `scripts/ci/test-source-coverage-report.py` — 28 tests OK
- `scripts/ci/test-release-workflow.sh` — OK
- `bash -n scripts/ci/*.sh` — clean
- Extracted the new step's script from the parsed YAML and ran it against all three states (token missing / token present with failed upload / happy path): correct summary and warning in each, exit 0 throughout.

## Out of scope

The `Swift compatibility` and `Documentation` badges are also currently red, from unrelated GitHub infrastructure failures on 2026-08-06 — an action-download `Service Unavailable` during `Set up job`, and `actions/deploy-pages` status polling hitting its 600s default timeout on a deployment that actually landed (the live site serves the correct commit and run id). Those need a re-run of the failed runs, not a code change.
