### PR TITLE
Register custom functions for RETURNING requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.5.7] - Unreleased
+
+### Fixed
+
+- A `RETURNING` request now registers custom functions that opt into implicit
+  registration, so a data-changing statement whose clauses call one executes
+  instead of failing with SQLite's "no such function" error (issue #553).
+  `GRDBDatabase.makeRequest(with: any XLReturningStatement<Row>)` built its
+  request without passing the rendered encoding's registrations, so the
+  registration table reaching the connection was empty -- a predicate that
+  worked in a plain `SELECT` failed once the same statement was written as
+  `UPDATE ... RETURNING` or `DELETE ... RETURNING`. Functions registered
+  upfront with `GRDBDatabaseBuilder.addFunction(_:)` were never affected.
+  Static query descriptors still register nothing, which is deliberate and now
+  documented: a descriptor keeps only deterministic SQL and parameter
+  metadata, and a registration is a live closure that cannot survive into it.
+
 ## [1.5.6] - 2026-08-04
 
 ### Added

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -1186,14 +1186,14 @@ public struct GRDBDatabase: XLDatabase {
     ///
     /// Unlike the encodable overloads, this path deliberately registers no
     /// custom functions. A descriptor carries only deterministic SQL and
-    /// immutable parameter metadata -- ``XLStaticStatementDefinition/init(validating:)``
-    /// discards the expression graph, and with it the
-    /// ``XLCustomFunctionRegistration`` closures that implicit registration
+    /// immutable parameter metadata -- `XLStaticStatementDefinition`'s
+    /// `init(validating:)` discards the expression graph, and with it the
+    /// `XLCustomFunctionRegistration` closures that implicit registration
     /// needs -- so there is nothing to register here. A statement that calls a
     /// custom function must therefore have that function registered upfront
     /// with `GRDBDatabaseBuilder.addFunction(_:)` before it is executed as a
     /// static descriptor; implicit registration through
-    /// ``XLBuilder/customFunctionCall(_:parameters:)`` applies only to the
+    /// `XLBuilder.customFunctionCall(_:parameters:)` applies only to the
     /// `makeRequest(with:)` and `prepareInvocation(with: any XLEncodable)`
     /// paths, which still hold the rendered encoding.
     public func prepareInvocation(

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -1183,6 +1183,19 @@ public struct GRDBDatabase: XLDatabase {
     /// Validation happens before a runtime handle is returned. Physical SQLite
     /// statements remain connection-owned and are created only while executing
     /// through the GRDB driver.
+    ///
+    /// Unlike the encodable overloads, this path deliberately registers no
+    /// custom functions. A descriptor carries only deterministic SQL and
+    /// immutable parameter metadata -- ``XLStaticStatementDefinition/init(validating:)``
+    /// discards the expression graph, and with it the
+    /// ``XLCustomFunctionRegistration`` closures that implicit registration
+    /// needs -- so there is nothing to register here. A statement that calls a
+    /// custom function must therefore have that function registered upfront
+    /// with `GRDBDatabaseBuilder.addFunction(_:)` before it is executed as a
+    /// static descriptor; implicit registration through
+    /// ``XLBuilder/customFunctionCall(_:parameters:)`` applies only to the
+    /// `makeRequest(with:)` and `prepareInvocation(with: any XLEncodable)`
+    /// paths, which still hold the rendered encoding.
     public func prepareInvocation(
         with descriptor: XLStaticQueryDescriptor
     ) throws -> GRDBPreparedStaticQuery {
@@ -1224,6 +1237,7 @@ public struct GRDBDatabase: XLDatabase {
             parameterLayoutError: preparedParameterLayoutError(for: encoding),
             valueEncodingError: encoding.valueEncodingError,
             requiresWriteConnection: true,
+            customFunctions: encoding.customFunctions,
             liveQueryRetryPolicy: liveQueryRetryPolicy,
             liveQueryRetryScheduler: liveQueryRetryScheduler
         )

--- a/Sources/SwiftQL/SQLStaticQueryDescriptor.swift
+++ b/Sources/SwiftQL/SQLStaticQueryDescriptor.swift
@@ -9,6 +9,14 @@ extension XLStaticStatementDefinition {
     /// The SwiftQL expression graph is deliberately discarded here. Static
     /// descriptors retain only deterministic SQL, dialect requirements,
     /// referenced entities, and immutable parameter metadata.
+    ///
+    /// `encoding.customFunctions` is discarded with the graph: a registration
+    /// is a live closure, not deterministic metadata, so it cannot survive into
+    /// a database-independent descriptor. A statement that calls a custom
+    /// function therefore has to have it registered upfront with
+    /// `GRDBDatabaseBuilder.addFunction(_:)` to be executed as a static
+    /// descriptor -- implicit registration covers only the request and
+    /// encodable-invocation paths, which still hold the encoding.
     public init(validating encoding: XLEncoding) throws {
         if let valueEncodingError = encoding.valueEncodingError {
             throw valueEncodingError

--- a/Tests/SQLTests/SQLDocumentationCatalogTests.swift
+++ b/Tests/SQLTests/SQLDocumentationCatalogTests.swift
@@ -810,7 +810,7 @@ final class SQLDocumentationCatalogTests: XCTestCase {
         // RELEASING.md step 4 dates this heading during release preparation,
         // replacing `Unreleased` with the release date; update this pin in the
         // same change.
-        XCTAssertEqual(firstReleaseHeading, "## [1.5.6] - 2026-08-04")
+        XCTAssertEqual(firstReleaseHeading, "## [1.5.7] - Unreleased")
     }
 
     /// `check-docc-output.sh` proves one built page per catalog article. An

--- a/Tests/SQLTests/SQLImplicitFunctionRegistrationTests.swift
+++ b/Tests/SQLTests/SQLImplicitFunctionRegistrationTests.swift
@@ -164,6 +164,53 @@ final class XLImplicitFunctionRegistrationTests: XCTestCase {
         }
     }
 
+    // MARK: - RETURNING requests
+
+    /// `makeRequest(with: any XLReturningStatement<Row>)` builds its own `GRDBRequest` rather than
+    /// going through the query overload, and originally omitted `customFunctions:` from that
+    /// construction -- so the request's registration table was empty and the implicitly registered
+    /// function never reached the connection. A data-changing statement whose `WHERE` clause calls an
+    /// implicitly registered function then failed with SQLite's "no such function" error, even though
+    /// the identical predicate worked in a plain `SELECT`.
+    func testCustomFunctionCallRegistersImplicitlyForReturningRequests() throws {
+        let database = try makeDatabase()
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "a", value: 4))).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "b", value: 5))).execute()
+
+        let schema = XLSchema()
+        let target = schema.into(TestTable.self)
+        let projection = schema.table(TestTable.self)
+        let statement = update(target)
+            .set { row in row.value = 99 }
+            .where(ImplicitSquareFunction(target.value) == 16)
+            .returning(projection)
+
+        let updated: [TestTable] = try database.makeRequest(with: statement).fetchAll()
+
+        XCTAssertEqual(updated, [TestTable(id: "a", value: 99)])
+    }
+
+    /// The same omission, on the delete form of the RETURNING request, to confirm the fix is in the
+    /// shared request factory rather than in one statement kind.
+    func testCustomFunctionCallRegistersImplicitlyForDeleteReturningRequests() throws {
+        let database = try makeDatabase()
+        try database.makeRequest(with: sqlCreate(TestTable.self)).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "a", value: 4))).execute()
+        try database.makeRequest(with: sqlInsert(TestTable(id: "b", value: 5))).execute()
+
+        let schema = XLSchema()
+        let target = schema.into(TestTable.self)
+        let projection = schema.table(TestTable.self)
+        let statement = delete(target)
+            .where(ImplicitSquareFunction(target.value) == 25)
+            .returning(projection)
+
+        let deleted: [TestTable] = try database.makeRequest(with: statement).fetchAll()
+
+        XCTAssertEqual(deleted, [TestTable(id: "b", value: 5)])
+    }
+
     // MARK: - Pool concurrency
 
     /// `DatabasePool` maintains several persistent reader connections and hands any given read to whichever


