### PR TITLE
ci: survive a slow Pages deployment status poll

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,8 +33,11 @@ jobs:
       }}
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Headroom for a patient deploy poll (15m) plus the independent
+    # verification sweep below, which retries for a further 5m.
+    timeout-minutes: 35
     permissions:
+      contents: read
       pages: write
       id-token: write
     concurrency:
@@ -45,13 +48,52 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      # This action publishes the deployment and then polls the Pages status
+      # API until it reports success. Those are separate failures: on
+      # 2026-08-06 two consecutive runs published correctly and then aborted
+      # at the poll's 600000ms default ("Timeout reached, aborting!"), turning
+      # a live, correct deployment into a red badge.
+      #
+      # Be more patient with the poll, and -- because the verification step
+      # below proves deployment from the live site far more strongly than the
+      # status API does -- do not let a poll timeout alone fail the job. A
+      # deployment that genuinely did not land still fails, in that step, with
+      # a far more useful diagnostic.
       - name: Deploy Pages artifact
         id: deployment
+        continue-on-error: true
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        with:
+          timeout: 900000
+          error_count: 20
+
+      # page_url is empty when the poll aborted, so fall back to the Pages
+      # API rather than losing the ability to verify.
+      - name: Resolve Pages site URL
+        id: site
+        env:
+          DEPLOYMENT_OUTCOME: ${{ steps.deployment.outcome }}
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          page_url="$PAGE_URL"
+          if [[ -z "$page_url" ]]; then
+            page_url="$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')"
+          fi
+          if [[ -z "$page_url" ]]; then
+            echo "error: could not determine the Pages site URL" >&2
+            exit 1
+          fi
+          printf 'page_url=%s\n' "$page_url" >> "$GITHUB_OUTPUT"
+          if [[ "$DEPLOYMENT_OUTCOME" != success ]]; then
+            printf '::warning::Pages deploy step reported `%s`; verifying the live site directly.\n' \
+              "$DEPLOYMENT_OUTCOME"
+          fi
 
       - name: Verify deployed commit and catalog pages
         env:
-          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          PAGE_URL: ${{ steps.site.outputs.page_url }}
         run: |
           set -euo pipefail
           site_url="${PAGE_URL%/}/"
@@ -128,7 +170,8 @@ jobs:
       - name: Record deployment summary
         env:
           ARTIFACT_ID: ${{ needs.build.outputs.artifact_id }}
-          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          PAGE_URL: ${{ steps.site.outputs.page_url }}
+          DEPLOYMENT_OUTCOME: ${{ steps.deployment.outcome }}
         run: |
           {
             printf '### SwiftQL documentation deployment\n\n'
@@ -137,4 +180,5 @@ jobs:
             printf -- '- Run: https://github.com/%s/actions/runs/%s\n' \
               "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
             printf -- '- Site: %s\n' "$PAGE_URL"
+            printf -- '- Deploy step outcome: `%s`\n' "$DEPLOYMENT_OUTCOME"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What changed

Makes the Pages deployment resilient to a slow status API, and moves the pass/fail decision onto the evidence we already collect from the live site.

`.github/workflows/documentation.yml`:
- `actions/deploy-pages` gets `timeout: 900000` (15m, up from the 600000ms default) and `error_count: 20`.
- The deploy step becomes `continue-on-error: true`; the existing provenance verification is now the gate.
- New `Resolve Pages site URL` step falls back to the Pages API when `page_url` is empty.
- `timeout-minutes` 15 → 35; added `contents: read`.
- Job summary records the deploy step's outcome.

## Why

`actions/deploy-pages` does two separable things: it publishes the deployment, then polls the Pages status API until that API reports success. On 2026-08-06 the second one failed twice in a row while the first one succeeded:

| Run | Artifact | Deploy step |
|---|---|---|
| [30922473793](https://github.com/lukevanin/swiftql/actions/runs/30922473793) (Aug 4) | 4.03 MiB | success in **6s** |
| [31106507055](https://github.com/lukevanin/swiftql/actions/runs/31106507055) (Aug 6) | 4.04 MiB | failure at **exactly 10m00s** |
| [31113573537](https://github.com/lukevanin/swiftql/actions/runs/31113573537) (Aug 6) | 4.03 MiB | failure at **exactly 10m00s** |

Both failures land precisely on the action's `600000` ms default — confirmed against `action.yml` at our pinned SHA, which documents `timeout` as "Time in milliseconds after which to timeout and cancel the deployment (default: 10 minutes)".

**The deployments had actually landed.** The live site still serves the provenance of the run that "failed":

```json
{ "commit_sha": "9c2c2f51ee0701f69e1ba0c2fc6e71d2b45cdb0d",
  "run_id": "31113573537", "run_attempt": "1" }
```

A byte-for-byte comparable artifact deployed in 6 seconds two days earlier, so this was status-API latency, not our payload.

Raising the timeout alone would only move the cliff. The real fix is that we already have stronger evidence than the status API: the verification step fetches `swiftql-pages-provenance.json` from the live site and matches it against this exact commit **and** run id, then sweeps the catalog, blog, and DocC JSON. That is a much better gate than "GitHub's status endpoint answered in time", so the poll no longer decides the job's fate.

## Notes for the reviewer

- **This does not weaken the gate.** A deployment that genuinely did not land still fails — in the verification step, which retries for 5 minutes and then errors with `deployed provenance did not match this commit and run`. That is a strictly more useful diagnostic than a bare timeout.
- The URL fallback matters: `page_url` is an output of the step that timed out, so it is empty in exactly the scenario we are hardening against. Without the fallback, `continue-on-error` would just move the failure into the verify step with an empty URL.
- `concurrency: github-pages` with `cancel-in-progress: false` is unchanged, so a patient poll cannot cause overlapping deployments — later runs queue.

## Verification

- `ruby -ryaml` parses all four workflows
- `scripts/ci/test-swift-compatibility-workflow.py` — 12 tests OK (it asserts on `documentation.yml`'s concurrency block, untouched here)
- `scripts/ci/test-source-coverage-report.py` — 28 tests OK
- `scripts/ci/test-release-workflow.sh` — OK
- `bash -n scripts/ci/*.sh` — clean
- Confirmed `timeout` / `error_count` are real inputs on `actions/deploy-pages` at the pinned SHA `cd2ce8f`
- Ran the new resolve step against both states — action succeeded with a URL, and poll-timed-out with an empty URL — and both resolve `https://lukevanin.github.io/swiftql/`, the second emitting the warning annotation

## Testing note

The `deploy` job only runs on push to `main`, so PR CI cannot exercise this path. It gets its first real run when this merges.
