### PR TITLE
Capture bound SQLite values in one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Fixed
 
+- A NaN `Double` bound through a `@SQLQuery` macro parameter is now rejected
+  where the value is captured, rather than further down at the driver boundary
+  (issue #554). SwiftQL's documented policy is that binding a NaN throws
+  `XLSQLValueEncodingError.realBindingWouldBecomeNull` instead of letting SQLite silently store SQL `NULL` in its place, and
+  `_xlQueryParameterBinding` -- the capture behind every macro parameter --
+  was the one capture path missing that check. **Nothing was ever stored as
+  `NULL` through it**: `GRDBDatabaseDriver` rejects a NaN `REAL` before the
+  value reaches SQLite, so executing such a query already threw. It now throws
+  from the capture, with the same error the driver produced, so every capture
+  path agrees. A caller who invokes `_xlQueryParameterBinding` directly and
+  inspects its result, rather than executing, sees the throw where they
+  previously saw `.real(nan)`. Infinities are unaffected: they survive
+  SQLite's binding round trip and remain valid bound values.
+
 - A `RETURNING` request now registers custom functions that opt into implicit
   registration, so a data-changing statement whose clauses call one executes
   instead of failing with SQLite's "no such function" error (issue #553).

--- a/Sources/SwiftQL/Codecs/LiteralValueCapture.swift
+++ b/Sources/SwiftQL/Codecs/LiteralValueCapture.swift
@@ -1,0 +1,112 @@
+//
+//  LiteralValueCapture.swift
+//  SwiftQL
+//
+//  The one place a Swift value written through `XLBindable.bind(context:)` is
+//  captured as a normalized `XLSQLiteValue` (issue #554). Four byte-identical
+//  private capture contexts used to do this, three of them recovering the
+//  written value with a force cast.
+//
+
+import Foundation
+
+
+///
+/// Captures the single normalized SQLite value an `XLBindable` conformer writes
+/// through its binding context.
+///
+/// Every capture path in SwiftQL shares this type, so the mapping from a bound
+/// Swift value to an ``XLSQLiteValue`` is defined exactly once.
+///
+struct XLSQLiteValueCapture: XLBindingContext {
+
+    var value: XLSQLiteValue = .null
+
+    mutating func bindNull() {
+        value = .null
+    }
+
+    mutating func bindInteger(value: Int) {
+        self.value = .integer(Int64(value))
+    }
+
+    mutating func bindReal(value: Double) {
+        self.value = .real(value)
+    }
+
+    mutating func bindText(value: String) {
+        self.value = .text(value)
+    }
+
+    mutating func bindBlob(value: Data) {
+        self.value = .blob(value)
+    }
+}
+
+
+///
+/// Runs `bind` against a fresh ``XLSQLiteValueCapture`` and returns the value it
+/// wrote.
+///
+/// `bind(context:)` receives its context `inout` as an existential, so a
+/// conformer is free to replace it with a context of another type. Intrinsic
+/// literal conformers never do. If one does, the value it wrote is unreachable
+/// and there is no correct value to return, so this traps -- as the force casts
+/// it replaces did -- but names the offending type instead of reporting an
+/// unexplained cast failure.
+///
+/// - Parameters:
+///   - valueType: Names the conformer in the diagnostic. Evaluated only when
+///     the context was replaced.
+///   - bind: Writes one value into the provided context.
+func _xlCapturedSQLiteValue(
+    of valueType: @autoclosure () -> String,
+    bind: (inout any XLBindingContext) -> Void
+) -> XLSQLiteValue {
+    var context: any XLBindingContext = XLSQLiteValueCapture()
+    bind(&context)
+    guard let capture = context as? XLSQLiteValueCapture else {
+        preconditionFailure(
+            "\(valueType()).bind(context:) replaced the binding context with "
+            + "\(type(of: context)); expected it to write the value into the "
+            + "provided XLSQLiteValueCapture."
+        )
+    }
+    return capture.value
+}
+
+
+///
+/// Captures `value` as a normalized SQLite value, rejecting one that SQLite
+/// would silently store as something other than what was bound.
+///
+/// SQLite's binding API turns an IEEE 754 NaN into SQL `NULL`. SwiftQL treats
+/// that as an error rather than a silent change of meaning, so a NaN `REAL`
+/// throws ``XLSQLValueEncodingError/realBindingWouldBecomeNull(value:valueType:context:)``
+/// here, at the point of capture, for every path that binds a value. Infinities
+/// survive the round trip and are captured unchanged. See
+/// <doc:RealValues>.
+///
+/// - Parameters:
+///   - value: The Swift value to capture.
+///   - valueType: The value's type name, as it appears in the thrown error.
+///   - codingContext: The parameter or property the value is bound for, as it
+///     appears in the thrown error.
+func _xlCaptureSQLiteValue<T>(
+    _ value: T,
+    valueType: @autoclosure () -> String,
+    codingContext: @autoclosure () -> XLValueCodingContext
+) throws -> XLSQLiteValue where T: XLBindable {
+    let captured = _xlCapturedSQLiteValue(of: valueType()) { context in
+        value.bind(context: &context)
+    }
+    if case .real(let real) = captured,
+       let error = XLSQLValueEncodingError.bindingFailure(
+           for: real,
+           valueType: valueType(),
+           context: codingContext()
+       ) {
+        throw error
+    }
+    return captured
+}

--- a/Sources/SwiftQL/GRDBSQLDatabase.swift
+++ b/Sources/SwiftQL/GRDBSQLDatabase.swift
@@ -104,32 +104,6 @@ package struct GRDBRowDecoder<Output> {
 }
 
 
-fileprivate struct BindingContext: XLBindingContext {
-
-    var value: XLSQLiteValue = .null
-    
-    mutating func bindNull() {
-        self.value = .null
-    }
-    
-    mutating func bindInteger(value: Int) {
-        self.value = .integer(Int64(value))
-    }
-    
-    mutating func bindReal(value: Double) {
-        self.value = .real(value)
-    }
-    
-    mutating func bindText(value: String) {
-        self.value = .text(value)
-    }
-    
-    mutating func bindBlob(value: Data) {
-        self.value = .blob(value)
-    }
-}
-
-
 struct GRDBRequest<Row>: XLRequest {
 
     private let executor: GRDBInvocationExecutor
@@ -240,9 +214,13 @@ struct GRDBRequest<Row>: XLRequest {
             }
             return
         }
-        var context: any XLBindingContext = BindingContext()
-        bind(&context)
-        let value = (context as! BindingContext).value
+        // No NaN guard here: this legacy setter has no throwing channel, and
+        // `compatibilityBindingError` carries an `XLInvocationBindingError`
+        // rather than an encoding error. The driver boundary rejects a NaN
+        // `REAL` for this path when the packet is executed.
+        let value = _xlCapturedSQLiteValue(of: declaration.valueTypeName) { context in
+            bind(&context)
+        }
         do {
             compatibilityBindings = try replacingBinding(
                 value,
@@ -740,9 +718,13 @@ struct GRDBWriteRequest: XLWriteRequest {
             }
             return
         }
-        var context: any XLBindingContext = BindingContext()
-        bind(&context)
-        let value = (context as! BindingContext).value
+        // No NaN guard here: this legacy setter has no throwing channel, and
+        // `compatibilityBindingError` carries an `XLInvocationBindingError`
+        // rather than an encoding error. The driver boundary rejects a NaN
+        // `REAL` for this path when the packet is executed.
+        let value = _xlCapturedSQLiteValue(of: declaration.valueTypeName) { context in
+            bind(&context)
+        }
         do {
             compatibilityBindings = try replacingBinding(
                 value,

--- a/Sources/SwiftQL/LegacyLiteralValueCodec.swift
+++ b/Sources/SwiftQL/LegacyLiteralValueCodec.swift
@@ -35,18 +35,11 @@ public struct XLV1LiteralCodec<Value>: Sendable where Value: XLLiteral & Sendabl
                 rawValue: storageClass.rawValue
             ),
             encode: { value, _, codingContext in
-                var context: any XLBindingContext = _XLV1LiteralBindingContext()
-                value.bind(context: &context)
-                let encoded = (context as! _XLV1LiteralBindingContext).value
-                if case .real(let real) = encoded,
-                   let error = XLSQLValueEncodingError.bindingFailure(
-                       for: real,
-                       valueType: String(reflecting: Value.self),
-                       context: codingContext
-                   ) {
-                    throw error
-                }
-                return encoded
+                try _xlCaptureSQLiteValue(
+                    value,
+                    valueType: String(reflecting: Value.self),
+                    codingContext: codingContext
+                )
             },
             decode: { value, _, _ in
                 try Value(
@@ -55,31 +48,5 @@ public struct XLV1LiteralCodec<Value>: Sendable where Value: XLLiteral & Sendabl
                 )
             }
         )
-    }
-}
-
-
-private struct _XLV1LiteralBindingContext: XLBindingContext {
-
-    var value: XLSQLiteValue = .null
-
-    mutating func bindNull() {
-        value = .null
-    }
-
-    mutating func bindInteger(value: Int) {
-        self.value = .integer(Int64(value))
-    }
-
-    mutating func bindReal(value: Double) {
-        self.value = .real(value)
-    }
-
-    mutating func bindText(value: String) {
-        self.value = .text(value)
-    }
-
-    mutating func bindBlob(value: Data) {
-        self.value = .blob(value)
     }
 }