### PR DESCRIPTION
Closes #553.

`GRDBDatabase.makeRequest(with: any XLReturningStatement<Row>)` built its `GRDBRequest` without passing `customFunctions: encoding.customFunctions`, unlike the query overload beside it. `GRDBRequest.init` defaults that argument to `[:]`, so `boundStatement`'s `registerCustomFunctions` registered nothing and a function that opts into implicit registration via `XLBuilder.customFunctionCall` never reached the connection.

A predicate that worked in a plain `SELECT` therefore failed with SQLite's `no such function` as soon as the same statement was written as `UPDATE ... RETURNING` or `DELETE ... RETURNING`. Functions registered upfront with `GRDBDatabaseBuilder.addFunction(_:)` were never affected.

### Scope checklist

- [x] Pass `customFunctions: encoding.customFunctions` in the RETURNING request factory.
- [x] Regression tests: implicitly-registered custom function with `UPDATE ... RETURNING` and `DELETE ... RETURNING`. Both fail with `no such function` against the unfixed source and pass with the fix.
- [x] `prepareInvocation(with: XLStaticQueryDescriptor)` — confirmed intentional and documented rather than fixed. `XLStaticStatementDefinition.init(validating:)` discards the expression graph, and an `XLCustomFunctionRegistration` is a live closure rather than deterministic metadata, so it cannot survive into a database-independent descriptor. Both the descriptor initializer and the `prepareInvocation` overload now say so, and point callers at upfront `addFunction(_:)`.

### Also in this change

Opens the `## [1.5.7] - Unreleased` changelog section, per RELEASING.md step 4's heading convention, and moves `SQLDocumentationCatalogTests`' first-release-heading pin onto it.

### Verification

`swift test` — full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)