### PR TITLE
Run the build-validation plugin fixture in CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -999,6 +999,19 @@ jobs:
             "$RESOLUTION_MODE" \
             "$RUNNER_TEMP/swift5-client.log"
 
+      # A build-tool plugin's createBuildCommands cannot be unit-tested without
+      # a live PluginContext, so this fixture package is the only check of the
+      # plugin's real invocation contract. It was manual-only until #556, which
+      # is how the #492 target/product naming break shipped across v1.5.2-v1.5.5
+      # with the fixture that catches it sitting in the repo unrun. Only the
+      # `swift build` half runs here; verify-xcode.sh stays manual because Xcode
+      # is not part of the pinned matrix (see COMPATIBILITY.md).
+      - name: Verify the build-validation plugin's invocation contract
+        run: |
+          set -euo pipefail
+          cd "$SWIFTQL_SOURCE"
+          IntegrationTests/BuildValidationPluginFixture/verify.sh
+
       # make-docs.sh builds Website/blog with Hugo as part of the site, so this
       # job needs it for the same reason documentation-build.yml does.
       - name: Install Hugo

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -68,6 +68,10 @@ against `IntegrationTests/BuildValidationPluginFixture`: `verify.sh` drives
 'platform=macOS'`, and both assert the same outcomes — a valid manifest builds,
 and an invalid one fails with the validator's own diagnostic.
 
+`verify.sh` runs in CI on every cell of the pinned compatibility matrix, so the
+`swift build` contract is gated on each supported Swift series and platform.
+`verify-xcode.sh` remains a manual check: Xcode is not part of that matrix.
+
 On v1.5.2 through v1.5.5 the plugin is `swift build`-only. Adopting it in a
 target that Xcode builds fails that build with `Build input file cannot be
 found` naming the validator executable, before validation runs, on a valid

--- a/Documentation/Architecture/SQLiteBuildValidationPlugin.md
+++ b/Documentation/Architecture/SQLiteBuildValidationPlugin.md
@@ -81,9 +81,11 @@ bundle resources for the target's own product.
 
 For a self-contained, runnable version of this walkthrough see
 `IntegrationTests/BuildValidationPluginFixture` and its `verify.sh`, which
-drives exactly these steps against the real pinned Northwind snapshot.
-`verify-xcode.sh` next to it drives the same steps through Xcode's build
-system (see [Build systems](#build-systems)).
+drives exactly these steps against the real pinned Northwind snapshot and runs
+on every cell of the pinned compatibility matrix in CI. `verify-xcode.sh` next
+to it drives the same steps through Xcode's build system (see
+[Build systems](#build-systems)); that one stays a manual check, because Xcode
+is not part of the pinned matrix.
 
 ## Package layout example
 

--- a/IntegrationTests/BuildValidationPluginFixture/Package.swift
+++ b/IntegrationTests/BuildValidationPluginFixture/Package.swift
@@ -17,6 +17,13 @@ let package = Package(
         ),
         // A second target adopting the plugin, proving report paths are
         // namespaced per target rather than colliding on one shared path.
+        //
+        // Its manifest and snapshot are byte-identical copies of
+        // ValidatedLibrary's, and have to be: the plugin resolves both inputs
+        // as `sourceTarget.directory.appending(...)` and fails the build when
+        // either is absent from the target's own directory, so an opted-in
+        // target cannot borrow another's files. Two copies of the 588K snapshot
+        // is the cost of covering the multi-target case at all.
         .target(
             name: "SecondValidatedLibrary",
             plugins: [


### PR DESCRIPTION
Closes #556.

`IntegrationTests/BuildValidationPluginFixture/verify.sh` is the only check of `SwiftQLSQLiteBuildValidationPlugin`'s real invocation contract — a build-tool plugin's `createBuildCommands` cannot be unit-tested without a live `PluginContext` — but nothing under `.github/workflows/` invoked it; only prose referred to it. That is how the #492 target/product naming break shipped across v1.5.2–v1.5.5 with the fixture that catches it sitting unrun in the repo.

### Scope checklist

- [x] `verify.sh` now runs beside the downstream Swift 5 client check, on **every cell** of the pinned compatibility matrix — Swift 5.9 on Linux and Swift 6.0 on macOS, committed and clean resolution. That job is the one that gates pull requests; `swift-series` runs only on pushes to `main`.
- [x] `verify-xcode.sh` left manual, and COMPATIBILITY.md now says why (Xcode is not in the pinned matrix).
- [x] Optional bullet — the two byte-identical 588K snapshots **cannot** be shared. The plugin resolves both inputs as `sourceTarget.directory.appending(...)` and fails the build when either is absent from the target's *own* directory, so an opted-in target cannot borrow another's copy. `Package.swift` records that next to the second target.

### Why this stays clean in the workspace

The committed-resolution cell runs with `SWIFTQL_SOURCE == GITHUB_WORKSPACE`, and the job ends by asserting the checkout is unmodified. `verify.sh` is safe there: the fixture carries its own `.gitignore` with `/.build`, and the manifest it swaps in step 2 is restored by an `EXIT` trap. Verified locally — `git status --porcelain` is empty after a full run.

### Verification

- `IntegrationTests/BuildValidationPluginFixture/verify.sh` — all five checks pass locally (~22s), workspace clean afterwards.
- `swift test` — full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)