--- a/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
+++ b/Sources/SwiftQL/SQLQueryPeerMacroSupport.swift
@@ -11,35 +11,6 @@ import Foundation
 
 
 ///
-/// Captures one normalized SQLite value from an `XLBindable` conformer.
-///
-private struct XLSQLiteValueCaptureContext: XLBindingContext {
-
-    var value: XLSQLiteValue = .null
-
-    mutating func bindNull() {
-        self.value = .null
-    }
-
-    mutating func bindInteger(value: Int) {
-        self.value = .integer(Int64(value))
-    }
-
-    mutating func bindReal(value: Double) {
-        self.value = .real(value)
-    }
-
-    mutating func bindText(value: String) {
-        self.value = .text(value)
-    }
-
-    mutating func bindBlob(value: Data) {
-        self.value = .blob(value)
-    }
-}
-
-
-///
 /// Encodes one intrinsic literal parameter value for a named placeholder in a
 /// prepared parameter layout.
 ///
@@ -70,19 +41,11 @@ public func _xlQueryParameterBinding<T>(
             actual: declaration.slot(at: slot.index)
         )
     }
-    var context: any XLBindingContext = XLSQLiteValueCaptureContext()
-    value.bind(context: &context)
-    guard let capture = context as? XLSQLiteValueCaptureContext else {
-        // `bind(context:)` receives the context `inout`, so a conformer could
-        // replace it with a different type. Intrinsic literal conformers never
-        // do; fail with a diagnostic that names the offender if one does.
-        preconditionFailure(
-            "\(T.self).bind(context:) replaced the binding context with "
-            + "\(type(of: context)); expected it to write the value into the "
-            + "provided XLSQLiteValueCaptureContext."
-        )
-    }
-    let sqliteValue = capture.value
+    let sqliteValue = try _xlCaptureSQLiteValue(
+        value,
+        valueType: slot.valueTypeName,
+        codingContext: slot.codingContext
+    )
     if sqliteValue == .null, slot.nullability == .required {
         throw XLInvocationBindingError.nullForRequiredParameter(slot: slot)
     }

--- a/Sources/SwiftQL/SQLStaticRowLayout.swift
+++ b/Sources/SwiftQL/SQLStaticRowLayout.swift
@@ -808,18 +808,11 @@ where Dialect == XLSQLiteDialect, Value: XLLiteral, Storage == Value {
                 )
             },
             encode: { value in
-                var context: any XLBindingContext = _XLStaticLiteralBindingContext()
-                value.bind(context: &context)
-                let encoded = (context as! _XLStaticLiteralBindingContext).value
-                if case .real(let real) = encoded,
-                   let error = XLSQLValueEncodingError.bindingFailure(
-                       for: real,
-                       valueType: metadata.typeName,
-                       context: codingContext
-                   ) {
-                    throw error
-                }
-                return encoded
+                try _xlCaptureSQLiteValue(
+                    value,
+                    valueType: metadata.typeName,
+                    codingContext: codingContext
+                )
             }
         )
     }
@@ -864,17 +857,6 @@ where Dialect: XLValueCodingDialect {
         }
         return value
     }
-}
-
-
-private struct _XLStaticLiteralBindingContext: XLBindingContext {
-    var value: XLSQLiteValue = .null
-
-    mutating func bindNull() { value = .null }
-    mutating func bindInteger(value: Int) { self.value = .integer(Int64(value)) }
-    mutating func bindReal(value: Double) { self.value = .real(value) }
-    mutating func bindText(value: String) { self.value = .text(value) }
-    mutating func bindBlob(value: Data) { self.value = .blob(value) }
 }
 
 

--- a/Tests/SQLTests/SQLQueryPeerMacroTests.swift
+++ b/Tests/SQLTests/SQLQueryPeerMacroTests.swift
@@ -73,6 +73,16 @@ extension GRDBDatabase {
     }
 
     @SQLQuery
+    func doubleRowsMatchingValue(value: Double) -> any XLQueryStatement<DoubleTest> {
+        sql { schema in
+            let table = schema.table(DoubleTest.self)
+            Select(table)
+            From(table)
+            Where(table.value == value)
+        }
+    }
+
+    @SQLQuery
     func nullableRowsMatchingValue(value: Int?) -> any XLQueryStatement<TestNullablesTable> {
         sql { schema in
             let table = schema.table(TestNullablesTable.self)
@@ -302,7 +312,87 @@ final class XLQueryPeerMacroTests: XCTestCase {
     }
 
 
+    // MARK: - Non-finite REAL parameters
+
+    /// SwiftQL rejects a bound NaN rather than letting SQLite's binding API
+    /// silently store SQL `NULL` in its place (see the Real Values article).
+    /// `_xlQueryParameterBinding` -- the capture the generated executors call
+    /// for every macro parameter -- used to skip that check, unlike the codec
+    /// and static-layout captures beside it, and returned `.real(nan)`. The
+    /// driver boundary caught it before it ever reached SQLite, so nothing was
+    /// ever stored as `NULL`; the value now fails at the point of capture, with
+    /// the same error the driver produced.
+    func testNaNDoubleParameterIsRejectedAtCapture() throws {
+        let layout = encoder
+            .makeSQL(database.doubleRowsMatchingValueStatement())
+            .parameterLayout
+
+        XCTAssertThrowsError(
+            try _xlQueryParameterBinding(Double.nan, named: "value", in: layout)
+        ) { error in
+            XCTAssertEqual(
+                error as? XLSQLValueEncodingError,
+                .realBindingWouldBecomeNull(
+                    value: .notANumber,
+                    valueType: String(reflecting: Double.self),
+                    context: XLValueCodingContext(
+                        site: .parameter,
+                        path: XLValueCodingPath("value")
+                    )
+                )
+            )
+        }
+    }
+
+    /// The same rejection seen through the generated executor, which is how a
+    /// caller meets it.
+    func testNaNDoubleParameterIsRejectedThroughTheGeneratedExecutor() throws {
+        try createDoubleTable()
+
+        XCTAssertThrowsError(
+            try database.fetchDoubleRowsMatchingValue(value: .nan)
+        ) { error in
+            XCTAssertEqual(
+                error as? XLSQLValueEncodingError,
+                .realBindingWouldBecomeNull(
+                    value: .notANumber,
+                    valueType: String(reflecting: Double.self),
+                    context: XLValueCodingContext(
+                        site: .parameter,
+                        path: XLValueCodingPath("value")
+                    )
+                )
+            )
+        }
+    }
+
+    /// Infinities survive SQLite's binding round trip, so the guard must let
+    /// them through -- it rejects NaN specifically, not every non-finite value.
+    /// Only the bound parameter carries an infinity here: an inline `REAL`
+    /// literal is a separate policy and is rejected before SQLite parses the
+    /// statement, so the fixture rows hold finite values.
+    func testInfiniteDoubleParametersRemainBindable() throws {
+        try createDoubleTable()
+        try insert(DoubleTest(id: "finite", value: 1.5))
+
+        XCTAssertEqual(try database.fetchDoubleRowsMatchingValue(value: .infinity), [])
+        XCTAssertEqual(try database.fetchDoubleRowsMatchingValue(value: -.infinity), [])
+        XCTAssertEqual(
+            try database.fetchDoubleRowsMatchingValue(value: 1.5),
+            [DoubleTest(id: "finite", value: 1.5)]
+        )
+    }
+
+
     // MARK: - Helpers
+
+    private func createDoubleTable() throws {
+        try database.makeRequest(with: sqlCreate(DoubleTest.self)).execute()
+    }
+
+    private func insert(_ row: DoubleTest) throws {
+        try database.makeRequest(with: sqlInsert(row)).execute()
+    }
 
     private func createTestTable() throws {
         try database.makeRequest(with: sqlCreate(TestTable.self)).execute()


### PR DESCRIPTION
Closes #554.

> **Stacked on [#568](https://github.com/lukevanin/swiftql/pull/568)** (issue #553) — both touch `GRDBSQLDatabase.swift`, and the changelog entry goes in the `## [1.5.7] - Unreleased` section #568 opens. Base is `issue/553-returning-custom-functions`; retarget to `version/1.5.7` once #568 lands. (I don't have permission to merge in this session.)

### The issue's premise does not hold, and the PR says so

The issue reports that "a NaN `Double` bound through a `@SQLQuery` macro parameter silently becomes SQL `NULL`". I could not reproduce that, and the reason is structural: `GRDBDatabaseDriver` checks every `.real` binding in the packet before executing ([`GRDBDatabaseDriver.swift:433`](Sources/SwiftQL/GRDBDatabaseDriver.swift)), and again at each physical bind. A probe through a generated executor — required *and* nullable parameter — throws `realBindingWouldBecomeNull` today, on unmodified `version/1.5.7`.

What **is** true is the rest of the diagnosis. `_xlQueryParameterBinding` returns `.real(nan)` from the capture where the codec and static-layout captures throw, so the macro path is the one capture that does not enforce SwiftQL's documented REAL policy at the point of capture — it just happens to be caught downstream.

So the guard is worth adding as the consistency fix the issue is really about, and the tests say what they actually pin. The error value is identical (same `valueType`, same `codingContext`), because the capture reads them from the same slot the driver did.

### Scope checklist

- [x] One internal `_xlCaptureSQLiteValue` helper in `Sources/SwiftQL/Codecs/LiteralValueCapture.swift`: single capture struct, checked downcast, NaN guard.
- [x] All four call sites collapsed onto it — `LegacyLiteralValueCodec`, `SQLStaticRowLayout`, `SQLQueryPeerMacroSupport`, and `GRDBSQLDatabase` (which had it **twice**, once per request type). The three force-casts are gone; the checked downcast still traps, but names the conformer that replaced the context instead of reporting an unexplained cast failure.
- [x] Test: a NaN parameter through a `@SQLQuery` declaration throws — at the capture and through the generated executor — plus that infinities still bind.
- [x] CHANGELOG note, written to the narrower truth above rather than claiming a silent-data-loss fix that never happened.

### The one site that deliberately keeps no guard

`GRDBRequest`/`GRDBWriteRequest`'s legacy `set(parameter:value:)` shim. It is non-throwing and its error field carries `XLInvocationBindingError`, not an encoding error, so the driver boundary stays its check. The call site now says that instead of leaving it to be noticed.

### Verification

`swift test` — full suite passes. DocC builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)